### PR TITLE
feat(wasm): run Nanocodex core on SpaceWasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5579,6 +5579,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanocodex-spacewasm"
+version = "0.5.0"
+dependencies = [
+ "nanocodex-oai-api",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "nanocodex-subagents"
 version = "0.5.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/nanocodex-managed",
     "crates/nanocodex-durability",
     "crates/experimental/nanocodex-browser",
+    "crates/experimental/nanocodex-spacewasm",
     "crates/experimental/nanocodex-egress",
     "crates/experimental/nanocodex-voice",
     "crates/experimental/nanocodex-voice-protocol",

--- a/crates/experimental/nanocodex-spacewasm/Cargo.toml
+++ b/crates/experimental/nanocodex-spacewasm/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "nanocodex-spacewasm"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Host-stepped Nanocodex core for SpaceWasm and WASI Preview 1"
+
+[dependencies]
+nanocodex-oai-api = { version = "0.5.0", path = "../../nanocodex-oai-api", default-features = false }
+serde.workspace = true
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/experimental/nanocodex-spacewasm/README.md
+++ b/crates/experimental/nanocodex-spacewasm/README.md
@@ -1,0 +1,37 @@
+# Nanocodex on SpaceWasm
+
+SpaceWasm is a synchronous Wasm 1.0 interpreter, not a browser or an async
+application server. This adapter therefore runs the deterministic Nanocodex
+transcript and tool loop inside the guest and leaves capabilities with the
+embedding flight host:
+
+- the guest owns typed Responses history, turn phase, tool-call correlation,
+  revision fencing, and checkpoints;
+- the host owns the OpenAI connection, credentials, timers, durable storage,
+  and every tool effect;
+- the guest never receives a provider credential or opens a socket;
+- every mutating command carries `expected_revision`, so a replay after an
+  ambiguous host failure is rejected instead of duplicating an effect.
+
+The `nanocodex-spacewasm` binary exposes this boundary as one JSON command and
+one JSON action per line over WASI Preview 1 stdin/stdout. It is deliberately a
+thin test/embed adapter; a flight integration can bind the same `FlightCore`
+through fixed native SpaceWasm imports.
+
+```text
+host -> {"op":"init","expected_revision":0,"instructions":"Be terse","tools":[...]}
+guest <- {"kind":"ready","revision":1}
+host -> {"op":"prompt","expected_revision":1,"text":"Check channel 7"}
+guest <- {"kind":"model_request","revision":2,"input":[...]}
+host -> {"op":"model_output","expected_revision":2,"items":[...]}
+guest <- {"kind":"tool_calls","revision":3,"calls":[...]}
+```
+
+Build the guest for `wasm32-wasip1`, lower post-MVP instructions with
+`scripts/wasm2spacewasm.sh`, then run it with `spacewasi`. The wrapper enables
+the bulk-memory input emitted by current Rust before lowering it; SpaceWasm's
+upstream helper otherwise rejects that input on current Binaryen. The
+repository-level `scripts/test-spacewasm.sh` performs the complete mocked-host
+proof and links the guest with a 64 MiB maximum linear memory. Override that
+bound with `NANOCODEX_SPACEWASM_MAX_MEMORY_BYTES` when the embedding has a
+different fixed allocation.

--- a/crates/experimental/nanocodex-spacewasm/src/lib.rs
+++ b/crates/experimental/nanocodex-spacewasm/src/lib.rs
@@ -1,0 +1,627 @@
+//! Synchronous, host-stepped Nanocodex execution for SpaceWasm.
+//!
+//! SpaceWasm deliberately exposes a fixed, synchronous host boundary. This
+//! crate keeps the typed transcript and tool loop inside the guest while the
+//! embedding host owns model transport, credentials, effects, storage, and
+//! scheduling. The JSONL binary is one WASI Preview 1 adapter for this core.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use nanocodex_oai_api::responses::{
+    ContentItem, FunctionOutputBody, MessageRole, ResponseItem, ResponseToolCallRef, ToolDefinition,
+};
+use serde::{Deserialize, Serialize};
+
+const SNAPSHOT_VERSION: u32 = 1;
+
+/// One host command accepted by the flight core.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum Command {
+    /// Initializes a fresh guest with immutable instructions and tool declarations.
+    Init {
+        /// Revision observed by the host before applying this command.
+        expected_revision: u64,
+        /// Stable developer instructions.
+        instructions: String,
+        /// Exact tools the host can execute.
+        #[serde(default)]
+        tools: Vec<ToolDefinition>,
+    },
+    /// Adds one user turn and requests a model call from the host.
+    Prompt {
+        /// Revision observed by the host before applying this command.
+        expected_revision: u64,
+        /// User text.
+        text: String,
+    },
+    /// Returns one completed model output to the guest.
+    ModelOutput {
+        /// Revision observed by the host before applying this command.
+        expected_revision: u64,
+        /// Complete typed output items from one successful Responses call.
+        items: Vec<ResponseItem>,
+    },
+    /// Returns one completed host tool effect to the guest.
+    ToolOutput {
+        /// Revision observed by the host before applying this command.
+        expected_revision: u64,
+        /// Exact provider call identity.
+        call_id: String,
+        /// Tool output returned to the model.
+        output: FunctionOutputBody,
+    },
+    /// Reads a complete durable checkpoint without changing state.
+    Snapshot,
+    /// Replaces guest state from a previously returned checkpoint.
+    Restore {
+        /// Complete checkpoint.
+        snapshot: Snapshot,
+    },
+    /// Ends the JSONL adapter cleanly.
+    Shutdown,
+}
+
+/// One guest response for the embedding host.
+#[derive(Debug, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum HostAction {
+    /// The guest accepted initialization or restoration.
+    Ready {
+        /// Current guest revision.
+        revision: u64,
+    },
+    /// The host must execute one Responses call using this authoritative input.
+    ModelRequest {
+        /// Current guest revision.
+        revision: u64,
+        /// Complete typed input, including stable prefix and committed history.
+        input: Vec<ResponseItem>,
+    },
+    /// The host must execute every listed tool call and return each output.
+    ToolCalls {
+        /// Current guest revision.
+        revision: u64,
+        /// Pending calls in provider order.
+        calls: Vec<HostToolCall>,
+    },
+    /// One tool result was accepted while other dispatched calls remain pending.
+    AwaitingToolOutputs {
+        /// Current guest revision.
+        revision: u64,
+        /// Number of dispatched tool calls still awaiting results.
+        remaining: usize,
+    },
+    /// One agent turn completed without pending tools.
+    Complete {
+        /// Current guest revision.
+        revision: u64,
+        /// Terminal model output.
+        items: Vec<ResponseItem>,
+    },
+    /// Complete durable state.
+    Snapshot {
+        /// Current checkpoint.
+        snapshot: Snapshot,
+    },
+    /// The guest rejected a command without changing its state.
+    Error {
+        /// Current guest revision.
+        revision: u64,
+        /// Stable machine-readable category.
+        code: ErrorCode,
+        /// Human-readable detail safe for logs.
+        detail: String,
+    },
+    /// The adapter should stop reading commands.
+    Shutdown {
+        /// Final guest revision.
+        revision: u64,
+    },
+}
+
+/// A model-requested effect that the embedding host must execute.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct HostToolCall {
+    /// Function or custom tool kind.
+    pub kind: ToolCallKind,
+    /// Tool name.
+    pub name: String,
+    /// Optional Responses namespace.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+    /// JSON function arguments or free-form custom input.
+    pub input: String,
+    /// Provider call identity.
+    pub call_id: String,
+}
+
+/// Supported model tool-call kinds.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolCallKind {
+    /// JSON-schema function call.
+    Function,
+    /// Grammar-constrained custom tool call.
+    Custom,
+}
+
+/// Stable command rejection categories.
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorCode {
+    /// The host used a stale or future revision.
+    RevisionConflict,
+    /// The command is invalid in the current phase.
+    InvalidPhase,
+    /// The guest has not been initialized.
+    NotInitialized,
+    /// The model returned no output items.
+    EmptyModelOutput,
+    /// Two pending calls used the same identity.
+    DuplicateToolCall,
+    /// A tool result did not match a pending call.
+    UnknownToolCall,
+    /// The model requested a tool outside the initialized declaration set.
+    UndeclaredToolCall,
+}
+
+/// Complete serializable guest checkpoint.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Snapshot {
+    version: u32,
+    revision: u64,
+    initialized: bool,
+    instructions: String,
+    tools: Vec<ToolDefinition>,
+    history: Vec<ResponseItem>,
+    phase: Phase,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum Phase {
+    #[default]
+    Idle,
+    AwaitingModel,
+    AwaitingTools {
+        pending: BTreeMap<String, PendingTool>,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct PendingTool {
+    call: HostToolCall,
+}
+
+/// Deterministic, host-stepped Nanocodex guest state.
+#[derive(Debug, Default)]
+pub struct FlightCore {
+    revision: u64,
+    initialized: bool,
+    instructions: String,
+    tools: Vec<ToolDefinition>,
+    history: Vec<ResponseItem>,
+    phase: Phase,
+}
+
+impl FlightCore {
+    /// Creates an empty guest waiting for `init` or `restore`.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            revision: 0,
+            initialized: false,
+            instructions: String::new(),
+            tools: Vec::new(),
+            history: Vec::new(),
+            phase: Phase::Idle,
+        }
+    }
+
+    /// Applies one command atomically and returns the next host action.
+    pub fn apply(&mut self, command: Command) -> HostAction {
+        match command {
+            Command::Init {
+                expected_revision,
+                instructions,
+                tools,
+            } => {
+                if let Some(error) = self.check_revision(expected_revision) {
+                    return error;
+                }
+                if self.initialized || !matches!(self.phase, Phase::Idle) {
+                    return self.error(ErrorCode::InvalidPhase, "guest is already initialized");
+                }
+                self.instructions = instructions;
+                self.tools = tools;
+                self.initialized = true;
+                self.bump();
+                HostAction::Ready {
+                    revision: self.revision,
+                }
+            }
+            Command::Prompt {
+                expected_revision,
+                text,
+            } => {
+                if let Some(error) = self.check_mutation(expected_revision, true) {
+                    return error;
+                }
+                if !matches!(self.phase, Phase::Idle) {
+                    return self.error(ErrorCode::InvalidPhase, "a turn is already active");
+                }
+                self.history.push(ResponseItem::message(
+                    MessageRole::User,
+                    [ContentItem::input_text(text)],
+                ));
+                self.phase = Phase::AwaitingModel;
+                self.bump();
+                self.model_request()
+            }
+            Command::ModelOutput {
+                expected_revision,
+                items,
+            } => {
+                if let Some(error) = self.check_mutation(expected_revision, true) {
+                    return error;
+                }
+                if !matches!(self.phase, Phase::AwaitingModel) {
+                    return self.error(
+                        ErrorCode::InvalidPhase,
+                        "guest is not awaiting model output",
+                    );
+                }
+                if items.is_empty() {
+                    return self.error(
+                        ErrorCode::EmptyModelOutput,
+                        "model output contained no items",
+                    );
+                }
+
+                let mut seen = BTreeSet::new();
+                let mut calls = Vec::new();
+                for item in &items {
+                    let Some(call) = item.tool_call() else {
+                        continue;
+                    };
+                    let (namespace, name) = match call {
+                        ResponseToolCallRef::Function {
+                            namespace, name, ..
+                        }
+                        | ResponseToolCallRef::Custom {
+                            namespace, name, ..
+                        } => (namespace, name),
+                    };
+                    if !self
+                        .tools
+                        .iter()
+                        .any(|tool| tool.accepts_call(namespace, name))
+                    {
+                        return self.error(
+                            ErrorCode::UndeclaredToolCall,
+                            match namespace {
+                                Some(namespace) => {
+                                    format!("tool {namespace}.{name} was not declared")
+                                }
+                                None => format!("tool {name} was not declared"),
+                            },
+                        );
+                    }
+                    if !seen.insert(call.call_id().to_owned()) {
+                        return self.error(
+                            ErrorCode::DuplicateToolCall,
+                            format!("duplicate call_id {}", call.call_id()),
+                        );
+                    }
+                    calls.push(host_tool_call(call));
+                }
+
+                self.history.extend(items.iter().cloned());
+                self.bump();
+                if calls.is_empty() {
+                    self.phase = Phase::Idle;
+                    HostAction::Complete {
+                        revision: self.revision,
+                        items,
+                    }
+                } else {
+                    let pending = calls
+                        .iter()
+                        .map(|call| (call.call_id.clone(), PendingTool { call: call.clone() }))
+                        .collect();
+                    self.phase = Phase::AwaitingTools { pending };
+                    HostAction::ToolCalls {
+                        revision: self.revision,
+                        calls,
+                    }
+                }
+            }
+            Command::ToolOutput {
+                expected_revision,
+                call_id,
+                output,
+            } => {
+                if let Some(error) = self.check_mutation(expected_revision, true) {
+                    return error;
+                }
+                let (tool, remaining) = {
+                    let Phase::AwaitingTools { pending } = &mut self.phase else {
+                        return self
+                            .error(ErrorCode::InvalidPhase, "guest is not awaiting tool output");
+                    };
+                    let Some(tool) = pending.remove(&call_id) else {
+                        return self.error(
+                            ErrorCode::UnknownToolCall,
+                            format!("call_id {call_id} is not pending"),
+                        );
+                    };
+                    let remaining = pending.len();
+                    (tool, remaining)
+                };
+                let item = match tool.call.kind {
+                    ToolCallKind::Function => ResponseItem::function_call_output(call_id, output),
+                    ToolCallKind::Custom => {
+                        ResponseItem::custom_tool_output(call_id, Some(tool.call.name), output)
+                    }
+                };
+                self.history.push(item);
+                let finished = remaining == 0;
+                self.bump();
+                if finished {
+                    self.phase = Phase::AwaitingModel;
+                    self.model_request()
+                } else {
+                    HostAction::AwaitingToolOutputs {
+                        revision: self.revision,
+                        remaining,
+                    }
+                }
+            }
+            Command::Snapshot => HostAction::Snapshot {
+                snapshot: self.snapshot(),
+            },
+            Command::Restore { snapshot } => {
+                if snapshot.version != SNAPSHOT_VERSION {
+                    return self.error(
+                        ErrorCode::InvalidPhase,
+                        format!("unsupported snapshot version {}", snapshot.version),
+                    );
+                }
+                self.revision = snapshot.revision;
+                self.initialized = snapshot.initialized;
+                self.instructions = snapshot.instructions;
+                self.tools = snapshot.tools;
+                self.history = snapshot.history;
+                self.phase = snapshot.phase;
+                HostAction::Ready {
+                    revision: self.revision,
+                }
+            }
+            Command::Shutdown => HostAction::Shutdown {
+                revision: self.revision,
+            },
+        }
+    }
+
+    fn check_mutation(&self, expected_revision: u64, initialized: bool) -> Option<HostAction> {
+        self.check_revision(expected_revision).or_else(|| {
+            (initialized && !self.initialized)
+                .then(|| self.error(ErrorCode::NotInitialized, "guest requires init or restore"))
+        })
+    }
+
+    fn check_revision(&self, expected_revision: u64) -> Option<HostAction> {
+        (expected_revision != self.revision).then(|| {
+            self.error(
+                ErrorCode::RevisionConflict,
+                format!(
+                    "expected revision {expected_revision}, current revision is {}",
+                    self.revision
+                ),
+            )
+        })
+    }
+
+    const fn bump(&mut self) {
+        self.revision = self.revision.saturating_add(1);
+    }
+
+    fn model_request(&self) -> HostAction {
+        let mut input = Vec::with_capacity(self.history.len() + 2);
+        input.push(ResponseItem::message(
+            MessageRole::Developer,
+            [ContentItem::input_text(self.instructions.clone())],
+        ));
+        if !self.tools.is_empty() {
+            input.push(ResponseItem::additional_tools(self.tools.clone()));
+        }
+        input.extend(self.history.iter().cloned());
+        HostAction::ModelRequest {
+            revision: self.revision,
+            input,
+        }
+    }
+
+    fn snapshot(&self) -> Snapshot {
+        Snapshot {
+            version: SNAPSHOT_VERSION,
+            revision: self.revision,
+            initialized: self.initialized,
+            instructions: self.instructions.clone(),
+            tools: self.tools.clone(),
+            history: self.history.clone(),
+            phase: self.phase.clone(),
+        }
+    }
+
+    fn error(&self, code: ErrorCode, detail: impl Into<String>) -> HostAction {
+        HostAction::Error {
+            revision: self.revision,
+            code,
+            detail: detail.into(),
+        }
+    }
+}
+
+fn host_tool_call(call: ResponseToolCallRef<'_>) -> HostToolCall {
+    match call {
+        ResponseToolCallRef::Function {
+            name,
+            namespace,
+            arguments,
+            call_id,
+        } => HostToolCall {
+            kind: ToolCallKind::Function,
+            name: name.to_owned(),
+            namespace: namespace.map(str::to_owned),
+            input: arguments.to_owned(),
+            call_id: call_id.to_owned(),
+        },
+        ResponseToolCallRef::Custom {
+            name,
+            namespace,
+            input,
+            call_id,
+        } => HostToolCall {
+            kind: ToolCallKind::Custom,
+            name: name.to_owned(),
+            namespace: namespace.map(str::to_owned),
+            input: input.to_owned(),
+            call_id: call_id.to_owned(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn apply_json(core: &mut FlightCore, json: &str) -> HostAction {
+        core.apply(serde_json::from_str(json).expect("valid command"))
+    }
+
+    #[test]
+    fn drives_multiple_turns_and_a_host_tool() {
+        let mut core = FlightCore::new();
+        assert!(matches!(
+            apply_json(
+                &mut core,
+                r#"{"op":"init","expected_revision":0,"instructions":"Be terse","tools":[{"type":"function","name":"read_sensor","description":"Read one sensor","strict":false,"parameters":{"type":"object"}}]}"#
+            ),
+            HostAction::Ready { revision: 1 }
+        ));
+        assert!(matches!(
+            apply_json(
+                &mut core,
+                r#"{"op":"prompt","expected_revision":1,"text":"inspect"}"#
+            ),
+            HostAction::ModelRequest { revision: 2, .. }
+        ));
+        let tool = apply_json(
+            &mut core,
+            r#"{"op":"model_output","expected_revision":2,"items":[{"type":"function_call","name":"read_sensor","arguments":"{\"channel\":7}","call_id":"call-1"}]}"#,
+        );
+        assert!(matches!(tool, HostAction::ToolCalls { revision: 3, .. }));
+        assert!(matches!(
+            apply_json(
+                &mut core,
+                r#"{"op":"tool_output","expected_revision":3,"call_id":"call-1","output":"nominal"}"#
+            ),
+            HostAction::ModelRequest { revision: 4, .. }
+        ));
+        assert!(matches!(
+            apply_json(
+                &mut core,
+                r#"{"op":"model_output","expected_revision":4,"items":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"nominal"}]}]}"#
+            ),
+            HostAction::Complete { revision: 5, .. }
+        ));
+        assert!(matches!(
+            apply_json(
+                &mut core,
+                r#"{"op":"prompt","expected_revision":5,"text":"again"}"#
+            ),
+            HostAction::ModelRequest { revision: 6, .. }
+        ));
+    }
+
+    #[test]
+    fn snapshot_restores_an_in_flight_effect_boundary() {
+        let mut core = FlightCore::new();
+        let _ = apply_json(
+            &mut core,
+            r#"{"op":"init","expected_revision":0,"instructions":"x","tools":[]}"#,
+        );
+        let _ = apply_json(
+            &mut core,
+            r#"{"op":"prompt","expected_revision":1,"text":"x"}"#,
+        );
+        let snapshot = match core.apply(Command::Snapshot) {
+            HostAction::Snapshot { snapshot } => snapshot,
+            other => panic!("unexpected action: {other:?}"),
+        };
+        let mut replacement = FlightCore::new();
+        assert!(matches!(
+            replacement.apply(Command::Restore { snapshot }),
+            HostAction::Ready { revision: 2 }
+        ));
+        assert!(matches!(
+            apply_json(
+                &mut replacement,
+                r#"{"op":"model_output","expected_revision":2,"items":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}]}"#
+            ),
+            HostAction::Complete { revision: 3, .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_stale_replays_without_mutation() {
+        let mut core = FlightCore::new();
+        let _ = apply_json(
+            &mut core,
+            r#"{"op":"init","expected_revision":0,"instructions":"x","tools":[]}"#,
+        );
+        assert!(matches!(
+            apply_json(
+                &mut core,
+                r#"{"op":"prompt","expected_revision":0,"text":"stale"}"#
+            ),
+            HostAction::Error {
+                revision: 1,
+                code: ErrorCode::RevisionConflict,
+                ..
+            }
+        ));
+        assert!(matches!(
+            core.apply(Command::Snapshot),
+            HostAction::Snapshot {
+                snapshot: Snapshot { revision: 1, .. }
+            }
+        ));
+    }
+
+    #[test]
+    fn rejects_tools_not_declared_by_the_host() {
+        let mut core = FlightCore::new();
+        let _ = apply_json(
+            &mut core,
+            r#"{"op":"init","expected_revision":0,"instructions":"x","tools":[]}"#,
+        );
+        let _ = apply_json(
+            &mut core,
+            r#"{"op":"prompt","expected_revision":1,"text":"x"}"#,
+        );
+        assert!(matches!(
+            apply_json(
+                &mut core,
+                r#"{"op":"model_output","expected_revision":2,"items":[{"type":"function_call","name":"undeclared","arguments":"{}","call_id":"call-1"}]}"#
+            ),
+            HostAction::Error {
+                revision: 2,
+                code: ErrorCode::UndeclaredToolCall,
+                ..
+            }
+        ));
+    }
+}

--- a/crates/experimental/nanocodex-spacewasm/src/main.rs
+++ b/crates/experimental/nanocodex-spacewasm/src/main.rs
@@ -1,0 +1,39 @@
+use std::io::{self, BufRead, Write};
+
+use nanocodex_spacewasm::{Command, FlightCore, HostAction};
+
+fn main() {
+    let stdin = io::stdin();
+    let mut stdout = io::stdout().lock();
+    let mut core = FlightCore::new();
+
+    for line in stdin.lock().lines() {
+        let action = match line {
+            Ok(line) if line.trim().is_empty() => continue,
+            Ok(line) => match serde_json::from_str::<Command>(&line) {
+                Ok(command) => core.apply(command),
+                Err(error) => {
+                    let _ = writeln!(
+                        io::stderr(),
+                        "nanocodex-spacewasm: invalid command: {error}"
+                    );
+                    continue;
+                }
+            },
+            Err(error) => {
+                let _ = writeln!(io::stderr(), "nanocodex-spacewasm: stdin failed: {error}");
+                break;
+            }
+        };
+        let shutdown = matches!(action, HostAction::Shutdown { .. });
+        if serde_json::to_writer(&mut stdout, &action).is_err()
+            || writeln!(&mut stdout).is_err()
+            || stdout.flush().is_err()
+        {
+            break;
+        }
+        if shutdown {
+            break;
+        }
+    }
+}

--- a/crates/nanocodex-oai-api/src/lib.rs
+++ b/crates/nanocodex-oai-api/src/lib.rs
@@ -3,9 +3,15 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-#[cfg(all(target_family = "wasm", not(target_os = "unknown")))]
+#[cfg(all(
+    target_family = "wasm",
+    not(target_os = "unknown"),
+    feature = "client"
+))]
 compile_error!(
-    "nanocodex-oai-api supports native targets and hosted wasm*-unknown-unknown targets; WASI is not yet supported"
+    "nanocodex-oai-api client transports support native targets and hosted \
+     wasm*-unknown-unknown targets; WASI supports protocol-only builds with \
+     default features disabled"
 );
 
 /// Authentication sources and managed credential snapshots.

--- a/crates/nanocodex-oai-api/src/responses/item.rs
+++ b/crates/nanocodex-oai-api/src/responses/item.rs
@@ -273,7 +273,76 @@ pub enum ResponseItem {
     Other(JsonValue),
 }
 
+/// Borrowed model-requested tool call extracted from a response item.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ResponseToolCallRef<'a> {
+    /// JSON-schema function call.
+    Function {
+        /// Tool name.
+        name: &'a str,
+        /// Optional Responses namespace.
+        namespace: Option<&'a str>,
+        /// JSON-encoded arguments.
+        arguments: &'a str,
+        /// Provider call identity.
+        call_id: &'a str,
+    },
+    /// Grammar-constrained custom tool call.
+    Custom {
+        /// Tool name.
+        name: &'a str,
+        /// Optional Responses namespace.
+        namespace: Option<&'a str>,
+        /// Free-form tool input.
+        input: &'a str,
+        /// Provider call identity.
+        call_id: &'a str,
+    },
+}
+
+impl ResponseToolCallRef<'_> {
+    /// Returns the provider call identity.
+    #[must_use]
+    pub const fn call_id(&self) -> &str {
+        match self {
+            Self::Function { call_id, .. } | Self::Custom { call_id, .. } => call_id,
+        }
+    }
+}
+
 impl ResponseItem {
+    /// Returns the model-requested host tool call carried by this item.
+    #[must_use]
+    pub fn tool_call(&self) -> Option<ResponseToolCallRef<'_>> {
+        match self {
+            Self::FunctionCall {
+                name,
+                namespace,
+                arguments,
+                call_id,
+                ..
+            } => Some(ResponseToolCallRef::Function {
+                name,
+                namespace: namespace.as_deref(),
+                arguments,
+                call_id,
+            }),
+            Self::CustomToolCall {
+                name,
+                namespace,
+                input,
+                call_id,
+                ..
+            } => Some(ResponseToolCallRef::Custom {
+                name,
+                namespace: namespace.as_deref(),
+                input,
+                call_id,
+            }),
+            _ => None,
+        }
+    }
+
     /// Creates the stable developer item that declares session tools.
     #[must_use]
     pub const fn additional_tools(tools: Vec<ToolDefinition>) -> Self {

--- a/crates/nanocodex-oai-api/src/responses/mod.rs
+++ b/crates/nanocodex-oai-api/src/responses/mod.rs
@@ -17,7 +17,7 @@ pub use event::{
     CompletedResponse, InputTokenDetails, OutputTokenDetails, ResponseEvent, ServerEvent, Usage,
     WarmupResponse, WarmupServerEvent,
 };
-pub use item::{ResponseItem, ResponseItemId};
+pub use item::{ResponseItem, ResponseItemId, ResponseToolCallRef};
 #[cfg(feature = "client")]
 pub(crate) use request::{CreatePolicy, ResponseCreate};
 #[cfg(feature = "client")]

--- a/crates/nanocodex-oai-api/src/responses/tool.rs
+++ b/crates/nanocodex-oai-api/src/responses/tool.rs
@@ -225,6 +225,28 @@ impl ToolDefinition {
         }
     }
 
+    /// Returns whether this declaration authorizes one exact client-executed call.
+    #[must_use]
+    pub fn accepts_call(&self, namespace: Option<&str>, name: &str) -> bool {
+        match self {
+            Self::Function { name: declared, .. } | Self::Custom { name: declared, .. } => {
+                namespace.is_none() && declared.as_ref() == name
+            }
+            Self::Namespace {
+                name: declared,
+                tools,
+                ..
+            } => {
+                namespace == Some(declared.as_ref())
+                    && tools.iter().any(|tool| {
+                        matches!(tool, Self::Function { .. } | Self::Custom { .. })
+                            && tool.name() == name
+                    })
+            }
+            Self::ToolSearch { .. } => namespace.is_none() && name == "tool_search",
+        }
+    }
+
     /// Returns the model-visible tool description.
     #[must_use]
     pub fn description(&self) -> &str {
@@ -342,6 +364,22 @@ mod tests {
             serde_json::to_value(namespace).unwrap()["tools"][0]["type"],
             "custom"
         );
+    }
+
+    #[test]
+    fn exact_call_authorization_respects_namespaces() {
+        let direct = ToolDefinition::function("read_sensor", "Read", json!({}));
+        let namespaced = ToolDefinition::namespace(
+            "flight",
+            "Flight tools",
+            [ToolDefinition::function("read_sensor", "Read", json!({}))],
+        );
+
+        assert!(direct.accepts_call(None, "read_sensor"));
+        assert!(!direct.accepts_call(Some("flight"), "read_sensor"));
+        assert!(namespaced.accepts_call(Some("flight"), "read_sensor"));
+        assert!(!namespaced.accepts_call(None, "read_sensor"));
+        assert!(!namespaced.accepts_call(Some("other"), "read_sensor"));
     }
 
     #[test]

--- a/scripts/test-spacewasm.sh
+++ b/scripts/test-spacewasm.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+spacewasm_root="${SPACEWASM_ROOT:?set SPACEWASM_ROOT to a nasa/spacewasm checkout}"
+guest="$repo_root/target/wasm32-wasip1/release/nanocodex-spacewasm.wasm"
+
+cargo test -p nanocodex-spacewasm
+RUSTFLAGS="${RUSTFLAGS:-} -C link-arg=--max-memory=${NANOCODEX_SPACEWASM_MAX_MEMORY_BYTES:-67108864}" \
+  cargo build --release --target wasm32-wasip1 -p nanocodex-spacewasm
+"$repo_root/scripts/wasm2spacewasm.sh" "$guest"
+wasm-dis "$guest" -o - | grep -Eq '^ \(memory \$0 [0-9]+ 1024\)$'
+cargo build --manifest-path "$spacewasm_root/Cargo.toml" -p spacewasi
+
+input="$(mktemp)"
+output="$(mktemp)"
+trap 'rm -f "$input" "$output"' EXIT
+
+printf '%s\n' \
+  '{"op":"init","expected_revision":0,"instructions":"Be terse","tools":[{"type":"function","name":"read_sensor","description":"Read one sensor","strict":false,"parameters":{"type":"object"}}]}' \
+  '{"op":"prompt","expected_revision":1,"text":"Inspect channel 7"}' \
+  '{"op":"model_output","expected_revision":2,"items":[{"type":"function_call","name":"read_sensor","arguments":"{\"channel\":7}","call_id":"call-1"}]}' \
+  '{"op":"tool_output","expected_revision":3,"call_id":"call-1","output":"nominal"}' \
+  '{"op":"model_output","expected_revision":4,"items":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Channel 7 is nominal."}]}]}' \
+  '{"op":"snapshot"}' \
+  '{"op":"shutdown"}' >"$input"
+
+"$spacewasm_root/target/debug/spacewasi" "$guest" <"$input" >"$output"
+
+grep -q '"kind":"model_request","revision":2' "$output"
+grep -q '"kind":"tool_calls","revision":3' "$output"
+grep -q '"kind":"complete","revision":5' "$output"
+grep -q '"kind":"snapshot"' "$output"
+grep -q '"kind":"shutdown","revision":5' "$output"
+
+echo "nanocodex-spacewasm: SpaceWasm JSONL E2E passed"

--- a/scripts/wasm2spacewasm.sh
+++ b/scripts/wasm2spacewasm.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v wasm-opt >/dev/null 2>&1; then
+  echo "wasm-opt is required (install Binaryen)" >&2
+  exit 1
+fi
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "usage: $0 input.wasm [output.wasm]" >&2
+  exit 1
+fi
+
+input="$1"
+output="${2:-$1}"
+temporary=""
+if [[ "$input" == "$output" ]]; then
+  temporary="${input}.mvp.tmp"
+  output="$temporary"
+fi
+
+trap '[[ -z "$temporary" ]] || rm -f "$temporary"' EXIT
+
+# Binaryen must first accept the proposals emitted by current Rust before it
+# can lower them. SpaceWasm's upstream helper omits --enable-bulk-memory, which
+# makes recent wasm-opt versions reject Rust's memory.copy/memory.fill input
+# before llvm-memory-copy-fill-lowering can run.
+wasm-opt \
+  --enable-bulk-memory \
+  --llvm-memory-copy-fill-lowering \
+  --signext-lowering \
+  --llvm-nontrapping-fptoint-lowering \
+  --disable-multivalue \
+  --disable-simd \
+  --disable-bulk-memory \
+  "$input" \
+  -o "$output"
+
+if [[ -n "$temporary" ]]; then
+  mv "$temporary" "$input"
+  temporary=""
+fi


### PR DESCRIPTION
## Summary

- add a synchronous, host-stepped Nanocodex core for NASA SpaceWasm / WASI Preview 1
- keep typed Responses history, tool-call correlation, revision fencing, and snapshots inside the guest
- keep model transport, credentials, durability storage, and tool effects in the host
- reject undeclared tool calls and stale revision replays without mutating guest state
- add an MVP-lowering wrapper for current Rust/Binaryen output and cap guest linear memory at 64 MiB by default

## Evidence

```bash
SPACEWASM_ROOT=/path/to/nasa/spacewasm scripts/test-spacewasm.sh
```

This builds `nanocodex-spacewasm` for `wasm32-wasip1`, lowers bulk-memory/sign-extension instructions to Wasm 1.0 MVP, runs the artifact through SpaceWasm's `spacewasi`, and verifies:

`prompt -> model request -> host tool call -> tool result -> model request -> final answer -> snapshot`

Locally passed:

- 4 `nanocodex-spacewasm` unit tests
- 26 protocol-only `nanocodex-oai-api` tests
- Clippy with `-D warnings`
- actual SpaceWasm JSONL E2E

## Boundary

The example uses mocked host-supplied model outputs. The Nanocodex loop executes inside SpaceWasm; a production flight host would connect emitted `model_request` actions to OpenAI and route only declared spacecraft tools back into the guest.