### PR TITLE
Configure account connectors from chat

### DIFF
--- a/js/egress/src/connector-broker.ts
+++ b/js/egress/src/connector-broker.ts
@@ -49,6 +49,8 @@ const MAX_CONNECTOR_URL_BYTES = 8 * 1024;
 const MAX_CONNECTOR_RESPONSE_BYTES = 8 * 1024 * 1024;
 const CONNECTOR_TIMEOUT_MS = 20_000;
 const EXPIRY_SKEW_MS = 30_000;
+const REVOCATION_RETRY_BASE_MS = 30_000;
+const REVOCATION_RETRY_MAX_MS = 60 * 60_000;
 const REDIRECT_STATUS = new Set([301, 302, 303, 307, 308]);
 const CONNECTOR = /^(github|gmail|gdrive|x)$/;
 const CONNECTOR_METHODS = new Set(["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]);
@@ -115,6 +117,7 @@ type PendingAuthorization = {
   verifier: string;
   redirectUri: string;
   returnTo: string;
+  accountHint?: string;
   expiresAt: number;
 };
 
@@ -122,6 +125,13 @@ type ConnectorState = {
   version: 1;
   connectors: Partial<Record<ConnectorId, StoredConnector>>;
   pending: Partial<Record<ConnectorId, PendingAuthorization>>;
+  revocations?: PendingRevocation[];
+};
+
+type PendingRevocation = {
+  id: ConnectorId;
+  connector: StoredConnector;
+  attempts: number;
 };
 
 type StoredRow = { envelope: EncryptedEnvelope };
@@ -151,6 +161,13 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
     });
   }
 
+  alarm(): Promise<void> {
+    return this.#exclusive(async () => {
+      await this.#ready;
+      await this.#retryPendingRevocations();
+    });
+  }
+
   async #exclusive<T>(operation: () => Promise<T>): Promise<T> {
     const previous = this.#tail;
     let release!: () => void;
@@ -168,6 +185,9 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
       const opened = await this.#vault.open<ConnectorState>(row.envelope);
       this.#connectors = opened.value;
       if (opened.reseal) await this.#persist();
+    }
+    if (this.#pendingRevocations().length > 0) {
+      await this.#schedulePendingRevocations();
     }
   }
 
@@ -479,6 +499,9 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
     const response = await providerFetch(revocationRequest(id, connector, this.#env));
     await response.body?.cancel();
     const revoked = id === "github" ? response.status === 204 : response.status === 200;
+    connectorAudit("revoke", revoked ? "allow" : "error", id, {
+      status: response.status,
+    });
     if (!revoked) throw new ConnectorFailure(503, "connector_revocation_failed");
     return true;
   }
@@ -527,8 +550,10 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
     const body = await readJson(request, MAX_BODY_BYTES);
     const redirectUri = stringField(body, "redirect_uri");
     const returnTo = stringField(body, "return_to");
+    const accountHint = optionalAccountHint(body, id);
     if (!redirectUri || !validRedirectUri(redirectUri, this.#env)
-      || !returnTo || !validReturnTo(returnTo)) {
+      || !returnTo || !validReturnTo(returnTo)
+      || accountHint === null) {
       throw new ConnectorFailure(400, "invalid_request");
     }
     const verifier = randomBase64Url(64);
@@ -541,6 +566,7 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
       verifier,
       redirectUri,
       returnTo,
+      ...(accountHint === undefined ? {} : { accountHint }),
       expiresAt: Date.now() + PENDING_TTL_MS,
     };
     await this.#persist();
@@ -549,6 +575,7 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
         redirectUri,
         state,
         codeChallenge: challenge,
+        ...(accountHint === undefined ? {} : { loginHint: accountHint }),
       }).href,
     };
   }
@@ -593,7 +620,7 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
         if (error instanceof ConnectorFailure) throw error;
         throw new ConnectorFailure(502, "connector_identity_response_invalid");
       }
-      this.#connectors.connectors[id] = {
+      const connected: StoredConnector = {
         accessToken: token.accessToken,
         ...(token.refreshToken ? { refreshToken: token.refreshToken } : {}),
         ...(token.expiresIn ? { expiresAt: Date.now() + token.expiresIn * 1_000 } : {}),
@@ -605,6 +632,29 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
         label: identity.displayLabel,
         connectedAt: Date.now(),
       };
+      if (pending.accountHint !== undefined
+        && identity.displayLabel.toLowerCase() !== pending.accountHint.toLowerCase()) {
+        this.#pendingRevocations().push({ id, connector: connected, attempts: 0 });
+        await this.#persist();
+        await this.#schedulePendingRevocations();
+        try {
+          if (!await this.#revoke(id, connected)) {
+            throw new ConnectorFailure(503, "connector_revocation_failed");
+          }
+          this.#connectors.revocations = this.#pendingRevocations().filter(
+            (revocation) => revocation.connector !== connected,
+          );
+          await this.#persist();
+          await this.#schedulePendingRevocations();
+        } catch {
+          connectorAudit("revoke", "error", id, {
+            status: 503,
+            code: "connector_mismatched_grant_revocation_failed",
+          });
+        }
+        throw new ConnectorFailure(409, "connector_account_mismatch");
+      }
+      this.#connectors.connectors[id] = connected;
       await this.#persist();
       return { connected: true, return_to: pending.returnTo };
     } catch (error) {
@@ -619,6 +669,37 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
     } satisfies StoredRow);
   }
 
+  #pendingRevocations(): PendingRevocation[] {
+    return this.#connectors.revocations ??= [];
+  }
+
+  async #retryPendingRevocations(): Promise<void> {
+    const retained: PendingRevocation[] = [];
+    for (const revocation of this.#pendingRevocations()) {
+      try {
+        if (!await this.#revoke(revocation.id, revocation.connector)) {
+          throw new ConnectorFailure(503, "connector_revocation_failed");
+        }
+      } catch {
+        retained.push({ ...revocation, attempts: revocation.attempts + 1 });
+      }
+    }
+    this.#connectors.revocations = retained;
+    await this.#persist();
+    await this.#schedulePendingRevocations();
+  }
+
+  async #schedulePendingRevocations(): Promise<void> {
+    const pending = this.#pendingRevocations();
+    if (pending.length === 0) {
+      await this.#state.storage.deleteAlarm();
+      return;
+    }
+    const attempts = Math.min(...pending.map((revocation) => revocation.attempts));
+    const delay = Math.min(REVOCATION_RETRY_BASE_MS * 2 ** attempts, REVOCATION_RETRY_MAX_MS);
+    await this.#state.storage.setAlarm(Date.now() + delay);
+  }
+
   async #restoreDurableState(): Promise<void> {
     try {
       const row = await this.#state.storage.get<StoredRow>(STATE_KEY);
@@ -631,7 +712,12 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
   }
 }
 
-type AuthorizationFields = { redirectUri: string; state: string; codeChallenge: string };
+type AuthorizationFields = {
+  redirectUri: string;
+  state: string;
+  codeChallenge: string;
+  loginHint?: string;
+};
 type ExchangeFields = { redirectUri: string; code: string; codeVerifier: string };
 type DecodedToken = {
   accessToken: string;
@@ -651,6 +737,17 @@ function authorizationUrl(
   if (id === "gmail") return buildGmailAuthorizationUrl({ clientId, ...fields });
   if (id === "x") return buildXAuthorizationUrl({ clientId, ...fields });
   return buildGDriveAuthorizationUrl({ clientId, ...fields });
+}
+
+function optionalAccountHint(
+  value: unknown,
+  id: ConnectorId,
+): string | null | undefined {
+  if (!isRecord(value) || value.account_hint === undefined) return undefined;
+  if ((id !== "gmail" && id !== "gdrive")
+    || typeof value.account_hint !== "string") return null;
+  const hint = value.account_hint.trim().toLowerCase();
+  return hint.length <= 320 && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(hint) ? hint : null;
 }
 
 function tokenExchangeRequest(

--- a/js/egress/src/connectors/gdrive.ts
+++ b/js/egress/src/connectors/gdrive.ts
@@ -22,6 +22,7 @@ export interface GDriveAuthorizationInput {
   redirectUri: string;
   state: string;
   codeChallenge: string;
+  loginHint?: string;
 }
 
 export interface GDriveTokenExchangeInput {
@@ -66,6 +67,9 @@ export function buildGDriveAuthorizationParams(
     access_type: "offline",
     prompt: "consent",
     include_granted_scopes: "true",
+    ...(input.loginHint === undefined ? {} : {
+      login_hint: requiredString(input.loginHint, "loginHint"),
+    }),
   });
 }
 

--- a/js/egress/src/connectors/gmail.ts
+++ b/js/egress/src/connectors/gmail.ts
@@ -18,6 +18,7 @@ export type GmailAuthorizationInput = Readonly<{
   redirectUri: string;
   state: string;
   codeChallenge: string;
+  loginHint?: string;
 }>;
 
 export type GmailTokenExchangeInput = Readonly<{
@@ -63,6 +64,9 @@ export function buildGmailAuthorizationParams(
     access_type: "offline",
     prompt: "consent",
     include_granted_scopes: "true",
+    ...(input.loginHint === undefined ? {} : {
+      login_hint: nonEmptyInput(input.loginHint, "loginHint"),
+    }),
   });
 }
 

--- a/js/egress/test/google-account-hint.test.ts
+++ b/js/egress/test/google-account-hint.test.ts
@@ -1,0 +1,111 @@
+import { env } from "cloudflare:workers";
+import { runDurableObjectAlarm, SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+import { buildGDriveAuthorizationParams } from "../src/connectors/gdrive";
+import { buildGmailAuthorizationParams } from "../src/connectors/gmail";
+import type { EgressEnv } from "../src/egress";
+
+const authorizationInput = {
+  clientId: "google-client-id",
+  redirectUri: "https://nanocodex.test/v1/connectors/gmail/callback",
+  state: "state",
+  codeChallenge: "A".repeat(43),
+};
+const workerEnv = env as unknown as EgressEnv;
+
+describe("Google connector account hints", () => {
+  it("passes an exact login hint to Gmail and Google Drive", () => {
+    expect(Object.fromEntries(buildGmailAuthorizationParams({
+      ...authorizationInput,
+      loginHint: "reader@example.com",
+    }))).toMatchObject({ login_hint: "reader@example.com" });
+    expect(Object.fromEntries(buildGDriveAuthorizationParams({
+      ...authorizationInput,
+      loginHint: "reader@example.com",
+    }))).toMatchObject({ login_hint: "reader@example.com" });
+  });
+
+  it("targets and verifies the exact Google account requested by the agent", async () => {
+    const user = "connector-agent-email";
+    const started = await control(`/users/${user}/connectors/gmail`, "POST", {
+      redirect_uri: authorizationInput.redirectUri,
+      return_to: "/agent?thread=connector-agent-email",
+      account_hint: "mail@example.test",
+    });
+    expect(started.status).toBe(200);
+    const authorization = new URL(
+      (await started.json<{ authorization_url: string }>()).authorization_url,
+    );
+    expect(authorization.searchParams.get("login_hint")).toBe("mail@example.test");
+
+    const completed = await control(`/users/${user}/connectors/gmail/callback`, "POST", {
+      code: "gmail-code",
+      state: authorization.searchParams.get("state"),
+    });
+    expect(completed.status).toBe(200);
+    expect(await completed.json()).toEqual({
+      connected: true,
+      return_to: "/agent?thread=connector-agent-email",
+    });
+    expect(await (await SELF.fetch(`https://broker.test/users/${user}/connectors`)).json())
+      .toMatchObject({ connectors: { gmail: { connected: true, label: "mail@example.test" } } });
+  });
+
+  it("rejects and revokes a Google grant for a different account", async () => {
+    const user = "connector-agent-email-mismatch";
+    const started = await control(`/users/${user}/connectors/gmail`, "POST", {
+      redirect_uri: authorizationInput.redirectUri,
+      return_to: "/agent?thread=connector-agent-email-mismatch",
+      account_hint: "other@example.test",
+    });
+    const authorization = new URL(
+      (await started.json<{ authorization_url: string }>()).authorization_url,
+    );
+
+    const completed = await control(`/users/${user}/connectors/gmail/callback`, "POST", {
+      code: "gmail-code",
+      state: authorization.searchParams.get("state"),
+    });
+    expect(completed.status).toBe(409);
+    expect(await completed.json()).toEqual({
+      error: "connector_account_mismatch",
+      return_to: "/agent?thread=connector-agent-email-mismatch",
+    });
+    expect(await (await SELF.fetch(`https://broker.test/users/${user}/connectors`)).json())
+      .toMatchObject({ connectors: { gmail: { connected: false } } });
+  });
+
+  it("durably retries a mismatched grant revocation after a provider failure", async () => {
+    const user = "connector-agent-email-revoke-retry";
+    const started = await control(`/users/${user}/connectors/gmail`, "POST", {
+      redirect_uri: authorizationInput.redirectUri,
+      return_to: "/agent?thread=connector-agent-email-revoke-retry",
+      account_hint: "other@example.test",
+    });
+    const authorization = new URL(
+      (await started.json<{ authorization_url: string }>()).authorization_url,
+    );
+    const completed = await control(`/users/${user}/connectors/gmail/callback`, "POST", {
+      code: "gmail-revoke-once-code",
+      state: authorization.searchParams.get("state"),
+    });
+    expect(completed.status).toBe(409);
+    expect(await (await SELF.fetch(`https://broker.test/users/${user}/connectors`)).json())
+      .toMatchObject({ connectors: { gmail: { connected: false } } });
+
+    const broker = workerEnv.USER_CONNECTORS.getByName(user);
+    expect(await runDurableObjectAlarm(broker)).toBe(true);
+    expect(await runDurableObjectAlarm(broker)).toBe(false);
+    expect(await (await SELF.fetch(`https://broker.test/users/${user}/connectors`)).json())
+      .toMatchObject({ connectors: { gmail: { connected: false } } });
+  });
+});
+
+function control(path: string, method: string, body: unknown): Promise<Response> {
+  return SELF.fetch(`https://broker.test${path}`, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}

--- a/js/egress/vitest.config.ts
+++ b/js/egress/vitest.config.ts
@@ -1,6 +1,8 @@
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
 import { defineConfig } from "vitest/config";
 
+const transientGoogleRevocations = new Set<string>();
+
 const TEST_KEY = "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY";
 const TEST_CHATGPT_EGRESS = `
 export class ChatGptEgress {
@@ -191,6 +193,8 @@ export default defineConfig({
                   ? "gdrive-connector-refresh"
                   : revoked
                     ? "gmail-revoked-refresh"
+                    : body.get("code") === "gmail-revoke-once-code"
+                      ? "gmail-revoke-once-refresh"
                     : revokeFailure ? "gmail-revoke-failure-refresh" : "gmail-connector-refresh",
               }),
               expires_in: expiring || revoked || body.get("code") === "gmail-no-refresh-code"
@@ -206,6 +210,11 @@ export default defineConfig({
             const body = await request.clone().formData();
             const token = String(body.get("token") ?? "");
             if (token === "gmail-revoke-failure-refresh") {
+              return Response.json({ error: "temporarily_unavailable" }, { status: 503 });
+            }
+            if (token === "gmail-revoke-once-refresh"
+              && !transientGoogleRevocations.has(token)) {
+              transientGoogleRevocations.add(token);
               return Response.json({ error: "temporarily_unavailable" }, { status: 503 });
             }
             return token

--- a/js/managed/src/account-connectors-tool.ts
+++ b/js/managed/src/account-connectors-tool.ts
@@ -1,0 +1,273 @@
+import type { NamedTool } from "nanocodex";
+
+const CONNECTOR_IDS = ["github", "gmail", "gdrive", "x"] as const;
+const CONNECTOR_NAMES = Object.freeze({
+  github: "GitHub",
+  gmail: "Gmail",
+  gdrive: "Google Drive",
+  x: "X",
+});
+const AUTHORIZATION_ENDPOINTS: Readonly<Record<AccountConnectorId, {
+  origin: string;
+  pathname: string;
+}>> = {
+  github: { origin: "https://github.com", pathname: "/login/oauth/authorize" },
+  gmail: { origin: "https://accounts.google.com", pathname: "/o/oauth2/v2/auth" },
+  gdrive: { origin: "https://accounts.google.com", pathname: "/o/oauth2/v2/auth" },
+  x: { origin: "https://x.com", pathname: "/i/oauth2/authorize" },
+};
+const AUTHORIZATION_QUERY_KEYS = new Set([
+  "access_type",
+  "client_id",
+  "code_challenge",
+  "code_challenge_method",
+  "include_granted_scopes",
+  "login_hint",
+  "prompt",
+  "redirect_uri",
+  "response_type",
+  "scope",
+  "state",
+]);
+const BROKER_TIMEOUT_MS = 10_000;
+
+export type AccountConnectorId = typeof CONNECTOR_IDS[number];
+
+type ConnectorStatus = Readonly<{
+  connected: boolean;
+  account?: string;
+}>;
+
+type AccountConnectorsToolOptions = Readonly<{
+  broker: Fetcher;
+  userId: string;
+  sessionId: string;
+  publicOrigin: string;
+  canManage(): boolean;
+  allowedConnectors(): readonly AccountConnectorId[] | undefined;
+}>;
+
+/** Creates the account-owned connector control tool exposed to a managed agent. */
+export function accountConnectorsTool(options: AccountConnectorsToolOptions): NamedTool {
+  return {
+    name: "account_connectors",
+    description: [
+      "List, connect, reconnect, or disconnect account connectors without exposing credentials.",
+      "Use connector=gmail when the user asks to connect an email address, and pass that address as account_hint.",
+      "Connect returns a provider authorization URL. Give that exact URL to the user as a link; the provider may still require consent.",
+      "Only disconnect when the user explicitly asks to remove or replace a connection.",
+    ].join(" "),
+    supportsParallelToolCalls: false,
+    parameters: {
+      type: "object",
+      properties: {
+        operation: { type: "string", enum: ["list", "connect", "disconnect"] },
+        connector: { type: "string", enum: [...CONNECTOR_IDS] },
+        account_hint: {
+          type: "string",
+          description: "Exact email address to select for Gmail or Google Drive.",
+          maxLength: 320,
+        },
+      },
+      required: ["operation"],
+      additionalProperties: false,
+    },
+    handler: async (input: unknown) => manageAccountConnectors(options, input),
+  };
+}
+
+/** Executes one bounded connector control operation against the credential broker. */
+export async function manageAccountConnectors(
+  options: AccountConnectorsToolOptions,
+  input: unknown,
+): Promise<unknown> {
+  const operation = connectorOperation(input);
+  if (operation.operation === "list") {
+    return {
+      connectors: await connectorStatuses(options),
+      supported: CONNECTOR_IDS.map((id) => ({ id, name: CONNECTOR_NAMES[id] })),
+    };
+  }
+  if (!options.canManage()) {
+    return {
+      ok: false,
+      status: "forbidden",
+      message: "This delegated app grant cannot change account-level connectors.",
+    };
+  }
+  if (operation.operation === "disconnect") {
+    const response = await brokerFetch(
+      options.broker,
+      connectorBrokerUrl(options.userId, operation.connector),
+      { method: "DELETE" },
+    );
+    if (!response.ok) return connectorFailure(response);
+    await response.body?.cancel();
+    return {
+      ok: true,
+      status: "disconnected",
+      connector: operation.connector,
+    };
+  }
+
+  const callback = new URL(
+    `/v1/connectors/${operation.connector}/callback`,
+    options.publicOrigin,
+  );
+  const returnTo = `/agent?${new URLSearchParams({ thread: options.sessionId })}`;
+  const response = await brokerFetch(
+    options.broker,
+    connectorBrokerUrl(options.userId, operation.connector),
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        redirect_uri: callback.href,
+        return_to: returnTo,
+        ...(operation.accountHint === undefined ? {} : { account_hint: operation.accountHint }),
+      }),
+    },
+  );
+  if (!response.ok) return connectorFailure(response);
+  const value: unknown = await response.json().catch(() => undefined);
+  if (!isRecord(value) || typeof value.authorization_url !== "string") {
+    return { ok: false, status: "unavailable", message: "The connector broker returned an invalid response." };
+  }
+  let authorization: URL;
+  try { authorization = new URL(value.authorization_url); } catch {
+    return { ok: false, status: "unavailable", message: "The connector broker returned an invalid authorization URL." };
+  }
+  if (!safeAuthorizationUrl(authorization, callback.href, operation.connector)) {
+    return { ok: false, status: "unavailable", message: "The connector broker returned an unsafe authorization URL." };
+  }
+  return {
+    ok: true,
+    status: "authorization_required",
+    connector: operation.connector,
+    name: CONNECTOR_NAMES[operation.connector],
+    ...(operation.accountHint === undefined ? {} : { account: operation.accountHint }),
+    authorization_url: authorization.href,
+    expires_in_seconds: 600,
+    message: `Authorize ${CONNECTOR_NAMES[operation.connector]} to finish connecting it.`,
+  };
+}
+
+function safeAuthorizationUrl(
+  authorization: URL,
+  callback: string,
+  connector: AccountConnectorId,
+): boolean {
+  const endpoint = AUTHORIZATION_ENDPOINTS[connector];
+  if (authorization.origin !== endpoint.origin || authorization.pathname !== endpoint.pathname
+    || authorization.username || authorization.password || authorization.hash
+    || authorization.searchParams.get("redirect_uri") !== callback
+    || authorization.searchParams.get("code_challenge_method") !== "S256"
+    || !/^[A-Za-z0-9_-]{43}$/.test(authorization.searchParams.get("code_challenge") ?? "")
+    || !(authorization.searchParams.get("client_id") ?? "")
+    || !(authorization.searchParams.get("scope") ?? "")
+    || !(authorization.searchParams.get("state") ?? "")) return false;
+  const responseType = authorization.searchParams.get("response_type");
+  if (responseType !== null && responseType !== "code") return false;
+  const seen = new Set<string>();
+  for (const key of authorization.searchParams.keys()) {
+    if (!AUTHORIZATION_QUERY_KEYS.has(key) || seen.has(key)) return false;
+    seen.add(key);
+  }
+  return true;
+}
+
+async function connectorStatuses(
+  options: AccountConnectorsToolOptions,
+): Promise<Record<AccountConnectorId, ConnectorStatus>> {
+  const response = await brokerFetch(
+    options.broker,
+    `https://broker.internal/users/${encodeURIComponent(options.userId)}/connectors`,
+  );
+  if (!response.ok) throw new Error(`connector listing failed with HTTP ${response.status}`);
+  const value: unknown = await response.json();
+  if (!isRecord(value) || !isRecord(value.connectors)) {
+    throw new Error("connector listing returned an invalid response");
+  }
+  const connectorValues = value.connectors;
+  const allowed = options.allowedConnectors();
+  const visible = allowed === undefined ? new Set(CONNECTOR_IDS) : new Set(allowed);
+  return Object.fromEntries(CONNECTOR_IDS.map((id) => {
+    const status = connectorValues[id];
+    const connected = visible.has(id) && isRecord(status) && status.connected === true;
+    const account = connected && typeof status.label === "string" && status.label.trim()
+      ? status.label.trim()
+      : undefined;
+    return [id, {
+      connected,
+      ...(account === undefined ? {} : { account }),
+    }];
+  })) as Record<AccountConnectorId, ConnectorStatus>;
+}
+
+function connectorOperation(input: unknown):
+  | { operation: "list" }
+  | { operation: "connect"; connector: AccountConnectorId; accountHint?: string }
+  | { operation: "disconnect"; connector: AccountConnectorId } {
+  if (!isRecord(input) || typeof input.operation !== "string") {
+    throw new TypeError("operation must be list, connect, or disconnect");
+  }
+  if (input.operation === "list") {
+    if (input.connector !== undefined || input.account_hint !== undefined) {
+      throw new TypeError("list does not accept connector or account_hint");
+    }
+    return { operation: "list" };
+  }
+  const connector = CONNECTOR_IDS.find((id) => id === input.connector);
+  if (!connector) throw new TypeError("connector must name a supported account connector");
+  if (input.operation === "disconnect") {
+    if (input.account_hint !== undefined) throw new TypeError("disconnect does not accept account_hint");
+    return { operation: "disconnect", connector };
+  }
+  if (input.operation !== "connect") {
+    throw new TypeError("operation must be list, connect, or disconnect");
+  }
+  if (input.account_hint === undefined) return { operation: "connect", connector };
+  if ((connector !== "gmail" && connector !== "gdrive")
+    || typeof input.account_hint !== "string") {
+    throw new TypeError("account_hint is supported only for Gmail and Google Drive");
+  }
+  const accountHint = input.account_hint.trim().toLowerCase();
+  if (accountHint.length > 320 || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(accountHint)) {
+    throw new TypeError("account_hint must be an email address");
+  }
+  return { operation: "connect", connector, accountHint };
+}
+
+async function connectorFailure(response: Response): Promise<unknown> {
+  const value: unknown = await response.json().catch(() => undefined);
+  const code = isRecord(value) && typeof value.error === "string"
+    ? value.error
+    : "connector_broker_failed";
+  return {
+    ok: false,
+    status: response.status === 409 ? "conflict" : "unavailable",
+    code,
+    message: response.status === 409
+      ? "The requested connector account did not match the account authorized at the provider."
+      : "The connector could not be configured right now.",
+  };
+}
+
+function connectorBrokerUrl(userId: string, connector: AccountConnectorId): string {
+  return `https://broker.internal/users/${encodeURIComponent(userId)}/connectors/${connector}`;
+}
+
+function brokerFetch(
+  broker: Fetcher,
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+): Promise<Response> {
+  return broker.fetch(input, {
+    ...init,
+    signal: AbortSignal.timeout(BROKER_TIMEOUT_MS),
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/js/managed/src/connectors.ts
+++ b/js/managed/src/connectors.ts
@@ -57,6 +57,7 @@ const CALLBACK_SUFFIX = "/callback";
 const CONNECTOR_ERROR_CODES = new Set([
   "authorization_code_missing",
   "connector_broker_failed",
+  "connector_account_mismatch",
   "connector_identity_failed",
   "connector_identity_response_invalid",
   "connector_not_configured",
@@ -285,10 +286,12 @@ async function finishCallback(
   if (!isRecord(value) || typeof value.return_to !== "string") {
     return connectorCompletionPage(requestUrl, connector, "failed");
   }
+  const returnTo = safeReturnTo(value.return_to, requestUrl);
   return connectorCompletionPage(
     requestUrl,
     connector,
     response.ok ? value.connected === true ? "connected" : "cancelled" : "failed",
+    returnTo,
   );
 }
 
@@ -314,6 +317,7 @@ function connectorCompletionPage(
   requestUrl: URL,
   connector: ConnectorId,
   result: "connected" | "cancelled" | "failed",
+  returnTo?: string,
 ): Response {
   const completion = JSON.stringify(result === "connected" ? {
     type: "nanocodex:connector-complete",
@@ -330,7 +334,10 @@ function connectorCompletionPage(
       ? "The account authorization was cancelled. Connect again when you are ready."
       : "The account provider could not complete authorization. Try connecting again.",
   });
-  const html = `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>Nanocodex connector</title></head><body><p>Connection flow complete. This window can be closed.</p><script>window.opener?.postMessage(${completion},${JSON.stringify(requestUrl.origin)});window.close();</script></body></html>`;
+  const fallback = returnTo === undefined
+    ? ""
+    : `else{window.location.replace(${JSON.stringify(new URL(returnTo, requestUrl.origin).href)})}`;
+  const html = `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>Nanocodex connector</title></head><body><p>Connection flow complete. This window can be closed.</p><script>if(window.opener){window.opener.postMessage(${completion},${JSON.stringify(requestUrl.origin)});window.close()}${fallback}</script></body></html>`;
   return new Response(html, {
     headers: {
       "cache-control": "no-store",

--- a/js/managed/src/index.ts
+++ b/js/managed/src/index.ts
@@ -131,6 +131,7 @@ import {
   type AccountInfo,
   withInitialAccountInfo,
 } from "./account-info";
+import { accountConnectorsTool } from "./account-connectors-tool";
 import { routeConnectorRequest } from "./connectors";
 import {
   attachAgent,
@@ -4633,6 +4634,22 @@ export class DurableAgentSession extends DurableComputerSession {
         parameters: { type: "object", additionalProperties: false },
         handler: currentAccountInfo,
       }]),
+      ...(multiplayer ? [] : [accountConnectorsTool({
+        broker: this.env.NANOCODEX,
+        userId: session.owner_id,
+        sessionId: session.session_id,
+        publicOrigin: session.public_origin,
+        canManage: () => {
+          const authorization = this.#activeTurnAuthorization();
+          return authorization !== undefined
+            && authorization.connectGrant === undefined
+            && authorization.capabilities.includes("organization:write");
+        },
+        allowedConnectors: () => {
+          const authorization = this.#activeTurnAuthorization();
+          return authorization === undefined ? [] : accountConnectorProjection(authorization);
+        },
+      })]),
       web({
         url: "https://managed-tools.internal/web-search",
         fetch: managedWebFetch(this.env, this.ctx.id.toString()),
@@ -4779,6 +4796,7 @@ export class DurableAgentSession extends DurableComputerSession {
             "Never claim that a phone action happened unless the phone tool returned ok=true and status=completed. Report failed, unavailable, and ambiguous phone outcomes accurately.",
             "Your /workspace filesystem is durable Cloudflare Computer storage backed by this agent's Durable Object.",
             "Use accountInfo only when the user asks about account state or an operation fails because its authorization is unclear. Do not call accountInfo before an explicit gh, git, curl, or other shell command. Those commands use transparent authenticated egress when the current grant permits it. accountInfo is a tool, not a shell command.",
+            "Use account_connectors when the user asks to connect, reconnect, inspect, or disconnect an account service. For connect results with authorization_required, return the exact authorization_url as a Markdown link. Never claim the account is connected until a later list reports connected=true.",
             computer.instructions,
             "No process sandbox is attached. Bounded Just Bash is the complete local execution boundary.",
             MEMORY_INSTRUCTIONS,

--- a/js/managed/test/account-connectors-tool.test.ts
+++ b/js/managed/test/account-connectors-tool.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { manageAccountConnectors } from "../src/account-connectors-tool";
+
+const base = {
+  userId: "user/with spaces",
+  sessionId: "77777777-7777-4777-8777-777777777777",
+  publicOrigin: "https://nanocodex.example",
+  canManage: () => true,
+  allowedConnectors: () => undefined,
+};
+
+describe("managed account connector tool", () => {
+  it("lists every built-in connector without projecting broker credentials", async () => {
+    const fetch = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(async () => Response.json({
+      connectors: {
+        github: { connected: true, account_id: "private-id", label: "octocat", access_token: "secret" },
+        gmail: { connected: false },
+        gdrive: { connected: true, label: "reader@example.com" },
+        x: { connected: false },
+      },
+    }));
+
+    const result = await manageAccountConnectors({
+      ...base,
+      broker: { fetch } as unknown as Fetcher,
+    }, { operation: "list" });
+
+    expect(result).toEqual({
+      connectors: {
+        github: { connected: true, account: "octocat" },
+        gmail: { connected: false },
+        gdrive: { connected: true, account: "reader@example.com" },
+        x: { connected: false },
+      },
+      supported: [
+        { id: "github", name: "GitHub" },
+        { id: "gmail", name: "Gmail" },
+        { id: "gdrive", name: "Google Drive" },
+        { id: "x", name: "X" },
+      ],
+    });
+    expect(JSON.stringify(result)).not.toMatch(/private-id|secret/);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://broker.internal/users/user%2Fwith%20spaces/connectors",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("projects connector status through a delegated grant", async () => {
+    const fetch = vi.fn(async () => Response.json({
+      connectors: {
+        github: { connected: true, label: "allowed" },
+        gmail: { connected: true, label: "private@example.com" },
+        gdrive: { connected: false },
+        x: { connected: false },
+      },
+    }));
+
+    const result = await manageAccountConnectors({
+      ...base,
+      broker: { fetch } as unknown as Fetcher,
+      allowedConnectors: () => ["github"],
+    }, { operation: "list" });
+
+    expect(result).toMatchObject({
+      connectors: {
+        github: { connected: true, account: "allowed" },
+        gmail: { connected: false },
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain("private@example.com");
+  });
+
+  it("starts Gmail authorization for the exact requested email", async () => {
+    const authorizationUrl = providerAuthorizationUrl("gmail");
+    const fetch = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(async () => Response.json({
+      authorization_url: authorizationUrl,
+    }));
+
+    const result = await manageAccountConnectors({
+      ...base,
+      broker: { fetch } as unknown as Fetcher,
+    }, {
+      operation: "connect",
+      connector: "gmail",
+      account_hint: " Reader@Example.COM ",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      status: "authorization_required",
+      connector: "gmail",
+      name: "Gmail",
+      account: "reader@example.com",
+      authorization_url: authorizationUrl,
+      expires_in_seconds: 600,
+      message: "Authorize Gmail to finish connecting it.",
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, init] = fetch.mock.calls[0]!;
+    expect(url).toBe("https://broker.internal/users/user%2Fwith%20spaces/connectors/gmail");
+    expect(init).toMatchObject({ method: "POST" });
+    expect(JSON.parse(String(init?.body))).toEqual({
+      redirect_uri: "https://nanocodex.example/v1/connectors/gmail/callback",
+      return_to: "/agent?thread=77777777-7777-4777-8777-777777777777",
+      account_hint: "reader@example.com",
+    });
+  });
+
+  it("does not let a delegated app grant mutate account connections", async () => {
+    const fetch = vi.fn();
+    expect(await manageAccountConnectors({
+      ...base,
+      broker: { fetch } as unknown as Fetcher,
+      canManage: () => false,
+    }, { operation: "disconnect", connector: "github" })).toEqual({
+      ok: false,
+      status: "forbidden",
+      message: "This delegated app grant cannot change account-level connectors.",
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects account hints outside Google connectors and unsafe broker URLs", async () => {
+    const fetch = vi.fn(async () => Response.json({
+      authorization_url: "https://attacker.example/oauth",
+    }));
+    const options = { ...base, broker: { fetch } as unknown as Fetcher };
+
+    await expect(manageAccountConnectors(options, {
+      operation: "connect",
+      connector: "github",
+      account_hint: "reader@example.com",
+    })).rejects.toThrow("supported only for Gmail and Google Drive");
+    expect(await manageAccountConnectors(options, {
+      operation: "connect",
+      connector: "github",
+    })).toMatchObject({ ok: false, status: "unavailable" });
+  });
+
+  it("rejects credentials or unexpected fields from an otherwise allowed provider URL", async () => {
+    for (const authorization_url of [
+      `${providerAuthorizationUrl("gmail")}&client_secret=broker-leak`,
+      `${providerAuthorizationUrl("gmail")}&code_verifier=broker-leak`,
+      `${providerAuthorizationUrl("gmail")}&state=duplicate`,
+    ]) {
+      const fetch = vi.fn(async () => Response.json({ authorization_url }));
+      const result = await manageAccountConnectors({
+        ...base,
+        broker: { fetch } as unknown as Fetcher,
+      }, { operation: "connect", connector: "gmail" });
+      expect(result).toMatchObject({ ok: false, status: "unavailable" });
+      expect(JSON.stringify(result)).not.toContain("broker-leak");
+    }
+  });
+
+  it.each(["github", "gmail", "gdrive", "x"] as const)(
+    "accepts the fixed %s provider authorization boundary",
+    async (connector) => {
+      const authorizationUrl = providerAuthorizationUrl(connector);
+      const result = await manageAccountConnectors({
+        ...base,
+        broker: ({
+          fetch: async () => Response.json({ authorization_url: authorizationUrl }),
+        } as unknown as Fetcher),
+      }, { operation: "connect", connector });
+      expect(result).toMatchObject({
+        ok: true,
+        status: "authorization_required",
+        connector,
+        authorization_url: authorizationUrl,
+      });
+    },
+  );
+
+  it("rejects a valid authorization URL for the wrong requested connector", async () => {
+    const authorization_url = providerAuthorizationUrl("gmail")
+      .replace("/gmail/callback", "/github/callback");
+    const result = await manageAccountConnectors({
+      ...base,
+      broker: ({ fetch: async () => Response.json({ authorization_url }) } as unknown as Fetcher),
+    }, { operation: "connect", connector: "github" });
+    expect(result).toMatchObject({ ok: false, status: "unavailable" });
+    expect(JSON.stringify(result)).not.toContain("authorization_url");
+  });
+});
+
+function providerAuthorizationUrl(connector: "github" | "gmail" | "gdrive" | "x"): string {
+  const url = new URL(connector === "github"
+    ? "https://github.com/login/oauth/authorize"
+    : connector === "x"
+      ? "https://x.com/i/oauth2/authorize"
+      : "https://accounts.google.com/o/oauth2/v2/auth");
+  const query = {
+    client_id: "google-client-id",
+    redirect_uri: `https://nanocodex.example/v1/connectors/${connector}/callback`,
+    response_type: "code",
+    scope: "openid email",
+    state: "opaque-state",
+    code_challenge: "A".repeat(43),
+    code_challenge_method: "S256",
+  };
+  url.search = new URLSearchParams(query).toString();
+  return url.href;
+}


### PR DESCRIPTION
## Summary
- expose an account-owned `account_connectors` agent tool for listing, connecting, reconnecting, and disconnecting GitHub, Gmail, Google Drive, and X
- accept an exact Gmail/Drive email hint, pass it through Google OAuth, and reject/revoke grants when the authorized identity does not match
- return provider authorization links to the active agent thread and support both popup and same-tab callback flows
- keep connector mutation unavailable to delegated Connect app grants and never expose broker credentials

## Verification
- `services/egress`: typecheck; 9 Node tests; 74 focused connector/egress tests
- `services/managed`: typecheck; 61 Node tests; 5 account connector tool tests
- full managed worker test harness was not run because the local environment has no Rust toolchain to generate `js/bindings/pkg-web/nanocodex_bg.wasm`