### PR TITLE
fix(js): forward invoking model to web hosts

### DIFF
--- a/js/bindings/README.md
+++ b/js/bindings/README.md
@@ -339,8 +339,10 @@ schemas, bounds, and image-edit modes, and normalize common malformed model
 arguments before dispatch. In a browser, they default to the same-origin
 `/api/tools/web-search` and `/api/tools/image-generation` routes. The host owns
 only a bounded JSON endpoint, credentials, authorization, and persistence.
-`web(...)` posts `{ commands, session_id }`; `imageGeneration(...)` posts
-`{ images, prompt }`. Pass `url` when the host route lives elsewhere.
+`web(...)` posts `{ commands, session_id, model }`, where `model` is the
+effective model of the invoking root or subagent; `imageGeneration(...)` posts
+`{ images, prompt }`. The host owns model authorization and may ignore or
+override this value. Pass `url` when the host route lives elsewhere.
 
 `dataset()` runs entirely in the caller and inspects public HTTPS Parquet,
 uncompressed JSONL, and Hugging Face datasets. It opens a session-scoped handle,

--- a/js/bindings/test/tools.test.mjs
+++ b/js/bindings/test/tools.test.mjs
@@ -17,6 +17,7 @@ const context = Object.freeze({
   callId: "call-1",
   parentCallId: "",
   sessionId: "session-1",
+  model: "gpt-5.6-terra",
   signal: new AbortController().signal,
 });
 
@@ -45,6 +46,7 @@ test("web forwards the complete command object through a caller-owned host adapt
   assert.deepEqual(JSON.parse(requests[0].init.body), {
     commands: { search_query: [{ q: "nanocodex" }] },
     session_id: "session-1",
+    model: "gpt-5.6-terra",
   });
   assert.equal(requests[0].init.headers.authorization, "Bearer host");
   assert.equal(requests[0].init.redirect, "manual");

--- a/js/bindings/test/types.test-d.mts
+++ b/js/bindings/test/types.test-d.mts
@@ -158,7 +158,7 @@ async function check() {
   const parallelTool: Tool = {
     description: "Parallel read-only fixture.",
     supportsParallelToolCalls: true,
-    handler: async (_input, context) => context.signal.aborted,
+    handler: async (_input, context) => context.model.length > 0 && context.signal.aborted,
   };
   const parallelMcp: McpServer = {
     url: "https://mcp.example.com",

--- a/js/bindings/tools/standard.mjs
+++ b/js/bindings/tools/standard.mjs
@@ -20,6 +20,7 @@ export function web(options = {}) {
       const result = requireObject(await request({
         commands,
         session_id: context.sessionId,
+        model: context.model,
       }, context.signal), "web__run response");
       return requireString(result.output, "web__run response.output");
     },

--- a/js/bindings/types.d.mts
+++ b/js/bindings/types.d.mts
@@ -415,6 +415,8 @@ export type ToolContext = {
   callId: string;
   parentCallId: string;
   sessionId: string;
+  /** Runtime-reported model identifier for the agent invoking this tool. */
+  model: string;
   signal: AbortSignal;
   /** Present for tools invoked by a subagent; absent for the root agent. */
   subagent?: SubagentToolContext | undefined;


### PR DESCRIPTION
## Summary

Pass the invoking agent's model through JavaScript web-tool dispatch.

## Motivation

Native web search builds each request from `ToolContext::model()`. The JavaScript runtime already carries the same model into application tools, but the public `ToolContext` type omitted it and `web()` dropped it before calling the host endpoint. Node and browser hosts therefore could not preserve inherited or explicitly overridden subagent model selection.

## Changes

- Add the runtime-reported model identifier to the public JavaScript `ToolContext`
- Include that model in the standard `{ commands, session_id, model }` web request
- Update the request contract, type test, and bindings documentation

The host still owns model authorization and may ignore or override the supplied value.

## Testing

- `node --test test/tools.test.mjs test/tool-router.test.mjs test/attachment.test.mjs` — 58 passed
- `npm run test:typecheck`
- `git diff --check`
