### PR TITLE
feat(browser): embed WebMCP with trusted action approvals

### DIFF
--- a/examples/react-vite/vite.config.ts
+++ b/examples/react-vite/vite.config.ts
@@ -6,7 +6,7 @@ import { defineConfig } from "vite";
 const repositoryRoot = fileURLToPath(new URL("../..", import.meta.url));
 
 export default defineConfig({
-  plugins: [react(), nanocodex()],
+  plugins: [react(), nanocodex({ webMcp: true })],
   build: {
     manifest: true,
   },

--- a/examples/react-vite/vite.config.ts
+++ b/examples/react-vite/vite.config.ts
@@ -6,7 +6,7 @@ import { defineConfig } from "vite";
 const repositoryRoot = fileURLToPath(new URL("../..", import.meta.url));
 
 export default defineConfig({
-  plugins: [react(), nanocodex({ webMcp: true })],
+  plugins: [react(), nanocodex()],
   build: {
     manifest: true,
   },

--- a/examples/react-vite/webmcp.manifest.json
+++ b/examples/react-vite/webmcp.manifest.json
@@ -1,0 +1,79 @@
+{
+  "version": 1,
+  "generatedAt": "2026-08-30T22:37:11.412Z",
+  "root": ".",
+  "tools": [
+    {
+      "name": "form_form_1",
+      "title": "form 1",
+      "description": "Submit the form 1 form through the website's current authenticated page.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "fields"
+        ],
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "untrustedContentHint": false
+      },
+      "implementation": {
+        "kind": "form",
+        "selector": "form:nth-of-type(1)"
+      },
+      "evidence": [
+        {
+          "file": "src/App.tsx",
+          "line": 255,
+          "kind": "HTML form GET current URL",
+          "sourceHash": "62e95700d47f750c0d594ead45e5bc01e93a624b9dc11efd2dc0278eb480144a"
+        }
+      ],
+      "approved": false
+    },
+    {
+      "name": "form_form_2",
+      "title": "form 2",
+      "description": "Submit the form 2 form through the website's current authenticated page.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "fields"
+        ],
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "untrustedContentHint": false
+      },
+      "implementation": {
+        "kind": "form",
+        "selector": "form:nth-of-type(2)"
+      },
+      "evidence": [
+        {
+          "file": "src/App.tsx",
+          "line": 308,
+          "kind": "HTML form GET current URL",
+          "sourceHash": "62e95700d47f750c0d594ead45e5bc01e93a624b9dc11efd2dc0278eb480144a"
+        }
+      ],
+      "approved": false
+    }
+  ]
+}

--- a/examples/vercel-workflows/next.config.ts
+++ b/examples/vercel-workflows/next.config.ts
@@ -2,6 +2,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import type { NextConfig } from "next";
+import { withWebMcp } from "nanocodex/next";
 import { withWorkflow } from "workflow/next";
 
 const exampleRoot = dirname(fileURLToPath(import.meta.url));
@@ -27,4 +28,4 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default withWorkflow(nextConfig);
+export default withWebMcp(withWorkflow(nextConfig), { root: exampleRoot });

--- a/examples/vercel-workflows/webmcp.manifest.json
+++ b/examples/vercel-workflows/webmcp.manifest.json
@@ -1,0 +1,262 @@
+{
+  "version": 1,
+  "generatedAt": "2026-08-30T22:37:55.984Z",
+  "root": ".",
+  "tools": [
+    {
+      "name": "form_prompt-form",
+      "title": "prompt form",
+      "description": "Submit the prompt form form through the website's current authenticated page.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "fields"
+        ],
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "untrustedContentHint": false
+      },
+      "implementation": {
+        "kind": "form",
+        "selector": "#prompt-form"
+      },
+      "evidence": [
+        {
+          "file": "app/page.tsx",
+          "line": 42,
+          "kind": "HTML form GET current URL",
+          "sourceHash": "19dcf0d3df4ea55572c8c3fb407319549684e9637f9f351a0bc48592b8739536"
+        }
+      ],
+      "approved": false
+    },
+    {
+      "name": "get_api_sessions_sessionId_stream",
+      "title": "GET /api/sessions/[sessionId]/stream",
+      "description": "GET /api/sessions/[sessionId]/stream through the website's same-origin authenticated session.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "object",
+            "properties": {
+              "sessionId": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "sessionId"
+            ],
+            "additionalProperties": false
+          },
+          "query": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "untrustedContentHint": true
+      },
+      "implementation": {
+        "kind": "fetch",
+        "method": "GET",
+        "path": "/api/sessions/[sessionId]/stream"
+      },
+      "evidence": [
+        {
+          "file": "app/api/sessions/[sessionId]/stream/route.ts",
+          "line": 13,
+          "kind": "Next.js route GET /api/sessions/[sessionId]/stream",
+          "sourceHash": "6d3bbfc8a796aada494f17a1a78c9ff1deddfc75c5d71b12cda8e94d24d7c212"
+        }
+      ],
+      "approved": false
+    },
+    {
+      "name": "get_api_ws",
+      "title": "GET /api/ws",
+      "description": "GET /api/ws through the website's same-origin authenticated session.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "untrustedContentHint": true
+      },
+      "implementation": {
+        "kind": "fetch",
+        "method": "GET",
+        "path": "/api/ws"
+      },
+      "evidence": [
+        {
+          "file": "app/api/ws/route.ts",
+          "line": 11,
+          "kind": "Next.js route GET /api/ws",
+          "sourceHash": "e21bc0f01a531500c1acb5b1aa20207ad68a76aaa712e0c76d964edc149d5276"
+        }
+      ],
+      "approved": false
+    },
+    {
+      "name": "post_api_sessions",
+      "title": "POST /api/sessions",
+      "description": "POST /api/sessions through the website's same-origin authenticated session.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "body": {}
+        },
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "untrustedContentHint": true
+      },
+      "implementation": {
+        "kind": "fetch",
+        "method": "POST",
+        "path": "/api/sessions"
+      },
+      "evidence": [
+        {
+          "file": "app/api/sessions/route.ts",
+          "line": 8,
+          "kind": "Next.js route POST /api/sessions",
+          "sourceHash": "cdc051a34899013410e81acc4d8ced0dd391cd3060f4ef23821e95f6159d6d52"
+        },
+        {
+          "file": "public/app.js",
+          "line": 71,
+          "kind": "frontend fetch POST /api/sessions",
+          "sourceHash": "c0609c5b9c097fec3feea8208343566fcedf2cc1e1958acca79d8b4d0204fcf0"
+        }
+      ],
+      "approved": false
+    },
+    {
+      "name": "post_api_sessions_sessionId_prompt",
+      "title": "POST /api/sessions/[sessionId]/prompt",
+      "description": "POST /api/sessions/[sessionId]/prompt through the website's same-origin authenticated session.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "object",
+            "properties": {
+              "sessionId": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "sessionId"
+            ],
+            "additionalProperties": false
+          },
+          "query": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "body": {}
+        },
+        "required": [
+          "path"
+        ],
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "untrustedContentHint": true
+      },
+      "implementation": {
+        "kind": "fetch",
+        "method": "POST",
+        "path": "/api/sessions/[sessionId]/prompt"
+      },
+      "evidence": [
+        {
+          "file": "app/api/sessions/[sessionId]/prompt/route.ts",
+          "line": 9,
+          "kind": "Next.js route POST /api/sessions/[sessionId]/prompt",
+          "sourceHash": "3ef6ba5b955f2db3f6340dce34841708ff12cdff4f752d615700c5527dd09eb2"
+        }
+      ],
+      "approved": false
+    },
+    {
+      "name": "post_api_sessions_sessionId_terminal",
+      "title": "POST /api/sessions/[sessionId]/terminal",
+      "description": "POST /api/sessions/[sessionId]/terminal through the website's same-origin authenticated session.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "object",
+            "properties": {
+              "sessionId": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "sessionId"
+            ],
+            "additionalProperties": false
+          },
+          "query": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "body": {}
+        },
+        "required": [
+          "path"
+        ],
+        "additionalProperties": false
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "untrustedContentHint": true
+      },
+      "implementation": {
+        "kind": "fetch",
+        "method": "POST",
+        "path": "/api/sessions/[sessionId]/terminal"
+      },
+      "evidence": [
+        {
+          "file": "app/api/sessions/[sessionId]/terminal/route.ts",
+          "line": 7,
+          "kind": "Next.js route POST /api/sessions/[sessionId]/terminal",
+          "sourceHash": "982f475521c72ad784e0f44ef6b17c7e25dc30dc86f6bb5ba0e3b29063bd87c8"
+        }
+      ],
+      "approved": false
+    }
+  ]
+}

--- a/js/bindings/README.md
+++ b/js/bindings/README.md
@@ -156,10 +156,7 @@ import { Agent, Transport } from "nanocodex/browser";
 
 const agent = await Agent.create({
   transport: Transport.hostManaged({ websocketUrl: "/api/responses" }),
-  webMcp: {
-    fallback: "when-empty",
-    confirm: (action) => showApplicationApproval(action),
-  },
+  webMcp: { fallback: "when-empty" },
 });
 ```
 
@@ -167,9 +164,12 @@ Native `document.modelContext` tools update live on `toolchange`. When none are
 available, the default bounded fallback can observe visible page text and
 controls, fill fields, activate controls, and submit forms. It never exposes
 arbitrary page JavaScript, hidden elements, raw selectors, HTML, or password
-values. Set `fallback: "never"` for native-only behavior. Mutating calls use
-the application-owned `confirm` callback when supplied and propagate
-cancellation.
+values. Set `fallback: "never"` for native-only behavior. Every mutating call
+opens the bundled Nanocodex approval dialog. Its trusted chrome shows the
+requesting website, destination, exact action, one-time scope, and expandable
+payload. The dialog remains in `Applying…` until the website handler settles;
+rejection never invokes it. Read-only tools do not prompt. A `confirm` callback
+is available only as a headless/custom-host override.
 
 Managed browser agents accept the same `webMcp` option. Nanocodex automatically
 reverse-attaches the page provider, preserving website authentication in the
@@ -191,7 +191,6 @@ import manifest from "./webmcp.manifest.json" with { type: "json" };
 import { publish } from "nanocodex/webmcp";
 
 const publication = await publish(manifest, {
-  confirm: (action) => showApplicationApproval(action),
   handlers: {
     get_account: (input, { signal }) => accountClient.get(input, { signal }),
   },

--- a/js/bindings/README.md
+++ b/js/bindings/README.md
@@ -178,13 +178,42 @@ browser while the account-owned conversation remains hosted.
 Existing applications can generate a reviewable publisher manifest without
 running repository code:
 
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import { nanocodex } from "nanocodex/vite";
+
+export default defineConfig({
+  plugins: [nanocodex({ webMcp: true })],
+});
+```
+
+```ts
+// next.config.ts
+import type { NextConfig } from "next";
+import { withWebMcp } from "nanocodex/next";
+
+const nextConfig: NextConfig = {};
+export default withWebMcp(nextConfig);
+```
+
+Both plugins generate `webmcp.manifest.json` automatically. Vite keeps it
+current while the development server runs; Next.js generates it at startup and
+watches source during development. An approval survives regeneration only
+while the tool's source digest, method, schema, annotations, description, and
+implementation remain identical. A source or contract change returns to
+`approved: false`.
+
+The equivalent explicit commands are:
+
 ```sh
 npx nanocodex-webmcp generate . --out webmcp.manifest.json
 npx nanocodex-webmcp check webmcp.manifest.json
 ```
 
-Every candidate is emitted with `approved: false`. After reviewing its source
-evidence and marking intentional tools approved, publish it from the website:
+Every new or changed candidate is emitted with `approved: false`. After
+reviewing its source evidence and marking intentional tools approved, publish
+it from the website:
 
 ```js
 import manifest from "./webmcp.manifest.json" with { type: "json" };

--- a/js/bindings/README.md
+++ b/js/bindings/README.md
@@ -144,6 +144,68 @@ Agent host rejects the same value. Do not also supply legacy top-level
 workspace or MCP configuration to an Agent that already receives them through
 `Tools`.
 
+### Use the embedding website through WebMCP
+
+`nanocodex/browser` can turn the live host page's WebMCP registry into dynamic
+agent tools. Handlers remain in the window so they use the website's existing
+signed-in session and UI state; only structured definitions and bounded calls
+cross into the package-owned Agent Worker.
+
+```js
+import { Agent, Transport } from "nanocodex/browser";
+
+const agent = await Agent.create({
+  transport: Transport.hostManaged({ websocketUrl: "/api/responses" }),
+  webMcp: {
+    fallback: "when-empty",
+    confirm: (action) => showApplicationApproval(action),
+  },
+});
+```
+
+Native `document.modelContext` tools update live on `toolchange`. When none are
+available, the default bounded fallback can observe visible page text and
+controls, fill fields, activate controls, and submit forms. It never exposes
+arbitrary page JavaScript, hidden elements, raw selectors, HTML, or password
+values. Set `fallback: "never"` for native-only behavior. Mutating calls use
+the application-owned `confirm` callback when supplied and propagate
+cancellation.
+
+Managed browser agents accept the same `webMcp` option. Nanocodex automatically
+reverse-attaches the page provider, preserving website authentication in the
+browser while the account-owned conversation remains hosted.
+
+Existing applications can generate a reviewable publisher manifest without
+running repository code:
+
+```sh
+npx nanocodex-webmcp generate . --out webmcp.manifest.json
+npx nanocodex-webmcp check webmcp.manifest.json
+```
+
+Every candidate is emitted with `approved: false`. After reviewing its source
+evidence and marking intentional tools approved, publish it from the website:
+
+```js
+import manifest from "./webmcp.manifest.json" with { type: "json" };
+import { publish } from "nanocodex/webmcp";
+
+const publication = await publish(manifest, {
+  confirm: (action) => showApplicationApproval(action),
+  handlers: {
+    get_account: (input, { signal }) => accountClient.get(input, { signal }),
+  },
+});
+```
+
+The publisher ignores unapproved entries and unregisters approved tools when
+`publication.close()` aborts their registrations. Same-origin fetch and form
+candidates can execute directly; framework-client candidates such as GraphQL,
+tRPC, and server actions require an explicit handler. Cross-origin frames also
+require `allow="tools"`, exact `exposedTo` origins when publishing, and matching
+`fromOrigins` when consuming. See the
+[WebMCP capability guide](https://nanocodex.ai/capabilities/webmcp).
+
 Browser consumers can attach Codex's ChatGPT Realtime voice lifecycle to the
 same retained Agent. The resource owns microphone, speaker, WebRTC, sideband,
 and delegation cleanup; stopping voice does not cancel an active coding turn.

--- a/js/bindings/README.md
+++ b/js/bindings/README.md
@@ -175,8 +175,10 @@ Managed browser agents accept the same `webMcp` option. Nanocodex automatically
 reverse-attaches the page provider, preserving website authentication in the
 browser while the account-owned conversation remains hosted.
 
-Existing applications can generate a reviewable publisher manifest without
-running repository code:
+Existing Vite applications need no generation command or WebMCP specification.
+The plugin derives bounded candidates from source and injects the normal
+Accounts-backed Nanocodex embed in development so the authenticated Agent can
+verify them against the live page:
 
 ```ts
 // vite.config.ts
@@ -184,7 +186,7 @@ import { defineConfig } from "vite";
 import { nanocodex } from "nanocodex/vite";
 
 export default defineConfig({
-  plugins: [nanocodex({ webMcp: true })],
+  plugins: [nanocodex()],
 });
 ```
 
@@ -197,14 +199,18 @@ const nextConfig: NextConfig = {};
 export default withWebMcp(nextConfig);
 ```
 
-Both plugins generate `webmcp.manifest.json` automatically. Vite keeps it
-current while the development server runs; Next.js generates it at startup and
-watches source during development. An approval survives regeneration only
-while the tool's source digest, method, schema, annotations, description, and
-implementation remain identical. A source or contract change returns to
-`approved: false`.
+Vite owns the complete generation and verification lifecycle when the page
+opens in development. It reuses `tempoxyz/accounts` for remembered passkeys,
+ChatGPT subscription, Tempo MPP, and provider selection. Credentials stay in
+Accounts and the broker; Vite receives only the source revision and manifest.
+The Agent may improve the public contract or remove false positives, but Vite
+pins execution targets, source evidence, and read/write annotations. A source
+change invalidates the verified revision. Production builds make no model call.
 
-The equivalent explicit commands are:
+Next.js currently retains deterministic source generation through
+`withWebMcp()`.
+
+Lower-level explicit commands remain available for non-Vite build systems:
 
 ```sh
 npx nanocodex-webmcp generate . --out webmcp.manifest.json

--- a/js/bindings/browser/Agent.d.mts
+++ b/js/bindings/browser/Agent.d.mts
@@ -6,6 +6,7 @@ import type {
 } from "../types.mjs";
 import type { ManagedTransport, WorkerTransport } from "./Transport.mjs";
 import type { Tools } from "../tools/Tools.mjs";
+import type { WebMcpProviderOptions, WebMcpToolProvider } from "../webmcp/WebMcp.mjs";
 
 export type Agent = DefaultAgent;
 
@@ -32,6 +33,8 @@ export declare namespace create {
   type ManagedOptions = Readonly<{
     transport: ManagedTransport;
     tools?: Tools | undefined;
+    /** Attach the host page's WebMCP capabilities under its existing session. */
+    webMcp?: true | WebMcpProviderOptions | WebMcpToolProvider | false | undefined;
   }>;
   type Options = AgentOptions & WorkerToolExposureOptions & {
     /** Precompiled browser module; WebAssembly modules are structured-clone-safe. */
@@ -46,6 +49,8 @@ export declare namespace create {
     durability?: false | undefined;
     /** Set false to omit the default OPFS, shell, web, image, plan, and artifact tools. */
     harness?: false | undefined;
+    /** Discover WebMCP tools in the embedding page and bridge them into the Agent Worker. */
+    webMcp?: true | WebMcpProviderOptions | WebMcpToolProvider | false | undefined;
   };
   type ReturnType = Agent;
 }

--- a/js/bindings/browser/InlineAgent.mjs
+++ b/js/bindings/browser/InlineAgent.mjs
@@ -27,6 +27,7 @@ import { resolveTools } from "../runtime/tool-configuration.mjs";
 import {
   hostManaged as defaultHostManagedTransport,
 } from "./Transport.mjs";
+import { createProvider as createWebMcpProvider, isProvider as isWebMcpProvider } from "../webmcp/WebMcp.mjs";
 
 /** Creates the Rust/WASM Agent in the current Web API host isolate. */
 export async function create(options = {}) {
@@ -57,8 +58,8 @@ export async function create(options = {}) {
     mcp,
     executionEnvironment,
     codeEvaluator,
+    webMcp,
   } = options;
-  const toolProviders = internalRuntime?.toolProviders;
   const stableSessionId = sessionId ?? createSessionId();
   const {
     apiKey,
@@ -80,28 +81,47 @@ export async function create(options = {}) {
   const events = createEventChannel();
   const tempoMcp = mpp?.[Symbol.for("nanocodex.tempo.mcp")];
   let hostDefinitionId;
-  const host = createBrowserHost({
-    WebSocketImpl,
-    createWebSocket,
-    hostAuth: hostAuth === true
-      || (apiKey === undefined && mpp === undefined && subscription === undefined),
-    hostManagedProtocol,
-    mpp,
-    onEvent: events.emit,
-    filesystem,
-    filesystemTools,
-    tools: hostTools,
-    toolProviders,
-    toolMode,
-    mcp: mcp === false
-      ? undefined
-      : tempoMcp ? { ...tempoMcp, ...mcp } : mcp,
-    codeEvaluator,
-    applyPatch: applyBrowserPatch,
-    websocketPreconnect,
-    websocketUrl,
-    onDispose: () => releaseDefinitionHost(hostDefinitionId),
-  });
+  let webMcpProvider;
+  if (webMcp !== undefined && webMcp !== false) {
+    webMcpProvider = isWebMcpProvider(webMcp)
+      ? webMcp
+      : await createWebMcpProvider(webMcp === true ? {} : webMcp);
+  }
+  const toolProviders = [
+    ...(internalRuntime?.toolProviders ?? []),
+    ...(webMcpProvider ? [webMcpProvider] : []),
+  ];
+  let host;
+  try {
+    host = createBrowserHost({
+      WebSocketImpl,
+      createWebSocket,
+      hostAuth: hostAuth === true
+        || (apiKey === undefined && mpp === undefined && subscription === undefined),
+      hostManagedProtocol,
+      mpp,
+      onEvent: events.emit,
+      filesystem,
+      filesystemTools,
+      tools: hostTools,
+      toolProviders,
+      toolMode,
+      mcp: mcp === false
+        ? undefined
+        : tempoMcp ? { ...tempoMcp, ...mcp } : mcp,
+      codeEvaluator,
+      applyPatch: applyBrowserPatch,
+      websocketPreconnect,
+      websocketUrl,
+      onDispose: () => {
+        releaseDefinitionHost(hostDefinitionId);
+        webMcpProvider?.close();
+      },
+    });
+  } catch (error) {
+    webMcpProvider?.close();
+    throw error;
+  }
   let durabilityOwner;
   let creationStarted = false;
   hostDefinitionId = registerDefinitionHost(host);

--- a/js/bindings/browser/WorkerAgent.mjs
+++ b/js/bindings/browser/WorkerAgent.mjs
@@ -13,6 +13,7 @@ import {
 import { resolveResponsesTransport } from "../runtime/responses-transport.mjs";
 import { utf8ByteLength } from "../runtime/utf8.mjs";
 import { createIndexedDbDurabilityStore } from "./indexeddb-durability-store.mjs";
+import { createProvider as createWebMcpProvider, isProvider as isWebMcpProvider } from "../webmcp/WebMcp.mjs";
 
 const DEFAULT_MAX_PENDING_RPCS = 1_024;
 const MAX_RETAINED_RESULTS = 1_024;
@@ -32,21 +33,36 @@ let prewarmedWorker;
 /** Creates a DefaultAgent whose owned driver and browser host live in one module Worker. */
 export async function createWorkerAgent(options = {}, workerOptions = {}) {
   workerOptions.signal?.throwIfAborted();
-  const config = serializeConfig(options);
-  const reservation = config.sessionId === undefined
-    ? undefined
-    : reserveAgentSession(config.sessionId);
+  const providerResolution = resolveWebMcpProvider(options.webMcp);
+  const webMcpProvider = providerResolution instanceof Promise
+    ? await providerResolution
+    : providerResolution;
+  let config;
+  let reservation;
+  try {
+    config = serializeConfig(options, webMcpProvider);
+    reservation = config.sessionId === undefined
+      ? undefined
+      : reserveAgentSession(config.sessionId);
+  } catch (error) {
+    webMcpProvider?.close();
+    throw error;
+  }
   let worker;
   try {
     const claimed = claimWorker(config.harness, config.module, workerOptions);
     worker = claimed instanceof Promise ? await claimed : claimed;
   } catch (error) {
+    webMcpProvider?.close();
     releaseAgentSession(reservation);
     throw error;
   }
   let connection;
   try {
-    connection = new WorkerConnection(worker, workerOptions);
+    connection = new WorkerConnection(worker, {
+      ...workerOptions,
+      hostToolProviders: webMcpProvider ? [webMcpProvider] : [],
+    });
   } catch (error) {
     const errors = [error];
     try {
@@ -54,6 +70,7 @@ export async function createWorkerAgent(options = {}, workerOptions = {}) {
     } catch (cleanupError) {
       appendErrors(errors, cleanupError);
     } finally {
+      webMcpProvider?.close();
       releaseAgentSession(reservation);
     }
     throwErrors(errors, "Worker Agent connection construction and cleanup both failed");
@@ -207,6 +224,9 @@ export function installWorkerAgentRuntime(scope = globalThis, options = {}) {
   const turns = new Map();
   const results = new Map();
   const voices = new Map();
+  const hostToolProviders = new Map();
+  const hostToolCalls = new Map();
+  let nextHostToolCall = 1;
 
   const post = (message, expectedGeneration = generation, transfer) => {
     if (expectedGeneration !== generation) return;
@@ -233,6 +253,11 @@ export function installWorkerAgentRuntime(scope = globalThis, options = {}) {
     }
     agents.clear();
     voices.clear();
+    for (const pending of hostToolCalls.values()) {
+      pending.reject(new Error("Worker Agent host tool execution was cancelled"));
+    }
+    hostToolCalls.clear();
+    hostToolProviders.clear();
   };
 
   const boot = async (message) => {
@@ -244,7 +269,15 @@ export function installWorkerAgentRuntime(scope = globalThis, options = {}) {
     nextResult = 1;
     nextVoice = 1;
     try {
-      const hydration = hydrateConfig(message.config, createDurabilityStore);
+      for (const descriptor of message.config.hostToolProviders ?? []) {
+        const provider = createHostToolProxy(descriptor, callHostTool);
+        hostToolProviders.set(provider.sourceId, provider);
+      }
+      const hydration = hydrateConfig(
+        message.config,
+        createDurabilityStore,
+        [...hostToolProviders.values()],
+      );
       const preparation = prewarmBoot?.(message.config.harness, {
         module: message.config.module,
       });
@@ -470,6 +503,14 @@ export function installWorkerAgentRuntime(scope = globalThis, options = {}) {
     }
     if (message.channel !== channel || !bootPromise) return;
     const currentGeneration = generation;
+    if (message.type === "host-tool.resolve" || message.type === "host-tool.reject") {
+      settleHostToolCall(message);
+      return;
+    }
+    if (message.type === "host-tools.update") {
+      hostToolProviders.get(message.sourceId)?.update(message.definitions);
+      return;
+    }
     if (message.type === "liveness.ping") {
       if (Number.isSafeInteger(message.sequence) && message.sequence > 0) {
         post({ type: "liveness.pong", sequence: message.sequence }, currentGeneration);
@@ -482,6 +523,52 @@ export function installWorkerAgentRuntime(scope = globalThis, options = {}) {
   };
 
   return Object.freeze({ dispose() { generation += 1; cleanup(); scope.onmessage = null; } });
+
+  function callHostTool(sourceId, name, input, context = {}) {
+    const callId = `host-tool-${nextHostToolCall++}`;
+    const signal = context.signal ?? new AbortController().signal;
+    signal.throwIfAborted?.();
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const finish = (complete, value) => {
+        if (settled) return;
+        settled = true;
+        signal.removeEventListener?.("abort", abort);
+        hostToolCalls.delete(callId);
+        complete(value);
+      };
+      const abort = () => {
+        post({ type: "host-tool.cancel", callId }, currentGeneration());
+        finish(reject, signal.reason ?? new Error("host tool execution was cancelled"));
+      };
+      hostToolCalls.set(callId, {
+        resolve: (value) => finish(resolve, value),
+        reject: (error) => finish(reject, error),
+      });
+      signal.addEventListener?.("abort", abort, { once: true });
+      post({
+        type: "host-tool.call",
+        callId,
+        sourceId,
+        name,
+        input,
+        context: {
+          callId: context.callId,
+          parentCallId: context.parentCallId,
+          sessionId: context.sessionId,
+        },
+      }, currentGeneration());
+    });
+  }
+
+  function settleHostToolCall(message) {
+    const pending = hostToolCalls.get(message.callId);
+    if (!pending) return;
+    if (message.type === "host-tool.resolve") pending.resolve(message.value);
+    else pending.reject(decodeError(message.error));
+  }
+
+  function currentGeneration() { return generation; }
 }
 
 async function dispatch(message, state) {
@@ -675,6 +762,32 @@ class WorkerConnection {
     this.heartbeatTimer = undefined;
     this.closed = false;
     this.closeError = undefined;
+    this.hostToolProviders = new Map();
+    this.hostToolCalls = new Map();
+    for (const provider of options.hostToolProviders ?? []) {
+      if (!provider || typeof provider.sourceId !== "string"
+          || typeof provider.definitions !== "function"
+          || typeof provider.resolve !== "function") {
+        throw new TypeError("Worker Agent host tool provider is invalid");
+      }
+      if (this.hostToolProviders.has(provider.sourceId)) {
+        throw new Error(`duplicate Worker Agent host tool provider: ${provider.sourceId}`);
+      }
+      const stop = provider.subscribe?.((definitions) => {
+        if (this.closed) return;
+        try {
+          assertCloneable(definitions, `host tool provider ${provider.sourceId} definitions`);
+          this.send({
+            type: "host-tools.update",
+            sourceId: provider.sourceId,
+            definitions,
+          });
+        } catch (error) {
+          this.fail(error);
+        }
+      });
+      this.hostToolProviders.set(provider.sourceId, { provider, stop });
+    }
     worker.onmessage = ({ data }) => this.receive(data);
     worker.onerror = (event) => this.fail(new Error(event?.message || "Nanocodex Agent Worker failed"));
     worker.onmessageerror = () => this.fail(new Error("Nanocodex Agent Worker returned an unreadable message"));
@@ -990,10 +1103,60 @@ class WorkerConnection {
       this.receiveEventChunk(message);
       return;
     }
+    if (message.type === "host-tool.call") {
+      void this.executeHostTool(message);
+      return;
+    }
+    if (message.type === "host-tool.cancel") {
+      this.hostToolCalls.get(message.callId)?.abort(
+        new Error("Worker Agent cancelled the host tool execution"),
+      );
+      return;
+    }
     if (message.type === "ready") return this.resolvePending("boot", message.root);
     if (message.type === "fatal") return this.fail(decodeError(message.error));
     if (message.type === "resolve") return this.resolvePending(message.id, message.value);
     if (message.type === "reject") return this.rejectPending(message.id, decodeError(message.error));
+  }
+
+  async executeHostTool(message) {
+    if (typeof message.callId !== "string" || !message.callId
+        || typeof message.sourceId !== "string" || !message.sourceId
+        || typeof message.name !== "string" || !message.name
+        || this.hostToolCalls.has(message.callId)) {
+      this.fail(new Error("Nanocodex Agent Worker requested an invalid host tool call"));
+      return;
+    }
+    const entry = this.hostToolProviders.get(message.sourceId);
+    const tool = entry?.provider.resolve(message.name);
+    if (!tool || typeof tool.handler !== "function") {
+      this.send({
+        type: "host-tool.reject",
+        callId: message.callId,
+        error: encodeError(new Error(`unknown host tool: ${message.name}`)),
+      });
+      return;
+    }
+    const controller = new AbortController();
+    this.hostToolCalls.set(message.callId, controller);
+    try {
+      const value = await tool.handler(message.input, {
+        callId: message.context?.callId ?? message.callId,
+        parentCallId: message.context?.parentCallId ?? "",
+        sessionId: message.context?.sessionId ?? "default",
+        signal: controller.signal,
+      });
+      if (this.closed || this.hostToolCalls.get(message.callId) !== controller) return;
+      assertCloneable(value, `host tool ${message.name} result`);
+      this.send({ type: "host-tool.resolve", callId: message.callId, value });
+    } catch (error) {
+      if (this.closed || this.hostToolCalls.get(message.callId) !== controller) return;
+      this.send({ type: "host-tool.reject", callId: message.callId, error: encodeError(error) });
+    } finally {
+      if (this.hostToolCalls.get(message.callId) === controller) {
+        this.hostToolCalls.delete(message.callId);
+      }
+    }
   }
 
   resolvePending(id, value) {
@@ -1158,6 +1321,13 @@ class WorkerConnection {
       this.listeners.clear();
       this.chunkedEvent = undefined;
       this.onFailure = undefined;
+      for (const controller of this.hostToolCalls.values()) controller.abort(error);
+      this.hostToolCalls.clear();
+      for (const { provider, stop } of this.hostToolProviders.values()) {
+        try { stop?.(); } catch (failure) { reportError(failure); }
+        try { provider.close?.(); } catch (failure) { reportError(failure); }
+      }
+      this.hostToolProviders.clear();
     }
   }
 }
@@ -1282,8 +1452,89 @@ function listenForAbort(signal, listener) {
   };
 }
 
-function serializeConfig(options) {
+function resolveWebMcpProvider(value) {
+  if (value === undefined || value === false) return undefined;
+  if (!isWebMcpProvider(value)) {
+    return createWebMcpProvider(value === true ? {} : value).then(settleProvider);
+  }
+  const settling = value.settled?.();
+  return settling instanceof Promise
+    ? settling.then(() => value, (error) => closeRejectedProvider(value, error))
+    : value;
+}
+
+async function settleProvider(provider) {
+  try {
+    await provider.settled?.();
+    return provider;
+  } catch (error) { return closeRejectedProvider(provider, error); }
+}
+
+function closeRejectedProvider(provider, error) {
+  try { provider.close?.(); }
+  catch (cleanupError) {
+    throw new AggregateError([error, cleanupError], "WebMCP discovery and cleanup failed");
+  }
+  throw error;
+}
+
+function createHostToolProxy(descriptor, call) {
+  if (!descriptor || typeof descriptor !== "object" || Array.isArray(descriptor)
+      || typeof descriptor.sourceId !== "string" || !descriptor.sourceId
+      || !Array.isArray(descriptor.definitions)) {
+    throw new TypeError("Worker Agent host tool provider descriptor is invalid");
+  }
+  let definitions = cloneDefinitions(descriptor.definitions, descriptor.sourceId);
+  const provider = {
+    sourceId: descriptor.sourceId,
+    kind: descriptor.kind ?? "attached",
+    mode: descriptor.mode ?? "attached-over-cloud",
+    deferred: descriptor.deferred ?? true,
+    definitions: () => definitions,
+    resolve(name) {
+      if (!definitions.some((definition) => definition.name === name)) return undefined;
+      return Object.freeze({
+        name,
+        parallelSafe: false,
+        handler: (input, context) => call(descriptor.sourceId, name, input, context),
+      });
+    },
+    update(next) {
+      definitions = cloneDefinitions(next, descriptor.sourceId);
+    },
+  };
+  return Object.freeze(provider);
+}
+
+function cloneDefinitions(value, sourceId) {
+  if (!Array.isArray(value)) {
+    throw new TypeError(`host tool provider ${sourceId} definitions must be an array`);
+  }
+  const names = new Set();
+  const definitions = JSON.parse(JSON.stringify(value));
+  for (const definition of definitions) {
+    if (!definition || typeof definition !== "object" || Array.isArray(definition)
+        || typeof definition.name !== "string" || !definition.name
+        || names.has(definition.name)) {
+      throw new TypeError(`host tool provider ${sourceId} returned invalid definitions`);
+    }
+    names.add(definition.name);
+  }
+  return Object.freeze(definitions.map((definition) => Object.freeze(definition)));
+}
+
+function serializeConfig(options, webMcpProvider) {
   const config = { ...options };
+  delete config.webMcp;
+  if (webMcpProvider) {
+    config.hostToolProviders = [{
+      sourceId: webMcpProvider.sourceId,
+      kind: webMcpProvider.kind,
+      mode: webMcpProvider.mode,
+      deferred: webMcpProvider.deferred,
+      definitions: webMcpProvider.definitions(),
+    }];
+  }
   const workerDurability = config.durability !== false;
   if (!workerDurability) delete config.durability;
   const stableThreadId = nonEmptyString(options.threadId) ?? nonEmptyString(options.sessionId);
@@ -1329,8 +1580,8 @@ function serializeConfig(options) {
   return config;
 }
 
-async function hydrateConfig(config, createDurabilityStore) {
-  const { harness, workerDurabilityId, ...options } = config;
+async function hydrateConfig(config, createDurabilityStore, hostToolProviders = []) {
+  const { harness, workerDurabilityId, hostToolProviders: _hostToolProviders, ...options } = config;
   const [Transport, harnessRuntime] = await Promise.all([
     import("./Transport.mjs"),
     harness === false || harness === undefined
@@ -1374,6 +1625,11 @@ async function hydrateConfig(config, createDurabilityStore) {
       tools: harnessRuntime.tools,
       executionEnvironment: options.executionEnvironment ?? harnessRuntime.executionEnvironment,
     });
+  }
+  if (hostToolProviders.length) {
+    options[Symbol.for("nanocodex.browser.internalRuntime")] = {
+      toolProviders: hostToolProviders,
+    };
   }
   return options;
 }

--- a/js/bindings/browser/config.d.mts
+++ b/js/bindings/browser/config.d.mts
@@ -1,12 +1,12 @@
-import type { DefaultAgent } from "../types.mjs";
+import type { AgentLifecycle, DefaultAgent } from "../types.mjs";
 import type { create as createAgent } from "./Agent.mjs";
 
 export type AgentStatus = "idle" | "pending" | "success" | "error";
 
-export type AgentSnapshot =
+export type AgentSnapshot<agent extends AgentLifecycle = DefaultAgent> =
   | Readonly<{ data: undefined; error: undefined; status: "idle" }>
   | Readonly<{ data: undefined; error: undefined; status: "pending" }>
-  | Readonly<{ data: DefaultAgent; error: undefined; status: "success" }>
+  | Readonly<{ data: agent; error: undefined; status: "success" }>
   | Readonly<{ data: undefined; error: unknown; status: "error" }>;
 
 export type AgentParameters = Readonly<{
@@ -14,8 +14,8 @@ export type AgentParameters = Readonly<{
   threadId?: string | undefined;
 }>;
 
-export type Config = Readonly<{
-  getAgent(parameters?: AgentParameters): AgentSnapshot;
+export type Config<agent extends AgentLifecycle = DefaultAgent> = Readonly<{
+  getAgent(parameters?: AgentParameters): AgentSnapshot<agent>;
   subscribeAgent(parameters: AgentParameters, listener: () => void): () => void;
   refetchAgent(parameters?: AgentParameters): void;
   destroy(): Promise<void>;
@@ -32,5 +32,15 @@ export type CreateConfigParameters = Readonly<{
   retryDelay?: ((attempt: number, error: unknown) => number) | undefined;
 }>;
 
+export type CreateManagedConfigParameters = Readonly<{
+  /** Managed Agent and reverse host-tool attachment owned by this config. */
+  agent: createAgent.ManagedOptions;
+  /** Agent startup retries after the first attempt. Defaults to 2. */
+  retry?: number | undefined;
+  /** Backoff before a startup retry. Defaults to 400ms × attempt. */
+  retryDelay?: ((attempt: number, error: unknown) => number) | undefined;
+}>;
+
 /** Creates the stable browser runtime consumed by framework bindings. */
+export function createConfig(options: CreateManagedConfigParameters): Config<AgentLifecycle>;
 export function createConfig(options?: CreateConfigParameters): Config;

--- a/js/bindings/browser/config.mjs
+++ b/js/bindings/browser/config.mjs
@@ -1,4 +1,6 @@
-import { createWorkerAgent, prepareWorkerAgent } from "./WorkerAgent.mjs";
+import { managedTransportOptions } from "../runtime/managed-transport.mjs";
+import { create as createBrowserAgent } from "./Agent.mjs";
+import { prepareWorkerAgent } from "./WorkerAgent.mjs";
 
 const IDLE_SNAPSHOT = Object.freeze({
   data: undefined,
@@ -9,8 +11,19 @@ const IDLE_SNAPSHOT = Object.freeze({
 /** Creates the stable browser runtime consumed by framework bindings. */
 export function createConfig(options = {}) {
   return createAgentConfig(options, {
-    create: createWorkerAgent,
-    prepare: prepareWorkerAgent,
+    create: createBrowserAgent,
+    prepare(agentOptions, workerOptions) {
+      if (managedTransportOptions(agentOptions.transport)) return;
+      return prepareWorkerAgent(agentOptions, workerOptions);
+    },
+    resolveOptions(agentOptions, { origin, threadId }) {
+      if (managedTransportOptions(agentOptions.transport)) return agentOptions;
+      return {
+        ...agentOptions,
+        threadId,
+        ...(origin === undefined ? {} : { origin }),
+      };
+    },
   });
 }
 
@@ -35,11 +48,13 @@ export function createAgentConfig(options = {}, runtime) {
   }
 
   function createEntry(threadId) {
-    const createOptions = Object.freeze({
-      ...agentOptions,
-      threadId,
-      ...(options.origin === undefined ? {} : { origin: options.origin }),
-    });
+    const createOptions = Object.freeze(runtime.resolveOptions
+      ? runtime.resolveOptions(agentOptions, { origin: options.origin, threadId })
+      : {
+          ...agentOptions,
+          threadId,
+          ...(options.origin === undefined ? {} : { origin: options.origin }),
+        });
     const entry = {
       activeSubscribers: 0,
       activeTurns: 0,

--- a/js/bindings/browser/index.d.mts
+++ b/js/bindings/browser/index.d.mts
@@ -60,6 +60,7 @@ export * as ChatGptSubscription from "./ChatGptSubscription.mjs";
 export * as Subagents from "../runtime/subagents.mjs";
 export * as Transport from "./Transport.mjs";
 export * as Voice from "./Voice.mjs";
+export * as WebMcp from "../webmcp/WebMcp.mjs";
 export * as Workspace from "./workspace.mjs";
 export * as Tools from "../tools/index.mjs";
 export {

--- a/js/bindings/browser/index.d.mts
+++ b/js/bindings/browser/index.d.mts
@@ -70,6 +70,7 @@ export {
   type AgentStatus,
   type Config,
   type CreateConfigParameters,
+  type CreateManagedConfigParameters,
 } from "./config.mjs";
 export {
   defaultHostManagedWebSocketUrl,

--- a/js/bindings/browser/index.mjs
+++ b/js/bindings/browser/index.mjs
@@ -14,6 +14,7 @@ export * as ChatGptSubscription from "./ChatGptSubscription.mjs";
 export * as Subagents from "../runtime/subagents.mjs";
 export * as Transport from "./Transport.mjs";
 export * as Voice from "./Voice.mjs";
+export * as WebMcp from "../webmcp/WebMcp.mjs";
 export * as Workspace from "./workspace.mjs";
 export * as Tools from "../tools/index.mjs";
 export { createConfig } from "./config.mjs";

--- a/js/bindings/cloud/Dialog.d.mts
+++ b/js/bindings/cloud/Dialog.d.mts
@@ -1,6 +1,6 @@
 export const DEFAULT_HOST: "https://nanocodex.gakonst.workers.dev/connect-dialog/";
 
-export type Request = ConnectionRequest | FundingRequest;
+export type Request = ConnectionRequest | FundingRequest | WebMcpApprovalRequest;
 
 export type ConnectionRequest = Readonly<{
   id: string;
@@ -59,9 +59,29 @@ export type FundingRequest = Readonly<{
   usdAmountCents: number;
 }>;
 
+export type WebMcpApprovalRequest = Readonly<{
+  id: string;
+  type: "webMcpApproval";
+  app: Readonly<{ id: string; name: string; origin: string }>;
+  action: Readonly<{
+    kind: "webmcp" | "semantic";
+    name: string;
+    title?: string | undefined;
+    description?: string | undefined;
+    origin?: string | undefined;
+    input: unknown;
+    readOnly: false;
+    element?: Readonly<Record<string, unknown>> | undefined;
+  }>;
+}>;
+
+export type Execution = Readonly<{
+  execute?(): unknown | Promise<unknown>;
+}>;
+
 export type Instance = Readonly<{
   host: string;
-  open(request: Request): Promise<unknown>;
+  open(request: Request, execution?: Execution): Promise<unknown>;
   /** Internal WATA iframe target used by the bundled Accounts provider. */
   walletTarget?(options: Readonly<{ host?: string | undefined }>): Window | null | undefined;
   /** Resolves after the bundled Accounts iframe has completed navigation. */
@@ -72,8 +92,8 @@ export type Instance = Readonly<{
   resetWallet?(): Promise<void>;
   getRequest?(): Request | undefined;
   subscribe?(listener: () => void): () => void;
-  respond?(result: unknown): void;
-  reject?(error?: unknown): void;
+  respond?(result: unknown): unknown | Promise<unknown>;
+  reject?(error?: unknown): unknown | Promise<unknown>;
 }>;
 
 export type Dialog<type extends string = string> = Readonly<{

--- a/js/bindings/cloud/Dialog.mjs
+++ b/js/bindings/cloud/Dialog.mjs
@@ -89,10 +89,10 @@ export function memory(options = {}) {
 
       return {
         host: options.host ?? "https://connect.nanocodex.xyz",
-        open(request) {
+        open(request, options = {}) {
           if (pending) return Promise.reject(new DialogBusyError());
           return new Promise((resolve, reject) => {
-            pending = { reject, request, resolve };
+            pending = { execute: options.execute, reject, request, resolve };
             publish(Object.freeze(request));
           });
         },
@@ -109,6 +109,19 @@ export function memory(options = {}) {
         respond(result) {
           if (!pending) throw new Error("The Nanocodex dialog has no pending request");
           const current = pending;
+          if (typeof current.execute === "function") {
+            return Promise.resolve(current.execute()).then((executionResult) => {
+              if (pending !== current) return;
+              pending = undefined;
+              publish(undefined);
+              current.resolve(executionResult);
+            }, (error) => {
+              if (pending !== current) return;
+              pending = undefined;
+              publish(undefined);
+              current.reject(error);
+            });
+          }
           pending = undefined;
           publish(undefined);
           current.resolve(result);
@@ -170,6 +183,7 @@ function createIframeInstance(host) {
 
   function rejectActive(error) {
     if (!active) return;
+    if (active.executing) return;
     const current = active;
     active = undefined;
     if (modal?.open) modal.close();
@@ -182,18 +196,53 @@ function createIframeInstance(host) {
   function onMessage(event) {
     if (!active || event.origin !== new URL(host).origin || event.source !== frame?.contentWindow) return;
     const message = event.data;
-    if (!message || message.type !== "nanocodex:response" || message.id !== active.request.id) return;
+    if (!message || message.id !== active.request.id) return;
+    if (message.type === "nanocodex:approval") {
+      executeApprovedAction();
+      return;
+    }
+    if (message.type !== "nanocodex:response") return;
     const current = active;
+    if (typeof current.execute === "function" && !current.executed && !message.error) return;
     active = undefined;
     modal?.close();
     frame.tabIndex = -1;
     frame.setAttribute("inert", "");
     frame.style.display = "none";
     if (message.error) {
-      current.reject(new UserRejectedRequestError(message.error.message));
+      current.reject(current.executionError
+        ?? new UserRejectedRequestError(message.error.message));
       return;
     }
-    current.resolve(message.result);
+    current.resolve(current.executed ? current.executionResult : message.result);
+  }
+
+  function executeApprovedAction() {
+    if (!active || typeof active.execute !== "function" || active.executing || active.executed) return;
+    const current = active;
+    current.executing = true;
+    Promise.resolve().then(() => current.execute()).then((result) => {
+      if (active !== current) return;
+      current.executing = false;
+      current.executed = true;
+      current.executionResult = result;
+      frame.contentWindow.postMessage({
+        type: "nanocodex:completion",
+        id: current.request.id,
+        ok: true,
+      }, new URL(host).origin);
+    }, (error) => {
+      if (active !== current) return;
+      current.executing = false;
+      current.executed = true;
+      current.executionError = error;
+      frame.contentWindow.postMessage({
+        type: "nanocodex:completion",
+        id: current.request.id,
+        ok: false,
+        error: { message: errorMessage(error) },
+      }, new URL(host).origin);
+    });
   }
 
   window.addEventListener("message", onMessage);
@@ -286,12 +335,12 @@ function createIframeInstance(host) {
     host,
     hideWallet,
     resetWallet,
-    async open(request) {
+    async open(request, options = {}) {
       if (active) throw new DialogBusyError();
       mount();
       await ready;
       return new Promise((resolve, reject) => {
-        active = { reject, request, resolve };
+        active = { execute: options.execute, reject, request, resolve };
         frame.removeAttribute("inert");
         frame.tabIndex = 0;
         frame.style.display = "block";
@@ -314,6 +363,12 @@ function createIframeInstance(host) {
       return walletFrame?.contentWindow;
     },
   };
+}
+
+function errorMessage(error) {
+  if (error instanceof Error && error.message) return error.message;
+  if (typeof error === "string" && error) return error;
+  return "The action failed.";
 }
 
 function createPopupInstance(host, options) {

--- a/js/bindings/cloud/actions/agent.d.mts
+++ b/js/bindings/cloud/actions/agent.d.mts
@@ -10,6 +10,8 @@ export function create(
 export declare namespace create {
   type Options = Readonly<{
     connection: Connection;
+    /** Reverse-attach the embedding page's WebMCP tools to this durable Agent. */
+    webMcp?: true | import("../../webmcp/WebMcp.mjs").WebMcpProviderOptions | undefined;
   }>;
   type ReturnType = ConnectAgent;
   type TurnUsageResult = TurnUsage;

--- a/js/bindings/cloud/actions/agent.mjs
+++ b/js/bindings/cloud/actions/agent.mjs
@@ -3,6 +3,7 @@ import { registerManagedAgentAlias } from "../../managed/internal.mjs";
 import { reportError } from "../../internal.mjs";
 import { createTools } from "../../tools/Tools.mjs";
 import { AttachmentRejectedError } from "../../tools/attachment.mjs";
+import { createProvider as createWebMcpProvider } from "../../webmcp/WebMcp.mjs";
 
 const PROVIDER_NAME = "ChatGPT · Nanocodex Connect";
 const MCP_CONNECTION_ID = /^[A-Za-z0-9_-]{43}$/;
@@ -20,7 +21,7 @@ export async function create(client, options) {
   if (!connection.grant.connectors?.includes("chatgpt")) {
     throw new Error("Connect ChatGPT before opening the durable Nanocodex agent.");
   }
-  const unsupported = Object.keys(options ?? {}).find((key) => key !== "connection");
+  const unsupported = Object.keys(options ?? {}).find((key) => !["connection", "webMcp"].includes(key));
   if (unsupported) {
     throw new TypeError(`Connect durable agents do not accept app-local ${unsupported}`);
   }
@@ -32,8 +33,13 @@ export async function create(client, options) {
     grantSession,
   };
   let tools;
-  if (connection.grant.mcpConnections.length > 0) {
-    tools = await createGrantMcpTools(transport, connection.grant.id, connection.grant.mcpConnections);
+  if (connection.grant.mcpConnections.length > 0 || options.webMcp) {
+    tools = await createGrantTools(
+      transport,
+      connection.grant.id,
+      connection.grant.mcpConnections,
+      options.webMcp,
+    );
   }
   const managedOptions = {
     baseUrl: client.transport.baseUrl,
@@ -127,7 +133,7 @@ function connectAgent(managed, connection, transport, tools) {
   return Object.freeze(agent);
 }
 
-async function createGrantMcpTools({ baseUrl, grantSession }, grantId, connections) {
+async function createGrantTools({ baseUrl, grantSession }, grantId, connections, webMcp) {
   const mcp = Object.fromEntries(connections.map(({ id, name }) => {
     if (!MCP_CONNECTION_ID.test(id)) {
       throw new TypeError("Connect grant contains an invalid MCP connection ID");
@@ -138,12 +144,23 @@ async function createGrantMcpTools({ baseUrl, grantSession }, grantId, connectio
       url: new URL(`/v1/grants/${grantId}/mcp/${id}`, baseUrl),
     }];
   }));
-  return createTools({
-    mcp,
-    mcpOptions: {
-      catalogProvider: (connectionId) => `mcp:${connectionId}`,
-    },
-  });
+  const webMcpProvider = webMcp
+    ? await createWebMcpProvider(webMcp === true ? {} : webMcp)
+    : undefined;
+  try {
+    return await createTools({
+      ...(connections.length === 0 ? {} : {
+        mcp,
+        mcpOptions: {
+          catalogProvider: (connectionId) => `mcp:${connectionId}`,
+        },
+      }),
+      ...(webMcpProvider === undefined ? {} : { providers: [webMcpProvider] }),
+    });
+  } catch (error) {
+    await webMcpProvider?.close?.();
+    throw error;
+  }
 }
 
 function grantMcpFetch(session, baseUrl, grantId, connectionId) {

--- a/js/bindings/next/index.d.mts
+++ b/js/bindings/next/index.d.mts
@@ -1,0 +1,15 @@
+import type { GenerateWebMcpManifestOptions } from "../webmcp/generator.mjs";
+
+export type NanocodexNextWebMcpOptions = GenerateWebMcpManifestOptions;
+
+/** Generate a review-first WebMCP manifest on Next.js startup and build. */
+export function withWebMcp<const arguments_ extends readonly unknown[], const config extends object>(
+  nextConfig: (...arguments_: arguments_) => config | Promise<config>,
+  options?: NanocodexNextWebMcpOptions,
+): (...arguments_: arguments_) => Promise<config>;
+
+/** Generate a review-first WebMCP manifest on Next.js startup and build. */
+export function withWebMcp<const config extends object = Readonly<Record<string, unknown>>>(
+  nextConfig?: config,
+  options?: NanocodexNextWebMcpOptions,
+): (phase: string, context: unknown) => Promise<config>;

--- a/js/bindings/next/index.mjs
+++ b/js/bindings/next/index.mjs
@@ -1,0 +1,112 @@
+import { watch } from "node:fs";
+import { extname, relative, resolve, sep } from "node:path";
+
+import { generateFile } from "../webmcp/generator.mjs";
+
+const watchers = new Map();
+
+/**
+ * Wraps a Next.js config with build/startup WebMCP manifest generation.
+ * Development servers also keep the manifest current as source files change.
+ */
+export function withWebMcp(nextConfig = {}, options = {}) {
+  validateOptions(options);
+  if (typeof nextConfig !== "function"
+      && (!nextConfig || typeof nextConfig !== "object" || Array.isArray(nextConfig))) {
+    throw new TypeError("withWebMcp requires a Next.js config object or function");
+  }
+  return async function nanocodexNextConfig(phase, context) {
+    const resolved = typeof nextConfig === "function"
+      ? await nextConfig(phase, context)
+      : nextConfig;
+    const generation = manifestOptions(options);
+    const result = await generateFile(generation);
+    if (result.changed) {
+      console.info(
+        `[nanocodex] generated ${relative(generation.root, result.path)} (${result.manifest.tools.length} review-required tools)`,
+      );
+    }
+    if (phase === "phase-development-server") watchManifest(generation);
+    return resolved;
+  };
+}
+
+function manifestOptions(options) {
+  const root = resolve(options.root ?? process.cwd());
+  return {
+    ...options,
+    root,
+    output: options.output ?? "webmcp.manifest.json",
+  };
+}
+
+function watchManifest(options) {
+  const output = resolve(options.root, options.output);
+  if (watchers.has(output)) return;
+  let timer;
+  let running;
+  let queued = false;
+  const update = () => {
+    if (running) {
+      queued = true;
+      return running;
+    }
+    running = generateFile(options).then((result) => {
+      if (result.changed) {
+        console.info(
+          `[nanocodex] generated ${relative(options.root, result.path)} (${result.manifest.tools.length} review-required tools)`,
+        );
+      }
+    }).catch((error) => {
+      console.error(`[nanocodex] WebMCP generation failed: ${errorMessage(error)}`);
+    }).finally(() => {
+      running = undefined;
+      if (queued) {
+        queued = false;
+        void update();
+      }
+    });
+    return running;
+  };
+  const watcher = watch(options.root, { recursive: true }, (_event, filename) => {
+    if (!filename) return;
+    const path = resolve(options.root, String(filename));
+    const local = relative(options.root, path);
+    if (path === output || local.startsWith(`..${sep}`)
+        || ignored(local) || !SOURCE_EXTENSIONS.has(extname(path).toLowerCase())) return;
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = undefined;
+      void update();
+    }, 50);
+  });
+  watcher.unref();
+  watchers.set(output, watcher);
+}
+
+function ignored(path) {
+  return path.split(/[\\/]/).some((part) => IGNORED_DIRECTORIES.has(part));
+}
+
+function validateOptions(options) {
+  if (!options || typeof options !== "object" || Array.isArray(options)) {
+    throw new TypeError("withWebMcp options must be an object");
+  }
+  const allowed = new Set(["maxFileBytes", "maxFiles", "output", "root"]);
+  for (const name of Object.keys(options)) {
+    if (!allowed.has(name)) throw new TypeError(`unsupported withWebMcp option: ${name}`);
+  }
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+const SOURCE_EXTENSIONS = new Set([
+  ".cjs", ".gql", ".graphql", ".htm", ".html", ".js", ".json",
+  ".jsx", ".mjs", ".ts", ".tsx", ".yaml", ".yml",
+]);
+const IGNORED_DIRECTORIES = new Set([
+  ".git", ".next", ".turbo", "__fixtures__", "__tests__", "build", "coverage",
+  "dist", "fixtures", "node_modules", "out", "target", "test", "tests", "vendor",
+]);

--- a/js/bindings/package.json
+++ b/js/bindings/package.json
@@ -67,6 +67,11 @@
       "types": "./managed/index.d.mts",
       "import": "./managed/index.mjs"
     },
+    "./next": {
+      "types": "./next/index.d.mts",
+      "import": "./next/index.mjs",
+      "require": "./next/index.mjs"
+    },
     "./connect": {
       "types": "./cloud/index.d.mts",
       "import": "./cloud/index.mjs"
@@ -146,6 +151,7 @@
     "cloud",
     "host",
     "managed",
+    "next",
     "node",
     "worker",
     "pkg-node",

--- a/js/bindings/package.json
+++ b/js/bindings/package.json
@@ -119,6 +119,14 @@
       "types": "./tools/vite.d.mts",
       "import": "./tools/vite.mjs"
     },
+    "./webmcp": {
+      "types": "./webmcp/WebMcp.d.mts",
+      "import": "./webmcp/WebMcp.mjs"
+    },
+    "./webmcp/generator": {
+      "types": "./webmcp/generator.d.mts",
+      "import": "./webmcp/generator.mjs"
+    },
     "./worker": {
       "types": "./worker/index.d.mts",
       "import": "./worker/index.mjs"
@@ -127,6 +135,9 @@
       "types": "./wasm.d.mts",
       "import": "./pkg-web/nanocodex_bg.wasm"
     }
+  },
+  "bin": {
+    "nanocodex-webmcp": "webmcp/cli.mjs"
   },
   "files": [
     "actions",
@@ -142,6 +153,7 @@
     "runtime",
     "tools",
     "vite",
+    "webmcp",
     "internal.mjs",
     "index.d.mts",
     "index.mjs",

--- a/js/bindings/package.json
+++ b/js/bindings/package.json
@@ -43,6 +43,10 @@
       "types": "./vite/index.d.mts",
       "import": "./vite/index.mjs"
     },
+    "./vite/client": {
+      "types": "./vite/auto-webmcp-client.d.mts",
+      "import": "./vite/auto-webmcp-client.mjs"
+    },
     "./vite/cloudflare": {
       "types": "./vite/cloudflare.d.mts",
       "import": "./vite/cloudflare.mjs"

--- a/js/bindings/runtime/managed-transport.mjs
+++ b/js/bindings/runtime/managed-transport.mjs
@@ -3,13 +3,17 @@ import { registerManagedAgentAlias } from "../managed/internal.mjs";
 import { reportError } from "../internal.mjs";
 import { AttachmentRejectedError } from "../tools/attachment.mjs";
 import {
+  providerSource,
   toolRouterBrand,
+  toolRouterRuntime,
   toolRuntimeLifecycle,
 } from "./tool-router.mjs";
+import { createTools } from "../tools/Tools.mjs";
+import { createProvider as createWebMcpProvider, isProvider as isWebMcpProvider } from "../webmcp/WebMcp.mjs";
 
 const MANAGED_AGENT_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const TRANSPORT_OPTIONS = new Set(["agent", "apiKey", "baseUrl", "fetch", "toolsTransport"]);
-const CREATE_OPTIONS = new Set(["tools", "transport"]);
+const CREATE_OPTIONS = new Set(["tools", "transport", "webMcp"]);
 const ATTACHMENT_BACKOFF_MS = [250, 500, 1_000, 2_000, 5_000];
 const managedTransports = new WeakMap();
 let nextManagedAgent = 1;
@@ -41,23 +45,61 @@ export async function createManagedAgent(options) {
   validateCreateOptions(options);
   const setup = managedTransportOptions(options.transport);
   if (!setup) throw new TypeError("Agent.create requires a managed transport");
-  const tools = options.tools;
+  let tools = options.tools;
   if (tools !== undefined
       && (!tools?.[toolRouterBrand] || typeof tools.attach !== "function")) {
     throw new TypeError("managed Agent tools must be created by createTools()");
   }
   tools?.[toolRuntimeLifecycle].available();
-  const managed = setup.identity.kind === "create"
-    ? await ManagedAgent.create(setup.client)
-    : ManagedAgent.open(setup.identity.id, setup.client);
-  const managedState = await managed.state();
-  if (managedState.agent_id !== managed.id
-      || typeof managedState.session_id !== "string"
-      || !MANAGED_AGENT_ID.test(managedState.session_id)) {
-    throw new Error("managed Agent state returned inconsistent agent or session identity");
+  let automaticTools = false;
+  let addedWebMcpSource = false;
+  let webMcpProvider;
+  try {
+    if (options.webMcp !== undefined && options.webMcp !== false) {
+      webMcpProvider = isWebMcpProvider(options.webMcp)
+        ? options.webMcp
+        : await createWebMcpProvider(options.webMcp === true ? {} : options.webMcp);
+      if (tools === undefined) {
+        tools = await createTools({ providers: [webMcpProvider] });
+        automaticTools = true;
+      } else {
+        const router = tools[toolRouterRuntime];
+        router.addSource(providerSource(webMcpProvider.sourceId, webMcpProvider, {
+          kind: webMcpProvider.kind,
+          mode: webMcpProvider.mode,
+          deferred: webMcpProvider.deferred,
+        }));
+        addedWebMcpSource = true;
+        await webMcpProvider.settled?.();
+      }
+    }
+    const managed = setup.identity.kind === "create"
+      ? await ManagedAgent.create(setup.client)
+      : ManagedAgent.open(setup.identity.id, setup.client);
+    const managedState = await managed.state();
+    if (managedState.agent_id !== managed.id
+        || typeof managedState.session_id !== "string"
+        || !MANAGED_AGENT_ID.test(managedState.session_id)) {
+      throw new Error("managed Agent state returned inconsistent agent or session identity");
+    }
+    tools?.[toolRuntimeLifecycle].claim();
+    return managedAgentView(managed, managedState.agent_id, managedState.session_id, tools);
+  } catch (error) {
+    const cleanup = [];
+    if (automaticTools) cleanup.push(tools.close());
+    else if (addedWebMcpSource) {
+      cleanup.push((async () => {
+        await tools[toolRouterRuntime].detachSource(webMcpProvider.sourceId);
+        await webMcpProvider.close?.();
+      })());
+    } else if (webMcpProvider) cleanup.push(Promise.resolve(webMcpProvider.close?.()));
+    const settled = await Promise.allSettled(cleanup);
+    const failures = settled.filter((result) => result.status === "rejected").map((result) => result.reason);
+    if (failures.length) {
+      throw new AggregateError([error, ...failures], "managed Agent creation and WebMCP cleanup failed");
+    }
+    throw error;
   }
-  tools?.[toolRuntimeLifecycle].claim();
-  return managedAgentView(managed, managedState.agent_id, managedState.session_id, tools);
 }
 
 function managedAgentView(managed, agentId, sessionId, tools) {

--- a/js/bindings/scripts/check-package.mjs
+++ b/js/bindings/scripts/check-package.mjs
@@ -90,6 +90,11 @@ const requiredFiles = [
   "tools/browser/index.d.mts",
   "tools/vite.mjs",
   "tools/vite.d.mts",
+  "webmcp/WebMcp.mjs",
+  "webmcp/WebMcp.d.mts",
+  "webmcp/generator.mjs",
+  "webmcp/generator.d.mts",
+  "webmcp/cli.mjs",
   "vite/index.mjs",
   "vite/index.d.mts",
   "vite/cloudflare.mjs",
@@ -146,6 +151,9 @@ export async function checkPackage(packageRoot = root) {
   assert.equal(packageJson.exports?.["./tools/artifact"]?.import, "./tools/artifact.mjs");
   assert.equal(packageJson.exports?.["./tools/browser"]?.import, "./tools/browser/index.mjs");
   assert.equal(packageJson.exports?.["./tools/vite"]?.import, "./tools/vite.mjs");
+  assert.equal(packageJson.exports?.["./webmcp"]?.import, "./webmcp/WebMcp.mjs");
+  assert.equal(packageJson.exports?.["./webmcp/generator"]?.import, "./webmcp/generator.mjs");
+  assert.equal(packageJson.bin?.["nanocodex-webmcp"], "webmcp/cli.mjs");
   assert.equal(packageJson.exports?.["./vite"]?.import, "./vite/index.mjs");
   assert.equal(packageJson.exports?.["./vite/cloudflare"]?.import, "./vite/cloudflare.mjs");
   assert.equal(packageJson.exports?.["./wasm"]?.import, "./pkg-web/nanocodex_bg.wasm");

--- a/js/bindings/scripts/check-package.mjs
+++ b/js/bindings/scripts/check-package.mjs
@@ -62,6 +62,8 @@ const requiredFiles = [
   "managed/ManagedError.d.mts",
   "managed/index.mjs",
   "managed/index.d.mts",
+  "next/index.mjs",
+  "next/index.d.mts",
   "node/index.mjs",
   "node/index.d.mts",
   "node/workspace.mjs",
@@ -127,6 +129,8 @@ export async function checkPackage(packageRoot = root) {
   assert.equal(packageJson.exports?.["./host"]?.import, "./host/index.mjs");
   assert.equal(packageJson.exports?.["./cloudflare"]?.import, "./cloudflare/index.mjs");
   assert.equal(packageJson.exports?.["./managed"]?.import, "./managed/index.mjs");
+  assert.equal(packageJson.exports?.["./next"]?.import, "./next/index.mjs");
+  assert.equal(packageJson.exports?.["./next"]?.require, "./next/index.mjs");
   assert.equal(packageJson.exports?.["./connect"]?.import, "./cloud/index.mjs");
   assert.equal(packageJson.exports?.["./connect"]?.types, "./cloud/index.d.mts");
   assert.equal(packageJson.exports?.["./connect/actions"]?.import, "./cloud/actions/index.mjs");

--- a/js/bindings/test/browser-config.test.mjs
+++ b/js/bindings/test/browser-config.test.mjs
@@ -1,7 +1,64 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { createAgentConfig } from "../browser/config.mjs";
+import { createAgentConfig, createConfig } from "../browser/config.mjs";
+import { managed as managedTransport } from "../browser/Transport.mjs";
+
+const managedAgentId = "0198d3f0-8844-7000-8000-000000000001";
+const managedSessionId = "0198d3f0-8844-7000-8000-000000000002";
+
+test("the browser config reverse-attaches WebMCP to managed Agents without a Worker harness", async () => {
+  const socket = new ManagedToolSocket();
+  let providerClosed = false;
+  const provider = {
+    [Symbol.for("nanocodex.webmcp.provider")]: true,
+    sourceId: "webmcp:react-config",
+    kind: "webmcp",
+    mode: "union",
+    deferred: true,
+    definitions: () => [{
+      type: "function",
+      name: "web_current_page",
+      description: "Read the current page.",
+      strict: false,
+      defer_loading: true,
+      parameters: { type: "object", additionalProperties: false },
+    }],
+    resolve: (name) => name === "web_current_page" ? {
+      name,
+      parallelSafe: true,
+      handler: () => ({ title: "Managed site" }),
+    } : undefined,
+    async settled() {},
+    close() { providerClosed = true; },
+  };
+  const config = createConfig({
+    retry: 0,
+    agent: {
+      transport: managedTransport({
+        agent: { id: managedAgentId },
+        baseUrl: "https://managed.example",
+        fetch: async () => Response.json({
+          agent_id: managedAgentId,
+          session_id: managedSessionId,
+        }),
+        toolsTransport: () => socket,
+      }),
+      webMcp: provider,
+    },
+  });
+  const unsubscribe = config.subscribeAgent({}, () => {});
+  await waitFor(() => ["success", "error"].includes(config.getAgent().status));
+  assert.equal(config.getAgent().status, "success", String(config.getAgent().error));
+  await waitFor(() => socket.frames.some((frame) => frame.type === "catalog"));
+
+  assert.equal(config.getAgent().data.type, "managed");
+  assert.equal(socket.frames.find((frame) => frame.type === "catalog").tools[0].definition.name, "web_current_page");
+
+  unsubscribe();
+  await waitFor(() => providerClosed);
+  await config.destroy();
+});
 
 test("snapshot reads and refetch stay pure until a subscriber creates the entry", async () => {
   const calls = [];
@@ -1098,6 +1155,36 @@ function fakeAgent(id, closed) {
       async shutdown() { closed.push(id); },
     },
   };
+}
+
+class ManagedToolSocket {
+  readyState = 1;
+  frames = [];
+  listeners = new Map();
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  send(encoded) {
+    const frame = JSON.parse(encoded);
+    this.frames.push(frame);
+    if (frame.type === "catalog") queueMicrotask(() => this.receive({ type: "ready" }));
+    if (frame.type === "drain") queueMicrotask(() => this.receive({ type: "draining" }));
+  }
+
+  receive(frame) {
+    for (const listener of this.listeners.get("message") ?? []) {
+      listener({ data: JSON.stringify(frame) });
+    }
+  }
+
+  close(code, reason) {
+    this.readyState = 3;
+    for (const listener of this.listeners.get("close") ?? []) listener({ code, reason });
+  }
 }
 
 function deferred() {

--- a/js/bindings/test/cloud-dialog.test.mjs
+++ b/js/bindings/test/cloud-dialog.test.mjs
@@ -74,6 +74,55 @@ test("the default Connect dialog stays embedded and accepts responses only from 
   }
 });
 
+test("the embedded approval stays open while its exact action executes", async () => {
+  const browser = createBrowserHarness();
+  const previousDocument = globalThis.document;
+  const previousWindow = globalThis.window;
+  globalThis.document = browser.document;
+  globalThis.window = browser.window;
+  try {
+    const dialog = Dialog.iframe({ host: `${DEFAULT_HOST}?test=execution` }).setup({ appId: "execution-test" });
+    let finish;
+    const execution = new Promise((resolve) => { finish = resolve; });
+    const request = { id: "approval-1", type: "webMcpApproval" };
+    const result = dialog.open(request, { execute: () => execution });
+    const modal = browser.document.body.children.find(
+      (element) => element.attributes.get("aria-label") === "Nanocodex Connect permissions",
+    );
+    const frame = modal.children[0];
+    frame.dispatch("load");
+    await Promise.resolve();
+
+    browser.window.dispatchMessage({
+      data: { type: "nanocodex:approval", id: request.id },
+      origin: DEFAULT_ORIGIN,
+      source: frame.contentWindow,
+    });
+    await Promise.resolve();
+    assert.equal(modal.open, true);
+    assert.equal(frame.contentWindow.messages.length, 1);
+
+    finish({ transferred: true });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.deepEqual(frame.contentWindow.messages[1], {
+      message: { type: "nanocodex:completion", id: request.id, ok: true },
+      targetOrigin: DEFAULT_ORIGIN,
+    });
+    assert.equal(modal.open, true);
+
+    browser.window.dispatchMessage({
+      data: { type: "nanocodex:response", id: request.id, result: { approved: true } },
+      origin: DEFAULT_ORIGIN,
+      source: frame.contentWindow,
+    });
+    assert.deepEqual(await result, { transferred: true });
+    assert.equal(modal.open, false);
+  } finally {
+    globalThis.document = previousDocument;
+    globalThis.window = previousWindow;
+  }
+});
+
 test("the popup Connect dialog opens the canonical host as a top-level wallet target", () => {
   const previousWindow = globalThis.window;
   const opened = [];

--- a/js/bindings/test/managed-transport.test.mjs
+++ b/js/bindings/test/managed-transport.test.mjs
@@ -160,6 +160,50 @@ test("managed create reverse-attaches one Tools recipe and shutdown closes it wi
   assert.equal(requests.some((request) => request.method === "DELETE"), false);
 });
 
+test("managed browser Agent reverse-attaches the host page WebMCP provider under existing auth", async () => {
+  const socket = new ManagedToolSocket();
+  let closed = false;
+  const provider = {
+    [Symbol.for("nanocodex.webmcp.provider")]: true,
+    sourceId: "webmcp:managed-fixture",
+    kind: "webmcp",
+    mode: "union",
+    deferred: true,
+    definitions: () => [{
+      type: "function",
+      name: "web_current_user",
+      description: "Read the current website user.",
+      strict: false,
+      defer_loading: true,
+      parameters: { type: "object", additionalProperties: false },
+    }],
+    resolve: (name) => name === "web_current_user" ? {
+      name,
+      parallelSafe: true,
+      handler: () => ({ id: "website-session-user" }),
+    } : undefined,
+    async settled() {},
+    close() { closed = true; },
+  };
+  const agent = await BrowserAgent.create({
+    transport: BrowserTransport.managed({
+      agent: { id: agentId },
+      baseUrl: origin,
+      apiKey,
+      fetch: async () => Response.json({ agent_id: agentId, session_id: sessionId }),
+      toolsTransport: () => socket,
+    }),
+    webMcp: provider,
+  });
+
+  await waitFor(() => socket.frames.some(({ type }) => type === "catalog"));
+  assert.equal(socket.frames[0].tools[0].definition.name, "web_current_user");
+  assert.equal(socket.frames[0].tools[0].provider, "javascript");
+  await agent.session.shutdown();
+  assert.equal(closed, true);
+  assert.equal(socket.closed.code, 1000);
+});
+
 test("cold reverse attachment failure does not block the durable Agent and retries under its lifecycle", async () => {
   const socket = new ManagedToolSocket();
   let attempts = 0;

--- a/js/bindings/test/next.test.mjs
+++ b/js/bindings/test/next.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { withWebMcp } from "../next/index.mjs";
+
+test("the Next.js wrapper generates WebMCP before returning the application config", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "nanocodex-next-webmcp-"));
+  try {
+    const routeDirectory = join(directory, "app", "api", "checkout");
+    await mkdir(routeDirectory, { recursive: true });
+    await writeFile(
+      join(routeDirectory, "route.ts"),
+      "export async function POST() { return Response.json({ ok: true }); }\n",
+    );
+    const configure = withWebMcp({ reactStrictMode: true }, { root: directory });
+    const config = await configure("phase-production-build", {});
+    assert.deepEqual(config, { reactStrictMode: true });
+    const manifest = JSON.parse(await readFile(join(directory, "webmcp.manifest.json"), "utf8"));
+    assert.equal(manifest.tools.length, 1);
+    assert.equal(manifest.tools[0].name, "post_api_checkout");
+    assert.equal(manifest.tools[0].approved, false);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("the Next.js wrapper composes async application config functions", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "nanocodex-next-config-"));
+  try {
+    await writeFile(join(directory, "page.tsx"), "export default function Page() { return null; }\n");
+    const configure = withWebMcp(async (phase) => ({ phase }), {
+      root: directory,
+      output: "generated/webmcp.json",
+    });
+    assert.deepEqual(await configure("phase-production-build", {}), {
+      phase: "phase-production-build",
+    });
+    const manifest = JSON.parse(await readFile(join(directory, "generated", "webmcp.json"), "utf8"));
+    assert.deepEqual(manifest.tools, []);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/js/bindings/test/package.test.mjs
+++ b/js/bindings/test/package.test.mjs
@@ -93,12 +93,14 @@ test("the packed package ships and resolves every public entry point", async () 
       import { dataset } from "nanocodex/tools/dataset";
       import { nanocodexTools } from "nanocodex/tools/vite";
       import { nanocodex } from "nanocodex/vite";
+      import { withWebMcp } from "nanocodex/next";
       import { Agent as NodeAgent, Subagents as NodeSubagents, Transport as NodeTransport, Workspace as NodeWorkspace } from "nanocodex/node";
       import * as nodeExports from "nanocodex/node";
       import { Subagents as BrowserSubagents, Workspace as BrowserWorkspace } from "nanocodex/browser";
       import * as browserExports from "nanocodex/browser";
 
       assert.equal(typeof Actions.turn.prompt, "function");
+      assert.equal(typeof withWebMcp, "function");
       assert.equal(typeof ManagedAgent.create, "function");
       assert.equal(typeof ManagedAgent.list, "function");
       const durabilityValueNames = [

--- a/js/bindings/test/tool-router.test.mjs
+++ b/js/bindings/test/tool-router.test.mjs
@@ -54,6 +54,24 @@ test("createTools transfers caller tool ownership only after successful construc
   assert.equal(disposals, 0);
 });
 
+test("createTools transfers dynamic provider ownership only after successful construction", async () => {
+  let closes = 0;
+  const provider = {
+    sourceId: "dynamic",
+    definitions: () => [contract("dynamic")],
+    resolve: () => ({ name: "dynamic", handler: () => "ok" }),
+    async settled() { throw new Error("discovery failed"); },
+    close() { closes += 1; },
+  };
+  await assert.rejects(createTools({ providers: [provider] }), /discovery failed/);
+  assert.equal(closes, 0);
+
+  delete provider.settled;
+  const tools = await createTools({ providers: [provider] });
+  await tools.close();
+  assert.equal(closes, 1);
+});
+
 test("Tools close joins one exhaustive synchronous and asynchronous cleanup", async () => {
   const events = [];
   const tools = await createTools({ tools: {

--- a/js/bindings/test/types.test-d.mts
+++ b/js/bindings/test/types.test-d.mts
@@ -23,8 +23,10 @@ import {
   Agent as BrowserAgent,
   Subagents as BrowserSubagents,
   Transport as BrowserTransport,
+  WebMcp,
   Workspace as BrowserWorkspace,
 } from "../browser/index.mjs";
+import { generate as generateWebMcp } from "../webmcp/generator.mjs";
 import {
   Agent as HostAgent,
   type BrowserWebSocketRequest,
@@ -471,6 +473,20 @@ async function check() {
   const workerTransport: BrowserTransport.WorkerTransport = BrowserTransport.hostManaged({
     websocketUrl: "wss://example.com/api/responses",
   });
+  const webMcpProvider = await WebMcp.createProvider({
+    document,
+    fallback: "when-empty",
+    confirm: (action) => action.readOnly === false,
+  });
+  await BrowserAgent.create({ transport: workerTransport, webMcp: webMcpProvider });
+  await BrowserAgent.create({
+    transport: BrowserTransport.managed({ agent: { create: true } }),
+    webMcp: true,
+  });
+  const generatedWebMcp = await generateWebMcp({ root: ".", maxFiles: 10 });
+  generatedWebMcp.tools[0]?.approved;
+  // @ts-expect-error WebMCP fallback modes are closed.
+  await BrowserAgent.create({ transport: workerTransport, webMcp: { fallback: "unsafe" } });
   const durability = createMemoryDurabilityStore("journal-1");
   await HostAgent.create({
     transport: HostTransport.openAi({ apiKey }),

--- a/js/bindings/test/types.test-d.mts
+++ b/js/bindings/test/types.test-d.mts
@@ -26,7 +26,8 @@ import {
   WebMcp,
   Workspace as BrowserWorkspace,
 } from "../browser/index.mjs";
-import { generate as generateWebMcp } from "../webmcp/generator.mjs";
+import { generate as generateWebMcp, generateFile as generateWebMcpFile } from "../webmcp/generator.mjs";
+import { withWebMcp } from "../next/index.mjs";
 import {
   Agent as HostAgent,
   type BrowserWebSocketRequest,
@@ -154,6 +155,11 @@ async function check() {
   const workerOptions: WorkerAgentOptions = {
     onFailure(error) { error.message; },
   };
+  await generateWebMcpFile({ output: "generated/webmcp.json" });
+  nanocodex({ chatGpt: false, webMcp: { output: "generated/webmcp.json" } });
+  const nextConfig = withWebMcp({ reactStrictMode: true }, { output: "generated/webmcp.json" });
+  const resolvedNextConfig = await nextConfig("phase-production-build", {});
+  void resolvedNextConfig;
   await createWorkerAgent(workerResource, workerOptions);
   // @ts-expect-error non-disabled preparation requires one stable harness identity.
   await prepareWorkerAgent({ origin: "https://example.com" });

--- a/js/bindings/test/vite.test.mjs
+++ b/js/bindings/test/vite.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import { createServer } from "node:http";
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
@@ -10,6 +11,7 @@ import WebSocket, { WebSocketServer } from "ws";
 import { readCodexSubscription } from "../vite/codex-auth-file.mjs";
 import { createNanocodexCloudflarePlugins } from "../vite/cloudflare-plugin.mjs";
 import { startChatGptWorkerEgress } from "../vite/chatgpt-egress.mjs";
+import { nanocodex } from "../vite/index.mjs";
 
 test("one Vite plugin gives Cloudflare only exact development Worker bindings", async () => {
   const fixture = await authFixture();
@@ -60,6 +62,47 @@ test("production builds neither read local auth nor start development egress", a
   assert.equal(cloudflareOptions.config({ vars: { PRODUCTION: "yes" } }), undefined);
   assert.equal(typeof config.worker.plugins, "function");
   await plugin.closeBundle();
+});
+
+test("the Vite plugin generates a review-first WebMCP manifest", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "nanocodex-vite-webmcp-"));
+  try {
+    await writeFile(join(directory, "client.ts"), 'fetch("/api/profile");\n');
+    const plugin = nanocodex({ chatGpt: false, webMcp: true });
+    plugin.configResolved({ root: directory, logger: { info() {} } });
+    await plugin.buildStart();
+    const manifest = JSON.parse(await readFile(join(directory, "webmcp.manifest.json"), "utf8"));
+    assert.equal(manifest.tools.length, 1);
+    assert.equal(manifest.tools[0].name, "get_api_profile");
+    assert.equal(manifest.tools[0].approved, false);
+    await plugin.closeBundle();
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("the Vite development watcher regenerates changed WebMCP source", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "nanocodex-vite-webmcp-watch-"));
+  try {
+    const source = join(directory, "client.ts");
+    await writeFile(source, 'fetch("/api/profile");\n');
+    const watcher = new EventEmitter();
+    const plugin = nanocodex({ chatGpt: false, webMcp: true });
+    plugin.configResolved({ root: directory, logger: { info() {} } });
+    await plugin.configureServer({
+      config: { logger: { error(error) { throw error; } } },
+      watcher,
+    });
+    await writeFile(source, 'fetch("/api/profile", { method: "POST" });\n');
+    watcher.emit("change", source);
+    await waitFor(async () => {
+      const manifest = JSON.parse(await readFile(join(directory, "webmcp.manifest.json"), "utf8"));
+      return manifest.tools[0]?.name === "post_api_profile";
+    });
+    await plugin.closeBundle();
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
 });
 
 test("the Codex auth reader selects current subscription fields but never refresh data", async () => {
@@ -186,4 +229,12 @@ function listen(server) {
 
 function close(server) {
   return new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+}
+
+async function waitFor(predicate) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  assert.fail("timed out waiting for Vite WebMCP regeneration");
 }

--- a/js/bindings/test/vite.test.mjs
+++ b/js/bindings/test/vite.test.mjs
@@ -4,11 +4,13 @@ import { createServer } from "node:http";
 import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Readable } from "node:stream";
 import { test } from "node:test";
 
 import WebSocket, { WebSocketServer } from "ws";
 
 import { readCodexSubscription } from "../vite/codex-auth-file.mjs";
+import { startAutomaticWebMcp } from "../vite/auto-webmcp-client.mjs";
 import { createNanocodexCloudflarePlugins } from "../vite/cloudflare-plugin.mjs";
 import { startChatGptWorkerEgress } from "../vite/chatgpt-egress.mjs";
 import { nanocodex } from "../vite/index.mjs";
@@ -81,6 +83,120 @@ test("the Vite plugin generates a review-first WebMCP manifest", async () => {
   }
 });
 
+test("plain nanocodex() injects Accounts-backed automatic generation and verifies the Agent result", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "nanocodex-vite-automatic-webmcp-"));
+  try {
+    await writeFile(join(directory, "client.ts"), 'fetch("/api/balance");\n');
+    const watcher = new EventEmitter();
+    let endpoint;
+    let middleware;
+    const plugin = nanocodex({ chatGpt: false });
+    await plugin.config({}, { command: "serve" });
+    plugin.configResolved({ root: directory, logger: { info() {} } });
+    await plugin.configureServer({
+      config: { logger: { error(error) { throw error; }, info() {} } },
+      middlewares: {
+        use(path, handler) {
+          endpoint = path;
+          middleware = handler;
+        },
+      },
+      watcher,
+    });
+    assert.equal(endpoint, "/__nanocodex/webmcp");
+    assert.deepEqual(plugin.transformIndexHtml(), [{
+      tag: "script",
+      attrs: { type: "module", src: "/@id/virtual:nanocodex-webmcp" },
+      injectTo: "body",
+    }]);
+
+    const draft = await callMiddleware(middleware, "GET");
+    assert.match(draft.appId, /^webmcp-dev:/);
+    assert.match(draft.sourceRevision, /^[0-9a-f]{64}$/);
+    assert.equal(draft.manifest.tools[0].approved, false);
+    const proposed = structuredClone(draft.manifest);
+    proposed.tools[0].title = "Current balance";
+    proposed.tools[0].description = "Read the signed-in user's current balance.";
+    proposed.tools[0].approved = true;
+    const generated = await callMiddleware(middleware, "POST", {
+      sourceRevision: draft.sourceRevision,
+      manifest: proposed,
+    });
+    assert.equal(generated.generatedBy, "nanocodex-agent");
+    assert.equal(generated.tools[0].title, "Current balance");
+    assert.equal(generated.tools[0].approved, true);
+
+    const retained = JSON.parse(await readFile(join(directory, "webmcp.manifest.json"), "utf8"));
+    assert.equal(retained.generatedBy, "nanocodex-agent");
+    assert.equal(retained.sourceRevision, draft.sourceRevision);
+    await plugin.closeBundle();
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("the injected browser generator uses Connect, reverse-attached WebMCP, and publishes the verified result", async () => {
+  const sourceRevision = "a".repeat(64);
+  const candidate = {
+    name: "get_api_balance",
+    title: "GET /api/balance",
+    description: "candidate",
+    approved: false,
+    annotations: { readOnlyHint: true, untrustedContentHint: true },
+    implementation: { kind: "fetch", method: "GET", path: "/api/balance" },
+    evidence: [{ file: "client.ts", line: 1, kind: "frontend fetch", sourceHash: "b".repeat(64) }],
+  };
+  const generated = {
+    version: 1,
+    sourceRevision,
+    tools: [{ ...candidate, title: "Current balance", approved: true }],
+  };
+  const calls = [];
+  const connection = { grant: { status: "active" } };
+  const agent = {
+    session: { async shutdown() {} },
+    turn: {
+      prompt({ input }) {
+        calls.push(["prompt", input]);
+        return { async result() { return { finalMessage: JSON.stringify(generated) }; } };
+      },
+    },
+  };
+  const client = {
+    dialog: { async open() {} },
+    connection: {
+      async reconnect(options) { calls.push(["reconnect", options]); },
+      async connect(options) { calls.push(["connect", options]); return connection; },
+    },
+    agent: {
+      async create(options) { calls.push(["agent", options]); return agent; },
+    },
+  };
+  const fetchImpl = async (_input, init) => {
+    if (!init) return Response.json({
+      appId: "webmcp-dev:fixture",
+      sourceRevision,
+      manifest: { version: 1, sourceRevision, tools: [candidate] },
+    });
+    calls.push(["result", JSON.parse(init.body)]);
+    return Response.json({ ...generated, generatedBy: "nanocodex-agent" });
+  };
+  const ready = await startAutomaticWebMcp({
+    client,
+    fetch: fetchImpl,
+    async publish(manifest) {
+      calls.push(["publish", manifest]);
+      return { tools: [manifest.tools[0].name], close() {} };
+    },
+  });
+  assert.strictEqual(ready.agent, agent);
+  assert.equal(calls[2][0], "agent");
+  assert.deepEqual(calls[2][1].webMcp.fallback, "when-empty");
+  assert.match(calls[3][1], /web_page_observe/);
+  assert.equal(calls.at(-1)[0], "publish");
+  assert.equal(calls.at(-1)[1].tools[0].title, "Current balance");
+});
+
 test("the Vite development watcher regenerates changed WebMCP source", async () => {
   const directory = await mkdtemp(join(tmpdir(), "nanocodex-vite-webmcp-watch-"));
   try {
@@ -91,6 +207,7 @@ test("the Vite development watcher regenerates changed WebMCP source", async () 
     plugin.configResolved({ root: directory, logger: { info() {} } });
     await plugin.configureServer({
       config: { logger: { error(error) { throw error; } } },
+      middlewares: { use() {} },
       watcher,
     });
     await writeFile(source, 'fetch("/api/profile", { method: "POST" });\n');
@@ -237,4 +354,24 @@ async function waitFor(predicate) {
     await new Promise((resolve) => setTimeout(resolve, 5));
   }
   assert.fail("timed out waiting for Vite WebMCP regeneration");
+}
+
+async function callMiddleware(handler, method, body) {
+  const request = Readable.from(body === undefined ? [] : [Buffer.from(JSON.stringify(body))]);
+  request.method = method;
+  return new Promise((resolve, reject) => {
+    const headers = new Map();
+    const response = {
+      statusCode: 200,
+      setHeader(name, value) { headers.set(name, value); },
+      end(value) {
+        try {
+          const parsed = JSON.parse(String(value));
+          if (this.statusCode >= 400) reject(new Error(parsed.error));
+          else resolve(parsed);
+        } catch (error) { reject(error); }
+      },
+    };
+    Promise.resolve(handler(request, response)).catch(reject);
+  });
 }

--- a/js/bindings/test/webmcp-framework-e2e.test.mjs
+++ b/js/bindings/test/webmcp-framework-e2e.test.mjs
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { withWebMcp } from "../next/index.mjs";
+import { nanocodex } from "../vite/index.mjs";
+import { createProvider, publish } from "../webmcp/WebMcp.mjs";
+
+test("Vite and Next.js generated tools reach authenticated website endpoints through WebMCP", async () => {
+  const root = await mkdtemp(join(tmpdir(), "nanocodex-framework-webmcp-"));
+  const server = createServer(async (request, response) => {
+    const url = new URL(request.url, "http://localhost");
+    if (request.headers.cookie !== "session=website-user") {
+      response.writeHead(401, { "content-type": "application/json" });
+      response.end(JSON.stringify({ error: "unauthorized" }));
+      return;
+    }
+    if (request.method === "GET" && url.pathname === "/api/balance") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ balance: "125.50", currency: url.searchParams.get("currency") }));
+      return;
+    }
+    const transfer = url.pathname.match(/^\/api\/transfers\/([^/]+)$/);
+    if (request.method === "POST" && transfer) {
+      const body = JSON.parse(await readBody(request));
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ id: decodeURIComponent(transfer[1]), status: "sent", ...body }));
+      return;
+    }
+    response.writeHead(404, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: "not_found" }));
+  });
+  await listen(server);
+  const origin = `http://127.0.0.1:${server.address().port}`;
+
+  try {
+    const viteRoot = join(root, "vite");
+    await mkdir(viteRoot, { recursive: true });
+    await writeFile(join(viteRoot, "account.ts"), `
+      export const loadBalance = () => fetch("/api/balance");
+    `);
+    const vitePlugin = nanocodex({ chatGpt: false, webMcp: true });
+    vitePlugin.configResolved({ root: viteRoot, logger: { info() {} } });
+    await vitePlugin.buildStart();
+    await vitePlugin.closeBundle();
+
+    const nextRoot = join(root, "next");
+    const routeRoot = join(nextRoot, "app", "api", "transfers", "[id]");
+    await mkdir(routeRoot, { recursive: true });
+    await writeFile(join(routeRoot, "route.ts"), `
+      export async function POST(request: Request) {
+        return Response.json(await request.json());
+      }
+    `);
+    await withWebMcp({}, { root: nextRoot })("phase-production-build", {});
+
+    const viteManifest = approved(await manifest(join(viteRoot, "webmcp.manifest.json")));
+    const nextManifest = approved(await manifest(join(nextRoot, "webmcp.manifest.json")));
+    assert.deepEqual(viteManifest.tools.map(({ name }) => name), ["get_api_balance"]);
+    assert.deepEqual(nextManifest.tools.map(({ name }) => name), ["post_api_transfers_id"]);
+
+    const registry = modelContext(origin);
+    const document = {
+      location: { href: `${origin}/dashboard`, origin },
+      modelContext: registry,
+      title: "Example Bank",
+    };
+    const sessionFetch = (input, options = {}) => {
+      assert.equal(options.credentials, "same-origin");
+      const headers = new Headers(options.headers);
+      headers.set("cookie", "session=website-user");
+      return fetch(input, { ...options, headers });
+    };
+    const publications = await Promise.all([
+      publish(viteManifest, { baseUrl: origin, document, fetch: sessionFetch }),
+      publish(nextManifest, { baseUrl: origin, document, fetch: sessionFetch }),
+    ]);
+    const approvals = [];
+    const provider = await createProvider({
+      confirm(action) {
+        approvals.push(action);
+        return true;
+      },
+      document,
+      fallback: "never",
+    });
+
+    try {
+      assert.deepEqual(provider.definitions().map(({ name }) => name), [
+        "web_get_api_balance",
+        "web_post_api_transfers_id",
+      ]);
+      const balance = await provider.resolve("web_get_api_balance").handler({
+        query: { currency: "USD" },
+      });
+      const transfer = await provider.resolve("web_post_api_transfers_id").handler({
+        path: { id: "tx-7" },
+        body: { amount: "25.00", recipient: "Ada" },
+      });
+
+      assert.deepEqual(balance, { balance: "125.50", currency: "USD" });
+      assert.deepEqual(transfer, {
+        amount: "25.00",
+        id: "tx-7",
+        recipient: "Ada",
+        status: "sent",
+      });
+      assert.deepEqual(approvals.map(({ name }) => name), ["post_api_transfers_id"]);
+    } finally {
+      provider.close();
+      for (const publication of publications) publication.close();
+    }
+  } finally {
+    await close(server);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+function approved(value) {
+  return { ...value, tools: value.tools.map((tool) => ({ ...tool, approved: true })) };
+}
+
+async function manifest(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+function modelContext(origin) {
+  const tools = new Map();
+  return {
+    async registerTool(tool, options) {
+      tools.set(tool.name, tool);
+      options.signal.addEventListener("abort", () => tools.delete(tool.name), { once: true });
+    },
+    async getTools() {
+      return [...tools.values()].map((tool) => ({ ...tool, origin }));
+    },
+    async executeTool(tool, input, options) {
+      return tools.get(tool.name).execute(JSON.parse(input), options);
+    },
+  };
+}
+
+function readBody(request) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    request.on("data", (chunk) => chunks.push(chunk));
+    request.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    request.on("error", reject);
+  });
+}
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+}

--- a/js/bindings/test/webmcp.test.mjs
+++ b/js/bindings/test/webmcp.test.mjs
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { test } from "node:test";
 
 import { createProvider, publish } from "../webmcp/WebMcp.mjs";
-import { generate, validate } from "../webmcp/generator.mjs";
+import { generate, generateFile, validate } from "../webmcp/generator.mjs";
 
 test("WebMCP provider mirrors native tools, preserves session execution, and refreshes", async () => {
   const listeners = new Set();
@@ -332,6 +332,40 @@ test("repository generator finds routes, forms, GraphQL, tRPC, and server action
     const path = join(directory, "webmcp.manifest.json");
     await writeFile(path, `${JSON.stringify(manifest, null, 2)}\n`);
     assert.equal(validate(JSON.parse(await readFile(path, "utf8"))), true);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("manifest generation preserves only approvals for unchanged tool contracts", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "nanocodex-webmcp-manifest-"));
+  const route = join(directory, "app", "api", "orders", "route.ts");
+  const output = join(directory, "webmcp.manifest.json");
+  try {
+    await mkdir(join(directory, "app", "api", "orders"), { recursive: true });
+    await writeFile(route, "export async function GET() { return Response.json([]); }\n");
+    const first = await generateFile({ root: directory });
+    assert.equal(first.changed, true);
+    assert.equal(first.path, output);
+    const reviewed = JSON.parse(await readFile(output, "utf8"));
+    reviewed.tools[0].approved = true;
+    await writeFile(output, `${JSON.stringify(reviewed, null, 2)}\n`);
+
+    const unchanged = await generateFile({ root: directory });
+    assert.equal(unchanged.changed, false);
+    assert.equal(unchanged.manifest.tools[0].approved, true);
+
+    await writeFile(route, "export async function GET() { return Response.json([1]); }\n");
+    const implementationChanged = await generateFile({ root: directory });
+    assert.equal(implementationChanged.changed, true);
+    assert.equal(implementationChanged.manifest.tools[0].name, "get_api_orders");
+    assert.equal(implementationChanged.manifest.tools[0].approved, false);
+
+    await writeFile(route, "export async function POST() { return Response.json({ ok: true }); }\n");
+    const changed = await generateFile({ root: directory });
+    assert.equal(changed.changed, true);
+    assert.equal(changed.manifest.tools[0].name, "post_api_orders");
+    assert.equal(changed.manifest.tools[0].approved, false);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }

--- a/js/bindings/test/webmcp.test.mjs
+++ b/js/bindings/test/webmcp.test.mjs
@@ -1,0 +1,323 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { createProvider, publish } from "../webmcp/WebMcp.mjs";
+import { generate, validate } from "../webmcp/generator.mjs";
+
+test("WebMCP provider mirrors native tools, preserves session execution, and refreshes", async () => {
+  const listeners = new Set();
+  const calls = [];
+  const confirmations = [];
+  let tools = [registeredTool("search.products", true), registeredTool("checkout", false)];
+  const document = {
+    modelContext: {
+      addEventListener(type, listener) { if (type === "toolchange") listeners.add(listener); },
+      removeEventListener(type, listener) { if (type === "toolchange") listeners.delete(listener); },
+      async getTools(options) {
+        assert.deepEqual(options, { fromOrigins: ["https://shop.example"] });
+        return tools;
+      },
+      async executeTool(tool, input, options) {
+        const parsed = JSON.parse(input);
+        calls.push({ tool: tool.name, input: parsed, signal: options.signal });
+        return JSON.stringify({ tool: tool.name, input: parsed, authenticated: true });
+      },
+    },
+  };
+  const provider = await createProvider({
+    document,
+    fallback: false,
+    fromOrigins: ["https://shop.example"],
+    confirm: async (request) => { confirmations.push(request); return true; },
+  });
+
+  assert.deepEqual(provider.definitions().map(({ name }) => name), ["web_checkout", "web_search_products"]);
+  const signal = new AbortController().signal;
+  assert.deepEqual(
+    await provider.resolve("web_search_products").handler({ query: "boots" }, { signal }),
+    { tool: "search.products", input: { query: "boots" }, authenticated: true },
+  );
+  assert.equal(confirmations.length, 0);
+  assert.deepEqual(
+    await provider.resolve("web_checkout").handler({ cart: "current" }, { signal }),
+    { tool: "checkout", input: { cart: "current" }, authenticated: true },
+  );
+  assert.equal(confirmations.length, 1);
+  assert.equal(confirmations[0].origin, "https://shop.example");
+  assert.equal(calls.every((call) => call.signal === signal), true);
+
+  const snapshots = [];
+  provider.subscribe((definitions) => snapshots.push(definitions.map(({ name }) => name)));
+  tools = [registeredTool("account.profile", true)];
+  for (const listener of listeners) listener();
+  await waitFor(() => snapshots.length === 1);
+  assert.deepEqual(snapshots[0], ["web_account_profile"]);
+  assert.equal(provider.resolve("web_checkout"), undefined);
+  provider.close();
+  assert.equal(listeners.size, 0);
+});
+
+test("semantic fallback observes, fills, activates, and submits only retained visible elements", async () => {
+  const form = element("form", { name: "support" });
+  form.requestSubmit = () => { form.submitted = true; };
+  const input = element("input", { name: "email", type: "email" });
+  input.form = form;
+  const button = element("button", { text: "Send" });
+  button.form = form;
+  button.click = () => { button.clicked = true; };
+  const document = fakeDocument([button, input], [form]);
+  const approvals = [];
+  const provider = await createProvider({
+    document,
+    native: false,
+    fallback: "always",
+    confirm: (request) => { approvals.push(request.name); return true; },
+  });
+  const context = { signal: new AbortController().signal };
+  const observed = await provider.resolve("web_page_observe").handler({}, context);
+  assert.equal(observed.title, "Fixture");
+  assert.equal(observed.elements.length, 2);
+  assert.equal(observed.forms.length, 1);
+  const inputDescription = observed.elements.find(({ name }) => name === "email");
+  const buttonDescription = observed.elements.find(({ role }) => role === "button");
+
+  assert.deepEqual(
+    await provider.resolve("web_page_fill").handler({
+      values: [{ id: inputDescription.id, value: "agent@example.com" }],
+    }, context),
+    { filled: [inputDescription.id] },
+  );
+  assert.equal(input.value, "agent@example.com");
+  await provider.resolve("web_page_activate").handler({ id: buttonDescription.id }, context);
+  await provider.resolve("web_page_submit").handler({ id: observed.forms[0].id }, context);
+  assert.equal(button.clicked, true);
+  assert.equal(form.submitted, true);
+  assert.deepEqual(approvals, ["web_page_fill", "web_page_activate", "web_page_submit"]);
+
+  button.isConnected = false;
+  await assert.rejects(
+    provider.resolve("web_page_activate").handler({ id: buttonDescription.id }, context),
+    /no longer available/,
+  );
+  provider.close();
+});
+
+test("publisher registers only approved tools and aborts registrations on close", async () => {
+  const registrations = [];
+  const document = {
+    modelContext: {
+      async registerTool(tool, options) { registrations.push({ tool, options }); },
+    },
+  };
+  const publication = await publish({
+    version: 1,
+    tools: [
+      {
+        name: "get_profile",
+        description: "Read the signed-in profile.",
+        approved: true,
+        inputSchema: { type: "object", additionalProperties: false },
+        annotations: { readOnlyHint: true },
+        implementation: { kind: "custom" },
+      },
+      {
+        name: "delete_profile",
+        description: "Delete the signed-in profile.",
+        approved: false,
+        implementation: { kind: "custom" },
+      },
+    ],
+  }, {
+    document,
+    exposedTo: ["https://embed.example"],
+    handlers: { get_profile: () => ({ id: "current-user" }) },
+  });
+  assert.deepEqual(publication.tools, ["get_profile"]);
+  assert.equal(registrations.length, 1);
+  assert.deepEqual(registrations[0].options.exposedTo, ["https://embed.example"]);
+  assert.deepEqual(await registrations[0].tool.execute({}), { id: "current-user" });
+  assert.equal(registrations[0].options.signal.aborted, false);
+  publication.close();
+  assert.equal(registrations[0].options.signal.aborted, true);
+});
+
+test("publisher keeps generated fetches same-origin and preserves cancellation and session credentials", async () => {
+  let registration;
+  const requests = [];
+  const document = {
+    location: { href: "https://shop.example/account" },
+    modelContext: {
+      async registerTool(tool, options) { registration = { tool, options }; },
+    },
+  };
+  const publication = await publish({
+    version: 1,
+    tools: [{
+      name: "update_order",
+      description: "Update one signed-in order.",
+      approved: true,
+      annotations: { readOnlyHint: false },
+      implementation: { kind: "fetch", method: "POST", path: "/api/orders/[id]" },
+    }],
+  }, {
+    document,
+    confirm: () => true,
+    async fetch(url, options) {
+      requests.push({ url: String(url), options });
+      return Response.json({ updated: true });
+    },
+  });
+  const controller = new AbortController();
+  assert.deepEqual(await registration.tool.execute({
+    path: { id: "order 7" },
+    query: { view: "full" },
+    body: { status: "ready" },
+  }, { signal: controller.signal }), { updated: true });
+  assert.equal(requests[0].url, "https://shop.example/api/orders/order%207?view=full");
+  assert.equal(requests[0].options.credentials, "same-origin");
+  assert.equal(requests[0].options.signal, controller.signal);
+  assert.equal(requests[0].options.body, JSON.stringify({ status: "ready" }));
+  publication.close();
+
+  registration = undefined;
+  const unsafe = await publish({
+    version: 1,
+    tools: [{
+      name: "unsafe_fetch",
+      description: "An intentionally invalid cross-origin fixture.",
+      approved: true,
+      annotations: { readOnlyHint: true },
+      implementation: { kind: "fetch", method: "GET", path: "https://other.example/data" },
+    }],
+  }, { document, fetch: () => { throw new Error("must not fetch"); } });
+  await assert.rejects(registration.tool.execute({}), /must stay on https:\/\/shop\.example/);
+  unsafe.close();
+});
+
+test("publisher aborts every attempted registration when publication fails", async () => {
+  const signals = [];
+  const document = { modelContext: {
+    async registerTool(_tool, options) {
+      signals.push(options.signal);
+      if (signals.length === 2) throw new Error("registry rejected second tool");
+    },
+  } };
+  await assert.rejects(publish({ version: 1, tools: [
+    {
+      name: "first",
+      description: "First fixture.",
+      approved: true,
+      implementation: { kind: "custom" },
+    },
+    {
+      name: "second",
+      description: "Second fixture.",
+      approved: true,
+      implementation: { kind: "custom" },
+    },
+  ] }, {
+    document,
+    handlers: { first: () => null, second: () => null },
+  }), /registry rejected second tool/);
+  assert.equal(signals.length, 2);
+  assert.equal(signals.every((signal) => signal.aborted), true);
+});
+
+test("repository generator finds routes, forms, GraphQL, tRPC, and server actions without executing code", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "nanocodex-webmcp-"));
+  try {
+    await mkdir(join(directory, "app", "api", "orders", "[id]"), { recursive: true });
+    await writeFile(join(directory, "app", "api", "orders", "[id]", "route.ts"), `
+      export async function GET() { return Response.json({ ok: true }); }
+      export async function DELETE() { throw new Error("must never execute"); }
+    `);
+    await writeFile(join(directory, "page.html"), `
+      <form id="support" action="/api/support" method="post">
+        <input name="email" type="email" required>
+        <textarea name="message"></textarea>
+      </form>
+    `);
+    await writeFile(join(directory, "client.ts"), `
+      "use server";
+      export async function inviteMember(input: unknown) { return input; }
+      export const archiveMember = async (input: unknown) => input;
+      const GetViewer = gql\`query GetViewer($id: ID!) { viewer { id } }\`;
+      const router = { account: procedure
+        .query(() => ({ id: 1 })) };
+      fetch("/api/search", { method: "POST", body: "{}" });
+    `);
+
+    const manifest = await generate({ root: directory });
+    assert.equal(validate(manifest), true);
+    assert.equal(manifest.tools.every(({ approved }) => approved === false), true);
+    const names = manifest.tools.map(({ name }) => name);
+    assert.equal(names.includes("get_api_orders_id"), true);
+    assert.equal(names.includes("delete_api_orders_id"), true);
+    assert.equal(names.includes("form_support"), true);
+    assert.equal(names.includes("graphql_GetViewer"), true);
+    assert.equal(names.includes("action_inviteMember"), true);
+    assert.equal(names.includes("action_archiveMember"), true);
+    assert.equal(names.includes("trpc_account"), true);
+    assert.equal(names.includes("post_api_search"), true);
+    const encoded = JSON.stringify(manifest);
+    assert.equal(encoded.includes("must never execute"), false);
+
+    const path = join(directory, "webmcp.manifest.json");
+    await writeFile(path, `${JSON.stringify(manifest, null, 2)}\n`);
+    assert.equal(validate(JSON.parse(await readFile(path, "utf8"))), true);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+function registeredTool(name, readOnlyHint) {
+  return {
+    name,
+    title: name,
+    description: `Use ${name}.`,
+    inputSchema: { type: "object", additionalProperties: true },
+    origin: "https://shop.example",
+    annotations: { readOnlyHint, untrustedContentHint: readOnlyHint },
+    window: {},
+  };
+}
+
+function element(tagName, attributes = {}) {
+  const attrs = new Map(Object.entries(attributes)
+    .filter(([name]) => name !== "text")
+    .map(([name, value]) => [name, String(value)]));
+  return {
+    tagName: tagName.toUpperCase(),
+    type: attributes.type ?? "",
+    value: "",
+    checked: false,
+    hidden: false,
+    disabled: false,
+    isConnected: true,
+    innerText: attributes.text ?? "",
+    getAttribute: (name) => attrs.get(name) ?? null,
+    getClientRects: () => [{}],
+    dispatchEvent() {},
+  };
+}
+
+function fakeDocument(actionable, forms) {
+  return {
+    title: "Fixture",
+    location: { href: "https://app.example/settings" },
+    body: { innerText: "Account settings Send" },
+    defaultView: { Event: class { constructor(type) { this.type = type; } } },
+    querySelectorAll(selector) { return selector === "form" ? forms : actionable; },
+  };
+}
+
+async function waitFor(predicate) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.fail("timed out waiting for WebMCP update");
+}

--- a/js/bindings/test/webmcp.test.mjs
+++ b/js/bindings/test/webmcp.test.mjs
@@ -60,6 +60,70 @@ test("WebMCP provider mirrors native tools, preserves session execution, and ref
   assert.equal(listeners.size, 0);
 });
 
+test("mutating WebMCP tools execute only inside the one-time dialog approval", async () => {
+  let pageCalls = 0;
+  let request;
+  let execution;
+  const document = {
+    title: "Sodium Bank",
+    location: { href: "https://sodium.example/accounts", origin: "https://sodium.example" },
+    modelContext: {
+      async getTools() { return [registeredTool("send_transfer", false)]; },
+      async executeTool(_tool, input) {
+        pageCalls += 1;
+        return JSON.stringify({ sent: JSON.parse(input).amount });
+      },
+    },
+  };
+  const provider = await createProvider({
+    document,
+    fallback: false,
+    dialog: {
+      async open(nextRequest, nextExecution) {
+        request = nextRequest;
+        execution = nextExecution;
+        assert.equal(pageCalls, 0);
+        return nextExecution.execute();
+      },
+    },
+  });
+
+  assert.deepEqual(
+    await provider.resolve("web_send_transfer").handler({ amount: "25.00", to: "Ada" }, {}),
+    { sent: "25.00" },
+  );
+  assert.equal(pageCalls, 1);
+  assert.equal(request.type, "webMcpApproval");
+  assert.equal(request.app.name, "Sodium Bank");
+  assert.equal(request.app.origin, "https://sodium.example");
+  assert.equal(request.action.name, "send_transfer");
+  assert.deepEqual(request.action.input, { amount: "25.00", to: "Ada" });
+  assert.equal(typeof execution.execute, "function");
+  provider.close();
+});
+
+test("a rejected WebMCP approval never reaches the website handler", async () => {
+  let pageCalls = 0;
+  const provider = await createProvider({
+    document: {
+      title: "Sodium Bank",
+      location: { href: "https://sodium.example", origin: "https://sodium.example" },
+      modelContext: {
+        async getTools() { return [registeredTool("send_transfer", false)]; },
+        async executeTool() { pageCalls += 1; },
+      },
+    },
+    fallback: false,
+    dialog: { async open() { throw new Error("The request was not approved."); } },
+  });
+  await assert.rejects(
+    provider.resolve("web_send_transfer").handler({ amount: "25.00" }, {}),
+    /not approved/,
+  );
+  assert.equal(pageCalls, 0);
+  provider.close();
+});
+
 test("semantic fallback observes, fills, activates, and submits only retained visible elements", async () => {
   const form = element("form", { name: "support" });
   form.requestSubmit = () => { form.submitted = true; };

--- a/js/bindings/test/worker-agent.test.mjs
+++ b/js/bindings/test/worker-agent.test.mjs
@@ -105,6 +105,74 @@ test("Worker prompt acknowledgement waits for durable turn admission", async () 
   assert.equal(worker.terminated, 1);
 });
 
+test("Worker Agent bridges live page-owned WebMCP tools without cloning their handlers", async () => {
+  const fixture = createFixture();
+  let workerProvider;
+  const createAgent = async (options) => {
+    workerProvider = options[Symbol.for("nanocodex.browser.internalRuntime")].toolProviders[0];
+    return fixture.createAgent(options);
+  };
+  const worker = new LoopbackWorker(createAgent);
+  const listeners = new Set();
+  const calls = [];
+  let definitions = [{
+    type: "function",
+    name: "web_lookup",
+    description: "Look up the current website account.",
+    strict: false,
+    defer_loading: true,
+    parameters: { type: "object", additionalProperties: true },
+  }];
+  let closed = false;
+  const provider = {
+    [Symbol.for("nanocodex.webmcp.provider")]: true,
+    sourceId: "webmcp:fixture",
+    kind: "webmcp",
+    mode: "union",
+    deferred: true,
+    definitions: () => definitions,
+    resolve: (name) => name === "web_lookup" ? {
+      name,
+      parallelSafe: true,
+      handler(input, context) {
+        calls.push({ input, signal: context.signal });
+        return { account: "host-session", input };
+      },
+    } : undefined,
+    async settled() {},
+    subscribe(listener) { listeners.add(listener); return () => listeners.delete(listener); },
+    close() { closed = true; listeners.clear(); },
+  };
+  const agent = await createWorkerAgent({
+    sessionId: "webmcp-worker",
+    harness: false,
+    webMcp: provider,
+  }, { worker });
+
+  assert.deepEqual(workerProvider.definitions().map(({ name }) => name), ["web_lookup"]);
+  const signal = new AbortController().signal;
+  assert.deepEqual(
+    await workerProvider.resolve("web_lookup").handler({ id: 42 }, {
+      callId: "call-1",
+      parentCallId: "",
+      sessionId: "webmcp-worker",
+      signal,
+    }),
+    { account: "host-session", input: { id: 42 } },
+  );
+  assert.equal(calls[0].signal instanceof AbortSignal, true);
+
+  definitions = [{ ...definitions[0], name: "web_replacement" }];
+  for (const listener of listeners) listener(definitions);
+  await tick();
+  assert.deepEqual(workerProvider.definitions().map(({ name }) => name), ["web_replacement"]);
+  assert.equal(workerProvider.resolve("web_lookup"), undefined);
+
+  agent.dispose();
+  assert.equal(closed, true);
+  assert.equal(worker.terminated, 1);
+});
+
 test("Worker Agent retains and proxies the Rust browser voice handle", async () => {
   const fixture = createFixture();
   const worker = new LoopbackWorker(fixture.createAgent);

--- a/js/bindings/tools/Tools.d.mts
+++ b/js/bindings/tools/Tools.d.mts
@@ -36,6 +36,21 @@ export type Tools = Readonly<{
   close(): Promise<void>;
 }>;
 
+export type ToolProvider = Readonly<{
+  sourceId?: string | undefined;
+  kind?: string | undefined;
+  mode?: "union" | "attached-over-cloud" | undefined;
+  deferred?: boolean | undefined;
+  definitions(): readonly Record<string, unknown>[];
+  resolve(name: string): Readonly<{
+    name: string;
+    parallelSafe?: boolean | undefined;
+    handler(input: unknown, context: import("../types.mjs").ToolContext): unknown | Promise<unknown>;
+  }> | undefined;
+  settled?(): void | Promise<void>;
+  close?(): void | Promise<void>;
+}>;
+
 /**
  * Creates one owned tool runtime. Caller-supplied tool ownership transfers only
  * after this promise resolves; a rejected construction leaves those tools with
@@ -48,4 +63,6 @@ export function createTools(options?: {
   workspaceOptions?: { maxEntries?: number; maxReadBytes?: number; maxWriteBytes?: number };
   mcp?: McpServers | false;
   mcpOptions?: Readonly<Record<string, unknown>>;
+  /** Dynamic caller-owned capability sources such as the embedding page's WebMCP registry. */
+  providers?: readonly ToolProvider[] | undefined;
 }): Promise<Tools>;

--- a/js/bindings/tools/Tools.mjs
+++ b/js/bindings/tools/Tools.mjs
@@ -24,6 +24,7 @@ export async function createTools(options = {}) {
   );
   if (resolved.subagents) throw new TypeError("createTools does not accept agent-relative extensions");
   const custom = resolved.tools;
+  const providerIds = [];
   let mcp;
   try {
     if (Object.keys(custom).length) {
@@ -36,18 +37,37 @@ export async function createTools(options = {}) {
         { kind: "cloud" },
       ));
     }
+    for (const [index, provider] of (options.providers ?? []).entries()) {
+      const sourceId = provider.sourceId ?? `provider:${String(index).padStart(8, "0")}`;
+      router.addSource(providerSource(
+        sourceId,
+        provider,
+        {
+          kind: provider.kind ?? "union",
+          mode: provider.mode ?? "union",
+          deferred: provider.deferred,
+        },
+      ));
+      providerIds.push(sourceId);
+    }
     if (options.mcp !== undefined && options.mcp !== false) {
       const { createMcpRuntime } = await import("../runtime/mcp-runtime.mjs");
       mcp = await createMcpRuntime(options.mcp, options.mcpOptions);
       router.addSource(providerSource("mcp", mcp, { kind: "mcp" }));
     }
+    await Promise.all((options.providers ?? []).map((provider) => provider.settled?.()));
   } catch (error) {
-    if (!mcp) throw error;
-    try { await mcp.close(); }
-    catch (cleanupError) {
+    const cleanup = [
+      ...providerIds.map((sourceId) => router.detachSource(sourceId)),
+      ...(mcp ? [mcp.close()] : []),
+    ];
+    const failures = (await Promise.allSettled(cleanup))
+      .filter((result) => result.status === "rejected")
+      .map((result) => result.reason);
+    if (failures.length) {
       throw new AggregateError(
-        [error, cleanupError],
-        "Tools construction and MCP cleanup failed",
+        [error, ...failures],
+        "Tools construction and provider cleanup failed",
       );
     }
     throw error;
@@ -114,7 +134,7 @@ function validateOptions(options) {
   if (!options || typeof options !== "object" || Array.isArray(options)) {
     throw new TypeError("createTools options must be an object");
   }
-  const allowed = new Set(["tools", "workspace", "workspaceOptions", "mcp", "mcpOptions"]);
+  const allowed = new Set(["tools", "workspace", "workspaceOptions", "mcp", "mcpOptions", "providers"]);
   for (const name of Object.keys(options)) {
     if (!allowed.has(name)) throw new TypeError(`unsupported createTools option: ${name}`);
   }
@@ -123,5 +143,8 @@ function validateOptions(options) {
   }
   if ((options.mcp === undefined || options.mcp === false) && options.mcpOptions !== undefined) {
     throw new TypeError("mcpOptions requires mcp");
+  }
+  if (options.providers !== undefined && !Array.isArray(options.providers)) {
+    throw new TypeError("providers must be an array");
   }
 }

--- a/js/bindings/tools/index.d.mts
+++ b/js/bindings/tools/index.d.mts
@@ -44,5 +44,6 @@ export type {
   AttachmentSocket,
   AttachmentTarget,
   AttachmentTransport,
+  ToolProvider,
   Tools,
 } from "./Tools.mjs";

--- a/js/bindings/vite/auto-webmcp-client.d.mts
+++ b/js/bindings/vite/auto-webmcp-client.d.mts
@@ -1,0 +1,26 @@
+import type { Config } from "../browser/config.mjs";
+import type { ConnectAgent, Connection } from "../cloud/types.mjs";
+import type { WebMcpManifest } from "../webmcp/WebMcp.mjs";
+
+export const automaticWebMcpConfig: Config<ConnectAgent>;
+export function automaticWebMcpConnection(): Connection | undefined;
+
+export type AutomaticWebMcpReady = Readonly<{
+  agent: ConnectAgent;
+  connection: Connection;
+  manifest: WebMcpManifest;
+  publication: Readonly<{ tools: readonly string[]; close(): void }>;
+}>;
+
+export function startAutomaticWebMcp(options?: Readonly<{
+  endpoint?: string | undefined;
+  fetch?: typeof globalThis.fetch | undefined;
+  client?: import("../cloud/Client.mjs").Client | undefined;
+}>): Promise<AutomaticWebMcpReady>;
+
+export function prepareAutomaticWebMcp(options?: Readonly<{
+  endpoint?: string | undefined;
+  fetch?: typeof globalThis.fetch | undefined;
+  client?: import("../cloud/Client.mjs").Client | undefined;
+  force?: boolean | undefined;
+}>): Promise<AutomaticWebMcpReady>;

--- a/js/bindings/vite/auto-webmcp-client.mjs
+++ b/js/bindings/vite/auto-webmcp-client.mjs
@@ -1,0 +1,186 @@
+import { Client, Dialog, Transport } from "../cloud/index.mjs";
+import { publish } from "../webmcp/WebMcp.mjs";
+
+const DEFAULT_ENDPOINT = "/__nanocodex/webmcp";
+const DEFAULT_RESOURCES = Object.freeze([
+  "urn:nanocodex:agent:run",
+  "urn:nanocodex:agent:output:final",
+]);
+const listeners = new Set();
+let generation;
+let generationId = 0;
+let active;
+let snapshot = Object.freeze({ data: undefined, error: undefined, status: "pending" });
+
+/** Config consumed directly by nanocodex-react/vite; no application harness is required. */
+export const automaticWebMcpConfig = Object.freeze({
+  subscribeAgent(resource, listener) {
+    if (resource?.enabled === false) return () => {};
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+  getAgent(resource) {
+    return resource?.enabled === false
+      ? Object.freeze({ data: undefined, error: undefined, status: "idle" })
+      : snapshot;
+  },
+  refetchAgent() { void prepareAutomaticWebMcp({ force: true }).catch(() => {}); },
+  async destroy() {
+    generationId += 1;
+    await closeActive();
+    generation = undefined;
+    publishSnapshot(Object.freeze({ data: undefined, error: undefined, status: "idle" }));
+  },
+});
+
+/** Returns the signed connection that owns the current automatic Agent. */
+export function automaticWebMcpConnection() {
+  return active?.connection;
+}
+
+/** Starts at most one automatic generation/attachment lifecycle for this page. */
+export async function prepareAutomaticWebMcp(options = {}) {
+  if (generation && (options.force !== true || snapshot.status === "pending")) return generation;
+  if (options.force === true) await closeActive();
+  const id = ++generationId;
+  publishSnapshot(Object.freeze({ data: undefined, error: undefined, status: "pending" }));
+  const { force: _force, ...startOptions } = options;
+  generation = startAutomaticWebMcp(startOptions).then(async (ready) => {
+    if (id !== generationId) {
+      ready.publication.close?.();
+      await ready.agent.session.shutdown?.();
+      throw new Error("automatic WebMCP generation was superseded");
+    }
+    active = ready;
+    publishSnapshot(Object.freeze({ data: ready.agent, error: undefined, status: "success" }));
+    return ready;
+  }, (error) => {
+    if (id === generationId) {
+      publishSnapshot(Object.freeze({ data: undefined, error, status: "error" }));
+    }
+    throw error;
+  });
+  return generation;
+}
+
+async function closeActive() {
+  const current = active;
+  active = undefined;
+  current?.publication.close?.();
+  await current?.agent.session.shutdown?.();
+}
+
+/**
+ * Runs the Vite-owned development generator in the authenticated application
+ * page. Accounts remains the only identity and provider UI; neither tokens nor
+ * the generated Agent cross into the Vite process.
+ */
+export async function startAutomaticWebMcp(options = {}) {
+  const endpoint = options.endpoint ?? DEFAULT_ENDPOINT;
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  if (typeof fetchImpl !== "function") throw new TypeError("automatic WebMCP requires fetch");
+  const draft = await requestJson(fetchImpl, endpoint);
+  if (!draft?.manifest || typeof draft.sourceRevision !== "string") {
+    throw new Error("Nanocodex Vite returned no WebMCP generation draft");
+  }
+
+  const client = options.client ?? createConnectClient({
+    appId: draft.appId,
+    apiUrl: draft.apiUrl,
+    dialogHost: draft.dialogHost,
+  });
+  const connectionRequest = Object.freeze({
+    capabilities: Object.freeze({
+      agent: Object.freeze({ finalMessages: true }),
+      cloudAccounts: Object.freeze({ chatgpt: true }),
+    }),
+  });
+  let connection = await client.connection.reconnect(connectionRequest);
+  if (!connection) connection = await client.connection.connect(connectionRequest);
+
+  const agent = await client.agent.create({
+    connection,
+    webMcp: {
+      fallback: "when-empty",
+      dialog: client.dialog,
+    },
+  });
+  let manifest = draft.generated;
+  if (!manifest) {
+    const turn = agent.turn.prompt({ input: generatorPrompt(draft.manifest) });
+    const result = await turn.result();
+    const proposed = parseManifest(result.finalMessage, draft.sourceRevision);
+    manifest = await requestJson(fetchImpl, endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        sourceRevision: draft.sourceRevision,
+        manifest: proposed,
+      }),
+    });
+  }
+  const publication = await (options.publish ?? publish)(manifest);
+  const ready = Object.freeze({ agent, connection, manifest, publication });
+  if (typeof globalThis.CustomEvent === "function") {
+    globalThis.dispatchEvent?.(new CustomEvent("nanocodex:webmcp-ready", { detail: ready }));
+  }
+  return ready;
+}
+
+function createConnectClient({ appId, apiUrl, dialogHost }) {
+  const baseUrl = apiUrl ?? Transport.DEFAULT_API_URL;
+  return Client.create({
+    appId,
+    auth: {
+      challenge: `${baseUrl.replace(/\/$/, "")}/v1/connect/auth/challenge`,
+      verify: `${baseUrl.replace(/\/$/, "")}/v1/connect/auth`,
+      logout: `${baseUrl.replace(/\/$/, "")}/v1/connect/auth/logout`,
+      resources: DEFAULT_RESOURCES,
+      returnToken: true,
+    },
+    dialog: Dialog.iframe(dialogHost ? { host: dialogHost } : {}),
+    transport: Transport.http(baseUrl),
+  });
+}
+
+function generatorPrompt(draft) {
+  return [
+    "You are the WebMCP generator embedded in this running website.",
+    "Use web_page_observe to understand the visible product and the supplied source-derived candidates.",
+    "Return only one JSON WebMCP manifest. Do not use Markdown fences.",
+    "Keep version 1, sourceRevision, every implementation and every evidence entry exactly unchanged.",
+    "You may remove false-positive candidates and improve names, titles, descriptions, schemas, and annotations.",
+    "Set approved=true only for tools that correspond to a real user-facing operation you can establish from the page or source evidence.",
+    "Mutating tools remain protected by Nanocodex's per-call approval dialog even when published.",
+    JSON.stringify(draft),
+  ].join("\n\n");
+}
+
+function parseManifest(message, sourceRevision) {
+  if (typeof message !== "string" || !message.trim()) {
+    throw new Error("Nanocodex returned an empty WebMCP manifest");
+  }
+  let value;
+  try { value = JSON.parse(message.trim()); }
+  catch (error) {
+    throw new Error("Nanocodex returned invalid WebMCP JSON", { cause: error });
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)
+      || value.version !== 1 || value.sourceRevision !== sourceRevision
+      || !Array.isArray(value.tools)) {
+    throw new Error("Nanocodex returned a WebMCP manifest for the wrong source revision");
+  }
+  return value;
+}
+
+async function requestJson(fetchImpl, input, init) {
+  const response = await fetchImpl(input, init);
+  const body = await response.json().catch(() => undefined);
+  if (!response.ok) throw new Error(body?.error ?? `Nanocodex Vite request failed with ${response.status}`);
+  return body;
+}
+
+function publishSnapshot(value) {
+  snapshot = value;
+  for (const listener of [...listeners]) listener();
+}

--- a/js/bindings/vite/cloudflare-plugin.mjs
+++ b/js/bindings/vite/cloudflare-plugin.mjs
@@ -4,7 +4,7 @@ import { createNanocodexVitePlugin } from "./plugin.mjs";
 export function createNanocodexCloudflarePlugins(options, cloudflare) {
   let devBindings;
   const core = createNanocodexVitePlugin(
-    { chatGpt: options.chatGpt },
+    { chatGpt: options.chatGpt, webMcp: options.webMcp },
     {
       target: "cloudflare",
       setDevBindings(value) {

--- a/js/bindings/vite/cloudflare.d.mts
+++ b/js/bindings/vite/cloudflare.d.mts
@@ -1,13 +1,15 @@
 import type { PluginConfig } from "@cloudflare/vite-plugin";
 import type { PluginOption } from "vite";
 
-import type { NanocodexChatGptViteOptions } from "./index.mjs";
+import type { NanocodexChatGptViteOptions, NanocodexViteOptions } from "./index.mjs";
 
 export type NanocodexCloudflareViteOptions = Readonly<{
   /** Cloudflare Vite plugin options. Nanocodex adds only exact development credential bindings. */
   cloudflare?: PluginConfig | undefined;
   /** Local ChatGPT subscription support is on by default; pass false to disable it. */
   chatGpt?: Pick<NanocodexChatGptViteOptions, "authFile"> | false | undefined;
+  /** Generate and continuously reconcile a review-first WebMCP manifest. */
+  webMcp?: NanocodexViteOptions["webMcp"];
 }>;
 
 /** One call installs browser shims, local subscription brokering, and the Cloudflare Worker plugin. */

--- a/js/bindings/vite/index.d.mts
+++ b/js/bindings/vite/index.d.mts
@@ -8,14 +8,22 @@ export type NanocodexChatGptViteOptions = Readonly<{
 export type NanocodexViteOptions = Readonly<{
   /** Local ChatGPT subscription support is on by default; pass false to disable it. */
   chatGpt?: NanocodexChatGptViteOptions | false | undefined;
-  /** Generate and continuously reconcile a review-first WebMCP manifest. */
-  webMcp?: true | import("../webmcp/generator.mjs").GenerateWebMcpManifestOptions | false | undefined;
+  /**
+   * Automatic WebMCP generation is on by default. During development the
+   * authenticated browser Agent verifies source-derived candidates against the
+   * live page; pass false to disable the complete integration.
+   */
+  webMcp?: true | (import("../webmcp/generator.mjs").GenerateWebMcpManifestOptions & Readonly<{
+    automatic?: boolean | undefined;
+  }>) | false | undefined;
 }>;
 
 export type NanocodexVitePlugin = Readonly<{
   name: "nanocodex";
   enforce: "pre";
   resolveId(source: string, importer?: string): string | null;
+  load(id: string): string | null;
+  transformIndexHtml(): unknown;
   configResolved(config: Readonly<{ root?: string; logger?: unknown }>): void;
   config(config: unknown, environment: Readonly<{ command: "build" | "serve" }>): unknown | Promise<unknown>;
   configureServer(server: unknown): void | Promise<void>;

--- a/js/bindings/vite/index.d.mts
+++ b/js/bindings/vite/index.d.mts
@@ -8,14 +8,18 @@ export type NanocodexChatGptViteOptions = Readonly<{
 export type NanocodexViteOptions = Readonly<{
   /** Local ChatGPT subscription support is on by default; pass false to disable it. */
   chatGpt?: NanocodexChatGptViteOptions | false | undefined;
+  /** Generate and continuously reconcile a review-first WebMCP manifest. */
+  webMcp?: true | import("../webmcp/generator.mjs").GenerateWebMcpManifestOptions | false | undefined;
 }>;
 
 export type NanocodexVitePlugin = Readonly<{
   name: "nanocodex";
   enforce: "pre";
   resolveId(source: string, importer?: string): string | null;
+  configResolved(config: Readonly<{ root?: string; logger?: unknown }>): void;
   config(config: unknown, environment: Readonly<{ command: "build" | "serve" }>): unknown | Promise<unknown>;
   configureServer(server: unknown): void | Promise<void>;
+  buildStart(): void | Promise<void>;
   closeBundle(): void | Promise<void>;
 }>;
 

--- a/js/bindings/vite/plugin.mjs
+++ b/js/bindings/vite/plugin.mjs
@@ -1,9 +1,13 @@
 import { randomBytes } from "node:crypto";
-import { extname, relative, resolve, sep } from "node:path";
+import { mkdir, rename, unlink, writeFile } from "node:fs/promises";
+import { basename, dirname, extname, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { nanocodexTools } from "../tools/vite.mjs";
-import { generateFile as generateWebMcpManifest } from "../webmcp/generator.mjs";
+import {
+  generateFile as generateWebMcpManifest,
+  validate as validateWebMcpManifest,
+} from "../webmcp/generator.mjs";
 import { chatGptSubscription } from "./chatgpt-subscription.mjs";
 import { defaultCodexAuthFile, readCodexSubscription } from "./codex-auth-file.mjs";
 import { startChatGptWorkerEgress } from "./chatgpt-egress.mjs";
@@ -23,6 +27,8 @@ export function createNanocodexVitePlugin(options, integration) {
   let webMcpWatch;
   let webMcpGeneration;
   let webMcpQueued = false;
+  let webMcpResult;
+  let development = false;
 
   const cleanup = () => cleanupPromise ??= (async () => {
     if (webMcpTimer) clearTimeout(webMcpTimer);
@@ -41,12 +47,32 @@ export function createNanocodexVitePlugin(options, integration) {
   return {
     name: "nanocodex",
     enforce: "pre",
-    resolveId: tools.resolveId,
+    resolveId(source, importer) {
+      if (source === AUTOMATIC_WEBMCP_MODULE) return AUTOMATIC_WEBMCP_RESOLVED;
+      if (source === AUTOMATIC_WEBMCP_CLIENT) return automaticWebMcpClient;
+      return tools.resolveId(source, importer);
+    },
+    load(id) {
+      if (id !== AUTOMATIC_WEBMCP_RESOLVED) return null;
+      return [
+        `import { prepareAutomaticWebMcp } from ${JSON.stringify(AUTOMATIC_WEBMCP_CLIENT)};`,
+        "prepareAutomaticWebMcp().catch((error) => console.error('[nanocodex] automatic WebMCP generation failed', error));",
+      ].join("\n");
+    },
+    transformIndexHtml() {
+      if (!development || !automaticWebMcp(options)) return undefined;
+      return [{
+        tag: "script",
+        attrs: { type: "module", src: `/@id/${AUTOMATIC_WEBMCP_MODULE}` },
+        injectTo: "body",
+      }];
+    },
     configResolved(config) {
       viteRoot = resolve(config.root ?? process.cwd());
       viteLogger = config.logger;
     },
     async config(config, environment) {
+      development = environment.command === "serve";
       const nestedWorker = workerPlugins(config.worker?.plugins);
       if (
         integration.target !== "cloudflare"
@@ -89,6 +115,7 @@ export function createNanocodexVitePlugin(options, integration) {
     async configureServer(vite) {
       await updateWebMcpManifest();
       watchWebMcp(vite);
+      configureAutomaticWebMcp(vite);
       if (integration.target === "vite") {
         await direct?.configureServer(vite);
         return;
@@ -108,12 +135,12 @@ export function createNanocodexVitePlugin(options, integration) {
   };
 
   async function updateWebMcpManifest() {
-    if (options.webMcp === undefined || options.webMcp === false) return;
+    if (options.webMcp === false) return;
     if (webMcpGeneration) {
       webMcpQueued = true;
       return webMcpGeneration;
     }
-    const configured = options.webMcp === true ? {} : options.webMcp;
+    const configured = generationOptions(options.webMcp);
     if (!configured || typeof configured !== "object" || Array.isArray(configured)) {
       throw new TypeError("Nanocodex Vite webMcp must be true, false, or an options object");
     }
@@ -122,6 +149,7 @@ export function createNanocodexVitePlugin(options, integration) {
       ...configured,
       root,
     }).then((result) => {
+      webMcpResult = result;
       if (result.changed) {
         viteLogger?.info?.(
           `[nanocodex] generated ${relative(viteRoot, result.path)} (${result.manifest.tools.length} review-required tools)`,
@@ -139,8 +167,8 @@ export function createNanocodexVitePlugin(options, integration) {
   }
 
   function watchWebMcp(vite) {
-    if (options.webMcp === undefined || options.webMcp === false || webMcpWatch) return;
-    const configured = options.webMcp === true ? {} : options.webMcp;
+    if (options.webMcp === false || webMcpWatch) return;
+    const configured = generationOptions(options.webMcp);
     const root = resolve(viteRoot, configured.root ?? ".");
     const output = resolve(root, configured.output ?? "webmcp.manifest.json");
     const changed = (path) => {
@@ -151,7 +179,11 @@ export function createNanocodexVitePlugin(options, integration) {
       if (webMcpTimer) clearTimeout(webMcpTimer);
       webMcpTimer = setTimeout(() => {
         webMcpTimer = undefined;
-        void updateWebMcpManifest().catch((error) => vite.config.logger.error(errorMessage(error)));
+        void updateWebMcpManifest().then((result) => {
+          if (automaticWebMcp(options) && result?.changed) {
+            vite.ws?.send?.({ type: "full-reload" });
+          }
+        }).catch((error) => vite.config.logger.error(errorMessage(error)));
       }, 50);
     };
     vite.watcher.on("add", changed);
@@ -163,12 +195,141 @@ export function createNanocodexVitePlugin(options, integration) {
       vite.watcher.off("unlink", changed);
     };
   }
+
+  function configureAutomaticWebMcp(vite) {
+    if (!automaticWebMcp(options)) return;
+    if (typeof vite.middlewares?.use !== "function") {
+      throw new TypeError("Nanocodex automatic WebMCP requires Vite middleware support");
+    }
+    vite.middlewares.use(AUTOMATIC_WEBMCP_ENDPOINT, async (request, response) => {
+      try {
+        if (request.method === "GET") {
+          const result = webMcpResult ?? await updateWebMcpManifest();
+          const generated = result.manifest.generatedBy === "nanocodex-agent"
+            ? result.manifest
+            : undefined;
+          return json(response, 200, {
+            appId: developmentAppId(viteRoot),
+            sourceRevision: result.manifest.sourceRevision,
+            manifest: result.manifest,
+            ...(generated === undefined ? {} : { generated }),
+          });
+        }
+        if (request.method !== "POST") return json(response, 405, { error: "method not allowed" });
+        const body = await readJson(request);
+        const current = webMcpResult ?? await updateWebMcpManifest();
+        if (body?.sourceRevision !== current.manifest.sourceRevision) {
+          return json(response, 409, { error: "website source changed during WebMCP generation" });
+        }
+        validateWebMcpManifest(body.manifest);
+        const manifest = verifiedAgentManifest(current.manifest, body.manifest);
+        await writeManifest(current.path, manifest);
+        webMcpResult = Object.freeze({ changed: true, manifest, path: current.path });
+        vite.config.logger.info(
+          `[nanocodex] verified ${relative(viteRoot, current.path)} with the authenticated browser Agent (${manifest.tools.length} tools)`,
+        );
+        return json(response, 200, manifest);
+      } catch (error) {
+        vite.config.logger.error(errorMessage(error));
+        return json(response, 400, { error: errorMessage(error) });
+      }
+    });
+  }
+}
+
+function generationOptions(webMcp) {
+  if (webMcp === undefined || webMcp === true) return {};
+  if (!webMcp || typeof webMcp !== "object" || Array.isArray(webMcp)) {
+    throw new TypeError("Nanocodex Vite webMcp must be true, false, or an options object");
+  }
+  const { automatic: _automatic, ...generation } = webMcp;
+  return generation;
+}
+
+function automaticWebMcp(options) {
+  return options.webMcp !== false && options.webMcp?.automatic !== false;
+}
+
+function verifiedAgentManifest(draft, proposed) {
+  if (proposed.sourceRevision !== draft.sourceRevision) {
+    throw new Error("Nanocodex returned a manifest for the wrong source revision");
+  }
+  const candidates = new Map(draft.tools.map((tool) => [
+    JSON.stringify(tool.implementation),
+    tool,
+  ]));
+  const tools = proposed.tools.map((tool) => {
+    const implementation = JSON.stringify(tool.implementation);
+    const candidate = candidates.get(implementation);
+    if (!candidate || JSON.stringify(tool.evidence) !== JSON.stringify(candidate.evidence)) {
+      throw new Error(`Nanocodex changed source-owned execution evidence for ${tool.name}`);
+    }
+    candidates.delete(implementation);
+    return Object.freeze({
+      ...tool,
+      annotations: candidate.annotations,
+      // The automatic browser publisher cannot supply application-owned
+      // handlers. Preserve custom candidates for review, but never expose an
+      // invocation that would only fail at call time.
+      approved: tool.approved === true && candidate.implementation.kind !== "custom",
+    });
+  });
+  return Object.freeze({
+    ...proposed,
+    generatedAt: new Date().toISOString(),
+    generatedBy: "nanocodex-agent",
+    root: ".",
+    sourceRevision: draft.sourceRevision,
+    tools: Object.freeze(tools),
+  });
+}
+
+async function writeManifest(path, manifest) {
+  await mkdir(dirname(path), { recursive: true });
+  const temporary = join(dirname(path), `.${basename(path)}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`);
+  try {
+    await writeFile(temporary, `${JSON.stringify(manifest, null, 2)}\n`, { flag: "wx" });
+    await rename(temporary, path);
+  } finally {
+    await unlink(temporary).catch((error) => {
+      if (error?.code !== "ENOENT") throw error;
+    });
+  }
+}
+
+function developmentAppId(root) {
+  const name = basename(root).replace(/[^A-Za-z0-9._:-]+/g, "-").replace(/^-+|-+$/g, "") || "website";
+  return `webmcp-dev:${name}`.slice(0, 128);
+}
+
+async function readJson(request) {
+  const chunks = [];
+  let bytes = 0;
+  for await (const chunk of request) {
+    bytes += chunk.length;
+    if (bytes > 2_000_000) throw new Error("automatic WebMCP result exceeds 2 MB");
+    chunks.push(chunk);
+  }
+  try { return JSON.parse(Buffer.concat(chunks).toString("utf8")); }
+  catch (error) { throw new Error("automatic WebMCP result is invalid JSON", { cause: error }); }
+}
+
+function json(response, status, value) {
+  response.statusCode = status;
+  response.setHeader("content-type", "application/json; charset=utf-8");
+  response.setHeader("cache-control", "no-store");
+  response.end(JSON.stringify(value));
 }
 
 const WEBMCP_SOURCE_EXTENSIONS = new Set([
   ".cjs", ".gql", ".graphql", ".htm", ".html", ".js", ".json",
   ".jsx", ".mjs", ".ts", ".tsx", ".yaml", ".yml",
 ]);
+const AUTOMATIC_WEBMCP_MODULE = "virtual:nanocodex-webmcp";
+const AUTOMATIC_WEBMCP_RESOLVED = `\0${AUTOMATIC_WEBMCP_MODULE}`;
+const AUTOMATIC_WEBMCP_CLIENT = "virtual:nanocodex-webmcp-client";
+const AUTOMATIC_WEBMCP_ENDPOINT = "/__nanocodex/webmcp";
+const automaticWebMcpClient = fileURLToPath(new URL("./auto-webmcp-client.mjs", import.meta.url));
 
 function workerPlugins(existing) {
   return () => {

--- a/js/bindings/vite/plugin.mjs
+++ b/js/bindings/vite/plugin.mjs
@@ -1,7 +1,9 @@
 import { randomBytes } from "node:crypto";
+import { extname, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { nanocodexTools } from "../tools/vite.mjs";
+import { generateFile as generateWebMcpManifest } from "../webmcp/generator.mjs";
 import { chatGptSubscription } from "./chatgpt-subscription.mjs";
 import { defaultCodexAuthFile, readCodexSubscription } from "./codex-auth-file.mjs";
 import { startChatGptWorkerEgress } from "./chatgpt-egress.mjs";
@@ -15,8 +17,18 @@ export function createNanocodexVitePlugin(options, integration) {
   let workerAuth;
   let egress;
   let cleanupPromise;
+  let viteRoot = process.cwd();
+  let viteLogger;
+  let webMcpTimer;
+  let webMcpWatch;
+  let webMcpGeneration;
+  let webMcpQueued = false;
 
   const cleanup = () => cleanupPromise ??= (async () => {
+    if (webMcpTimer) clearTimeout(webMcpTimer);
+    webMcpTimer = undefined;
+    webMcpWatch?.();
+    webMcpWatch = undefined;
     try {
       await egress?.close();
     } finally {
@@ -30,6 +42,10 @@ export function createNanocodexVitePlugin(options, integration) {
     name: "nanocodex",
     enforce: "pre",
     resolveId: tools.resolveId,
+    configResolved(config) {
+      viteRoot = resolve(config.root ?? process.cwd());
+      viteLogger = config.logger;
+    },
     async config(config, environment) {
       const nestedWorker = workerPlugins(config.worker?.plugins);
       if (
@@ -71,6 +87,8 @@ export function createNanocodexVitePlugin(options, integration) {
       return { worker: { plugins: nestedWorker } };
     },
     async configureServer(vite) {
+      await updateWebMcpManifest();
+      watchWebMcp(vite);
       if (integration.target === "vite") {
         await direct?.configureServer(vite);
         return;
@@ -81,11 +99,76 @@ export function createNanocodexVitePlugin(options, integration) {
       );
       vite.httpServer?.once("close", () => { void cleanup(); });
     },
+    async buildStart() {
+      await updateWebMcpManifest();
+    },
     async closeBundle() {
       await cleanup();
     },
   };
+
+  async function updateWebMcpManifest() {
+    if (options.webMcp === undefined || options.webMcp === false) return;
+    if (webMcpGeneration) {
+      webMcpQueued = true;
+      return webMcpGeneration;
+    }
+    const configured = options.webMcp === true ? {} : options.webMcp;
+    if (!configured || typeof configured !== "object" || Array.isArray(configured)) {
+      throw new TypeError("Nanocodex Vite webMcp must be true, false, or an options object");
+    }
+    const root = resolve(viteRoot, configured.root ?? ".");
+    webMcpGeneration = generateWebMcpManifest({
+      ...configured,
+      root,
+    }).then((result) => {
+      if (result.changed) {
+        viteLogger?.info?.(
+          `[nanocodex] generated ${relative(viteRoot, result.path)} (${result.manifest.tools.length} review-required tools)`,
+        );
+      }
+      return result;
+    }).finally(async () => {
+      webMcpGeneration = undefined;
+      if (webMcpQueued) {
+        webMcpQueued = false;
+        await updateWebMcpManifest();
+      }
+    });
+    return webMcpGeneration;
+  }
+
+  function watchWebMcp(vite) {
+    if (options.webMcp === undefined || options.webMcp === false || webMcpWatch) return;
+    const configured = options.webMcp === true ? {} : options.webMcp;
+    const root = resolve(viteRoot, configured.root ?? ".");
+    const output = resolve(root, configured.output ?? "webmcp.manifest.json");
+    const changed = (path) => {
+      const absolute = resolve(path);
+      const local = relative(root, absolute);
+      if (absolute === output || local.startsWith(`..${sep}`) || local === ".."
+          || !WEBMCP_SOURCE_EXTENSIONS.has(extname(absolute).toLowerCase())) return;
+      if (webMcpTimer) clearTimeout(webMcpTimer);
+      webMcpTimer = setTimeout(() => {
+        webMcpTimer = undefined;
+        void updateWebMcpManifest().catch((error) => vite.config.logger.error(errorMessage(error)));
+      }, 50);
+    };
+    vite.watcher.on("add", changed);
+    vite.watcher.on("change", changed);
+    vite.watcher.on("unlink", changed);
+    webMcpWatch = () => {
+      vite.watcher.off("add", changed);
+      vite.watcher.off("change", changed);
+      vite.watcher.off("unlink", changed);
+    };
+  }
 }
+
+const WEBMCP_SOURCE_EXTENSIONS = new Set([
+  ".cjs", ".gql", ".graphql", ".htm", ".html", ".js", ".json",
+  ".jsx", ".mjs", ".ts", ".tsx", ".yaml", ".yml",
+]);
 
 function workerPlugins(existing) {
   return () => {

--- a/js/bindings/webmcp/WebMcp.d.mts
+++ b/js/bindings/webmcp/WebMcp.d.mts
@@ -1,0 +1,79 @@
+import type { ToolContext } from "../types.mjs";
+
+export type WebMcpActionRequest = Readonly<{
+  kind: "webmcp" | "semantic" | "published";
+  name: string;
+  title?: string | undefined;
+  origin?: string | undefined;
+  input: unknown;
+  readOnly: false;
+  element?: Readonly<Record<string, unknown>> | undefined;
+}>;
+
+export type WebMcpProviderOptions = Readonly<{
+  document?: Document | undefined;
+  native?: true | false | "require" | undefined;
+  fallback?: true | false | "always" | "when-empty" | "never" | undefined;
+  fromOrigins?: readonly string[] | undefined;
+  sourceId?: string | undefined;
+  maxElements?: number | undefined;
+  maxTextChars?: number | undefined;
+  confirm?(request: WebMcpActionRequest): boolean | Promise<boolean>;
+}>;
+
+export type WebMcpToolProvider = Readonly<{
+  sourceId: string;
+  kind: "webmcp";
+  mode: "union";
+  deferred: true;
+  definitions(): readonly Record<string, unknown>[];
+  resolve(name: string): Readonly<{
+    name: string;
+    parallelSafe: boolean;
+    handler(input: unknown, context: ToolContext): unknown | Promise<unknown>;
+  }> | undefined;
+  settled(): Promise<void>;
+  refresh(): Promise<void>;
+  subscribe(listener: (definitions: readonly Record<string, unknown>[]) => void): () => void;
+  close(): void;
+}>;
+
+export type GeneratedWebMcpTool = Readonly<{
+  name: string;
+  title?: string | undefined;
+  description: string;
+  approved: boolean;
+  inputSchema?: Record<string, unknown> | undefined;
+  annotations?: Readonly<{
+    readOnlyHint?: boolean | undefined;
+    untrustedContentHint?: boolean | undefined;
+  }> | undefined;
+  implementation?: Readonly<{
+    kind: "fetch" | "form" | "custom";
+    method?: string | undefined;
+    path?: string | undefined;
+    selector?: string | undefined;
+  }> | undefined;
+  evidence?: readonly Readonly<Record<string, unknown>>[] | undefined;
+}>;
+
+export type WebMcpManifest = Readonly<{
+  version: number;
+  generatedAt?: string | undefined;
+  tools: readonly GeneratedWebMcpTool[];
+}>;
+
+export function createProvider(options?: WebMcpProviderOptions): Promise<WebMcpToolProvider>;
+export function isProvider(value: unknown): value is WebMcpToolProvider;
+
+export function publish(manifest: WebMcpManifest, options?: {
+  document?: Document | undefined;
+  exposedTo?: readonly string[] | undefined;
+  baseUrl?: string | URL | undefined;
+  fetch?: typeof globalThis.fetch | undefined;
+  handlers?: Readonly<Record<string, (input: unknown, context: { signal: AbortSignal }) => unknown | Promise<unknown>>> | undefined;
+  confirm?(request: WebMcpActionRequest): boolean | Promise<boolean>;
+}): Promise<Readonly<{
+  tools: readonly string[];
+  close(): void;
+}>>;

--- a/js/bindings/webmcp/WebMcp.d.mts
+++ b/js/bindings/webmcp/WebMcp.d.mts
@@ -4,6 +4,7 @@ export type WebMcpActionRequest = Readonly<{
   kind: "webmcp" | "semantic" | "published";
   name: string;
   title?: string | undefined;
+  description?: string | undefined;
   origin?: string | undefined;
   input: unknown;
   readOnly: false;
@@ -18,6 +19,14 @@ export type WebMcpProviderOptions = Readonly<{
   sourceId?: string | undefined;
   maxElements?: number | undefined;
   maxTextChars?: number | undefined;
+  /** Overrides the bundled Nanocodex iframe, primarily for custom hosts and tests. */
+  dialog?: Readonly<{
+    open(
+      request: import("../cloud/Dialog.mjs").WebMcpApprovalRequest,
+      execution: import("../cloud/Dialog.mjs").Execution,
+    ): Promise<unknown>;
+  }> | undefined;
+  /** Headless approval override. The bundled dialog is used when omitted. */
   confirm?(request: WebMcpActionRequest): boolean | Promise<boolean>;
 }>;
 

--- a/js/bindings/webmcp/WebMcp.d.mts
+++ b/js/bindings/webmcp/WebMcp.d.mts
@@ -69,6 +69,8 @@ export type GeneratedWebMcpTool = Readonly<{
 export type WebMcpManifest = Readonly<{
   version: number;
   generatedAt?: string | undefined;
+  sourceRevision?: string | undefined;
+  generatedBy?: "nanocodex-agent" | undefined;
   tools: readonly GeneratedWebMcpTool[];
 }>;
 

--- a/js/bindings/webmcp/WebMcp.mjs
+++ b/js/bindings/webmcp/WebMcp.mjs
@@ -1,0 +1,789 @@
+const PROVIDER_BRAND = Symbol.for("nanocodex.webmcp.provider");
+const DEFAULT_MAX_ELEMENTS = 256;
+const DEFAULT_MAX_TEXT_CHARS = 20_000;
+const DEFAULT_SOURCE_ID = "webmcp:document";
+const FALLBACK_NAMES = new Set([
+  "web_page_observe",
+  "web_page_activate",
+  "web_page_fill",
+  "web_page_submit",
+]);
+
+/**
+ * Creates a live tool provider over the current document's WebMCP registry.
+ * When the browser has no WebMCP implementation, the bounded semantic fallback
+ * keeps the visible page usable without exposing arbitrary JavaScript execution.
+ */
+export async function createProvider(options = {}) {
+  validateProviderOptions(options);
+  const document = options.document ?? globalThis.document;
+  if (!document || typeof document !== "object") {
+    throw new Error("WebMCP requires a browser Document");
+  }
+  const nativeMode = options.native ?? true;
+  const fallbackMode = normalizeFallback(options.fallback);
+  const sourceId = nonEmptyString(options.sourceId) ?? DEFAULT_SOURCE_ID;
+  const confirm = options.confirm;
+  const fromOrigins = normalizeOrigins(options.fromOrigins);
+  const maxElements = boundedInteger(
+    options.maxElements ?? DEFAULT_MAX_ELEMENTS,
+    "maxElements",
+    1,
+    1_024,
+  );
+  const maxTextChars = boundedInteger(
+    options.maxTextChars ?? DEFAULT_MAX_TEXT_CHARS,
+    "maxTextChars",
+    1,
+    100_000,
+  );
+  const listeners = new Set();
+  const nativeTools = new Map();
+  const semantic = createSemanticPageTools(document, {
+    confirm,
+    maxElements,
+    maxTextChars,
+  });
+  let definitions = Object.freeze([]);
+  let fingerprint = "[]";
+  let closed = false;
+  let refreshing;
+  let stopNativeChange = () => {};
+
+  const provider = {
+    [PROVIDER_BRAND]: true,
+    sourceId,
+    kind: "webmcp",
+    mode: "union",
+    deferred: true,
+    definitions: () => definitions,
+    resolve(name) {
+      if (closed) return undefined;
+      const native = nativeTools.get(name);
+      if (native) {
+        return Object.freeze({
+          name,
+          parallelSafe: native.annotations?.readOnlyHint === true,
+          handler: (input, context) => executeNativeTool(
+            document,
+            native,
+            input,
+            context,
+            confirm,
+          ),
+        });
+      }
+      return semantic.resolve(name);
+    },
+    settled: () => refresh(),
+    refresh,
+    subscribe(listener) {
+      if (typeof listener !== "function") {
+        throw new TypeError("WebMCP provider subscribe requires a listener");
+      }
+      if (closed) return () => {};
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    close() {
+      if (closed) return;
+      closed = true;
+      stopNativeChange();
+      listeners.clear();
+      nativeTools.clear();
+      semantic.close();
+      definitions = Object.freeze([]);
+    },
+  };
+
+  await refresh();
+  const modelContext = document.modelContext;
+  if (nativeMode !== false && modelContext?.addEventListener) {
+    const changed = () => { void refresh().catch(reportError); };
+    modelContext.addEventListener("toolchange", changed);
+    stopNativeChange = () => modelContext.removeEventListener?.("toolchange", changed);
+  } else if (nativeMode !== false && "ontoolchange" in (modelContext ?? {})) {
+    const previous = modelContext.ontoolchange;
+    const changed = (event) => {
+      if (typeof previous === "function") previous.call(modelContext, event);
+      void refresh().catch(reportError);
+    };
+    modelContext.ontoolchange = changed;
+    stopNativeChange = () => {
+      if (modelContext.ontoolchange === changed) modelContext.ontoolchange = previous;
+    };
+  }
+  return Object.freeze(provider);
+
+  async function refresh() {
+    if (closed) return;
+    if (refreshing) return refreshing;
+    refreshing = Promise.resolve().then(async () => {
+      const modelContext = document.modelContext;
+      let registered = [];
+      if (nativeMode !== false && typeof modelContext?.getTools === "function") {
+        registered = fromOrigins === undefined
+          ? await modelContext.getTools()
+          : await modelContext.getTools({ fromOrigins });
+        if (!Array.isArray(registered)) {
+          throw new TypeError("document.modelContext.getTools() returned a non-array");
+        }
+      } else if (nativeMode === "require") {
+        throw new Error("this browser does not provide document.modelContext.getTools()");
+      }
+      const mirrored = mirrorNativeTools(registered);
+      nativeTools.clear();
+      for (const entry of mirrored) nativeTools.set(entry.definition.name, entry.tool);
+      const includeFallback = fallbackMode === "always"
+        || (fallbackMode === "when-empty" && mirrored.length === 0);
+      const next = Object.freeze([
+        ...mirrored.map((entry) => entry.definition),
+        ...(includeFallback ? semantic.definitions() : []),
+      ]);
+      const nextFingerprint = JSON.stringify(next);
+      definitions = next;
+      if (nextFingerprint !== fingerprint) {
+        fingerprint = nextFingerprint;
+        for (const listener of listeners) listener(next);
+      }
+    }).finally(() => { refreshing = undefined; });
+    return refreshing;
+  }
+}
+
+/** Returns true for providers constructed by createProvider(). */
+export function isProvider(value) {
+  return value?.[PROVIDER_BRAND] === true
+    && typeof value.definitions === "function"
+    && typeof value.resolve === "function";
+}
+
+/**
+ * Registers approved generated tools with the page's native WebMCP registry.
+ * The generated manifest remains inert until each tool is explicitly approved.
+ */
+export async function publish(manifest, options = {}) {
+  validatePublishOptions(options);
+  const document = options.document ?? globalThis.document;
+  const modelContext = document?.modelContext;
+  if (typeof modelContext?.registerTool !== "function") {
+    throw new Error("publishing WebMCP tools requires document.modelContext.registerTool()");
+  }
+  if (!manifest || typeof manifest !== "object" || !Array.isArray(manifest.tools)) {
+    throw new TypeError("WebMCP manifest requires a tools array");
+  }
+  const exposedTo = normalizeOrigins(options.exposedTo);
+  const registrations = [];
+  const names = new Set();
+  try {
+    for (const candidate of manifest.tools) {
+      if (candidate?.approved !== true) continue;
+      const tool = validateGeneratedTool(candidate);
+      if (names.has(tool.name)) throw new Error(`duplicate approved WebMCP tool: ${tool.name}`);
+      names.add(tool.name);
+      const controller = new AbortController();
+      const execute = generatedExecute(tool, document, options);
+      registrations.push({ controller, name: tool.name });
+      await modelContext.registerTool({
+        name: tool.name,
+        title: tool.title ?? tool.name,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+        annotations: {
+          readOnlyHint: tool.annotations?.readOnlyHint === true,
+          untrustedContentHint: tool.annotations?.untrustedContentHint === true,
+        },
+        execute,
+      }, {
+        signal: controller.signal,
+        ...(exposedTo === undefined ? {} : { exposedTo }),
+      });
+    }
+  } catch (error) {
+    for (const registration of registrations) registration.controller.abort();
+    throw error;
+  }
+  let closed = false;
+  return Object.freeze({
+    tools: Object.freeze(registrations.map(({ name }) => name)),
+    close() {
+      if (closed) return;
+      closed = true;
+      for (const registration of registrations) registration.controller.abort();
+    },
+  });
+}
+
+function mirrorNativeTools(registered) {
+  const prepared = registered.map((tool, index) => {
+    if (!tool || typeof tool !== "object"
+        || typeof tool.name !== "string" || !tool.name.trim()
+        || typeof tool.description !== "string" || !tool.description.trim()) {
+      throw new TypeError(`WebMCP tool ${index} is malformed`);
+    }
+    const origin = typeof tool.origin === "string" ? tool.origin : "same-origin";
+    return { key: `${origin}\u0000${tool.name}`, origin, tool };
+  }).sort((left, right) => left.key.localeCompare(right.key));
+  const baseCounts = new Map();
+  for (const entry of prepared) {
+    const base = mirroredName(entry.tool.name);
+    baseCounts.set(base, (baseCounts.get(base) ?? 0) + 1);
+  }
+  return prepared.map(({ origin, tool }) => {
+    const base = mirroredName(tool.name);
+    const name = baseCounts.get(base) === 1
+      ? base
+      : `${base.slice(0, 51)}_${shortHash(`${origin}\u0000${tool.name}`)}`;
+    const description = `${tool.description.trim()} (WebMCP: ${origin})`;
+    return Object.freeze({
+      tool,
+      definition: deepFreeze({
+        type: "function",
+        name,
+        description,
+        strict: false,
+        defer_loading: true,
+        parameters: jsonSchema(tool.inputSchema),
+      }),
+    });
+  });
+}
+
+async function executeNativeTool(document, tool, input, context, confirm) {
+  context?.signal?.throwIfAborted?.();
+  if (tool.annotations?.readOnlyHint !== true) {
+    await authorize(confirm, {
+      kind: "webmcp",
+      name: tool.name,
+      title: tool.title,
+      origin: tool.origin,
+      input,
+      readOnly: false,
+    });
+  }
+  const result = await document.modelContext.executeTool(
+    tool,
+    JSON.stringify(input && typeof input === "object" ? input : {}),
+    context?.signal === undefined ? undefined : { signal: context.signal },
+  );
+  return parseStructuredResult(result);
+}
+
+function createSemanticPageTools(document, options) {
+  const elements = new Map();
+  const ids = new WeakMap();
+  let nextId = 1;
+  let closed = false;
+  const definitions = Object.freeze([
+    definition(
+      "web_page_observe",
+      "Read the current page and return its visible text, forms, and actionable elements. Password values are never returned.",
+      {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+    ),
+    definition(
+      "web_page_activate",
+      "Activate one visible link, button, or control returned by web_page_observe.",
+      {
+        type: "object",
+        properties: { id: { type: "string", description: "Opaque element ID from web_page_observe." } },
+        required: ["id"],
+        additionalProperties: false,
+      },
+    ),
+    definition(
+      "web_page_fill",
+      "Fill visible form controls returned by web_page_observe without submitting the form.",
+      {
+        type: "object",
+        properties: {
+          values: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                id: { type: "string" },
+                value: { type: ["string", "boolean", "number", "null"] },
+              },
+              required: ["id", "value"],
+              additionalProperties: false,
+            },
+            maxItems: 128,
+          },
+        },
+        required: ["values"],
+        additionalProperties: false,
+      },
+    ),
+    definition(
+      "web_page_submit",
+      "Submit one visible form returned by web_page_observe using the website's normal authenticated page flow.",
+      {
+        type: "object",
+        properties: { id: { type: "string", description: "Opaque form ID from web_page_observe." } },
+        required: ["id"],
+        additionalProperties: false,
+      },
+    ),
+  ]);
+
+  return Object.freeze({
+    definitions: () => definitions,
+    resolve(name) {
+      if (closed || !FALLBACK_NAMES.has(name)) return undefined;
+      if (name === "web_page_observe") {
+        return Object.freeze({ name, parallelSafe: true, handler: observe });
+      }
+      if (name === "web_page_activate") {
+        return Object.freeze({ name, parallelSafe: false, handler: activate });
+      }
+      if (name === "web_page_fill") {
+        return Object.freeze({ name, parallelSafe: false, handler: fill });
+      }
+      return Object.freeze({ name, parallelSafe: false, handler: submit });
+    },
+    close() { closed = true; elements.clear(); },
+  });
+
+  function observe() {
+    requireOpen();
+    elements.clear();
+    const actionable = queryAll(document, [
+      "a[href]",
+      "button",
+      "input",
+      "select",
+      "textarea",
+      "[contenteditable='true']",
+      "[role='button']",
+      "[role='link']",
+      "[role='checkbox']",
+      "[role='switch']",
+    ].join(","))
+      .filter((element) => visible(element))
+      .slice(0, options.maxElements)
+      .map((element) => describeElement(element));
+    const forms = queryAll(document, "form")
+      .filter((element) => visible(element))
+      .slice(0, options.maxElements)
+      .map((form) => ({
+        id: retain(form),
+        role: "form",
+        name: accessibleName(form) || form.getAttribute?.("name") || "form",
+        action: form.getAttribute?.("action") || document.location?.href || "",
+        method: (form.getAttribute?.("method") || "get").toLowerCase(),
+      }));
+    const text = String(document.body?.innerText ?? document.documentElement?.innerText ?? "")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, options.maxTextChars);
+    return deepFreeze({
+      url: document.location?.href ?? "",
+      title: document.title ?? "",
+      text,
+      truncated: text.length === options.maxTextChars,
+      elements: actionable,
+      forms,
+    });
+  }
+
+  async function activate(input, context) {
+    const element = requiredElement(input?.id);
+    await authorize(options.confirm, {
+      kind: "semantic",
+      name: "web_page_activate",
+      input,
+      element: describeElement(element),
+      readOnly: false,
+    });
+    context?.signal?.throwIfAborted?.();
+    if (typeof element.click !== "function") throw new Error("page element cannot be activated");
+    element.click();
+    return { activated: input.id, url: document.location?.href ?? "" };
+  }
+
+  async function fill(input, context) {
+    requireOpen();
+    if (!Array.isArray(input?.values) || input.values.length > 128) {
+      throw new TypeError("web_page_fill values must be an array of at most 128 entries");
+    }
+    const changes = input.values.map((entry) => ({
+      element: requiredElement(entry?.id),
+      id: entry?.id,
+      value: entry?.value,
+    }));
+    await authorize(options.confirm, {
+      kind: "semantic",
+      name: "web_page_fill",
+      input,
+      element: {
+        controls: changes.map(({ element, id }) => ({
+          id,
+          name: accessibleName(element),
+          type: String(element.getAttribute?.("type") ?? element.type ?? ""),
+        })),
+      },
+      readOnly: false,
+    });
+    const changed = [];
+    for (const entry of changes) {
+      context?.signal?.throwIfAborted?.();
+      setControlValue(entry.element, entry.value, document);
+      changed.push(entry.id);
+    }
+    return { filled: changed };
+  }
+
+  async function submit(input, context) {
+    const form = requiredElement(input?.id);
+    if (String(form.tagName ?? "").toLowerCase() !== "form") {
+      throw new TypeError("web_page_submit requires a form ID");
+    }
+    await authorize(options.confirm, {
+      kind: "semantic",
+      name: "web_page_submit",
+      input,
+      element: { id: input.id, role: "form", name: accessibleName(form) },
+      readOnly: false,
+    });
+    context?.signal?.throwIfAborted?.();
+    if (typeof form.requestSubmit === "function") form.requestSubmit();
+    else if (typeof form.submit === "function") form.submit();
+    else throw new Error("page form cannot be submitted");
+    return { submitted: input.id, url: document.location?.href ?? "" };
+  }
+
+  function describeElement(element) {
+    const tag = String(element.tagName ?? "").toLowerCase();
+    const type = String(element.getAttribute?.("type") ?? element.type ?? "").toLowerCase();
+    const value = type === "password" ? undefined
+      : ("checked" in element && (type === "checkbox" || type === "radio"))
+        ? Boolean(element.checked)
+        : "value" in element ? String(element.value ?? "") : undefined;
+    const form = element.form ? retain(element.form) : undefined;
+    return deepFreeze({
+      id: retain(element),
+      role: element.getAttribute?.("role") || inferredRole(tag, type),
+      name: accessibleName(element),
+      tag,
+      ...(type ? { type } : {}),
+      ...(value === undefined ? {} : { value }),
+      ...(element.href ? { href: String(element.href) } : {}),
+      ...(form ? { form } : {}),
+    });
+  }
+
+  function retain(element) {
+    let id = ids.get(element);
+    if (!id) {
+      id = `page-${nextId++}`;
+      ids.set(element, id);
+    }
+    elements.set(id, element);
+    return id;
+  }
+
+  function requiredElement(id) {
+    requireOpen();
+    if (typeof id !== "string" || !id) throw new TypeError("page element ID must not be empty");
+    let element = elements.get(id);
+    if (!element) {
+      observe();
+      element = elements.get(id);
+    }
+    if (!element || !element.isConnected || !visible(element)) {
+      throw new Error(`page element is no longer available: ${id}`);
+    }
+    return element;
+  }
+
+  function requireOpen() {
+    if (closed) throw new Error("semantic page tools are closed");
+  }
+}
+
+function generatedExecute(tool, document, options) {
+  const custom = options.handlers?.[tool.name];
+  let implementation;
+  if (typeof custom === "function") implementation = custom;
+  else if (tool.implementation?.kind === "fetch") {
+    implementation = (input, context) => executeGeneratedFetch(tool, input, context, options);
+  } else if (tool.implementation?.kind === "form") {
+    implementation = (input) => executeGeneratedForm(tool, input, document);
+  } else {
+    throw new Error(`approved WebMCP tool requires a handler: ${tool.name}`);
+  }
+  return async (input, executeOptions = {}) => {
+    executeOptions.signal?.throwIfAborted?.();
+    if (tool.annotations?.readOnlyHint !== true) {
+      await authorize(options.confirm, {
+        kind: "published",
+        name: tool.name,
+        title: tool.title,
+        input,
+        readOnly: false,
+      });
+    }
+    executeOptions.signal?.throwIfAborted?.();
+    return implementation(input ?? {}, {
+      signal: executeOptions.signal ?? new AbortController().signal,
+    });
+  };
+}
+
+async function executeGeneratedFetch(tool, input, context, options) {
+  const implementation = tool.implementation;
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  if (typeof fetchImpl !== "function") throw new Error("generated WebMCP fetch tool requires fetch");
+  const baseUrl = options.baseUrl ?? options.document?.location?.href ?? globalThis.location?.href;
+  const base = new URL(baseUrl);
+  const url = new URL(fillPath(implementation.path, input.path), base);
+  if (url.origin !== base.origin) {
+    throw new Error(`generated WebMCP fetch must stay on ${base.origin}`);
+  }
+  if (input.query && typeof input.query === "object" && !Array.isArray(input.query)) {
+    for (const [name, value] of Object.entries(input.query)) {
+      if (value !== undefined && value !== null) url.searchParams.set(name, String(value));
+    }
+  }
+  const method = String(implementation.method ?? "GET").toUpperCase();
+  const response = await fetchImpl(url, {
+    method,
+    credentials: "same-origin",
+    headers: input.body === undefined ? undefined : { "content-type": "application/json" },
+    body: input.body === undefined || method === "GET" || method === "HEAD"
+      ? undefined
+      : JSON.stringify(input.body),
+    signal: context.signal,
+  });
+  const text = await response.text();
+  let body = text;
+  try { body = text ? JSON.parse(text) : null; } catch {}
+  if (!response.ok) {
+    throw new Error(`${tool.name} failed with HTTP ${response.status}: ${text.slice(0, 2_000)}`);
+  }
+  return body;
+}
+
+function executeGeneratedForm(tool, input, document) {
+  const selector = tool.implementation.selector;
+  const form = document.querySelector?.(selector);
+  if (!form || String(form.tagName ?? "").toLowerCase() !== "form") {
+    throw new Error(`generated WebMCP form is unavailable: ${selector}`);
+  }
+  const fields = input.fields;
+  if (!fields || typeof fields !== "object" || Array.isArray(fields)) {
+    throw new TypeError(`${tool.name} requires an object named fields`);
+  }
+  for (const [name, value] of Object.entries(fields)) {
+    const control = form.elements?.namedItem?.(name)
+      ?? form.querySelector?.(`[name="${cssEscape(name)}"]`);
+    if (!control) throw new Error(`form field is unavailable: ${name}`);
+    setControlValue(control, value, document);
+  }
+  if (typeof form.requestSubmit === "function") form.requestSubmit();
+  else if (typeof form.submit === "function") form.submit();
+  else throw new Error("generated WebMCP form cannot be submitted");
+  return { submitted: true };
+}
+
+function validateGeneratedTool(tool) {
+  if (!tool || typeof tool !== "object"
+      || typeof tool.name !== "string" || !/^[A-Za-z0-9_.-]{1,128}$/.test(tool.name)
+      || typeof tool.description !== "string" || !tool.description.trim()) {
+    throw new TypeError("approved WebMCP manifest contains an invalid tool");
+  }
+  return tool;
+}
+
+function validateProviderOptions(options) {
+  if (!options || typeof options !== "object" || Array.isArray(options)) {
+    throw new TypeError("WebMCP provider options must be an object");
+  }
+  const allowed = new Set([
+    "confirm", "document", "fallback", "fromOrigins", "maxElements",
+    "maxTextChars", "native", "sourceId",
+  ]);
+  for (const name of Object.keys(options)) {
+    if (!allowed.has(name)) throw new TypeError(`unsupported WebMCP provider option: ${name}`);
+  }
+  if (options.confirm !== undefined && typeof options.confirm !== "function") {
+    throw new TypeError("WebMCP confirm must be a function");
+  }
+  if (options.native !== undefined
+      && options.native !== true && options.native !== false && options.native !== "require") {
+    throw new TypeError("WebMCP native must be true, false, or require");
+  }
+}
+
+function validatePublishOptions(options) {
+  if (!options || typeof options !== "object" || Array.isArray(options)) {
+    throw new TypeError("WebMCP publish options must be an object");
+  }
+  const allowed = new Set([
+    "baseUrl", "confirm", "document", "exposedTo", "fetch", "handlers",
+  ]);
+  for (const name of Object.keys(options)) {
+    if (!allowed.has(name)) throw new TypeError(`unsupported WebMCP publish option: ${name}`);
+  }
+  if (options.confirm !== undefined && typeof options.confirm !== "function") {
+    throw new TypeError("WebMCP publish confirm must be a function");
+  }
+}
+
+function normalizeFallback(value = "when-empty") {
+  if (value === true) return "when-empty";
+  if (value === false) return "never";
+  if (value === "always" || value === "when-empty" || value === "never") return value;
+  throw new TypeError("WebMCP fallback must be always, when-empty, never, true, or false");
+}
+
+function normalizeOrigins(value) {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.some((origin) => typeof origin !== "string" || !origin)) {
+    throw new TypeError("WebMCP origins must be an array of non-empty strings");
+  }
+  return Object.freeze([...new Set(value)]);
+}
+
+function definition(name, description, parameters) {
+  return deepFreeze({
+    type: "function",
+    name,
+    description,
+    strict: false,
+    defer_loading: true,
+    parameters,
+  });
+}
+
+function jsonSchema(value) {
+  if (value === undefined) return { type: "object", additionalProperties: true };
+  try { return JSON.parse(JSON.stringify(value)); }
+  catch (error) { throw new TypeError("WebMCP input schema must be JSON-serializable", { cause: error }); }
+}
+
+function mirroredName(name) {
+  const normalized = [...name.trim()]
+    .map((character) => /[A-Za-z0-9_-]/.test(character) ? character : "_")
+    .join("")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "") || "tool";
+  const full = `web_${normalized}`;
+  return full.length <= 64 ? full : `${full.slice(0, 55)}_${shortHash(name)}`;
+}
+
+function shortHash(value) {
+  let hash = 0x811c9dc5;
+  for (const character of value) {
+    hash ^= character.codePointAt(0);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36).padStart(7, "0").slice(0, 7);
+}
+
+function parseStructuredResult(value) {
+  if (typeof value !== "string") return value;
+  try { return JSON.parse(value); } catch { return value; }
+}
+
+async function authorize(confirm, request) {
+  if (confirm === undefined) return;
+  if (await confirm(Object.freeze({ ...request })) !== true) {
+    throw new Error(`WebMCP action was not approved: ${request.name}`);
+  }
+}
+
+function queryAll(document, selector) {
+  const value = document.querySelectorAll?.(selector);
+  return value ? Array.from(value) : [];
+}
+
+function visible(element) {
+  if (!element || element.hidden || element.disabled || element.getAttribute?.("aria-hidden") === "true") {
+    return false;
+  }
+  if (typeof element.getClientRects === "function" && element.getClientRects().length === 0) {
+    return false;
+  }
+  return true;
+}
+
+function accessibleName(element) {
+  const labelled = element.getAttribute?.("aria-label")
+    || element.getAttribute?.("title")
+    || element.labels?.[0]?.innerText
+    || element.innerText
+    || element.getAttribute?.("placeholder")
+    || element.getAttribute?.("name")
+    || "";
+  return String(labelled).replace(/\s+/g, " ").trim().slice(0, 512);
+}
+
+function inferredRole(tag, type) {
+  if (tag === "a") return "link";
+  if (tag === "button") return "button";
+  if (tag === "select") return "combobox";
+  if (tag === "textarea") return "textbox";
+  if (tag === "input" && (type === "checkbox" || type === "radio")) return type;
+  if (tag === "input") return "textbox";
+  return "control";
+}
+
+function setControlValue(element, value, document) {
+  const type = String(element.getAttribute?.("type") ?? element.type ?? "").toLowerCase();
+  if (type === "checkbox" || type === "radio") {
+    element.checked = Boolean(value);
+  } else if ("value" in element) {
+    element.value = value === null ? "" : String(value);
+  } else if (element.isContentEditable) {
+    element.textContent = value === null ? "" : String(value);
+  } else {
+    throw new TypeError("page element is not a fillable control");
+  }
+  const EventImpl = document.defaultView?.Event ?? globalThis.Event;
+  if (typeof EventImpl === "function" && typeof element.dispatchEvent === "function") {
+    element.dispatchEvent(new EventImpl("input", { bubbles: true }));
+    element.dispatchEvent(new EventImpl("change", { bubbles: true }));
+  }
+}
+
+function fillPath(template, values = {}) {
+  if (typeof template !== "string" || !template) throw new TypeError("generated fetch path is invalid");
+  return template.replace(/\[([^\]]+)\]|:([A-Za-z0-9_]+)/g, (match, bracket, colon) => {
+    const name = bracket ?? colon;
+    const value = values?.[name];
+    if (value === undefined || value === null) throw new TypeError(`missing path parameter: ${name}`);
+    return encodeURIComponent(String(value));
+  });
+}
+
+function cssEscape(value) {
+  if (globalThis.CSS?.escape) return globalThis.CSS.escape(value);
+  return String(value).replace(/["\\]/g, "\\$&");
+}
+
+function boundedInteger(value, name, minimum, maximum) {
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    throw new TypeError(`${name} must be an integer from ${minimum} through ${maximum}`);
+  }
+  return value;
+}
+
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function deepFreeze(value) {
+  if (!value || typeof value !== "object" || Object.isFrozen(value)) return value;
+  for (const child of Object.values(value)) deepFreeze(child);
+  return Object.freeze(value);
+}
+
+function reportError(error) {
+  if (typeof globalThis.reportError === "function") globalThis.reportError(error);
+  else queueMicrotask(() => { throw error; });
+}

--- a/js/bindings/webmcp/WebMcp.mjs
+++ b/js/bindings/webmcp/WebMcp.mjs
@@ -23,7 +23,7 @@ export async function createProvider(options = {}) {
   const nativeMode = options.native ?? true;
   const fallbackMode = normalizeFallback(options.fallback);
   const sourceId = nonEmptyString(options.sourceId) ?? DEFAULT_SOURCE_ID;
-  const confirm = options.confirm;
+  const approval = createApproval(document, options);
   const fromOrigins = normalizeOrigins(options.fromOrigins);
   const maxElements = boundedInteger(
     options.maxElements ?? DEFAULT_MAX_ELEMENTS,
@@ -40,7 +40,7 @@ export async function createProvider(options = {}) {
   const listeners = new Set();
   const nativeTools = new Map();
   const semantic = createSemanticPageTools(document, {
-    confirm,
+    approval,
     maxElements,
     maxTextChars,
   });
@@ -69,7 +69,7 @@ export async function createProvider(options = {}) {
             native,
             input,
             context,
-            confirm,
+            approval,
           ),
         });
       }
@@ -249,24 +249,31 @@ function mirrorNativeTools(registered) {
   });
 }
 
-async function executeNativeTool(document, tool, input, context, confirm) {
+async function executeNativeTool(document, tool, input, context, approval) {
   context?.signal?.throwIfAborted?.();
+  const exactInput = cloneApprovalValue(input && typeof input === "object" ? input : {});
+  const encodedInput = JSON.stringify(exactInput);
+  const execute = async () => {
+    context?.signal?.throwIfAborted?.();
+    const result = await document.modelContext.executeTool(
+      tool,
+      encodedInput,
+      context?.signal === undefined ? undefined : { signal: context.signal },
+    );
+    return parseStructuredResult(result);
+  };
   if (tool.annotations?.readOnlyHint !== true) {
-    await authorize(confirm, {
+    return approval.execute({
       kind: "webmcp",
       name: tool.name,
       title: tool.title,
+      description: tool.description,
       origin: tool.origin,
-      input,
+      input: exactInput,
       readOnly: false,
-    });
+    }, execute);
   }
-  const result = await document.modelContext.executeTool(
-    tool,
-    JSON.stringify(input && typeof input === "object" ? input : {}),
-    context?.signal === undefined ? undefined : { signal: context.signal },
-  );
-  return parseStructuredResult(result);
+  return execute();
 }
 
 function createSemanticPageTools(document, options) {
@@ -392,17 +399,18 @@ function createSemanticPageTools(document, options) {
 
   async function activate(input, context) {
     const element = requiredElement(input?.id);
-    await authorize(options.confirm, {
+    return options.approval.execute({
       kind: "semantic",
       name: "web_page_activate",
       input,
       element: describeElement(element),
       readOnly: false,
+    }, () => {
+      context?.signal?.throwIfAborted?.();
+      if (typeof element.click !== "function") throw new Error("page element cannot be activated");
+      element.click();
+      return { activated: input.id, url: document.location?.href ?? "" };
     });
-    context?.signal?.throwIfAborted?.();
-    if (typeof element.click !== "function") throw new Error("page element cannot be activated");
-    element.click();
-    return { activated: input.id, url: document.location?.href ?? "" };
   }
 
   async function fill(input, context) {
@@ -415,7 +423,7 @@ function createSemanticPageTools(document, options) {
       id: entry?.id,
       value: entry?.value,
     }));
-    await authorize(options.confirm, {
+    return options.approval.execute({
       kind: "semantic",
       name: "web_page_fill",
       input,
@@ -427,14 +435,15 @@ function createSemanticPageTools(document, options) {
         })),
       },
       readOnly: false,
+    }, () => {
+      const changed = [];
+      for (const entry of changes) {
+        context?.signal?.throwIfAborted?.();
+        setControlValue(entry.element, entry.value, document);
+        changed.push(entry.id);
+      }
+      return { filled: changed };
     });
-    const changed = [];
-    for (const entry of changes) {
-      context?.signal?.throwIfAborted?.();
-      setControlValue(entry.element, entry.value, document);
-      changed.push(entry.id);
-    }
-    return { filled: changed };
   }
 
   async function submit(input, context) {
@@ -442,18 +451,19 @@ function createSemanticPageTools(document, options) {
     if (String(form.tagName ?? "").toLowerCase() !== "form") {
       throw new TypeError("web_page_submit requires a form ID");
     }
-    await authorize(options.confirm, {
+    return options.approval.execute({
       kind: "semantic",
       name: "web_page_submit",
       input,
       element: { id: input.id, role: "form", name: accessibleName(form) },
       readOnly: false,
+    }, () => {
+      context?.signal?.throwIfAborted?.();
+      if (typeof form.requestSubmit === "function") form.requestSubmit();
+      else if (typeof form.submit === "function") form.submit();
+      else throw new Error("page form cannot be submitted");
+      return { submitted: input.id, url: document.location?.href ?? "" };
     });
-    context?.signal?.throwIfAborted?.();
-    if (typeof form.requestSubmit === "function") form.requestSubmit();
-    else if (typeof form.submit === "function") form.submit();
-    else throw new Error("page form cannot be submitted");
-    return { submitted: input.id, url: document.location?.href ?? "" };
   }
 
   function describeElement(element) {
@@ -604,7 +614,7 @@ function validateProviderOptions(options) {
     throw new TypeError("WebMCP provider options must be an object");
   }
   const allowed = new Set([
-    "confirm", "document", "fallback", "fromOrigins", "maxElements",
+    "confirm", "dialog", "document", "fallback", "fromOrigins", "maxElements",
     "maxTextChars", "native", "sourceId",
   ]);
   for (const name of Object.keys(options)) {
@@ -612,6 +622,9 @@ function validateProviderOptions(options) {
   }
   if (options.confirm !== undefined && typeof options.confirm !== "function") {
     throw new TypeError("WebMCP confirm must be a function");
+  }
+  if (options.dialog !== undefined && typeof options.dialog?.open !== "function") {
+    throw new TypeError("WebMCP dialog must provide open(request, execution)");
   }
   if (options.native !== undefined
       && options.native !== true && options.native !== false && options.native !== "require") {
@@ -695,6 +708,64 @@ async function authorize(confirm, request) {
   if (await confirm(Object.freeze({ ...request })) !== true) {
     throw new Error(`WebMCP action was not approved: ${request.name}`);
   }
+}
+
+function createApproval(document, options) {
+  const confirm = options.confirm;
+  let dialog = options.dialog;
+  let defaultDialog;
+  return Object.freeze({
+    async execute(request, action) {
+      const frozen = deepFreeze(cloneApprovalValue({ ...request }));
+      if (confirm !== undefined) {
+        await authorize(confirm, frozen);
+        return action();
+      }
+      if (!dialog) {
+        defaultDialog ??= import("../cloud/Dialog.mjs").then(({ iframe }) => iframe().setup({
+          appId: approvalApp(document).id,
+        }));
+        dialog = await defaultDialog;
+      }
+      return dialog.open(deepFreeze({
+        id: randomId(),
+        type: "webMcpApproval",
+        app: approvalApp(document),
+        action: frozen,
+      }), { execute: action });
+    },
+  });
+}
+
+function cloneApprovalValue(value) {
+  try {
+    if (typeof globalThis.structuredClone === "function") return globalThis.structuredClone(value);
+    return JSON.parse(JSON.stringify(value));
+  } catch (error) {
+    throw new TypeError("WebMCP approval data must be structured-cloneable", { cause: error });
+  }
+}
+
+function approvalApp(document) {
+  const href = document.location?.href ?? globalThis.location?.href;
+  let origin = document.location?.origin ?? globalThis.location?.origin;
+  if (!origin && href) {
+    try { origin = new URL(href).origin; } catch {}
+  }
+  if (!origin || origin === "null") {
+    throw new Error("mutating WebMCP tools require a trusted browser origin");
+  }
+  const host = new URL(origin).hostname;
+  return deepFreeze({
+    id: `webmcp:${host}`.slice(0, 128),
+    name: nonEmptyString(document.title) ?? host,
+    origin,
+  });
+}
+
+function randomId() {
+  if (typeof globalThis.crypto?.randomUUID === "function") return globalThis.crypto.randomUUID();
+  return `webmcp-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
 }
 
 function queryAll(document, selector) {

--- a/js/bindings/webmcp/cli.mjs
+++ b/js/bindings/webmcp/cli.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
-import { generate, validate } from "./generator.mjs";
+import { generateFile, validate } from "./generator.mjs";
 
 const [command = "generate", ...argv] = process.argv.slice(2);
 
@@ -31,11 +31,10 @@ async function generateCommand(args) {
     } else if (root === ".") root = argument;
     else throw new Error(`unexpected argument: ${argument}`);
   }
-  const manifest = await generate({ root });
-  validate(manifest);
-  const path = resolve(output);
-  await writeFile(path, `${JSON.stringify(manifest, null, 2)}\n`, { flag: "w" });
-  process.stdout.write(`Generated ${manifest.tools.length} review-required WebMCP tools in ${path}\n`);
+  const result = await generateFile({ root, output: resolve(output) });
+  process.stdout.write(
+    `${result.changed ? "Generated" : "Unchanged"} ${result.manifest.tools.length} review-required WebMCP tools in ${result.path}\n`,
+  );
 }
 
 async function checkCommand(args) {

--- a/js/bindings/webmcp/cli.mjs
+++ b/js/bindings/webmcp/cli.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { generate, validate } from "./generator.mjs";
+
+const [command = "generate", ...argv] = process.argv.slice(2);
+
+try {
+  if (command === "generate") await generateCommand(argv);
+  else if (command === "check") await checkCommand(argv);
+  else if (command === "help" || command === "--help" || command === "-h") help();
+  else throw new Error(`unknown command: ${command}`);
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+}
+
+async function generateCommand(args) {
+  let root = ".";
+  let output = "webmcp.manifest.json";
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--out" || argument === "-o") {
+      output = requiredValue(args[++index], argument);
+    } else if (argument === "--help" || argument === "-h") {
+      help();
+      return;
+    } else if (argument.startsWith("-")) {
+      throw new Error(`unknown option: ${argument}`);
+    } else if (root === ".") root = argument;
+    else throw new Error(`unexpected argument: ${argument}`);
+  }
+  const manifest = await generate({ root });
+  validate(manifest);
+  const path = resolve(output);
+  await writeFile(path, `${JSON.stringify(manifest, null, 2)}\n`, { flag: "w" });
+  process.stdout.write(`Generated ${manifest.tools.length} review-required WebMCP tools in ${path}\n`);
+}
+
+async function checkCommand(args) {
+  if (args.length !== 1) throw new Error("usage: nanocodex-webmcp check <manifest.json>");
+  const path = resolve(args[0]);
+  const manifest = JSON.parse(await readFile(path, "utf8"));
+  validate(manifest);
+  const approved = manifest.tools.filter((tool) => tool.approved === true).length;
+  process.stdout.write(`Valid WebMCP manifest: ${manifest.tools.length} tools, ${approved} approved\n`);
+}
+
+function requiredValue(value, option) {
+  if (typeof value !== "string" || !value || value.startsWith("-")) {
+    throw new Error(`${option} requires a value`);
+  }
+  return value;
+}
+
+function help() {
+  process.stdout.write(`nanocodex-webmcp
+
+  generate [repository] [--out webmcp.manifest.json]
+      Analyze source as data and write inert draft tools for review.
+
+  check <manifest.json>
+      Validate a generated or edited manifest.
+
+Generated tools are never approved or published automatically.
+`);
+}

--- a/js/bindings/webmcp/generator.d.mts
+++ b/js/bindings/webmcp/generator.d.mts
@@ -2,8 +2,22 @@ import type { WebMcpManifest } from "./WebMcp.mjs";
 
 export function generate(options?: {
   root?: string | undefined;
+  exclude?: readonly string[] | undefined;
   maxFiles?: number | undefined;
   maxFileBytes?: number | undefined;
 }): Promise<WebMcpManifest>;
+
+export type GenerateWebMcpManifestOptions = Readonly<{
+  root?: string | undefined;
+  output?: string | undefined;
+  maxFiles?: number | undefined;
+  maxFileBytes?: number | undefined;
+}>;
+
+export function generateFile(options?: GenerateWebMcpManifestOptions): Promise<Readonly<{
+  changed: boolean;
+  manifest: WebMcpManifest;
+  path: string;
+}>>;
 
 export function validate(manifest: unknown): true;

--- a/js/bindings/webmcp/generator.d.mts
+++ b/js/bindings/webmcp/generator.d.mts
@@ -1,0 +1,9 @@
+import type { WebMcpManifest } from "./WebMcp.mjs";
+
+export function generate(options?: {
+  root?: string | undefined;
+  maxFiles?: number | undefined;
+  maxFileBytes?: number | undefined;
+}): Promise<WebMcpManifest>;
+
+export function validate(manifest: unknown): true;

--- a/js/bindings/webmcp/generator.mjs
+++ b/js/bindings/webmcp/generator.mjs
@@ -1,13 +1,14 @@
-import { readdir, readFile } from "node:fs/promises";
-import { extname, join, relative, resolve, sep } from "node:path";
+import { createHash } from "node:crypto";
+import { mkdir, readFile, readdir, rename, unlink, writeFile } from "node:fs/promises";
+import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from "node:path";
 
 const SOURCE_EXTENSIONS = new Set([
   ".cjs", ".gql", ".graphql", ".htm", ".html", ".js", ".json",
   ".jsx", ".mjs", ".ts", ".tsx", ".yaml", ".yml",
 ]);
 const IGNORED_DIRECTORIES = new Set([
-  ".git", ".next", ".turbo", "build", "coverage", "dist", "node_modules",
-  "out", "target", "vendor",
+  ".git", ".next", ".turbo", "__fixtures__", "__tests__", "build", "coverage",
+  "dist", "fixtures", "node_modules", "out", "target", "test", "tests", "vendor",
 ]);
 const HTTP_METHODS = new Set(["DELETE", "GET", "HEAD", "PATCH", "POST", "PUT"]);
 const DEFAULT_MAX_FILE_BYTES = 1_000_000;
@@ -27,7 +28,8 @@ export async function generate(options = {}) {
     16_000_000,
   );
   const maxFiles = boundedInteger(options.maxFiles ?? DEFAULT_MAX_FILES, "maxFiles", 1, 100_000);
-  const files = await sourceFiles(root, maxFiles);
+  const excluded = new Set((options.exclude ?? []).map((path) => resolve(root, path)));
+  const files = await sourceFiles(root, maxFiles, excluded);
   const candidates = [];
   for (const path of files) {
     let contents;
@@ -50,6 +52,52 @@ export async function generate(options = {}) {
     root: ".",
     tools,
   });
+}
+
+/**
+ * Generates and atomically updates a checked-in review manifest. Existing
+ * approvals survive only while the generated tool contract is unchanged.
+ */
+export async function generateFile(options = {}) {
+  validateFileOptions(options);
+  const root = resolve(options.root ?? process.cwd());
+  const output = isAbsolute(options.output ?? "")
+    ? options.output
+    : resolve(root, options.output ?? "webmcp.manifest.json");
+  const draft = await generate({
+    root,
+    exclude: [output],
+    ...(options.maxFiles === undefined ? {} : { maxFiles: options.maxFiles }),
+    ...(options.maxFileBytes === undefined ? {} : { maxFileBytes: options.maxFileBytes }),
+  });
+  let previous;
+  try {
+    previous = JSON.parse(await readFile(output, "utf8"));
+    validate(previous);
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      throw new Error(`existing WebMCP manifest is invalid: ${output}`, { cause: error });
+    }
+  }
+  const manifest = reconcileManifest(draft, previous);
+  if (previous && JSON.stringify(previous.tools) === JSON.stringify(manifest.tools)) {
+    return Object.freeze({ changed: false, manifest: deepFreeze(previous), path: output });
+  }
+  const serialized = `${JSON.stringify(manifest, null, 2)}\n`;
+  await mkdir(dirname(output), { recursive: true });
+  const temporary = join(
+    dirname(output),
+    `.${basename(output)}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`,
+  );
+  try {
+    await writeFile(temporary, serialized, { flag: "wx" });
+    await rename(temporary, output);
+  } finally {
+    await unlink(temporary).catch((error) => {
+      if (error?.code !== "ENOENT") throw error;
+    });
+  }
+  return Object.freeze({ changed: true, manifest, path: output });
 }
 
 /** Validates the stable generated-manifest shape without executing handlers. */
@@ -89,7 +137,11 @@ function analyzeFile(file, contents) {
   tools.push(...routerTools(file, contents));
   tools.push(...fetchTools(file, contents));
   tools.push(...trpcTools(file, contents));
-  return tools;
+  const sourceHash = createHash("sha256").update(contents).digest("hex");
+  return tools.map((tool) => ({
+    ...tool,
+    evidence: tool.evidence.map((entry) => ({ ...entry, sourceHash })),
+  }));
 }
 
 function nextRouteTools(file, contents) {
@@ -327,7 +379,7 @@ function deduplicate(candidates) {
   return tools.sort((left, right) => left.name.localeCompare(right.name));
 }
 
-async function sourceFiles(root, maximum) {
+async function sourceFiles(root, maximum, excluded) {
   const files = [];
   const pending = [root];
   while (pending.length) {
@@ -337,6 +389,7 @@ async function sourceFiles(root, maximum) {
     for (const entry of entries) {
       if (entry.isSymbolicLink()) continue;
       const path = join(directory, entry.name);
+      if (excluded.has(path)) continue;
       if (entry.isDirectory()) {
         if (!IGNORED_DIRECTORIES.has(entry.name) && !entry.name.startsWith(".wrangler")) pending.push(path);
         continue;
@@ -426,10 +479,52 @@ function validateOptions(options) {
   if (!options || typeof options !== "object" || Array.isArray(options)) {
     throw new TypeError("WebMCP generator options must be an object");
   }
-  const allowed = new Set(["maxFileBytes", "maxFiles", "root"]);
+  const allowed = new Set(["exclude", "maxFileBytes", "maxFiles", "root"]);
   for (const name of Object.keys(options)) {
     if (!allowed.has(name)) throw new TypeError(`unsupported WebMCP generator option: ${name}`);
   }
+  if (options.exclude !== undefined
+      && (!Array.isArray(options.exclude)
+        || options.exclude.some((path) => typeof path !== "string" || !path))) {
+    throw new TypeError("WebMCP generator exclude must be an array of non-empty paths");
+  }
+}
+
+function validateFileOptions(options) {
+  if (!options || typeof options !== "object" || Array.isArray(options)) {
+    throw new TypeError("WebMCP manifest generation options must be an object");
+  }
+  const allowed = new Set(["maxFileBytes", "maxFiles", "output", "root"]);
+  for (const name of Object.keys(options)) {
+    if (!allowed.has(name)) throw new TypeError(`unsupported WebMCP manifest option: ${name}`);
+  }
+  if (options.output !== undefined && (typeof options.output !== "string" || !options.output)) {
+    throw new TypeError("WebMCP manifest output must be a non-empty path");
+  }
+}
+
+function reconcileManifest(draft, previous) {
+  const approved = new Map((previous?.tools ?? []).map((tool) => [tool.name, tool]));
+  const tools = draft.tools.map((tool) => {
+    const prior = approved.get(tool.name);
+    return deepFreeze({
+      ...tool,
+      approved: prior?.approved === true && toolFingerprint(prior) === toolFingerprint(tool),
+    });
+  });
+  return deepFreeze({ ...draft, tools });
+}
+
+function toolFingerprint(tool) {
+  return JSON.stringify({
+    name: tool.name,
+    title: tool.title,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+    annotations: tool.annotations,
+    implementation: tool.implementation,
+    evidence: tool.evidence?.map(({ file, kind, sourceHash }) => ({ file, kind, sourceHash })),
+  });
 }
 
 function boundedInteger(value, name, minimum, maximum) {

--- a/js/bindings/webmcp/generator.mjs
+++ b/js/bindings/webmcp/generator.mjs
@@ -1,0 +1,446 @@
+import { readdir, readFile } from "node:fs/promises";
+import { extname, join, relative, resolve, sep } from "node:path";
+
+const SOURCE_EXTENSIONS = new Set([
+  ".cjs", ".gql", ".graphql", ".htm", ".html", ".js", ".json",
+  ".jsx", ".mjs", ".ts", ".tsx", ".yaml", ".yml",
+]);
+const IGNORED_DIRECTORIES = new Set([
+  ".git", ".next", ".turbo", "build", "coverage", "dist", "node_modules",
+  "out", "target", "vendor",
+]);
+const HTTP_METHODS = new Set(["DELETE", "GET", "HEAD", "PATCH", "POST", "PUT"]);
+const DEFAULT_MAX_FILE_BYTES = 1_000_000;
+const DEFAULT_MAX_FILES = 5_000;
+
+/**
+ * Statically inspects a repository and returns an inert, reviewable WebMCP
+ * manifest. Source is read as data and is never imported or executed.
+ */
+export async function generate(options = {}) {
+  validateOptions(options);
+  const root = resolve(options.root ?? process.cwd());
+  const maxFileBytes = boundedInteger(
+    options.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES,
+    "maxFileBytes",
+    1,
+    16_000_000,
+  );
+  const maxFiles = boundedInteger(options.maxFiles ?? DEFAULT_MAX_FILES, "maxFiles", 1, 100_000);
+  const files = await sourceFiles(root, maxFiles);
+  const candidates = [];
+  for (const path of files) {
+    let contents;
+    try { contents = await readFile(path, "utf8"); }
+    catch (error) {
+      if (error?.code === "ERR_STRING_TOO_LONG") continue;
+      throw error;
+    }
+    if (Buffer.byteLength(contents) > maxFileBytes || contents.includes("\u0000")) continue;
+    const file = relative(root, path).split(sep).join("/");
+    candidates.push(...analyzeFile(file, contents));
+  }
+  const tools = deduplicate(candidates).map((candidate) => Object.freeze({
+    ...candidate,
+    approved: false,
+  }));
+  return deepFreeze({
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    root: ".",
+    tools,
+  });
+}
+
+/** Validates the stable generated-manifest shape without executing handlers. */
+export function validate(manifest) {
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)
+      || manifest.version !== 1 || !Array.isArray(manifest.tools)) {
+    throw new TypeError("WebMCP manifest must use version 1 and contain a tools array");
+  }
+  const names = new Set();
+  for (const [index, tool] of manifest.tools.entries()) {
+    if (!tool || typeof tool !== "object" || Array.isArray(tool)
+        || typeof tool.name !== "string" || !/^[A-Za-z0-9_.-]{1,128}$/.test(tool.name)
+        || typeof tool.description !== "string" || !tool.description.trim()
+        || typeof tool.approved !== "boolean"
+        || !tool.implementation || typeof tool.implementation.kind !== "string"
+        || !Array.isArray(tool.evidence) || tool.evidence.length === 0) {
+      throw new TypeError(`WebMCP manifest tool ${index} is invalid`);
+    }
+    if (names.has(tool.name)) throw new Error(`duplicate WebMCP manifest tool: ${tool.name}`);
+    names.add(tool.name);
+  }
+  return true;
+}
+
+function analyzeFile(file, contents) {
+  const tools = [];
+  const extension = extname(file).toLowerCase();
+  if (extension === ".json") tools.push(...openApiTools(file, contents));
+  if (extension === ".html" || extension === ".htm" || /<form\b/i.test(contents)) {
+    tools.push(...formTools(file, contents));
+  }
+  if (/\b(?:query|mutation)\s+[A-Za-z_][A-Za-z0-9_]*/.test(contents)) {
+    tools.push(...graphqlTools(file, contents));
+  }
+  if (/\buse server\b/.test(contents)) tools.push(...serverActionTools(file, contents));
+  tools.push(...nextRouteTools(file, contents));
+  tools.push(...routerTools(file, contents));
+  tools.push(...fetchTools(file, contents));
+  tools.push(...trpcTools(file, contents));
+  return tools;
+}
+
+function nextRouteTools(file, contents) {
+  const match = file.match(/(?:^|\/)app\/(api\/.*?)\/route\.[cm]?[jt]sx?$/);
+  if (!match) return [];
+  const path = `/${match[1]}`.replace(/\/\([^/]+\)/g, "");
+  const tools = [];
+  const methodPattern = /export\s+(?:async\s+)?function\s+(DELETE|GET|HEAD|PATCH|POST|PUT)\b/g;
+  for (const result of contents.matchAll(methodPattern)) {
+    tools.push(fetchCandidate(file, lineNumber(contents, result.index), result[1], path, "Next.js route"));
+  }
+  return tools;
+}
+
+function routerTools(file, contents) {
+  const tools = [];
+  const pattern = /\b(?:api|app|fastify|router|server)\s*\.\s*(delete|get|head|patch|post|put)\s*\(\s*(["'`])([^"'`]+)\2/g;
+  for (const result of contents.matchAll(pattern)) {
+    const method = result[1].toUpperCase();
+    const path = result[3];
+    if (!path.startsWith("/")) continue;
+    tools.push(fetchCandidate(file, lineNumber(contents, result.index), method, path, "application route"));
+  }
+  return tools;
+}
+
+function fetchTools(file, contents) {
+  const tools = [];
+  const pattern = /\bfetch\s*\(\s*(["'`])([^"'`$]+)\1/g;
+  for (const result of contents.matchAll(pattern)) {
+    const path = result[2];
+    if (!path.startsWith("/") || path.startsWith("//")) continue;
+    const tail = contents.slice(result.index + result[0].length, result.index + result[0].length + 1_500);
+    const method = tail.match(/^\s*,\s*\{[\s\S]{0,1400}?\bmethod\s*:\s*["'`](DELETE|GET|HEAD|PATCH|POST|PUT)["'`]/i)?.[1]?.toUpperCase()
+      ?? "GET";
+    tools.push(fetchCandidate(file, lineNumber(contents, result.index), method, path, "frontend fetch"));
+  }
+  return tools;
+}
+
+function formTools(file, contents) {
+  const tools = [];
+  const pattern = /<form\b([^>]*)>([\s\S]*?)<\/form\s*>/gi;
+  let ordinal = 0;
+  for (const result of contents.matchAll(pattern)) {
+    ordinal += 1;
+    const attributes = htmlAttributes(result[1]);
+    const action = attributes.action || "";
+    const method = (attributes.method || "get").toUpperCase();
+    const formName = attributes.id || attributes.name || pathName(action) || `form_${ordinal}`;
+    const selector = attributes.id
+      ? `#${cssIdentifier(attributes.id)}`
+      : attributes.name ? `form[name="${cssString(attributes.name)}"]`
+        : action ? `form[action="${cssString(action)}"]` : `form:nth-of-type(${ordinal})`;
+    const properties = {};
+    const required = [];
+    const fieldPattern = /<(?:input|select|textarea)\b([^>]*)>/gi;
+    for (const field of result[2].matchAll(fieldPattern)) {
+      const fieldAttributes = htmlAttributes(field[1]);
+      if (!fieldAttributes.name || fieldAttributes.type === "hidden") continue;
+      properties[fieldAttributes.name] = {
+        type: fieldAttributes.type === "checkbox" ? "boolean" : "string",
+      };
+      if (Object.hasOwn(fieldAttributes, "required")) required.push(fieldAttributes.name);
+    }
+    tools.push(candidate({
+      name: `form_${formName}`,
+      title: humanize(formName),
+      description: `Submit the ${humanize(formName)} form through the website's current authenticated page.`,
+      inputSchema: {
+        type: "object",
+        properties: {
+          fields: {
+            type: "object",
+            properties,
+            ...(required.length ? { required } : {}),
+            additionalProperties: Object.keys(properties).length === 0,
+          },
+        },
+        required: ["fields"],
+        additionalProperties: false,
+      },
+      annotations: { readOnlyHint: false, untrustedContentHint: false },
+      implementation: { kind: "form", selector },
+      evidence: evidence(file, contents, result.index, `HTML form ${method} ${action || "current URL"}`),
+    }));
+  }
+  return tools;
+}
+
+function graphqlTools(file, contents) {
+  const tools = [];
+  const pattern = /\b(query|mutation)\s+([A-Za-z_][A-Za-z0-9_]*)\b/g;
+  for (const result of contents.matchAll(pattern)) {
+    const operation = result[1];
+    const name = result[2];
+    tools.push(candidate({
+      name: `graphql_${name}`,
+      title: humanize(name),
+      description: `Run the ${name} GraphQL ${operation} using the website's authenticated GraphQL client.`,
+      inputSchema: openObject("variables"),
+      annotations: { readOnlyHint: operation === "query", untrustedContentHint: true },
+      implementation: { kind: "custom", export: name, operation },
+      evidence: evidence(file, contents, result.index, `GraphQL ${operation} ${name}`),
+    }));
+  }
+  return tools;
+}
+
+function serverActionTools(file, contents) {
+  const tools = [];
+  const patterns = [
+    /export\s+(?:async\s+)?function\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*\(/g,
+    /export\s+const\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*async\s*\(/g,
+  ];
+  for (const pattern of patterns) {
+    for (const result of contents.matchAll(pattern)) {
+      const name = result[1];
+      tools.push(candidate({
+        name: `action_${name}`,
+        title: humanize(name),
+        description: `Run the website server action ${name} through an application-supplied handler.`,
+        inputSchema: openObject("input"),
+        annotations: { readOnlyHint: false, untrustedContentHint: false },
+        implementation: { kind: "custom", export: name },
+        evidence: evidence(file, contents, result.index, `server action ${name}`),
+      }));
+    }
+  }
+  return tools;
+}
+
+function trpcTools(file, contents) {
+  const tools = [];
+  const pattern = /\b([A-Za-z_$][A-Za-z0-9_$]*)\s*:\s*[^,;{}]{0,400}?\.(query|mutation)\s*\(/g;
+  for (const result of contents.matchAll(pattern)) {
+    const name = result[1];
+    const operation = result[2];
+    tools.push(candidate({
+      name: `trpc_${name}`,
+      title: humanize(name),
+      description: `Call the website tRPC ${operation} ${name} through its application client.`,
+      inputSchema: openObject("input"),
+      annotations: { readOnlyHint: operation === "query", untrustedContentHint: operation === "query" },
+      implementation: { kind: "custom", procedure: name, operation },
+      evidence: evidence(file, contents, result.index, `tRPC ${operation} ${name}`),
+    }));
+  }
+  return tools;
+}
+
+function openApiTools(file, contents) {
+  let document;
+  try { document = JSON.parse(contents); } catch { return []; }
+  if (!document || typeof document !== "object" || typeof document.openapi !== "string"
+      || !document.paths || typeof document.paths !== "object") return [];
+  const tools = [];
+  for (const [path, item] of Object.entries(document.paths)) {
+    if (!item || typeof item !== "object") continue;
+    for (const [methodName, operation] of Object.entries(item)) {
+      const method = methodName.toUpperCase();
+      if (!HTTP_METHODS.has(method) || !operation || typeof operation !== "object") continue;
+      const name = operation.operationId || `${method.toLowerCase()}_${pathName(path) || "root"}`;
+      tools.push(candidate({
+        ...fetchCandidate(file, 1, method, path, "OpenAPI operation"),
+        name,
+        title: operation.summary || humanize(name),
+        description: operation.description || operation.summary || `${method} ${path}`,
+        evidence: [{ file, line: 1, kind: `OpenAPI ${method} ${path}` }],
+      }));
+    }
+  }
+  return tools;
+}
+
+function fetchCandidate(file, line, method, path, kind) {
+  const readOnly = method === "GET" || method === "HEAD";
+  const name = `${method.toLowerCase()}_${pathName(path) || "root"}`;
+  const pathParameters = [...path.matchAll(/\[([^\]]+)\]|:([A-Za-z0-9_]+)/g)]
+    .map((match) => match[1] ?? match[2]);
+  return candidate({
+    name,
+    title: `${method} ${path}`,
+    description: `${method} ${path} through the website's same-origin authenticated session.`,
+    inputSchema: {
+      type: "object",
+      properties: {
+        ...(pathParameters.length ? {
+          path: {
+            type: "object",
+            properties: Object.fromEntries(pathParameters.map((parameter) => [parameter, { type: "string" }])),
+            required: pathParameters,
+            additionalProperties: false,
+          },
+        } : {}),
+        query: { type: "object", additionalProperties: true },
+        ...(!readOnly ? { body: {} } : {}),
+      },
+      ...(pathParameters.length ? { required: ["path"] } : {}),
+      additionalProperties: false,
+    },
+    annotations: { readOnlyHint: readOnly, untrustedContentHint: true },
+    implementation: { kind: "fetch", method, path },
+    evidence: [{ file, line, kind: `${kind} ${method} ${path}` }],
+  });
+}
+
+function candidate(tool) {
+  return {
+    ...tool,
+    name: safeName(tool.name),
+  };
+}
+
+function deduplicate(candidates) {
+  const exact = new Map();
+  for (const tool of candidates) {
+    const key = JSON.stringify(tool.implementation);
+    const existing = exact.get(key);
+    if (!existing) exact.set(key, tool);
+    else existing.evidence.push(...tool.evidence);
+  }
+  const byName = new Map();
+  const tools = [];
+  for (const tool of exact.values()) {
+    let name = tool.name;
+    const collision = byName.get(name);
+    if (collision && JSON.stringify(collision.implementation) !== JSON.stringify(tool.implementation)) {
+      name = `${name.slice(0, 119)}_${shortHash(JSON.stringify(tool.implementation))}`;
+    }
+    const next = { ...tool, name };
+    byName.set(name, next);
+    tools.push(next);
+  }
+  return tools.sort((left, right) => left.name.localeCompare(right.name));
+}
+
+async function sourceFiles(root, maximum) {
+  const files = [];
+  const pending = [root];
+  while (pending.length) {
+    const directory = pending.pop();
+    const entries = await readdir(directory, { withFileTypes: true });
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+      if (entry.isSymbolicLink()) continue;
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        if (!IGNORED_DIRECTORIES.has(entry.name) && !entry.name.startsWith(".wrangler")) pending.push(path);
+        continue;
+      }
+      if (!entry.isFile() || !SOURCE_EXTENSIONS.has(extname(entry.name).toLowerCase())) continue;
+      files.push(path);
+      if (files.length > maximum) throw new RangeError(`WebMCP generator exceeded ${maximum} source files`);
+    }
+  }
+  return files.sort();
+}
+
+function htmlAttributes(source) {
+  const attributes = {};
+  const pattern = /([:\w-]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
+  for (const result of source.matchAll(pattern)) {
+    attributes[result[1].toLowerCase()] = result[2] ?? result[3] ?? result[4] ?? "";
+  }
+  return attributes;
+}
+
+function evidence(file, contents, index, kind) {
+  return [{ file, line: lineNumber(contents, index), kind }];
+}
+
+function lineNumber(contents, index = 0) {
+  return contents.slice(0, index).split("\n").length;
+}
+
+function openObject(name) {
+  return {
+    type: "object",
+    properties: { [name]: { type: "object", additionalProperties: true } },
+    additionalProperties: false,
+  };
+}
+
+function pathName(path) {
+  return String(path)
+    .replace(/^https?:\/\/[^/]+/i, "")
+    .replace(/\?.*$/, "")
+    .replace(/\[|\]|:/g, "")
+    .split(/[^A-Za-z0-9_$]+/)
+    .filter(Boolean)
+    .join("_")
+    .slice(0, 96);
+}
+
+function safeName(value) {
+  const normalized = String(value)
+    .split("")
+    .map((character) => /[A-Za-z0-9_.-]/.test(character) ? character : "_")
+    .join("")
+    .replace(/_+/g, "_")
+    .replace(/^[_\-.]+|[_\-.]+$/g, "") || "tool";
+  return normalized.length <= 128
+    ? normalized
+    : `${normalized.slice(0, 119)}_${shortHash(normalized)}`;
+}
+
+function humanize(value) {
+  return String(value)
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_\-.]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function cssIdentifier(value) {
+  return String(value).replace(/[^A-Za-z0-9_-]/g, (character) => `\\${character}`);
+}
+
+function cssString(value) {
+  return String(value).replace(/["\\]/g, "\\$&");
+}
+
+function shortHash(value) {
+  let hash = 0x811c9dc5;
+  for (const character of value) {
+    hash ^= character.codePointAt(0);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36).padStart(7, "0").slice(0, 7);
+}
+
+function validateOptions(options) {
+  if (!options || typeof options !== "object" || Array.isArray(options)) {
+    throw new TypeError("WebMCP generator options must be an object");
+  }
+  const allowed = new Set(["maxFileBytes", "maxFiles", "root"]);
+  for (const name of Object.keys(options)) {
+    if (!allowed.has(name)) throw new TypeError(`unsupported WebMCP generator option: ${name}`);
+  }
+}
+
+function boundedInteger(value, name, minimum, maximum) {
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    throw new TypeError(`${name} must be an integer from ${minimum} through ${maximum}`);
+  }
+  return value;
+}
+
+function deepFreeze(value) {
+  if (!value || typeof value !== "object" || Object.isFrozen(value)) return value;
+  for (const child of Object.values(value)) deepFreeze(child);
+  return Object.freeze(value);
+}

--- a/js/bindings/webmcp/generator.mjs
+++ b/js/bindings/webmcp/generator.mjs
@@ -46,10 +46,14 @@ export async function generate(options = {}) {
     ...candidate,
     approved: false,
   }));
+  const sourceRevision = createHash("sha256")
+    .update(JSON.stringify(tools.map(toolFingerprint)))
+    .digest("hex");
   return deepFreeze({
     version: 1,
     generatedAt: new Date().toISOString(),
     root: ".",
+    sourceRevision,
     tools,
   });
 }
@@ -504,6 +508,10 @@ function validateFileOptions(options) {
 }
 
 function reconcileManifest(draft, previous) {
+  if (previous?.sourceRevision === draft.sourceRevision
+      && previous.generatedBy === "nanocodex-agent") {
+    return deepFreeze(previous);
+  }
   const approved = new Map((previous?.tools ?? []).map((tool) => [tool.name, tool]));
   const tools = draft.tools.map((tool) => {
     const prior = approved.get(tool.name);

--- a/js/react/README.md
+++ b/js/react/README.md
@@ -1,7 +1,7 @@
 # nanocodex-react
 
-React hooks over the headless browser SDK. The vanilla config owns the package
-Worker, Rust/WASM Agent, persistent workspace, and cleanup. React only reads
+React hooks over the headless browser SDK. The vanilla config owns either the
+package Worker or managed Agent lifecycle and its cleanup. React only reads
 that external state and binds event subscriptions.
 
 ## Headless conversation controller
@@ -140,4 +140,46 @@ preparation lifecycle.
 
 ```ts
 const config = createConfig({ agent: { /* tools and policy */ } });
+```
+
+## Drive the website through WebMCP
+
+With the Vite or Next.js WebMCP generator enabled, publish the reviewed
+`webmcp.manifest.json` from the application and enable WebMCP on the same config
+used by the React hook. Set `harness: false` when the website itself is the
+complete tool surface:
+
+```tsx
+import { Transport } from "nanocodex/browser";
+import { createConfig, useNanocodex } from "nanocodex-react";
+
+const config = createConfig({
+  agent: {
+    harness: false,
+    transport: Transport.hostManaged({ websocketUrl: "/api/responses" }),
+    webMcp: true,
+  },
+});
+
+function App() {
+  const { data: agent } = useNanocodex({ config });
+  return agent ? <Conversation agent={agent} /> : null;
+}
+```
+
+No caller-owned Worker or harness is required. WebMCP handlers stay in the
+page and use its signed-in session; the package Worker receives only the tool
+catalog and bounded calls.
+
+The same hook also owns a durable managed Agent. Its WebMCP tools are
+reverse-attached automatically over the remote tools protocol, so execution
+still returns to the current browser page:
+
+```ts
+const config = createConfig({
+  agent: {
+    transport: Transport.managed({ agent: { create: true } }),
+    webMcp: true,
+  },
+});
 ```

--- a/js/react/README.md
+++ b/js/react/README.md
@@ -144,42 +144,19 @@ const config = createConfig({ agent: { /* tools and policy */ } });
 
 ## Drive the website through WebMCP
 
-With the Vite or Next.js WebMCP generator enabled, publish the reviewed
-`webmcp.manifest.json` from the application and enable WebMCP on the same config
-used by the React hook. Set `harness: false` when the website itself is the
-complete tool surface:
+For Vite applications, `nanocodex()` automatically owns the Accounts-backed
+connection, Agent generation pass, publication, and reverse attachment. React
+consumes its Agent without creating a second config, Worker, or harness:
 
 ```tsx
-import { Transport } from "nanocodex/browser";
-import { createConfig, useNanocodex } from "nanocodex-react";
-
-const config = createConfig({
-  agent: {
-    harness: false,
-    transport: Transport.hostManaged({ websocketUrl: "/api/responses" }),
-    webMcp: true,
-  },
-});
+import { useNanocodex } from "nanocodex-react/vite";
 
 function App() {
-  const { data: agent } = useNanocodex({ config });
+  const { data: agent } = useNanocodex();
   return agent ? <Conversation agent={agent} /> : null;
 }
 ```
 
-No caller-owned Worker or harness is required. WebMCP handlers stay in the
-page and use its signed-in session; the package Worker receives only the tool
-catalog and bounded calls.
-
-The same hook also owns a durable managed Agent. Its WebMCP tools are
-reverse-attached automatically over the remote tools protocol, so execution
-still returns to the current browser page:
-
-```ts
-const config = createConfig({
-  agent: {
-    transport: Transport.managed({ agent: { create: true } }),
-    webMcp: true,
-  },
-});
-```
+WebMCP handlers stay in the signed-in page. The durable Agent receives only the
+catalog and bounded calls over the reverse tools protocol. Retained history is
+enabled only when the signed Connect grant exposes it.

--- a/js/react/index.d.mts
+++ b/js/react/index.d.mts
@@ -1,4 +1,4 @@
-import type { AgentEvent, DefaultAgent } from "nanocodex";
+import type { AgentEvent, AgentLifecycle, DefaultAgent } from "nanocodex";
 import type { ManagedAgent } from "nanocodex/managed";
 import type { ConnectAgent } from "nanocodex/connect";
 import type { Config } from "nanocodex/browser";
@@ -15,22 +15,26 @@ export {
   type AgentStatus,
   type Config,
   type CreateConfigParameters,
+  type CreateManagedConfigParameters,
 } from "nanocodex/browser";
 
-export type UseNanocodexParameters<Selection = UseNanocodexReturnType> = Readonly<{
+export type UseNanocodexParameters<
+  Selection = UseNanocodexReturnType,
+  agent extends AgentLifecycle = DefaultAgent,
+> = Readonly<{
   /** Defaults to true. Disabled hooks stay idle and do not prepare or create an Agent. */
   enabled?: boolean | undefined;
   /** Stable OPFS/Git workspace identity. Omitted or empty values use the config's stable default. */
   threadId?: string | undefined;
   /** Optional provider bypass for libraries and isolated consumers. */
-  config?: Config | undefined;
+  config?: Config<agent> | undefined;
   /** Selects the value observed by this component. Defaults to the full Agent resource. */
-  selector?: ((resource: UseNanocodexReturnType) => Selection) | undefined;
+  selector?: ((resource: UseNanocodexReturnType<agent>) => Selection) | undefined;
   /** Controls whether two selected values are observably different. Defaults to Object.is. */
   equalityFn?: ((previous: Selection, next: Selection) => boolean) | undefined;
 }>;
 
-export type UseNanocodexReturnType =
+export type UseNanocodexReturnType<agent extends AgentLifecycle = DefaultAgent> =
   | Readonly<{
     data: undefined;
     error: undefined;
@@ -52,7 +56,7 @@ export type UseNanocodexReturnType =
     refetch(): void;
   }>
   | Readonly<{
-    data: DefaultAgent;
+    data: agent;
     error: undefined;
     status: "success";
     isError: false;
@@ -74,21 +78,23 @@ export type UseNanocodexReturnType =
 
 export function NanocodexProvider(props: {
   children: ReactNode;
-  config: Config;
+  config: Config<AgentLifecycle>;
 }): ReactNode;
-export function useConfig(parameters?: { config?: Config | undefined }): Config;
-export function useNanocodex<Selection>(
-  options: UseNanocodexParameters<Selection> & {
-    selector: (resource: UseNanocodexReturnType) => Selection;
+export function useConfig<agent extends AgentLifecycle = DefaultAgent>(
+  parameters?: { config?: Config<agent> | undefined },
+): Config<agent>;
+export function useNanocodex<agent extends AgentLifecycle, Selection>(
+  options: UseNanocodexParameters<Selection, agent> & {
+    selector: (resource: UseNanocodexReturnType<agent>) => Selection;
   },
 ): Selection;
-export function useNanocodex(
-  options?: Omit<UseNanocodexParameters<UseNanocodexReturnType>, "selector"> & {
+export function useNanocodex<agent extends AgentLifecycle = DefaultAgent>(
+  options?: Omit<UseNanocodexParameters<UseNanocodexReturnType<agent>, agent>, "selector"> & {
     selector?: undefined;
   },
-): UseNanocodexReturnType;
+): UseNanocodexReturnType<agent>;
 export function useAgentEvents(
-  agent: DefaultAgent | undefined,
+  agent: AgentLifecycle | undefined,
   listener: (event: AgentEvent) => void,
   options?: { includeAllSessions?: boolean | undefined },
 ): void;

--- a/js/react/package.json
+++ b/js/react/package.json
@@ -16,11 +16,16 @@
     "./agent": {
       "types": "./agent/index.d.mts",
       "import": "./agent/index.mjs"
+    },
+    "./vite": {
+      "types": "./vite/index.d.mts",
+      "import": "./vite/index.mjs"
     }
   },
   "files": [
     "agent",
     "cloud",
+    "vite",
     "index.d.mts",
     "index.mjs",
     "README.md"

--- a/js/react/test/types.test-d.mts
+++ b/js/react/test/types.test-d.mts
@@ -1,5 +1,5 @@
 import type { ComponentProps } from "react";
-import type { DefaultAgent } from "nanocodex";
+import type { AgentLifecycle, DefaultAgent } from "nanocodex";
 import { Transport, type AgentStatus } from "nanocodex/browser";
 import type { ManagedAgent } from "nanocodex/managed";
 import {
@@ -28,8 +28,14 @@ import {
 import type { ConnectAgent } from "nanocodex/connect";
 
 const config = createConfig({
-  agent: { transport: Transport.hostManaged(), thinking: "high" },
+  agent: { transport: Transport.hostManaged(), thinking: "high", webMcp: true, harness: false },
   retry: 1,
+});
+const managedConfig = createConfig({
+  agent: {
+    transport: Transport.managed({ agent: { create: true } }),
+    webMcp: true,
+  },
 });
 const provider: ComponentProps<typeof NanocodexProvider> = { children: null, config };
 void provider;
@@ -62,6 +68,15 @@ function Consumer() {
   return result.data;
 }
 void Consumer;
+
+function ManagedConsumer() {
+  const result = useNanocodex({ config: managedConfig });
+  if (result.status !== "success") return result.status;
+  const agent: AgentLifecycle = result.data;
+  useAgentEvents(agent, (event) => event.seq);
+  return agent.sessionId;
+}
+void ManagedConsumer;
 
 function VoiceConsumer(agent: DefaultAgent | ManagedAgent | ConnectAgent | undefined) {
   const voice: UseVoiceReturnType = useVoice(agent, {

--- a/js/react/vite/index.d.mts
+++ b/js/react/vite/index.d.mts
@@ -1,0 +1,18 @@
+import type { Agent } from "../agent/index.mjs";
+
+export { automaticWebMcpConfig as config } from "nanocodex/vite/client";
+
+export type AutomaticNanocodexResource = Readonly<{
+  data: Agent | undefined;
+  error: unknown;
+  status: "idle" | "pending" | "success" | "error";
+  isError: boolean;
+  isIdle: boolean;
+  isPending: boolean;
+  isSuccess: boolean;
+  refetch(): void;
+}>;
+
+export function useNanocodex(options?: Readonly<{
+  enabled?: boolean | undefined;
+}>): AutomaticNanocodexResource;

--- a/js/react/vite/index.mjs
+++ b/js/react/vite/index.mjs
@@ -1,0 +1,45 @@
+"use client";
+
+import {
+  automaticWebMcpConfig,
+  automaticWebMcpConnection,
+} from "nanocodex/vite/client";
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+import { createConnectAgentSource } from "../cloud/connectAgentSource.mjs";
+
+/** Uses the Agent automatically connected and attached by nanocodex(). */
+export function useNanocodex(parameters = {}) {
+  const subscribe = useCallback(
+    (listener) => automaticWebMcpConfig.subscribeAgent(parameters, listener),
+    [parameters.enabled],
+  );
+  const getSnapshot = useCallback(
+    () => automaticWebMcpConfig.getAgent(parameters),
+    [parameters.enabled],
+  );
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, idleSnapshot);
+  const connection = snapshot.data ? automaticWebMcpConnection() : undefined;
+  const source = useMemo(
+    () => snapshot.data
+      ? createConnectAgentSource(snapshot.data, {
+        history: connection?.grant?.visibility?.conversationHistory === true,
+      })
+      : undefined,
+    [snapshot.data, connection],
+  );
+  return Object.freeze({
+    data: source,
+    error: snapshot.error,
+    status: snapshot.status,
+    isError: snapshot.status === "error",
+    isIdle: snapshot.status === "idle",
+    isPending: snapshot.status === "pending",
+    isSuccess: snapshot.status === "success",
+    refetch: () => automaticWebMcpConfig.refetchAgent(parameters),
+  });
+}
+
+export { automaticWebMcpConfig as config };
+
+const IDLE = Object.freeze({ data: undefined, error: undefined, status: "idle" });
+function idleSnapshot() { return IDLE; }

--- a/web/connect-dialog/src/App.tsx
+++ b/web/connect-dialog/src/App.tsx
@@ -118,6 +118,7 @@ type WizardAccountSelection = AccountSelection;
 export type { ConnectRequest } from "./connectTypes";
 
 export type ConnectOnboardingHost = Readonly<{
+  approve?(): Promise<void>;
   reject(error?: unknown): Promise<unknown>;
   respond(result: unknown): Promise<unknown>;
 }>;
@@ -489,7 +490,9 @@ export function ConnectOnboarding({
                   selectedAccount?.discoverCredential,
                   hostedAuthorization,
                 )
-              : activeRequest.rpc) as never,
+              : activeRequest.type === "walletRevokeAccessKey"
+                ? activeRequest.rpc
+                : (() => { throw new Error("The Connect request changed."); })()) as never,
           ) as Promise<typeof result>);
         } finally {
           if (activeRequest.type === "walletConnect") invalidateBrowserSession();
@@ -1101,7 +1104,7 @@ export function ConnectOnboarding({
     >
       {!wizard ? <header className="dialog-header">
         <span className="wordmark">nanocodex/connect</span>
-        <span className="secure-label"><span aria-hidden="true" /> passkey</span>
+        <span className="secure-label"><span aria-hidden="true" /> {request.type === "webMcpApproval" ? "one-time approval" : "passkey"}</span>
       </header> : null}
 
       {request.type === "walletConnect" ? (
@@ -1177,11 +1180,99 @@ export function ConnectOnboarding({
             </button>
           </div>
         </>
+      ) : request.type === "webMcpApproval" ? (
+        <WebMcpApproval host={host} request={request} onReject={reject} />
       ) : (
         <FundingApproval host={host} request={request} onReject={reject} />
       )}
     </section>
   );
+}
+
+function WebMcpApproval({ host, request, onReject }: Readonly<{
+  host: ConnectOnboardingHost;
+  request: Dialog.WebMcpApprovalRequest;
+  onReject(): void;
+}>) {
+  const [busy, setBusy] = useState(false);
+  const [failure, setFailure] = useState<string>();
+  const action = request.action;
+  const destination = action.origin ?? request.app.origin;
+  const title = action.title?.trim() || humanizeAction(action.name);
+
+  async function approve() {
+    if (busy || failure) return;
+    setBusy(true);
+    try {
+      if (!host.approve) throw new Error("This host cannot execute WebMCP approvals.");
+      await host.approve();
+      await host.respond({ approved: true });
+    } catch (error) {
+      setFailure(errorMessage(error));
+      setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <div className="dialog-content webmcp-approval">
+        <section className="request-title" aria-labelledby="webmcp-approval-heading">
+          <p className="eyebrow">Review action</p>
+          <h1 id="webmcp-approval-heading">{title}</h1>
+          <p className="request-copy">{action.description ?? "Review the exact website action before Nanocodex applies it."}</p>
+        </section>
+
+        <section className="action-route" aria-label="Action route">
+          <div>
+            <span>Requested by</span>
+            <strong>{request.app.name}</strong>
+            <small>{request.app.origin}</small>
+          </div>
+          <span aria-hidden="true">→</span>
+          <div>
+            <span>Destination</span>
+            <strong>{destinationLabel(destination)}</strong>
+            <small>{destination}</small>
+          </div>
+        </section>
+
+        <section className="detail-section" aria-labelledby="webmcp-effects-heading">
+          <SectionHeading id="webmcp-effects-heading" label="Exact effects" value="One time" />
+          <div className="permission-rows">
+            <PermissionRow label="Action" value={title} />
+            <PermissionRow label="Method" value={action.name} />
+            <PermissionRow label="Scope" value="This call only" />
+          </div>
+          <p className="period-note">Approval is bound to this method and payload. A later call requires a new approval.</p>
+        </section>
+
+        <details className="advanced-details">
+          <summary>Technical payload</summary>
+          <pre>{safeJson({ kind: action.kind, origin: destination, input: action.input, element: action.element })}</pre>
+        </details>
+        {failure ? <p className="dialog-error" role="alert">{failure}</p> : null}
+      </div>
+      <div className="dialog-actions">
+        <button type="button" disabled={busy} onClick={onReject}>{failure ? "Close" : "Cancel"}</button>
+        <button type="button" disabled={busy || Boolean(failure)} onClick={() => void approve()}>
+          {busy ? "Applying…" : "Confirm action"}
+        </button>
+      </div>
+    </>
+  );
+}
+
+function humanizeAction(value: string) {
+  const words = value.replace(/^web_/, "").replace(/[._-]+/g, " ").trim();
+  return words ? `${words[0]!.toUpperCase()}${words.slice(1)}` : "Website action";
+}
+
+function destinationLabel(value: string) {
+  try { return new URL(value).hostname; } catch { return value; }
+}
+
+function safeJson(value: unknown) {
+  try { return JSON.stringify(value, null, 2); } catch { return "The payload could not be displayed."; }
 }
 
 function RevocationApproval({ request }: Readonly<{ request: WalletRequest }>) {
@@ -2138,6 +2229,7 @@ function walletConnectContext(request: WalletRequest) {
 function walletRequestPolicyError(request: ConnectRequest | undefined) {
   if (!request
     || request.type === "machineUsdFund"
+    || request.type === "webMcpApproval"
     || request.type === "deviceError"
     || request.type === "deviceComplete") return undefined;
   try {

--- a/web/connect-dialog/src/connectPolicy.mjs
+++ b/web/connect-dialog/src/connectPolicy.mjs
@@ -88,7 +88,11 @@ export function registeredApp(embeddingOrigin, appId, dialogUrl, isTopLevel, all
     if (registered.id !== appId) throw new Error("This application ID does not match its registered origin.");
     return registered;
   }
-  if (isLocalDevelopmentOrigin(dialogOrigin) && isLocalDevelopmentOrigin(embeddingOrigin)) {
+  // A loopback application is developer-controlled even when it uses the
+  // production-hosted iframe. This is what lets `nanocodex()` work without a
+  // second local dialog server while keeping non-loopback iframe origins on
+  // the explicit production registry.
+  if (isLocalDevelopmentOrigin(embeddingOrigin)) {
     return Object.freeze({ id: appId, name: "Atlas Workspace", origin: embeddingOrigin });
   }
   if (allowDynamicPopup && isPopupPresentation(dialogUrl, isTopLevel) && isSecurePopupOrigin(embeddingOrigin)) {

--- a/web/connect-dialog/src/connectTypes.ts
+++ b/web/connect-dialog/src/connectTypes.ts
@@ -34,6 +34,7 @@ export type WalletRequest =
 export type ConnectRequest =
   | WalletRequest
   | Dialog.FundingRequest
+  | Dialog.WebMcpApprovalRequest
   | Readonly<{ id: string; message: string; type: "deviceError" }>
   | Readonly<{
       connectorName?: string | undefined;

--- a/web/connect-dialog/src/protocol.ts
+++ b/web/connect-dialog/src/protocol.ts
@@ -20,7 +20,11 @@ type WalletHostActions = Readonly<{
 const listeners = new Set<() => void>();
 let snapshot: Request | undefined;
 let walletEvent: WalletEvent | undefined;
-let fundingParent: Readonly<{ id: string; origin: string; source: Window }> | undefined;
+let dialogParent: Readonly<{ id: string; origin: string; source: Window }> | undefined;
+let executionCompletion: Readonly<{
+  reject(error: Error): void;
+  resolve(): void;
+}> | undefined;
 let started = false;
 
 export const parentDialog = Object.freeze({
@@ -38,7 +42,7 @@ export const parentDialog = Object.freeze({
       await event.respond(result);
       return;
     }
-    const current = fundingParent;
+    const current = dialogParent;
     if (!current) throw new Error("The Nanocodex dialog has no pending request");
     settle();
     current.source.postMessage({ type: "nanocodex:response", id: current.id, result }, current.origin);
@@ -51,7 +55,7 @@ export const parentDialog = Object.freeze({
       await event.reject({ code: 4001, message });
       return;
     }
-    const current = fundingParent;
+    const current = dialogParent;
     if (!current) throw new Error("The Nanocodex dialog has no pending request");
     settle();
     current.source.postMessage({
@@ -59,6 +63,19 @@ export const parentDialog = Object.freeze({
       id: current.id,
       error: { message },
     }, current.origin);
+  },
+  async approve() {
+    const current = dialogParent;
+    if (!current || snapshot?.type !== "webMcpApproval" || executionCompletion) {
+      throw new Error("The Nanocodex dialog has no pending WebMCP approval");
+    }
+    return new Promise<void>((resolve, reject) => {
+      executionCompletion = Object.freeze({ reject, resolve });
+      current.source.postMessage({
+        type: "nanocodex:approval",
+        id: current.id,
+      }, current.origin);
+    });
   },
 });
 
@@ -123,15 +140,19 @@ export function startWalletHost(actions: WalletHostActions) {
 }
 
 window.addEventListener("message", (event: MessageEvent<unknown>) => {
-  if (
-    window.parent === window ||
-    event.source !== window.parent ||
-    event.origin === "null" ||
-    snapshot !== undefined ||
-    !isFundingMessage(event.data)
-  ) return;
-
-  fundingParent = Object.freeze({ id: event.data.id, origin: event.origin, source: window.parent });
+  if (window.parent === window || event.source !== window.parent || event.origin === "null") return;
+  if (isCompletionMessage(event.data)
+    && dialogParent?.id === event.data.id
+    && dialogParent.origin === event.origin) {
+    const completion = executionCompletion;
+    executionCompletion = undefined;
+    if (!completion) return;
+    if (event.data.ok) completion.resolve();
+    else completion.reject(new Error(event.data.error?.message ?? "The action failed."));
+    return;
+  }
+  if (snapshot !== undefined || !isDialogMessage(event.data, event.origin)) return;
+  dialogParent = Object.freeze({ id: event.data.id, origin: event.origin, source: window.parent });
   publish(Object.freeze(event.data.request));
 });
 
@@ -142,7 +163,8 @@ function publish(request: Request | undefined) {
 
 function settle() {
   walletEvent = undefined;
-  fundingParent = undefined;
+  dialogParent = undefined;
+  executionCompletion = undefined;
   publish(undefined);
 }
 
@@ -224,13 +246,37 @@ function singleParameter(url: URL, name: string): string | null {
   return values.length === 1 ? values[0]! : null;
 }
 
-function isFundingMessage(value: unknown): value is Readonly<{
+function isDialogMessage(value: unknown, origin: string): value is Readonly<{
   type: "nanocodex:request";
   id: string;
-  request: Dialog.FundingRequest;
+  request: Dialog.FundingRequest | Dialog.WebMcpApprovalRequest;
 }> {
   if (!isRecord(value) || value.type !== "nanocodex:request" || typeof value.id !== "string") return false;
-  return isRecord(value.request) && value.request.type === "machineUsdFund" && value.request.id === value.id;
+  if (!isRecord(value.request) || value.request.id !== value.id) return false;
+  if (value.request.type === "machineUsdFund") return true;
+  if (value.request.type !== "webMcpApproval"
+    || !isRecord(value.request.app)
+    || value.request.app.origin !== origin
+    || typeof value.request.app.id !== "string"
+    || typeof value.request.app.name !== "string"
+    || !isRecord(value.request.action)
+    || value.request.action.readOnly !== false
+    || (value.request.action.kind !== "webmcp" && value.request.action.kind !== "semantic")
+    || typeof value.request.action.name !== "string"
+    || !value.request.action.name) return false;
+  return true;
+}
+
+function isCompletionMessage(value: unknown): value is Readonly<{
+  type: "nanocodex:completion";
+  id: string;
+  ok: boolean;
+  error?: Readonly<{ message?: string }>;
+}> {
+  return isRecord(value)
+    && value.type === "nanocodex:completion"
+    && typeof value.id === "string"
+    && typeof value.ok === "boolean";
 }
 
 function isRecord(value: unknown): value is Record<string, any> {

--- a/web/connect-dialog/src/styles.css
+++ b/web/connect-dialog/src/styles.css
@@ -90,6 +90,10 @@
   height: min(650px, calc(100vh - 24px));
 }
 
+:scope.dialog-shell[data-request="webMcpApproval"] {
+  height: min(650px, calc(100vh - 24px));
+}
+
 .dialog-header,
 .section-heading,
 .card-topline {
@@ -807,6 +811,47 @@
   color: var(--faint);
   font-size: 8px;
   line-height: 1.45;
+}
+
+.action-route {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  padding: 12px 0;
+  border-block: 1px solid var(--border);
+}
+
+.action-route > div {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.action-route > span {
+  color: var(--positive);
+  font-size: 14px;
+}
+
+.action-route div > span,
+.action-route small {
+  overflow: hidden;
+  color: var(--faint);
+  font-size: 8px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.action-route strong {
+  overflow: hidden;
+  font-size: 10px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.webmcp-approval .detail-section {
+  border-top: 0;
 }
 
 .advanced-details {

--- a/web/connect-dialog/test/connectPolicy.test.mjs
+++ b/web/connect-dialog/test/connectPolicy.test.mjs
@@ -222,7 +222,7 @@ test("only top-level popup dialogs admit unknown secure app origins", () => {
   assert.equal(isPopupPresentation("https://dialog.example/?mode=iframe", true), false);
 });
 
-test("loopback auth and apps are accepted only by a loopback dialog", () => {
+test("loopback apps can use the hosted dialog while loopback auth requires a loopback dialog", () => {
   assert.equal(connectApiOrigin({
     challenge: `${productionConnectApiOrigin}/v1/connect/auth/challenge`,
     verify: `${productionConnectApiOrigin}/v1/connect/auth`,
@@ -237,6 +237,16 @@ test("loopback auth and apps are accepted only by a loopback dialog", () => {
     "http://127.0.0.1:4177/connect-dialog/?mode=iframe",
     false,
   ).id, "atlas-workspace");
+  assert.deepEqual(registeredApp(
+    "http://localhost:5173",
+    "webmcp-dev:bank",
+    productionDialog,
+    false,
+  ), {
+    id: "webmcp-dev:bank",
+    name: "Atlas Workspace",
+    origin: "http://localhost:5173",
+  });
   assert.throws(() => connectApiOrigin({ url: "http://127.0.0.1:8787/v1/connect/auth" }, "https://dialog.example"), /production Connect API/);
   assert.throws(() => connectApiOrigin({
     challenge: "http://127.0.0.1:8787/v1/connect/auth/challenge",

--- a/web/connect-dialog/test/protocol.test.tsx
+++ b/web/connect-dialog/test/protocol.test.tsx
@@ -4,12 +4,74 @@ const MCP_ID = "abcdefghijklmnopqrstuvwxyz0123456789_-ABCDE";
 const OTHER_MCP_ID = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-abcde";
 
 let projectWalletRequest: typeof import("../src/protocol").projectWalletRequest;
+let parentDialog: typeof import("../src/protocol").parentDialog;
+let messageListener: (event: MessageEvent<unknown>) => void;
+const parent = { postMessage: vi.fn() };
 
 beforeAll(async () => {
   vi.stubGlobal("window", {
-    addEventListener: vi.fn(),
+    parent,
+    addEventListener: vi.fn((type, listener) => {
+      if (type === "message") messageListener = listener;
+    }),
   });
-  ({ projectWalletRequest } = await import("../src/protocol"));
+  ({ parentDialog, projectWalletRequest } = await import("../src/protocol"));
+});
+
+describe("embedded WebMCP approval protocol", () => {
+  it("binds the request to its parent origin and waits for execution completion", async () => {
+    const request = {
+      id: "webmcp-approval",
+      type: "webMcpApproval",
+      app: { id: "webmcp:consumer.example", name: "Sodium", origin: "https://consumer.example" },
+      action: {
+        kind: "webmcp",
+        name: "send_transfer",
+        input: { amount: "25.00", to: "Ada" },
+        readOnly: false,
+      },
+    } as const;
+    messageListener({
+      data: { type: "nanocodex:request", id: request.id, request },
+      origin: "https://consumer.example",
+      source: parent,
+    } as unknown as MessageEvent);
+    expect(parentDialog.getRequest()).toEqual(request);
+
+    const completion = parentDialog.approve();
+    expect(parent.postMessage).toHaveBeenLastCalledWith({
+      type: "nanocodex:approval",
+      id: request.id,
+    }, "https://consumer.example");
+    messageListener({
+      data: { type: "nanocodex:completion", id: request.id, ok: true },
+      origin: "https://consumer.example",
+      source: parent,
+    } as unknown as MessageEvent);
+    await completion;
+    await parentDialog.respond({ approved: true });
+    expect(parent.postMessage).toHaveBeenLastCalledWith({
+      type: "nanocodex:response",
+      id: request.id,
+      result: { approved: true },
+    }, "https://consumer.example");
+    expect(parentDialog.getRequest()).toBeUndefined();
+  });
+
+  it("rejects a WebMCP request that lies about its embedding origin", () => {
+    const request = {
+      id: "origin-substitution",
+      type: "webMcpApproval",
+      app: { id: "webmcp:attacker.example", name: "Attacker", origin: "https://attacker.example" },
+      action: { kind: "webmcp", name: "send_transfer", input: {}, readOnly: false },
+    } as const;
+    messageListener({
+      data: { type: "nanocodex:request", id: request.id, request },
+      origin: "https://consumer.example",
+      source: parent,
+    } as unknown as MessageEvent);
+    expect(parentDialog.getRequest()).toBeUndefined();
+  });
 });
 
 function walletRequest(context?: unknown) {

--- a/web/docs/src/pages/capabilities/webmcp.mdx
+++ b/web/docs/src/pages/capabilities/webmcp.mdx
@@ -17,10 +17,7 @@ import { Agent, Transport } from "nanocodex/browser";
 
 const agent = await Agent.create({
   transport: Transport.hostManaged({ websocketUrl: "/api/responses" }),
-  webMcp: {
-    fallback: "when-empty",
-    confirm: (action) => showApplicationApproval(action),
-  },
+  webMcp: { fallback: "when-empty" },
 });
 ```
 
@@ -36,8 +33,11 @@ the durable conversation remains managed.
 Native WebMCP tools are preferred. Tool names are exposed to the model with a
 `web_` prefix, schemas and annotations are retained, and an `AbortSignal`
 propagates from the agent to `document.modelContext.executeTool(...)`.
-When supplied, the embedding application's `confirm` hook gates non-read-only
-calls.
+Every non-read-only call opens the package-owned Connect dialog. The dialog
+shows requester → destination, exact effects, one-call scope, and the technical
+payload, then remains in `Applying…` until that exact handler settles. A
+rejection never invokes the page handler. The `confirm` option is only a
+headless or custom-host override.
 
 WebMCP is still an experimental browser API. When the registry is unavailable
 or empty, `fallback: "when-empty"` exposes four bounded page tools:
@@ -50,8 +50,7 @@ or empty, `fallback: "when-empty"` exposes four bounded page tools:
 
 The fallback does not expose arbitrary JavaScript, hidden elements, selectors,
 HTML, or password values. Element IDs are page-local and revalidated before
-use. Fill, activate, and submit all invoke the application confirmation hook
-when one is configured.
+use. Fill, activate, and submit use the same Nanocodex approval dialog.
 Choose `fallback: "never"` for native-only operation or `"always"` to make
 both native and semantic tools available.
 
@@ -61,7 +60,37 @@ The repository generator follows the same review-first model as tools such as
 Sodium. It statically reads source as data and drafts candidates for common
 application routes, frontend fetches, HTML forms, GraphQL operations, Next.js
 server actions, tRPC procedures, and OpenAPI JSON. It never imports or runs the
-repository, and every generated candidate starts with `approved: false`.
+repository, and every new or changed candidate starts with `approved: false`.
+
+Vite and Next.js can keep the review manifest generated automatically:
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import { nanocodex } from "nanocodex/vite";
+
+export default defineConfig({
+  plugins: [nanocodex({ webMcp: true })],
+});
+```
+
+```ts
+// next.config.ts
+import type { NextConfig } from "next";
+import { withWebMcp } from "nanocodex/next";
+
+const nextConfig: NextConfig = {};
+export default withWebMcp(nextConfig);
+```
+
+Both write `webmcp.manifest.json`. Vite regenerates during development and
+build; Next.js regenerates at startup/build and watches source in development.
+An existing approval is preserved only while the source digest, generated
+method, schema, annotations, description, and implementation are unchanged.
+Source or contract changes reset approval instead of silently broadening the
+website's tools.
+
+The CLI exposes the same reconciliation when explicit generation is preferable:
 
 ```sh
 npx nanocodex-webmcp generate . --out webmcp.manifest.json
@@ -77,7 +106,6 @@ import manifest from "./webmcp.manifest.json" with { type: "json" };
 import { publish } from "nanocodex/webmcp";
 
 const publication = await publish(manifest, {
-  confirm: (action) => showApplicationApproval(action),
   handlers: {
     get_account: ({ id }, { signal }) => accountClient.get(id, { signal }),
   },
@@ -112,9 +140,9 @@ const agent = await Agent.create({
 ```
 
 `readOnlyHint` and `untrustedContentHint` are metadata supplied by the website,
-not proof of safety. Keep approvals, grants, rate limits, audit UI, and
-authorization checks in the application. A Nanocodex Connect grant does not
-broaden merely because the page attaches more tools.
+not proof of safety. Keep server authorization and rate limits in the
+application; the Nanocodex dialog owns per-call user approval. A Connect grant
+does not broaden merely because the page attaches more tools.
 
 See the current [Chrome WebMCP imperative API](https://developer.chrome.com/docs/ai/webmcp/imperative-api)
 and [tool security guidance](https://developer.chrome.com/docs/ai/webmcp/secure-tools).

--- a/web/docs/src/pages/capabilities/webmcp.mdx
+++ b/web/docs/src/pages/capabilities/webmcp.mdx
@@ -56,13 +56,10 @@ both native and semantic tools available.
 
 ## Generate tools from an existing site
 
-The repository generator follows the same review-first model as tools such as
-Sodium. It statically reads source as data and drafts candidates for common
-application routes, frontend fetches, HTML forms, GraphQL operations, Next.js
-server actions, tRPC procedures, and OpenAPI JSON. It never imports or runs the
-repository, and every new or changed candidate starts with `approved: false`.
-
-Vite and Next.js can keep the review manifest generated automatically:
+With Vite there is no separate command and no WebMCP specification to write.
+`nanocodex()` derives bounded candidates from source, injects the normal
+Accounts-backed embed into the development page, and asks the authenticated
+Nanocodex Agent to verify them against the running product:
 
 ```ts
 // vite.config.ts
@@ -70,7 +67,7 @@ import { defineConfig } from "vite";
 import { nanocodex } from "nanocodex/vite";
 
 export default defineConfig({
-  plugins: [nanocodex({ webMcp: true })],
+  plugins: [nanocodex()],
 });
 ```
 
@@ -83,38 +80,30 @@ const nextConfig: NextConfig = {};
 export default withWebMcp(nextConfig);
 ```
 
-Both write `webmcp.manifest.json`. Vite regenerates during development and
-build; Next.js regenerates at startup/build and watches source in development.
-An existing approval is preserved only while the source digest, generated
-method, schema, annotations, description, and implementation are unchanged.
-Source or contract changes reset approval instead of silently broadening the
-website's tools.
+The browser module reuses the same Connect dialog and `tempoxyz/accounts`
+session as the normal embed. The managed Agent observes the page through the
+reverse WebMCP attachment and returns a manifest to Vite. Vite accepts it only
+for the exact source revision and pins every execution target, evidence record,
+and read/write annotation. Source changes repeat this lifecycle through HMR;
+production builds perform no model calls.
 
-React applications can make that published registry their entire Agent tool
-surface without owning a harness:
+Next.js currently keeps deterministic source generation through
+`withWebMcp()`.
+
+React consumes the automatically connected Agent without owning a config,
+Worker, or harness:
 
 ```tsx
-import { Transport } from "nanocodex/browser";
-import { createConfig, useNanocodex } from "nanocodex-react";
-
-const config = createConfig({
-  agent: {
-    harness: false,
-    transport: Transport.hostManaged({ websocketUrl: "/api/responses" }),
-    webMcp: true,
-  },
-});
+import { useNanocodex } from "nanocodex-react/vite";
 
 function App() {
-  const { data: agent } = useNanocodex({ config });
+  const { data: agent } = useNanocodex();
   return agent ? <Conversation agent={agent} /> : null;
 }
 ```
 
-Replace `hostManaged(...)` with
-`Transport.managed({ agent: { create: true } })` for a durable managed Agent.
-The same React config then reverse-attaches WebMCP over the remote tools
-protocol, so handlers and approvals remain in the live website.
+The hook adapts that durable Connect Agent for the existing headless
+conversation controller. Handlers and approvals stay in the authenticated page.
 
 The CLI exposes the same reconciliation when explicit generation is preferable:
 

--- a/web/docs/src/pages/capabilities/webmcp.mdx
+++ b/web/docs/src/pages/capabilities/webmcp.mdx
@@ -90,6 +90,32 @@ method, schema, annotations, description, and implementation are unchanged.
 Source or contract changes reset approval instead of silently broadening the
 website's tools.
 
+React applications can make that published registry their entire Agent tool
+surface without owning a harness:
+
+```tsx
+import { Transport } from "nanocodex/browser";
+import { createConfig, useNanocodex } from "nanocodex-react";
+
+const config = createConfig({
+  agent: {
+    harness: false,
+    transport: Transport.hostManaged({ websocketUrl: "/api/responses" }),
+    webMcp: true,
+  },
+});
+
+function App() {
+  const { data: agent } = useNanocodex({ config });
+  return agent ? <Conversation agent={agent} /> : null;
+}
+```
+
+Replace `hostManaged(...)` with
+`Transport.managed({ agent: { create: true } })` for a durable managed Agent.
+The same React config then reverse-attaches WebMCP over the remote tools
+protocol, so handlers and approvals remain in the live website.
+
 The CLI exposes the same reconciliation when explicit generation is preferable:
 
 ```sh

--- a/web/docs/src/pages/capabilities/webmcp.mdx
+++ b/web/docs/src/pages/capabilities/webmcp.mdx
@@ -1,0 +1,120 @@
+---
+title: Embedded WebMCP
+description: Let a Nanocodex browser or managed agent use the live website's approved tools and a bounded semantic fallback.
+---
+
+# Embedded WebMCP
+
+Enable `webMcp` when Nanocodex is embedded in a website. The browser binding
+discovers the live page's `document.modelContext` tools, mirrors them into the
+agent, and executes them back in the page. The tool therefore uses the
+website's current cookies, in-memory state, CSRF handling, and UI lifecycle;
+Nanocodex does not copy the website's credentials into its Worker or managed
+service.
+
+```js
+import { Agent, Transport } from "nanocodex/browser";
+
+const agent = await Agent.create({
+  transport: Transport.hostManaged({ websocketUrl: "/api/responses" }),
+  webMcp: {
+    fallback: "when-empty",
+    confirm: (action) => showApplicationApproval(action),
+  },
+});
+```
+
+The package-owned Agent Worker receives only structured tool definitions.
+Calls cross a bounded page-to-Worker RPC bridge and the actual handler remains
+in the window. `toolchange` updates are reflected without recreating the
+Agent. The same `webMcp` option on `Transport.managed(...)` agents creates a
+reverse attachment, so execution still occurs in the signed-in host page while
+the durable conversation remains managed.
+
+## Native tools and semantic fallback
+
+Native WebMCP tools are preferred. Tool names are exposed to the model with a
+`web_` prefix, schemas and annotations are retained, and an `AbortSignal`
+propagates from the agent to `document.modelContext.executeTool(...)`.
+When supplied, the embedding application's `confirm` hook gates non-read-only
+calls.
+
+WebMCP is still an experimental browser API. When the registry is unavailable
+or empty, `fallback: "when-empty"` exposes four bounded page tools:
+
+- `web_page_observe` returns bounded visible text, forms, and actionable
+  controls with opaque element IDs;
+- `web_page_fill` changes visible form controls;
+- `web_page_activate` clicks one retained visible control; and
+- `web_page_submit` uses the page's normal form submission path.
+
+The fallback does not expose arbitrary JavaScript, hidden elements, selectors,
+HTML, or password values. Element IDs are page-local and revalidated before
+use. Fill, activate, and submit all invoke the application confirmation hook
+when one is configured.
+Choose `fallback: "never"` for native-only operation or `"always"` to make
+both native and semantic tools available.
+
+## Generate tools from an existing site
+
+The repository generator follows the same review-first model as tools such as
+Sodium. It statically reads source as data and drafts candidates for common
+application routes, frontend fetches, HTML forms, GraphQL operations, Next.js
+server actions, tRPC procedures, and OpenAPI JSON. It never imports or runs the
+repository, and every generated candidate starts with `approved: false`.
+
+```sh
+npx nanocodex-webmcp generate . --out webmcp.manifest.json
+npx nanocodex-webmcp check webmcp.manifest.json
+```
+
+Review the evidence, schemas, descriptions, read-only annotations, and handler
+placement. Mark only intentional tools as approved. The publisher ignores all
+other candidates.
+
+```js
+import manifest from "./webmcp.manifest.json" with { type: "json" };
+import { publish } from "nanocodex/webmcp";
+
+const publication = await publish(manifest, {
+  confirm: (action) => showApplicationApproval(action),
+  handlers: {
+    get_account: ({ id }, { signal }) => accountClient.get(id, { signal }),
+  },
+});
+
+// Unregister all tools during application teardown.
+publication.close();
+```
+
+Approved same-origin fetch and HTML form candidates have built-in handlers.
+GraphQL, server-action, and tRPC candidates require an explicit application
+handler because the generator cannot safely infer a live client instance.
+
+## Cross-origin and trust boundaries
+
+Same-origin discovery is the default. For an embedded cross-origin frame, the
+parent must delegate the `tools` Permissions Policy, the publishing frame must
+set an exact `exposedTo` origin, and the consumer must request that origin with
+`fromOrigins`. Do not use wildcard origin policy.
+
+```html
+<iframe src="https://shop.example" allow="tools"></iframe>
+```
+
+```js
+await publish(manifest, { exposedTo: ["https://assistant.example"] });
+
+const agent = await Agent.create({
+  transport,
+  webMcp: { fromOrigins: ["https://shop.example"] },
+});
+```
+
+`readOnlyHint` and `untrustedContentHint` are metadata supplied by the website,
+not proof of safety. Keep approvals, grants, rate limits, audit UI, and
+authorization checks in the application. A Nanocodex Connect grant does not
+broaden merely because the page attaches more tools.
+
+See the current [Chrome WebMCP imperative API](https://developer.chrome.com/docs/ai/webmcp/imperative-api)
+and [tool security guidance](https://developer.chrome.com/docs/ai/webmcp/secure-tools).

--- a/web/docs/src/pages/sdks/javascript.mdx
+++ b/web/docs/src/pages/sdks/javascript.mdx
@@ -50,6 +50,7 @@ materialization or historical fork.
 - [Own turns, events, and cleanup](/sdks/javascript/agent-lifecycle).
 - [Choose authentication and socket routing](/sdks/javascript/transports-auth).
 - [Build a browser Worker and persistent workspace](/sdks/javascript/browser-workspace).
+- [Attach the embedding website through WebMCP](/capabilities/webmcp).
 - [Own a browser Worker from React](/sdks/javascript/react).
 - [Add tools, Code Mode, and Rust-backed subagents](/sdks/javascript/tools-code-mode-subagents).
 - Deploy through a concrete [Cloudflare](/deployments/cloudflare) or

--- a/web/docs/src/pages/sdks/javascript/react.mdx
+++ b/web/docs/src/pages/sdks/javascript/react.mdx
@@ -30,9 +30,10 @@ function App() {
 root.render(<App />);
 ```
 
-The vanilla `createConfig` store owns the package Worker, retries, replacement,
-and graceful shutdown. Active hooks with the same thread ID share exactly one
-Agent. A disabled hook stays idle without preparing or creating an Agent.
+The vanilla `createConfig` store owns the package Worker or managed Agent,
+retries, replacement, and graceful shutdown. Active hooks with the same thread
+ID share exactly one Agent. A disabled hook stays idle without preparing or
+creating an Agent.
 `useNanocodex` exposes a Wagmi-style status snapshot and
 `refetch`; `useAgentEvents` subscribes to the ordered typed event stream while
 always calling the latest committed React listener.
@@ -57,6 +58,48 @@ function App() {
 For many consumers, put the same config in `NanocodexProvider` and omit the
 `config` option from each hook. No React-specific prepare or preload step is
 required.
+
+## Make the website the tool surface
+
+After the Vite or Next.js plugin generates `webmcp.manifest.json`, publish its
+reviewed tools and enable WebMCP in the React-owned config. When the site itself
+provides everything the Agent needs, `harness: false` avoids installing the
+default coding harness:
+
+```tsx
+const config = createConfig({
+  agent: {
+    harness: false,
+    transport: Transport.hostManaged({ websocketUrl: "/api/responses" }),
+    webMcp: true,
+  },
+});
+
+function App() {
+  const { data: agent } = useNanocodex({ config });
+  return agent ? <Conversation agent={agent} /> : null;
+}
+```
+
+No caller-owned Worker or React-specific harness lifecycle is needed. The
+WebMCP implementation remains in the signed-in page while bounded definitions
+and calls cross the package Worker bridge.
+
+For a durable managed Agent, select the managed transport on the same config:
+
+```tsx
+const config = createConfig({
+  agent: {
+    transport: Transport.managed({ agent: { create: true } }),
+    webMcp: true,
+  },
+});
+```
+
+`useNanocodex` then owns the managed lifecycle and Nanocodex reverse-attaches
+the page's WebMCP provider over the remote tools protocol. Tool execution comes
+back to the live browser page, preserving its authenticated session and the
+same trusted approval dialog.
 
 ## Keep policy in the application
 

--- a/web/docs/src/pages/sdks/javascript/react.mdx
+++ b/web/docs/src/pages/sdks/javascript/react.mdx
@@ -61,45 +61,22 @@ required.
 
 ## Make the website the tool surface
 
-After the Vite or Next.js plugin generates `webmcp.manifest.json`, publish its
-reviewed tools and enable WebMCP in the React-owned config. When the site itself
-provides everything the Agent needs, `harness: false` avoids installing the
-default coding harness:
+With Vite, `nanocodex()` owns generation, the normal Accounts-backed connection,
+and reverse attachment. React consumes that already-owned Agent directly:
 
 ```tsx
-const config = createConfig({
-  agent: {
-    harness: false,
-    transport: Transport.hostManaged({ websocketUrl: "/api/responses" }),
-    webMcp: true,
-  },
-});
+import { useNanocodex } from "nanocodex-react/vite";
 
 function App() {
-  const { data: agent } = useNanocodex({ config });
+  const { data: agent } = useNanocodex();
   return agent ? <Conversation agent={agent} /> : null;
 }
 ```
 
-No caller-owned Worker or React-specific harness lifecycle is needed. The
-WebMCP implementation remains in the signed-in page while bounded definitions
-and calls cross the package Worker bridge.
-
-For a durable managed Agent, select the managed transport on the same config:
-
-```tsx
-const config = createConfig({
-  agent: {
-    transport: Transport.managed({ agent: { create: true } }),
-    webMcp: true,
-  },
-});
-```
-
-`useNanocodex` then owns the managed lifecycle and Nanocodex reverse-attaches
-the page's WebMCP provider over the remote tools protocol. Tool execution comes
-back to the live browser page, preserving its authenticated session and the
-same trusted approval dialog.
+No caller-owned Worker, config, or React-specific harness lifecycle is needed.
+The hook adapts the durable Connect Agent for the existing headless controller.
+Tool execution returns to the signed-in page and mutating calls use the same
+trusted approval dialog.
 
 ## Keep policy in the application
 

--- a/web/src/docsNavigation.ts
+++ b/web/src/docsNavigation.ts
@@ -112,6 +112,7 @@ export const docsNavigation: readonly DocsNavigationGroup[] = [
         label: "Browser and other capabilities",
         pages: [
           page("Browser-local agent", "/docs/capabilities/web-agent"),
+          page("Embedded WebMCP", "/docs/capabilities/webmcp"),
           page("VMs and sandboxes", "/docs/capabilities/vm-sandboxes"),
           page("Voice", "/docs/capabilities/voice"),
           page("Built with Nanocodex: Tact", "/docs/examples/tact"),

--- a/web/worker/docsPreview.ts
+++ b/web/worker/docsPreview.ts
@@ -27,6 +27,7 @@ export const docsPreview = {
   "/docs/sdks/javascript/react": ["React integration", "Let React own a module Worker and external store without making presentation part of the agent SDK."],
   "/docs/capabilities/web-agent": ["Web agent", "Run the Codex lifecycle and common coding tools locally in a browser Worker."],
   "/docs/deployments": ["Deployment patterns", "Run one owned agent in a CLI, browser, server isolate, durable actor, or cloud sandbox."],
+  "/docs/capabilities/webmcp": ["Embedded WebMCP", "Let a Nanocodex browser or managed agent use the live website's approved tools and a bounded semantic fallback."],
   "/docs/deployments/cloudflare": ["Cloudflare Durable Objects", "Run Rust/WASM inside one SQLite-backed Durable Object with an R2-backed Sandbox workspace."],
   "/docs/deployments/vercel": ["Vercel Workflows", "Reconstruct Rust/WASM in Function steps from an application-owned PostgreSQL journal."],
   "/docs/sdks/python": ["Python SDK", "A thin PyO3 binding over the native owned Rust lifecycle."],


### PR DESCRIPTION
## Summary

- expose the embedding website's live `document.modelContext` tools to browser and managed Nanocodex agents
- reverse-attach browser-owned tools to managed agents without moving website credentials server-side
- enforce mutating calls through the existing skinned Nanocodex Connect approval iframe
- generate review-first WebMCP manifests from Vite and Next.js source
- make plain `nanocodex()` own the full Vite development lifecycle:
  - derive bounded candidates from source
  - inject the normal Accounts-backed Nanocodex embed
  - reconnect or connect the user's ChatGPT subscription through Connect
  - let the authenticated managed Agent inspect the live page over reverse WebMCP
  - verify the returned manifest against the exact source revision and source-owned execution evidence
  - publish approved generated tools into the page
  - rerun after source changes through Vite reload
- expose `useNanocodex()` from `nanocodex-react/vite` so React consumes that Agent without a caller-owned config, Worker, or harness
- keep `withWebMcp()` deterministic for Next.js

## Vite usage

```ts
// vite.config.ts
import { defineConfig } from "vite";
import { nanocodex } from "nanocodex/vite";

export default defineConfig({
  plugins: [nanocodex()],
});
```

```tsx
import { useNanocodex } from "nanocodex-react/vite";

export function App() {
  const { data: agent, status } = useNanocodex();
  return agent ? <Conversation agent={agent} /> : <p>{status}</p>;
}
```

No `nanocodex dev` process or application-authored WebMCP specification is required. Accounts remains the identity/provider boundary for remembered accounts, ChatGPT subscription access, and Tempo MPP.

## Security model

- credentials and provider state stay in Accounts/Connect; Vite receives only a source revision and manifest
- the server accepts an Agent result only for the current SHA-256 source revision
- implementations, evidence, and read/write annotations are pinned to deterministic source-derived candidates
- duplicate or invented implementations are rejected
- custom-handler candidates remain review-only because the automatic publisher cannot safely invent application-owned handlers
- generated fetches stay same-origin and retain the website session
- every non-read-only invocation goes through the existing one-time Connect approval UI and waits for the exact handler to settle
- production Vite builds do not invoke a model
- unknown production iframe origins remain registration-gated; only loopback development apps may use the hosted iframe dynamically

## Verification

- bindings integration: 40 passed (Vite, Connect, WebMCP)
- managed/WebMCP focused suite: 72 passed
- React: 27 passed, plus type/package/pack checks
- Connect policy: 25 passed
- React/Vite example: production build and 14 tests passed
- bindings typecheck and package artifact check passed
- `git diff --check` passed
- generated Vite and Next.js endpoints are exercised against session-protected localhost HTTP endpoints in the framework E2E test
- browser automation was not available in the execution workspace, so no authenticated interactive browser sign-in is claimed
