### PR TITLE
feat(connectors): support multiple Google accounts

### DIFF
--- a/js/bindings/test/browser-gh.test.mjs
+++ b/js/bindings/test/browser-gh.test.mjs
@@ -23,7 +23,10 @@ test("browser egress sends one credential-free thread-scoped envelope", async ()
   });
 
   const result = await fetch("https://www.googleapis.com/drive/v3/files?pageSize=1", {
-    headers: { accept: "application/json" },
+    headers: {
+      accept: "application/json",
+      "x-nanocodex-connector-connection": "a".repeat(43),
+    },
   });
   assert.equal(new TextDecoder().decode(result.body), "drive");
   assert.equal(requests.length, 1);
@@ -33,7 +36,10 @@ test("browser egress sends one credential-free thread-scoped envelope", async ()
     thread_id: THREAD_ID,
     url: "https://www.googleapis.com/drive/v3/files?pageSize=1",
     method: "GET",
-    headers: { accept: "application/json" },
+    headers: {
+      accept: "application/json",
+      "x-nanocodex-connector-connection": "a".repeat(43),
+    },
   });
 });
 

--- a/js/bindings/test/browser-harness.test.mjs
+++ b/js/bindings/test/browser-harness.test.mjs
@@ -41,7 +41,10 @@ test("the default browser harness exposes one exact model-visible tool set", asy
         connectors: {
           github: { connected: true, label: "Nano Cat (nanocat)", account_id: "hidden" },
           gmail: { connected: false },
-          gdrive: { connected: true, label: "Drive User", access_token: "hidden" },
+          gdrive: { connected: true, connections: [
+            { id: "a".repeat(43), label: "Work Drive", account_id: "hidden-work" },
+            { id: "b".repeat(43), label: "Personal Drive", account_id: "hidden-personal" },
+          ], access_token: "hidden" },
           x: { connected: true, label: "Nano Cat (@nanocat)", account_id: "hidden" },
         },
       });
@@ -106,7 +109,11 @@ test("the default browser harness exposes one exact model-visible tool set", asy
   assert.deepEqual(accountInfo, {
     status: "ready",
     authenticated: ["github", "gdrive", "x"],
-    accounts: { github: "Nano Cat (nanocat)", gdrive: "Drive User", x: "Nano Cat (@nanocat)" },
+    accounts: { github: "Nano Cat (nanocat)", x: "Nano Cat (@nanocat)" },
+    connectorAccounts: { gdrive: [
+      { id: "a".repeat(43), label: "Work Drive" },
+      { id: "b".repeat(43), label: "Personal Drive" },
+    ] },
     identity: {},
     stablecoins: [],
     authorizations: [],
@@ -222,6 +229,7 @@ test("accountInfo adds app authorization without forwarding unknown control-plan
     status: "ready",
     authenticated: ["chatgpt"],
     accounts: { chatgpt: "Subscription" },
+    connectorAccounts: {},
     identity: { tempoAddress: "0xabc" },
     stablecoins: [{ token: "0x01", symbol: "MACHUSD", balance: "5000000", decimals: 6 }],
     authorizations: [{

--- a/js/bindings/tools/browser/accountInfo.mjs
+++ b/js/bindings/tools/browser/accountInfo.mjs
@@ -28,6 +28,19 @@ const ACCOUNT_INFO_SCHEMA = Object.freeze({
       properties: Object.fromEntries(CONNECTOR_IDS.map((id) => [id, { type: "string" }])),
       additionalProperties: false,
     },
+    connectorAccounts: {
+      type: "object",
+      properties: Object.fromEntries(CONNECTOR_IDS.map((id) => [id, {
+        type: "array",
+        items: {
+          type: "object",
+          properties: { id: { type: "string" }, label: { type: "string" } },
+          required: ["id", "label"],
+          additionalProperties: false,
+        },
+      }])),
+      additionalProperties: false,
+    },
     identity: {
       type: "object",
       properties: { tempoAddress: { type: "string" } },
@@ -109,7 +122,7 @@ const ACCOUNT_INFO_SCHEMA = Object.freeze({
       },
     },
   },
-  required: ["status", "authenticated", "accounts", "identity", "stablecoins", "authorizations"],
+  required: ["status", "authenticated", "accounts", "connectorAccounts", "identity", "stablecoins", "authorizations"],
   additionalProperties: false,
 });
 
@@ -169,11 +182,19 @@ export async function browserAccountInfo(options, signal) {
     const value = await response.json();
     if (!record(value) || !record(value.connectors)) return emptyInfo("unavailable");
     const accounts = {};
+    const connectorAccounts = {};
     const authenticated = CONNECTOR_IDS.filter((id) => {
       const connector = value.connectors[id];
       if (!record(connector) || connector.connected !== true) return false;
       if (typeof connector.label === "string" && connector.label.trim()) {
         accounts[id] = connector.label.trim();
+      }
+      if (Array.isArray(connector.connections)) {
+        const connections = connector.connections.map(connectorAccount);
+        if (connections.length > 32) throw new Error("too many connector accounts");
+        connectorAccounts[id] = connections;
+        if (connections.length === 1) accounts[id] = connections[0].label;
+        else delete accounts[id];
       }
       return true;
     });
@@ -195,6 +216,7 @@ export async function browserAccountInfo(options, signal) {
       status: "ready",
       authenticated,
       accounts,
+      connectorAccounts,
       identity: accountIdentity,
       stablecoins: accountStablecoins,
       authorizations: accountAuthorizations,
@@ -210,10 +232,19 @@ function emptyInfo(status) {
     status,
     authenticated: [],
     accounts: {},
+    connectorAccounts: {},
     identity: {},
     stablecoins: [],
     authorizations: [],
   };
+}
+
+function connectorAccount(value) {
+  if (!record(value) || typeof value.id !== "string" || !/^[A-Za-z0-9_-]{43}$/.test(value.id)
+    || typeof value.label !== "string" || !value.label.trim()) {
+    throw new Error("invalid connector account");
+  }
+  return { id: value.id, label: value.label.trim() };
 }
 
 function identity(value) {

--- a/js/bindings/tools/browser/browserShell.mjs
+++ b/js/bindings/tools/browser/browserShell.mjs
@@ -267,6 +267,10 @@ session, or sandbox escalation. HTTP commands use one thread-scoped, same-origin
 Destination policy and connected-account credentials stay outside the browser runtime. The C/C++
 commands compile sources to WASI WebAssembly in a lazy worker. Browser SSH is noninteractive and
 requires a wss:// endpoint that carries raw SSH because browsers cannot open TCP sockets. The
+accountInfo tool lists the grant-approved Gmail and Google Drive accounts. When more than one is
+available, choose the appropriate account by label and send its id in the
+X-Nanocodex-Connector-Connection header on that provider request. Never invent an account id.
+The
 repository's only publish branch is nanocodex; publish with git add, git commit -m "...", and git
 push origin nanocodex. Use the standard Rust apply_patch tool for focused edits. Create or update
 custom React interfaces with the render_artifact tool. Its source defines function App({ sendPrompt });

--- a/services/connect-api/src/index.ts
+++ b/services/connect-api/src/index.ts
@@ -163,6 +163,7 @@ const CONNECTOR_REQUEST_HEADERS = new Set([
   "if-modified-since",
   "if-none-match",
   "if-unmodified-since",
+  "x-nanocodex-connector-connection",
 ]);
 const CONNECTOR_RESPONSE_HEADERS = new Set([
   "accept-ranges",
@@ -198,7 +199,10 @@ type ConnectorStatus = Readonly<{
   connected: boolean;
   label?: string;
   account_id?: string;
+  connection_id?: string;
+  connections?: readonly ConnectorConnection[];
 }>;
+type ConnectorConnection = Readonly<{ id: string; label: string; account_id: string }>;
 type ConnectorState = Readonly<{
   accountAddress: `0x${string}`;
   brokerUserId: string;
@@ -294,6 +298,7 @@ type GrantRecord = Readonly<{
   conversationId?: string;
   appToolCatalogDigest?: `0x${string}`;
   mcpConnections?: readonly Readonly<{ id: string; name: string }>[];
+  connectorConnections?: Readonly<Record<string, readonly string[]>>;
   accessKey?: Record<string, unknown>;
   balanceAtomics?: string;
   spentAtomics: string;
@@ -636,9 +641,10 @@ export default {
         return error(request, 405, "method_not_allowed", "Unsupported MCP connection operation.");
       }
 
-      const connectorRoute = url.pathname.match(/^\/v1\/connectors\/(github|gmail|gdrive|x|chatgpt)$/);
+      const connectorRoute = url.pathname.match(/^\/v1\/connectors\/(github|gmail|gdrive|x|chatgpt)(?:\/([A-Za-z0-9_-]{43}))?$/);
       if (connectorRoute) {
         const connector = connectorRoute[1] as ConnectorId;
+        const connectionId = connectorRoute[2];
         const identity = await brokerIdentity(env, accountAddress);
         logContext = {
           ...logContext,
@@ -647,6 +653,7 @@ export default {
           connector,
         };
         if (request.method === "POST") {
+          if (connectionId) return error(request, 405, "method_not_allowed", "Unsupported connector operation.");
           const response = await startConnector(env, store, request, accountAddress, identity.userId, connector);
           console.info({
             type: "connect.connector.start",
@@ -657,7 +664,10 @@ export default {
           return cors(response, request);
         }
         if (request.method === "DELETE") {
-          await disconnectConnector(env, identity.userId, connector);
+          if (connectionId && connector !== "gmail" && connector !== "gdrive") {
+            return error(request, 404, "not_found", "Connector connection not found.");
+          }
+          await disconnectConnector(env, identity.userId, connector, connectionId);
           console.info({
             type: "connect.connector.disconnect",
             outcome: "success",
@@ -1270,6 +1280,10 @@ async function createConnection(
   const liveConnectorStatuses = (await connectorStatuses(env, identity.userId)).connectors;
   const connectors = requested.filter((connector) => liveConnectorStatuses[connector].connected);
   requireRequestedConnectors(connectors, requested);
+  const connectorConnections = Object.fromEntries(connectors.flatMap((connector) => {
+    const ids = liveConnectorStatuses[connector].connections?.map(({ id }) => id) ?? [];
+    return ids.length ? [[connector, ids] as const] : [];
+  }));
   if (credentialImport
     && liveConnectorStatuses.chatgpt.account_id !== credentialImport.account_id) {
     throw new ApiFailure(
@@ -1298,6 +1312,7 @@ async function createConnection(
     brokerUserId: identity.userId,
     capabilities: grantCapabilities,
     connectors,
+    connectorConnections,
     grantId,
     mcpIds: mcpConnections.map(({ id }) => id),
     ...(approvedAppToolCatalogDigest ? { appToolCatalogDigest: approvedAppToolCatalogDigest } : {}),
@@ -1329,6 +1344,7 @@ async function createConnection(
     status: "active",
     expiresAt,
     capabilities: grantCapabilities,
+    connectorConnections,
     ...(conversationId ? { conversationId } : {}),
     ...(approvedAppToolCatalogDigest ? { appToolCatalogDigest: approvedAppToolCatalogDigest } : {}),
     mcpConnections: mcpConnections.map(({ id, name }) => ({ id, name })),
@@ -1855,6 +1871,7 @@ function managedGrantAssertion(grant: GrantRecord): ManagedGrantAssertion {
     brokerUserId: grant.brokerUserId,
     capabilities: grant.capabilities,
     connectors: CONNECTOR_IDS.filter((connector) => grant.capabilities.includes(connector)),
+    connectorConnections: grant.connectorConnections ?? {},
     grantId: grant.id,
     mcpIds: (grant.mcpConnections ?? []).map(({ id }) => id),
     ...(grant.appToolCatalogDigest === undefined
@@ -2242,7 +2259,7 @@ async function connectAccountInfo(env: Env, store: Kv.Kv, current: GrantRecord) 
     accountAuthorizations(store, current),
   ]);
   return {
-    ...connectorInfo,
+    ...projectGrantConnectorStatuses(connectorInfo, current),
     identity: { tempoAddress: current.accountAddress },
     stablecoins: [
       { token: MACHINE_USD, symbol: "MACHUSD", balance: machineUsd.toString(), decimals: 6 },
@@ -2250,6 +2267,28 @@ async function connectAccountInfo(env: Env, store: Kv.Kv, current: GrantRecord) 
     ],
     authorizations,
   };
+}
+
+function projectGrantConnectorStatuses(
+  info: { connectors: Record<ConnectorId, ConnectorStatus> },
+  grant: GrantRecord,
+): { connectors: Record<ConnectorId, ConnectorStatus> } {
+  return { connectors: Object.fromEntries(CONNECTOR_IDS.map((connector) => {
+    if (!grant.capabilities.includes(connector)) return [connector, { connected: false }];
+    const status = info.connectors[connector];
+    if (connector !== "gmail" && connector !== "gdrive") return [connector, status];
+    const granted = new Set(grant.connectorConnections?.[connector] ?? []);
+    const connections = (status.connections ?? []).filter(({ id }) => granted.has(id));
+    return [connector, connections.length === 0 ? { connected: false, connections: [] } : {
+      connected: true,
+      connections,
+      ...(connections.length === 1 ? {
+        connection_id: connections[0]!.id,
+        account_id: connections[0]!.account_id,
+        label: connections[0]!.label,
+      } : {}),
+    }];
+  })) as Record<ConnectorId, ConnectorStatus> };
 }
 
 async function accountAuthorizations(store: Kv.Kv, current: GrantRecord) {
@@ -2290,6 +2329,7 @@ function grantAuthorization(grant: GrantRecord) {
     expiresAt: grant.expiresAt,
     capabilities: [...grant.capabilities],
     connectors: CONNECTOR_IDS.filter((connector) => grant.capabilities.includes(connector)),
+    connectorConnections: grant.connectorConnections ?? {},
     ...(accessKey ? { accessKey: {
       id: address(accessKey.key_id),
       expiry: safeInteger(accessKey.expiry, "access_key.expiry"),
@@ -2376,6 +2416,7 @@ async function grantBrowserEgress(request: Request, env: Env, grant: GrantRecord
       method: value.method,
       headers: value.headers,
       body: value.body,
+      connection_id: value.connection_id,
     });
     return new Response(result.body, { status: result.status, headers: result.headers });
   }
@@ -3196,6 +3237,8 @@ function isGrantRecord(value: unknown): value is GrantRecord {
     && Number.isSafeInteger(value.expiresAt)
     && Array.isArray(value.capabilities)
     && value.capabilities.every((capability) => typeof capability === "string")
+    && (value.connectorConnections === undefined
+      || validConnectorConnections(value.connectorConnections))
     && (value.appToolCatalogDigest === undefined
       || /^0x[0-9a-f]{64}$/.test(String(value.appToolCatalogDigest)))
     && (value.mcpConnections === undefined
@@ -3212,6 +3255,15 @@ function isGrantRecord(value: unknown): value is GrantRecord {
     && typeof value.egressSubject === "string"
     && (value.settlementBalanceAtomics === undefined || /^\d+$/.test(String(value.settlementBalanceAtomics)))
     && (value.sharedEgressSubject === undefined || typeof value.sharedEgressSubject === "boolean");
+}
+
+function validConnectorConnections(value: unknown): value is Readonly<Record<string, readonly string[]>> {
+  return isRecord(value) && Object.entries(value).every(([connector, ids]) => (
+    (connector === "gmail" || connector === "gdrive")
+    && Array.isArray(ids) && ids.length <= 32
+    && ids.every(isConnectorConnectionId)
+    && new Set(ids).size === ids.length
+  ));
 }
 
 function isBrokerUserId(value: unknown): value is string {
@@ -3371,11 +3423,33 @@ function connectorStatus(value: unknown): ConnectorStatus {
   if (!isRecord(value) || value.connected !== true) return { connected: false };
   const label = boundedOptionalString(value.label, 256);
   const accountId = boundedOptionalString(value.account_id, 256);
+  const connectionId = isConnectorConnectionId(value.connection_id) ? value.connection_id : undefined;
+  const connections = Array.isArray(value.connections) && value.connections.length <= 32
+    ? value.connections.map(publicConnectorConnection)
+    : undefined;
   return {
     connected: true,
     ...(label ? { label } : {}),
     ...(accountId ? { account_id: accountId } : {}),
+    ...(connectionId ? { connection_id: connectionId } : {}),
+    ...(connections ? { connections } : {}),
   };
+}
+
+function publicConnectorConnection(value: unknown): ConnectorConnection {
+  if (!isRecord(value) || !isConnectorConnectionId(value.id)) {
+    throw new ApiFailure(502, "connector_broker_invalid", "The connector broker returned invalid account metadata.");
+  }
+  const label = boundedOptionalString(value.label, 256);
+  const accountId = boundedOptionalString(value.account_id, 256);
+  if (!label || !accountId) {
+    throw new ApiFailure(502, "connector_broker_invalid", "The connector broker returned invalid account metadata.");
+  }
+  return { id: value.id, label, account_id: accountId };
+}
+
+function isConnectorConnectionId(value: unknown): value is string {
+  return typeof value === "string" && /^[A-Za-z0-9_-]{43}$/.test(value);
 }
 
 async function startConnector(
@@ -3593,10 +3667,11 @@ async function disconnectConnector(
   env: Env,
   brokerUserId: string,
   connector: ConnectorId,
+  connectionId?: string,
 ): Promise<void> {
   const path = connector === "chatgpt"
     ? `/users/${encodeURIComponent(brokerUserId)}/credentials/chatgpt`
-    : `/users/${encodeURIComponent(brokerUserId)}/connectors/${connector}`;
+    : `/users/${encodeURIComponent(brokerUserId)}/connectors/${connector}${connectionId ? `/${connectionId}` : ""}`;
   const response = await brokerFetch(env, path, { method: "DELETE" });
   if (!response.ok) {
     await response.body?.cancel();
@@ -4107,6 +4182,21 @@ async function grantConnectorRequest(
   }
   const target = connectorTarget(connector, value.path);
   const headers = connectorHeaders(value.headers);
+  const grantedConnections = grant.connectorConnections?.[connector] ?? [];
+  const requestedConnection = value.connection_id ?? headers.get("x-nanocodex-connector-connection") ?? undefined;
+  const connectionId = requestedConnection ?? (grantedConnections.length === 1 ? grantedConnections[0] : undefined);
+  if (grantedConnections.length > 1 && connectionId === undefined) {
+    throw new ApiFailure(409, "connector_connection_required", "Choose which connected account to use.");
+  }
+  if (connectionId !== undefined) {
+    if (!isConnectorConnectionId(connectionId)) {
+      throw new ApiFailure(400, "invalid_connector_connection", "The connector connection ID is invalid.");
+    }
+    if (grantedConnections.length > 0 && !grantedConnections.includes(connectionId)) {
+      throw new ApiFailure(403, "connector_connection_not_granted", "The connected account is outside this grant.");
+    }
+    headers.set("x-nanocodex-connector-connection", connectionId);
+  }
   headers.set("authorization", PROVIDER_CREDENTIAL_PLACEHOLDER);
   headers.set("x-nanocodex-subject", grant.egressSubject);
   const body = value.body;
@@ -4804,6 +4894,7 @@ function grantWire(grant: GrantRecord) {
     status: grant.status,
     expires_at: grant.expiresAt,
     capabilities: grant.capabilities,
+    connector_connections: grant.connectorConnections ?? {},
     ...(grant.conversationId ? { conversation_id: grant.conversationId } : {}),
     mcp_connections: grant.mcpConnections ?? [],
     ...(grant.appToolCatalogDigest
@@ -4952,7 +5043,7 @@ function cors(response: Response, request: Request) {
     }
     response.headers.set(
       "access-control-allow-headers",
-      "accept-payment, authorization, content-type, git-protocol, idempotency-key, last-event-id, mcp-protocol-version, mcp-session-id, payment-session, payment-session-snapshot, payment-signature, x-nanocodex-app-id, x-nanocodex-connect-client",
+      "accept-payment, authorization, content-type, git-protocol, idempotency-key, last-event-id, mcp-protocol-version, mcp-session-id, payment-session, payment-session-snapshot, payment-signature, x-nanocodex-app-id, x-nanocodex-connect-client, x-nanocodex-connector-connection",
     );
     response.headers.set("access-control-allow-methods", "GET, POST, PUT, DELETE, OPTIONS");
     response.headers.set("access-control-max-age", "86400");

--- a/services/connect-api/src/managedGrant.d.mts
+++ b/services/connect-api/src/managedGrant.d.mts
@@ -3,6 +3,7 @@ export type ManagedGrantAssertion = Readonly<{
   brokerUserId: string;
   capabilities: readonly string[];
   connectors: readonly string[];
+  connectorConnections?: Readonly<Record<string, readonly string[]>>;
   grantId: `0x${string}`;
   mcpIds: readonly string[];
 }>;

--- a/services/connect-api/src/managedGrant.mjs
+++ b/services/connect-api/src/managedGrant.mjs
@@ -23,6 +23,7 @@ export function managedGrantHeaders(assertion) {
       ...(portability ? ["agents:portability"] : []),
     ]),
     "x-nanocodex-connect-connectors": JSON.stringify(assertion.connectors),
+    "x-nanocodex-connect-connector-connections": JSON.stringify(assertion.connectorConnections ?? {}),
     "x-nanocodex-connect-mcp-ids": JSON.stringify(assertion.mcpIds),
     ...(assertion.appToolCatalogDigest === undefined
       ? {}

--- a/services/connect-api/test/managedGrant.test.mjs
+++ b/services/connect-api/test/managedGrant.test.mjs
@@ -57,7 +57,8 @@ test("managed grant headers serialize only the exact delegated slice", () => {
       "github",
       "mcp:not-a-header-capability",
     ],
-    connectors: ["github"],
+    connectors: ["github", "gmail"],
+    connectorConnections: { gmail: ["g".repeat(43)] },
     grantId: `0x${"a".repeat(64)}`,
     mcpIds: ["mcp-1"],
     appToolCatalogDigest: `0x${"c".repeat(64)}`,
@@ -70,7 +71,10 @@ test("managed grant headers serialize only the exact delegated slice", () => {
     "history:read",
     "memory:write",
   ]);
-  assert.deepEqual(JSON.parse(headers["x-nanocodex-connect-connectors"]), ["github"]);
+  assert.deepEqual(JSON.parse(headers["x-nanocodex-connect-connectors"]), ["github", "gmail"]);
+  assert.deepEqual(JSON.parse(headers["x-nanocodex-connect-connector-connections"]), {
+    gmail: ["g".repeat(43)],
+  });
   assert.deepEqual(JSON.parse(headers["x-nanocodex-connect-mcp-ids"]), ["mcp-1"]);
   assert.equal(
     headers["x-nanocodex-connect-app-tool-catalog-digest"],

--- a/services/egress/README.md
+++ b/services/egress/README.md
@@ -181,6 +181,10 @@ IDs and display labels. A provider request uses the sole connection
 automatically; once more than one is present, callers select one with
 `X-Nanocodex-Connector-Connection: <id>`. Connect grants snapshot those IDs, so
 authorizing another Google account later cannot broaden an existing grant.
+The agent receives only the grant-approved ID/label pairs, chooses an account by
+label for each request, and sends the opaque ID to the egress proxy. The proxy
+validates the choice against the active grant before the private broker replaces
+the credential placeholder; provider tokens never enter the agent runtime.
 Disconnecting `DELETE /v1/connectors/{gmail|gdrive}/<id>` revokes only that
 Google identity and its sibling Gmail/Drive grant for the same Google subject.
 

--- a/services/egress/README.md
+++ b/services/egress/README.md
@@ -175,6 +175,15 @@ PKCE/state validation, code exchange, identity lookup, encrypted token storage,
 and disconnect. OAuth callbacks return only a relative profile destination and
 connection result through the managed Worker.
 
+Gmail and Google Drive retain multiple Google identities per Nanocodex account.
+Their public status includes a secret-free `connections` list with stable opaque
+IDs and display labels. A provider request uses the sole connection
+automatically; once more than one is present, callers select one with
+`X-Nanocodex-Connector-Connection: <id>`. Connect grants snapshot those IDs, so
+authorizing another Google account later cannot broaden an existing grant.
+Disconnecting `DELETE /v1/connectors/{gmail|gdrive}/<id>` revokes only that
+Google identity and its sibling Gmail/Drive grant for the same Google subject.
+
 Register these exact callbacks on the provider applications, replacing the
 origin with the deployed website origin:
 

--- a/services/egress/src/connector-broker.ts
+++ b/services/egress/src/connector-broker.ts
@@ -51,6 +51,7 @@ const CONNECTOR_TIMEOUT_MS = 20_000;
 const EXPIRY_SKEW_MS = 30_000;
 const REDIRECT_STATUS = new Set([301, 302, 303, 307, 308]);
 const CONNECTOR = /^(github|gmail|gdrive|x)$/;
+const CONNECTION_ID = /^[A-Za-z0-9_-]{43}$/;
 const CONNECTOR_METHODS = new Set(["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]);
 
 type ProviderRule = Readonly<{
@@ -119,10 +120,19 @@ type PendingAuthorization = {
 };
 
 type ConnectorState = {
+  version: 2;
+  connectors: Partial<Record<ConnectorId, StoredConnector>>;
+  googleConnections: Partial<Record<GoogleConnectorId, Record<string, StoredConnector>>>;
+  pending: Partial<Record<ConnectorId, PendingAuthorization>>;
+};
+
+type LegacyConnectorState = {
   version: 1;
   connectors: Partial<Record<ConnectorId, StoredConnector>>;
   pending: Partial<Record<ConnectorId, PendingAuthorization>>;
 };
+
+type GoogleConnectorId = "gmail" | "gdrive";
 
 type StoredRow = { envelope: EncryptedEnvelope };
 
@@ -132,7 +142,7 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
   readonly #vault: CredentialVault;
   readonly #mcpConnections: McpConnectionOwner;
   readonly #ready: Promise<void>;
-  #connectors: ConnectorState = { version: 1, connectors: {}, pending: {} };
+  #connectors: ConnectorState = { version: 2, connectors: {}, googleConnections: {}, pending: {} };
   #tail: Promise<void> = Promise.resolve();
 
   constructor(state: DurableObjectState, env: ConnectorBrokerEnv) {
@@ -165,9 +175,9 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
       this.#mcpConnections.initialize(),
     ]);
     if (row) {
-      const opened = await this.#vault.open<ConnectorState>(row.envelope);
-      this.#connectors = opened.value;
-      if (opened.reseal) await this.#persist();
+      const opened = await this.#vault.open<ConnectorState | LegacyConnectorState>(row.envelope);
+      this.#connectors = migrateConnectorState(opened.value);
+      if (opened.reseal || opened.value.version === 1) await this.#persist();
     }
   }
 
@@ -195,10 +205,11 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
       if (request.method === "GET" && url.pathname === "/v1/status") {
         return json({ connectors: this.#publicStatus() }, 200);
       }
-      const match = url.pathname.match(/^\/v1\/(github|gmail|gdrive|x)(?:\/(start|callback))?$/);
+      const match = url.pathname.match(/^\/v1\/(github|gmail|gdrive|x)(?:\/(start|callback)|\/connections\/([A-Za-z0-9_-]{43}))?$/);
       const id = connectorId(match?.[1]);
       if (!id) return jsonError(404, "not_found");
       const operation = match?.[2];
+      const connectionId = match?.[3];
       if (request.method === "POST" && operation === "start") {
         auditAction = "authorize_start";
         auditConnector = id;
@@ -216,12 +227,34 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
         });
         return json(callback, 200);
       }
+      if (request.method === "DELETE" && connectionId) {
+        if (!isGoogleConnector(id)) return jsonError(404, "not_found");
+        auditAction = "disconnect";
+        auditConnector = id;
+        const connector = this.#googleConnections(id)[connectionId];
+        if (!connector) return jsonError(404, "connector_connection_not_found");
+        const providerRevoked = await this.#revoke(id, connector);
+        const disconnected = this.#deleteGoogleGrant(id, connectionId, connector);
+        await this.#persist();
+        connectorAudit("disconnect", "allow", id, {
+          status: 204,
+          provider_revoked: providerRevoked,
+          disconnected_connectors: disconnected,
+          connection_id: connectionId,
+        });
+        return new Response(null, { status: 204, headers: noStoreHeaders() });
+      }
       if (request.method === "DELETE" && operation === undefined) {
         auditAction = "disconnect";
         auditConnector = id;
-        const connector = this.#connectors.connectors[id];
-        const providerRevoked = connector ? await this.#revoke(id, connector) : false;
-        const disconnected = this.#deleteConnectorGrant(id, connector);
+        const google = isGoogleConnector(id) ? Object.entries(this.#googleConnections(id)) : [];
+        const connector = isGoogleConnector(id) ? undefined : this.#connectors.connectors[id];
+        let providerRevoked = false;
+        for (const [, connection] of google) providerRevoked = await this.#revoke(id, connection) || providerRevoked;
+        if (connector) providerRevoked = await this.#revoke(id, connector);
+        const disconnected = isGoogleConnector(id)
+          ? google.flatMap(([selectedId, connection]) => this.#deleteGoogleGrant(id, selectedId, connection))
+          : this.#deleteConnectorGrant(id, connector);
         delete this.#connectors.pending[id];
         await this.#persist();
         connectorAudit("disconnect", "allow", id, {
@@ -255,7 +288,11 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
       throw new ConnectorFailure(403, "destination_denied");
     }
     if (!safeQuery(url.searchParams)) throw new ConnectorFailure(403, "destination_denied");
-    const connector = await this.#usableConnector(provider.id);
+    const selectedConnectionId = request.headers.get("x-nanocodex-connector-connection");
+    if (selectedConnectionId !== null && !CONNECTION_ID.test(selectedConnectionId)) {
+      throw new ConnectorFailure(400, "connector_connection_invalid");
+    }
+    const connector = await this.#usableConnector(provider.id, selectedConnectionId ?? undefined);
     const headers = connectorRequestHeaders(request.headers, provider.id, connector.accessToken);
     let upstream: Response;
     try {
@@ -275,7 +312,12 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
     }
     if (upstream.status === 401) {
       await upstream.body?.cancel();
-      this.#deleteConnectorGrant(provider.id, connector);
+      const effectiveConnectionId = selectedConnectionId
+        ?? (isGoogleConnector(provider.id)
+          ? Object.entries(this.#googleConnections(provider.id))
+            .find(([, candidate]) => candidate.accountId === connector.accountId)?.[0]
+          : undefined);
+      this.#deleteSelectedGrant(provider.id, effectiveConnectionId, connector);
       await this.#persist();
       throw new ConnectorFailure(409, "connector_reauthentication_required");
     }
@@ -300,24 +342,25 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
     });
   }
 
-  async #usableConnector(id: ConnectorId): Promise<StoredConnector> {
-    const connector = this.#connectors.connectors[id];
+  async #usableConnector(id: ConnectorId, connectionId?: string): Promise<StoredConnector> {
+    const selected = this.#selectConnector(id, connectionId);
+    const connector = selected.connector;
     if (!connector) throw new ConnectorFailure(409, "connector_not_connected");
     if (connector.expiresAt === undefined || connector.expiresAt > Date.now() + EXPIRY_SKEW_MS) {
       return connector;
     }
     if (!connector.refreshToken) {
-      return this.#rejectRefresh(id, connector);
+      return this.#rejectRefresh(id, connector, selected.connectionId);
     }
     if (connector.refreshExpiresAt !== undefined
       && connector.refreshExpiresAt <= Date.now() + EXPIRY_SKEW_MS) {
-      this.#deleteConnectorGrant(id, connector);
+      this.#deleteSelectedGrant(id, selected.connectionId, connector);
       await this.#persist();
       throw new ConnectorFailure(409, "connector_reauthentication_required");
     }
     if (id === "github") return this.#refreshGitHubConnector(connector);
     if (id === "x") return this.#refreshXConnector(connector);
-    return this.#refreshGoogleConnector(id, connector);
+    return this.#refreshGoogleConnector(id, connector, selected.connectionId!);
   }
 
   async #refreshGitHubConnector(connector: StoredConnector): Promise<StoredConnector> {
@@ -364,8 +407,8 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
     return next;
   }
 
-  async #rejectRefresh(id: ConnectorId, connector: StoredConnector): Promise<never> {
-    this.#deleteConnectorGrant(id, connector);
+  async #rejectRefresh(id: ConnectorId, connector: StoredConnector, connectionId?: string): Promise<never> {
+    this.#deleteSelectedGrant(id, connectionId, connector);
     await this.#persist();
     connectorAudit("refresh", "deny", id, {
       status: 409,
@@ -414,6 +457,7 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
   async #refreshGoogleConnector(
     id: "gmail" | "gdrive",
     connector: StoredConnector,
+    connectionId: string,
   ): Promise<StoredConnector> {
     const credentials = providerCredentials(id, this.#env);
     const response = await providerFetch(new Request("https://oauth2.googleapis.com/token", {
@@ -432,7 +476,7 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
     if (REDIRECT_STATUS.has(response.status) || !response.ok) {
       await response.body?.cancel();
       if (response.status === 400 || response.status === 401) {
-        return this.#rejectRefresh(id, connector);
+        return this.#rejectRefresh(id, connector, connectionId);
       }
       connectorAudit("refresh", "error", id, {
         status: 503,
@@ -447,7 +491,7 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
       expiresAt: Date.now() + refreshed.expiresIn * 1_000,
       ...(refreshed.scopes ? { scopes: refreshed.scopes } : {}),
     };
-    this.#connectors.connectors[id] = next;
+    this.#googleConnections(id)[connectionId] = next;
     await this.#persist();
     connectorAudit("refresh", "allow", id, { status: 200 });
     return next;
@@ -499,17 +543,76 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
     return connectorIds;
   }
 
+  #googleConnections(id: GoogleConnectorId): Record<string, StoredConnector> {
+    return this.#connectors.googleConnections[id] ??= {};
+  }
+
+  #selectConnector(id: ConnectorId, connectionId?: string): { connector?: StoredConnector; connectionId?: string } {
+    if (!isGoogleConnector(id)) {
+      const connector = this.#connectors.connectors[id];
+      return connector ? { connector } : {};
+    }
+    const connections = this.#googleConnections(id);
+    if (connectionId) return { connector: connections[connectionId], connectionId };
+    const usable = Object.entries(connections).filter(([, connector]) => this.#isUsable(connector));
+    if (usable.length > 1) throw new ConnectorFailure(409, "connector_connection_required");
+    return usable[0] ? { connectionId: usable[0][0], connector: usable[0][1] } : {};
+  }
+
+  #deleteSelectedGrant(id: ConnectorId, connectionId: string | undefined, connector: StoredConnector): void {
+    if (isGoogleConnector(id) && connectionId) {
+      this.#deleteGoogleGrant(id, connectionId, connector);
+      return;
+    }
+    this.#deleteConnectorGrant(id, connector);
+  }
+
+  #deleteGoogleGrant(id: GoogleConnectorId, connectionId: string, connector: StoredConnector): number {
+    let deleted = 0;
+    for (const candidate of ["gmail", "gdrive"] as const) {
+      for (const [candidateId, candidateConnector] of Object.entries(this.#googleConnections(candidate))) {
+        if ((candidate === id && candidateId === connectionId)
+          || candidateConnector.accountId === connector.accountId) {
+          delete this.#googleConnections(candidate)[candidateId];
+          deleted += 1;
+        }
+      }
+    }
+    return deleted;
+  }
+
+  #isUsable(connector: StoredConnector): boolean {
+    const refreshable = connector.refreshToken
+      && (connector.refreshExpiresAt === undefined
+        || connector.refreshExpiresAt > Date.now() + EXPIRY_SKEW_MS);
+    return connector.expiresAt === undefined
+      || connector.expiresAt > Date.now() + EXPIRY_SKEW_MS
+      || Boolean(refreshable);
+  }
+
   #publicStatus(): Record<ConnectorId, Record<string, unknown>> {
     const status = (id: ConnectorId): Record<string, unknown> => {
+      if (isGoogleConnector(id)) {
+        const connections = Object.entries(this.#googleConnections(id))
+          .filter(([, connector]) => this.#isUsable(connector))
+          .sort(([, left], [, right]) => left.connectedAt - right.connectedAt)
+          .map(([connectionId, connector]) => ({
+            id: connectionId,
+            account_id: connector.accountId,
+            label: connector.label,
+          }));
+        return connections.length ? {
+          connected: true,
+          connections,
+          ...(connections.length === 1 ? {
+            connection_id: connections[0]!.id,
+            account_id: connections[0]!.account_id,
+            label: connections[0]!.label,
+          } : {}),
+        } : { connected: false, connections: [] };
+      }
       const connector = this.#connectors.connectors[id];
-      const refreshable = connector?.refreshToken
-        && (connector.refreshExpiresAt === undefined
-          || connector.refreshExpiresAt > Date.now() + EXPIRY_SKEW_MS);
-      const usable = connector
-        && (connector.expiresAt === undefined
-          || connector.expiresAt > Date.now() + EXPIRY_SKEW_MS
-          || refreshable);
-      return usable ? {
+      return connector && this.#isUsable(connector) ? {
         connected: true,
         account_id: connector.accountId,
         label: connector.label,
@@ -593,7 +696,7 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
         if (error instanceof ConnectorFailure) throw error;
         throw new ConnectorFailure(502, "connector_identity_response_invalid");
       }
-      this.#connectors.connectors[id] = {
+      const next = {
         accessToken: token.accessToken,
         ...(token.refreshToken ? { refreshToken: token.refreshToken } : {}),
         ...(token.expiresIn ? { expiresAt: Date.now() + token.expiresIn * 1_000 } : {}),
@@ -605,8 +708,17 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
         label: identity.displayLabel,
         connectedAt: Date.now(),
       };
+      let connectionId: string | undefined;
+      if (isGoogleConnector(id)) {
+        connectionId = Object.entries(this.#googleConnections(id))
+          .find(([, connector]) => connector.accountId === identity.accountId)?.[0]
+          ?? randomBase64Url(32);
+        this.#googleConnections(id)[connectionId] = next;
+      } else {
+        this.#connectors.connectors[id] = next;
+      }
       await this.#persist();
-      return { connected: true, return_to: pending.returnTo };
+      return { connected: true, return_to: pending.returnTo, ...(connectionId ? { connection_id: connectionId } : {}) };
     } catch (error) {
       const problem = connectorFailure(error);
       throw new ConnectorFailure(problem.status, problem.code, pending.returnTo);
@@ -623,10 +735,10 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
     try {
       const row = await this.#state.storage.get<StoredRow>(STATE_KEY);
       this.#connectors = row
-        ? (await this.#vault.open<ConnectorState>(row.envelope)).value
-        : { version: 1, connectors: {}, pending: {} };
+        ? migrateConnectorState((await this.#vault.open<ConnectorState | LegacyConnectorState>(row.envelope)).value)
+        : { version: 2, connectors: {}, googleConnections: {}, pending: {} };
     } catch {
-      this.#connectors = { version: 1, connectors: {}, pending: {} };
+      this.#connectors = { version: 2, connectors: {}, googleConnections: {}, pending: {} };
     }
   }
 }
@@ -997,6 +1109,23 @@ function stringField(value: unknown, key: string): string | undefined {
 
 function connectorId(value: string | undefined): ConnectorId | undefined {
   return value && CONNECTOR.test(value) ? value as ConnectorId : undefined;
+}
+
+function isGoogleConnector(id: ConnectorId): id is GoogleConnectorId {
+  return id === "gmail" || id === "gdrive";
+}
+
+function migrateConnectorState(value: ConnectorState | LegacyConnectorState): ConnectorState {
+  if (value.version === 2) return value;
+  const connectors = { ...value.connectors };
+  const googleConnections: ConnectorState["googleConnections"] = {};
+  for (const id of ["gmail", "gdrive"] as const) {
+    const connector = connectors[id];
+    if (!connector) continue;
+    delete connectors[id];
+    googleConnections[id] = { [randomBase64Url(32)]: connector };
+  }
+  return { version: 2, connectors, googleConnections, pending: value.pending };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/services/egress/src/egress.ts
+++ b/services/egress/src/egress.ts
@@ -558,18 +558,22 @@ async function handleControl(request: Request, url: URL, env: EgressEnv): Promis
   }
 
   const connectorMatch = url.pathname.match(
-    /^\/users\/([A-Za-z0-9][A-Za-z0-9._:-]{0,127})\/connectors(?:\/(github|gmail|gdrive|x)(\/callback)?)?$/,
+    /^\/users\/([A-Za-z0-9][A-Za-z0-9._:-]{0,127})\/connectors(?:\/(github|gmail|gdrive|x)(\/callback)?(?:\/([A-Za-z0-9_-]{43}))?)?$/,
   );
   if (connectorMatch) {
     const userId = connectorMatch[1]!;
     const connector = connectorMatch[2];
     const callback = connectorMatch[3] === "/callback";
+    const connectionId = connectorMatch[4];
     const target = connector
-      ? `https://connectors.internal/v1/${connector}${callback ? "/callback" : request.method === "POST" ? "/start" : ""}`
+      ? `https://connectors.internal/v1/${connector}${callback
+        ? "/callback"
+        : connectionId ? `/connections/${connectionId}` : request.method === "POST" ? "/start" : ""}`
       : "https://connectors.internal/v1/status";
     if ((!connector && request.method !== "GET")
       || (connector && callback && request.method !== "POST")
-      || (connector && !callback && request.method !== "POST" && request.method !== "DELETE")) {
+      || (connectionId && (connector === "github" || connector === "x" || request.method !== "DELETE"))
+      || (connector && !callback && !connectionId && request.method !== "POST" && request.method !== "DELETE")) {
       return jsonError(405, "method_not_allowed");
     }
     return connectorBroker(env, userId).fetch(target, {

--- a/services/egress/test/egress.test.ts
+++ b/services/egress/test/egress.test.ts
@@ -1106,7 +1106,7 @@ describe("per-user OAuth connectors", () => {
         state: authorization.searchParams.get("state"),
       });
       expect(completed.status).toBe(200);
-      expect(await completed.json()).toEqual({
+      expect(await completed.json()).toMatchObject({
         connected: true,
         return_to: "/agent?thread=connector-test",
       });
@@ -1122,6 +1122,38 @@ describe("per-user OAuth connectors", () => {
       }
     });
   }
+
+  it("retains multiple Gmail accounts and requires an exact account selection", async () => {
+    const user = "connector-many-gmail";
+    const subject = connectorSubject("many-gmail");
+    await control(`/subjects/${subject}`, "PUT", { user_id: user });
+    await connect(user, "gmail", "gmail-code");
+    await connect(user, "gmail", "gmail-second-code");
+
+    const status = await (await SELF.fetch(`https://broker.test/users/${user}/connectors`)).json<{
+      connectors: { gmail: { connected: boolean; connections: { id: string; label: string }[] } };
+    }>();
+    expect(status.connectors.gmail.connections.map(({ label }) => label)).toEqual([
+      "mail@example.test",
+      "mail-two@example.test",
+    ]);
+    expect((await SELF.fetch(connectorRequest(
+      "https://gmail.googleapis.com/gmail/v1/users/me/messages",
+      subject,
+    ))).status).toBe(409);
+
+    const accounts = [];
+    for (const connection of status.connectors.gmail.connections) {
+      const response = await SELF.fetch(connectorRequest(
+        "https://gmail.googleapis.com/gmail/v1/users/me/messages",
+        subject,
+        { connectionId: connection.id },
+      ));
+      expect(response.status).toBe(200);
+      accounts.push((await response.json<{ account: string }>()).account);
+    }
+    expect(accounts).toEqual(["mail-one", "mail-two"]);
+  });
 
   for (const [code, label] of [
     ["x-no-refresh-code", "refresh token"],
@@ -1709,6 +1741,7 @@ function connectorRequest(
     authorization?: string;
     body?: string;
     contentType?: string;
+    connectionId?: string;
   }> = {},
 ): Request {
   return new Request(url, {
@@ -1718,6 +1751,7 @@ function connectorRequest(
       cookie: "caller-secret=cookie",
       "proxy-authorization": "Basic caller-proxy-secret",
       ...(subject ? { "x-nanocodex-subject": subject } : {}),
+      ...(override.connectionId ? { "x-nanocodex-connector-connection": override.connectionId } : {}),
       ...(override.body === undefined
         ? {}
         : { "content-type": override.contentType ?? "application/octet-stream" }),

--- a/services/egress/vitest.config.ts
+++ b/services/egress/vitest.config.ts
@@ -178,6 +178,7 @@ export default defineConfig({
             }
             const code = String(body.get("code") ?? "");
             const sharedAccount = code.endsWith("-shared-account-code");
+            const secondAccount = code === "gmail-second-code";
             const drive = code === "gdrive-code" || code === "gdrive-shared-account-code";
             const expiring = body.get("code") === "gmail-expiring-code";
             const revoked = body.get("code") === "gmail-revoked-code";
@@ -185,10 +186,12 @@ export default defineConfig({
             return Response.json({
               access_token: sharedAccount
                 ? drive ? "gdrive-shared-account-access" : "gmail-shared-account-access"
+                : secondAccount ? "gmail-second-access"
                 : drive ? "gdrive-connector-access" : "gmail-connector-access",
               ...(body.get("code") === "gmail-no-refresh-code" ? {} : {
                 refresh_token: drive
                   ? "gdrive-connector-refresh"
+                  : secondAccount ? "gmail-second-refresh"
                   : revoked
                     ? "gmail-revoked-refresh"
                     : revokeFailure ? "gmail-revoke-failure-refresh" : "gmail-connector-refresh",
@@ -216,14 +219,17 @@ export default defineConfig({
             && url.pathname === "/v1/userinfo") {
             const authorization = request.headers.get("authorization");
             const sharedAccount = authorization?.endsWith("shared-account-access") === true;
+            const secondAccount = authorization === "Bearer gmail-second-access";
             const drive = authorization === "Bearer gdrive-connector-access"
               || authorization === "Bearer gdrive-shared-account-access";
             return Response.json({
               sub: sharedAccount
                 ? "google-shared-account"
+                : secondAccount ? "google-gmail-account-second"
                 : drive ? "google-drive-account" : "google-gmail-account",
               email: sharedAccount
                 ? "shared@example.test"
+                : secondAccount ? "mail-two@example.test"
                 : drive ? "drive@example.test" : "mail@example.test",
               email_verified: true,
               name: drive ? "Drive User" : "Mail User",
@@ -253,6 +259,8 @@ export default defineConfig({
               : authorization === "Bearer github-beta-access" ? "beta"
               : authorization === "Bearer github-refreshed-access" ? "github-refreshed"
               : authorization === "Bearer gmail-refreshed-access" ? "gmail-refreshed"
+              : authorization === "Bearer gmail-second-access" ? "mail-two"
+              : authorization === "Bearer gmail-connector-access" ? "mail-one"
               : authorization === "Bearer x-refreshed-access" ? "x-refreshed"
               : authorization.startsWith("Bearer ") ? "connected" : "missing";
             return Response.json({

--- a/services/managed/src/account-auth.ts
+++ b/services/managed/src/account-auth.ts
@@ -27,6 +27,7 @@ const CONNECT_USER_HEADER = "x-nanocodex-connect-user";
 const CONNECT_GRANT_ID_HEADER = "x-nanocodex-connect-grant-id";
 const CONNECT_CAPABILITIES_HEADER = "x-nanocodex-connect-capabilities";
 const CONNECT_CONNECTORS_HEADER = "x-nanocodex-connect-connectors";
+const CONNECT_CONNECTOR_CONNECTIONS_HEADER = "x-nanocodex-connect-connector-connections";
 const CONNECT_MCP_IDS_HEADER = "x-nanocodex-connect-mcp-ids";
 const CONNECT_APP_TOOL_CATALOG_DIGEST_HEADER = "x-nanocodex-connect-app-tool-catalog-digest";
 const SESSION_OWNER_ASSERTION = "x-nanocodex-owner-id";
@@ -70,6 +71,7 @@ export type ConnectConnectorId = "github" | "gmail" | "gdrive" | "x" | "chatgpt"
 export type ConnectGrantSlice = Readonly<{
   grantId: string;
   connectors: readonly ConnectConnectorId[];
+  connectorConnections: Readonly<Partial<Record<ConnectConnectorId, readonly string[]>>>;
   mcpIds: readonly string[];
   appToolCatalogDigest?: `0x${string}`;
 }>;
@@ -112,6 +114,7 @@ export function forwardPrincipalAssertions(headers: Headers, principal: Principa
     CONNECT_GRANT_ID_HEADER,
     CONNECT_CAPABILITIES_HEADER,
     CONNECT_CONNECTORS_HEADER,
+    CONNECT_CONNECTOR_CONNECTIONS_HEADER,
     CONNECT_MCP_IDS_HEADER,
     CONNECT_APP_TOOL_CATALOG_DIGEST_HEADER,
   ]) {
@@ -120,6 +123,7 @@ export function forwardPrincipalAssertions(headers: Headers, principal: Principa
   if (principal.connectGrant) {
     headers.set(CONNECT_GRANT_ID_HEADER, principal.connectGrant.grantId);
     headers.set(CONNECT_CONNECTORS_HEADER, JSON.stringify(principal.connectGrant.connectors));
+    headers.set(CONNECT_CONNECTOR_CONNECTIONS_HEADER, JSON.stringify(principal.connectGrant.connectorConnections));
     headers.set(CONNECT_MCP_IDS_HEADER, JSON.stringify(principal.connectGrant.mcpIds));
     if (principal.connectGrant.appToolCatalogDigest !== undefined) {
       headers.set(CONNECT_APP_TOOL_CATALOG_DIGEST_HEADER, principal.connectGrant.appToolCatalogDigest);
@@ -1713,6 +1717,7 @@ function parseConnectGrantAssertions(headers: Headers): Readonly<{
   const grantId = headers.get(CONNECT_GRANT_ID_HEADER);
   const capabilities = parseUniqueJsonArray(headers.get(CONNECT_CAPABILITIES_HEADER));
   const connectors = parseUniqueJsonArray(headers.get(CONNECT_CONNECTORS_HEADER));
+  const connectorConnections = parseConnectorConnections(headers.get(CONNECT_CONNECTOR_CONNECTIONS_HEADER));
   const mcpIds = parseUniqueJsonArray(headers.get(CONNECT_MCP_IDS_HEADER));
   const appToolCatalogDigest = headers.get(CONNECT_APP_TOOL_CATALOG_DIGEST_HEADER);
   if (!grantId || !CONNECT_GRANT_ID.test(grantId)
@@ -1722,6 +1727,8 @@ function parseConnectGrantAssertions(headers: Headers): Readonly<{
     || !connectors || !connectors.every((value): value is ConnectConnectorId => (
       CONNECT_CONNECTORS.has(value as ConnectConnectorId)
     ))
+    || !connectorConnections
+    || Object.keys(connectorConnections).some((connector) => !connectors.includes(connector as ConnectConnectorId))
     || !mcpIds || mcpIds.length > 16 || !mcpIds.every((value) => CONNECT_MCP_ID.test(value))
     || (appToolCatalogDigest !== null && !isAppToolCatalogDigest(appToolCatalogDigest))) {
     return undefined;
@@ -1731,10 +1738,27 @@ function parseConnectGrantAssertions(headers: Headers): Readonly<{
     slice: {
       grantId: grantId.toLowerCase(),
       connectors,
+      connectorConnections,
       mcpIds,
       ...(appToolCatalogDigest === null ? {} : { appToolCatalogDigest }),
     },
   };
+}
+
+function parseConnectorConnections(encoded: string | null): Partial<Record<ConnectConnectorId, readonly string[]>> | undefined {
+  if (encoded === null) return undefined;
+  let value: unknown;
+  try { value = JSON.parse(encoded); } catch { return undefined; }
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const result: Partial<Record<ConnectConnectorId, readonly string[]>> = {};
+  for (const [connector, ids] of Object.entries(value)) {
+    if (!CONNECT_CONNECTORS.has(connector as ConnectConnectorId)
+      || !Array.isArray(ids) || ids.length > 32
+      || ids.some((id) => typeof id !== "string" || !CONNECT_MCP_ID.test(id))
+      || new Set(ids).size !== ids.length) return undefined;
+    result[connector as ConnectConnectorId] = ids as string[];
+  }
+  return result;
 }
 
 function parseUniqueJsonArray(encoded: string | null): string[] | undefined {

--- a/services/managed/src/account-info.ts
+++ b/services/managed/src/account-info.ts
@@ -116,7 +116,9 @@ export function withInitialAccountInfo(input: PromptInput, info: AccountInfo): P
   const explanation = [
     "The managed runtime already resolved the following non-secret accountInfo snapshot for",
     "this agent. Use it as the current connected-account context. Do not call accountInfo",
-    "again unless the task requires state refreshed after this first prompt.",
+    "again unless the task requires state refreshed after this first prompt. When multiple Gmail",
+    "or Google Drive accounts are listed, choose the appropriate account by label and pass its id",
+    "as X-Nanocodex-Connector-Connection on that provider request. Never invent an account id.",
   ].join(" ");
   const context = {
     type: "text" as const,

--- a/services/managed/src/account-info.ts
+++ b/services/managed/src/account-info.ts
@@ -11,6 +11,7 @@ export type AccountInfo = Readonly<{
   status: "disabled" | "ready" | "unavailable";
   authenticated: readonly ConnectorId[];
   accounts: Readonly<Partial<Record<ConnectorId, string>>>;
+  connectorAccounts: Readonly<Partial<Record<ConnectorId, readonly Readonly<{ id: string; label: string }>[]>>>;
   identity: Readonly<Record<string, never>>;
   stablecoins: readonly [];
   authorizations: readonly [];
@@ -21,6 +22,7 @@ export async function accountInfo(
   userId: string,
   enabled: boolean,
   allowedConnectors?: readonly ConnectorId[],
+  allowedConnectorConnections?: Readonly<Partial<Record<ConnectorId, readonly string[]>>>,
 ): Promise<AccountInfo> {
   if (!enabled) return emptyInfo("disabled");
   try {
@@ -37,6 +39,7 @@ export async function accountInfo(
     }
     const connectors = value.connectors;
     const accounts: Partial<Record<ConnectorId, string>> = {};
+    const connectorAccounts: Partial<Record<ConnectorId, readonly Readonly<{ id: string; label: string }>[]>> = {};
     const allowed = allowedConnectors === undefined ? undefined : new Set(allowedConnectors);
     const authenticated = CONNECTOR_IDS.filter((id) => {
       if (allowed && !allowed.has(id)) return false;
@@ -45,16 +48,30 @@ export async function accountInfo(
       if (typeof connector.label === "string" && connector.label.trim()) {
         accounts[id] = connector.label.trim();
       }
+      if (Array.isArray(connector.connections)) {
+        const decoded = connector.connections.map((connection) => {
+          if (!isRecord(connection) || typeof connection.id !== "string"
+            || !/^[A-Za-z0-9_-]{43}$/.test(connection.id)
+            || typeof connection.label !== "string" || !connection.label.trim()) {
+            throw new Error("invalid connector account");
+          }
+          return { id: connection.id, label: connection.label.trim() };
+        });
+        if (decoded.length > 32) throw new Error("too many connector accounts");
+        connectorAccounts[id] = decoded;
+        if (decoded.length === 1) accounts[id] = decoded[0]!.label;
+      }
       return true;
     });
     return projectAccountInfo({
       status: "ready",
       authenticated,
       accounts,
+      connectorAccounts,
       identity: {},
       stablecoins: [],
       authorizations: [],
-    }, allowedConnectors);
+    }, allowedConnectors, allowedConnectorConnections);
   } catch {
     return emptyInfo("unavailable");
   }
@@ -63,15 +80,35 @@ export async function accountInfo(
 export function projectAccountInfo(
   info: AccountInfo,
   allowedConnectors?: readonly ConnectorId[],
+  allowedConnectorConnections?: Readonly<Partial<Record<ConnectorId, readonly string[]>>>,
 ): AccountInfo {
-  if (allowedConnectors === undefined) return info;
+  if (allowedConnectors === undefined && allowedConnectorConnections === undefined) return info;
   const allowed = new Set(allowedConnectors);
+  const connectorAccounts = Object.fromEntries(Object.entries(info.connectorAccounts).flatMap(([id, connections]) => {
+    if (!allowed.has(id as ConnectorId)) return [];
+    const allowedIds = allowedConnectorConnections?.[id as ConnectorId];
+    const filtered = allowedIds === undefined
+      ? connections
+      : connections.filter(({ id: connectionId }) => allowedIds.includes(connectionId));
+    return filtered.length ? [[id, filtered]] : [];
+  }));
+  const authenticated = info.authenticated.filter((id) => allowed.has(id)
+    && ((id !== "gmail" && id !== "gdrive")
+      || allowedConnectorConnections === undefined
+      || Object.hasOwn(connectorAccounts, id)));
+  const accounts = Object.fromEntries(Object.entries(info.accounts).filter(([id]) => (
+    authenticated.includes(id as ConnectorId)
+  )));
+  for (const id of ["gmail", "gdrive"] as const) {
+    const connections = connectorAccounts[id];
+    if (connections?.length === 1) accounts[id] = connections[0]!.label;
+    else delete accounts[id];
+  }
   return {
     ...info,
-    authenticated: info.authenticated.filter((id) => allowed.has(id)),
-    accounts: Object.fromEntries(Object.entries(info.accounts).filter(([id]) => (
-      allowed.has(id as ConnectorId)
-    ))),
+    authenticated,
+    accounts,
+    connectorAccounts,
   };
 }
 
@@ -95,6 +132,7 @@ function emptyInfo(status: "disabled" | "unavailable"): AccountInfo {
     status,
     authenticated: [],
     accounts: {},
+    connectorAccounts: {},
     identity: {},
     stablecoins: [],
     authorizations: [],

--- a/services/managed/src/computer-runtime.ts
+++ b/services/managed/src/computer-runtime.ts
@@ -86,7 +86,7 @@ export type ManagedComputerRuntime = Readonly<{
 export async function createManagedComputerRuntime(options: Readonly<{
   computer: DisposableComputerWorkspace;
   computerProvider?: ComputerProviderOption;
-  connectorAllowed?: (connector: ManagedEgressConnectorId) => boolean;
+  connectorAllowed?: (connector: ManagedEgressConnectorId, connectionId?: string) => boolean | string;
   egress: Fetcher;
   sshIdentityAllowed?: (reference: string) => boolean;
   subject?: string;

--- a/services/managed/src/computer-shell.ts
+++ b/services/managed/src/computer-shell.ts
@@ -43,7 +43,7 @@ const MAX_GIT_ENTRIES = 20_000;
 export function createManagedShellFetch(
   binding: Fetcher,
   subject?: string,
-  connectorAllowed?: (connector: ManagedEgressConnectorId) => boolean,
+  connectorAllowed?: (connector: ManagedEgressConnectorId, connectionId?: string) => boolean | string,
 ): ManagedShellFetch {
   return async (url, options = {}) => {
     const method = (options.method ?? "GET").toUpperCase();

--- a/services/managed/src/connectors.ts
+++ b/services/managed/src/connectors.ts
@@ -204,13 +204,15 @@ export async function routeConnectorRequest(
     );
   }
 
-  const match = url.pathname.match(/^\/v1\/connectors\/([^/]+)(\/callback)?$/);
+  const match = url.pathname.match(/^\/v1\/connectors\/([^/]+)(\/callback)?(?:\/([A-Za-z0-9_-]{43}))?$/);
   if (!match) return undefined;
   const connector = connectorId(match[1]);
   if (!connector) return json({ error: "not_found" }, 404);
   const callback = match[2] === CALLBACK_SUFFIX;
+  const connectionId = match[3];
   if ((!callback && request.method !== "POST" && request.method !== "DELETE")
-    || (callback && request.method !== "GET")) {
+    || (callback && request.method !== "GET")
+    || (connectionId && (connector === "github" || connector === "x" || request.method !== "DELETE"))) {
     return json({ error: "method_not_allowed" }, 405);
   }
 
@@ -221,7 +223,7 @@ export async function routeConnectorRequest(
     if (originFailure) return originFailure;
   }
 
-  const target = `https://broker.internal/users/${encodeURIComponent(principal.userId)}/connectors/${connector}${callback ? "/callback" : ""}`;
+  const target = `https://broker.internal/users/${encodeURIComponent(principal.userId)}/connectors/${connector}${callback ? "/callback" : connectionId ? `/${connectionId}` : ""}`;
   if (callback) return finishCallback(await env.NANOCODEX.fetch(target, {
     method: "POST",
     headers: { "content-type": "application/json" },

--- a/services/managed/src/index.ts
+++ b/services/managed/src/index.ts
@@ -4738,6 +4738,7 @@ export class DurableAgentSession extends DurableComputerSession {
             "Never claim that a phone action happened unless the phone tool returned ok=true and status=completed. Report failed, unavailable, and ambiguous phone outcomes accurately.",
             "Your /workspace filesystem is durable Cloudflare Computer storage backed by this agent's Durable Object.",
             "Use accountInfo only when the user asks about account state or an operation fails because its authorization is unclear. Do not call accountInfo before an explicit gh, git, curl, or other shell command. Those commands use transparent authenticated egress when the current grant permits it. accountInfo is a tool, not a shell command.",
+            "When accountInfo lists multiple Gmail or Google Drive accounts, choose the appropriate account by label and pass its id as X-Nanocodex-Connector-Connection on that provider request. Never invent an account id. The egress proxy validates the selected id against the active grant and injects the provider credential.",
             computer.instructions,
             "No process sandbox is attached. Bounded Just Bash is the complete local execution boundary.",
             MEMORY_INSTRUCTIONS,

--- a/services/managed/src/index.ts
+++ b/services/managed/src/index.ts
@@ -222,6 +222,7 @@ const SESSION_AUTHORIZATION_EPOCH_ASSERTION = "x-nanocodex-authorization-epoch";
 const SESSION_CAPABILITIES_ASSERTION = "x-nanocodex-capabilities";
 const CONNECT_GRANT_ID_ASSERTION = "x-nanocodex-connect-grant-id";
 const CONNECT_CONNECTORS_ASSERTION = "x-nanocodex-connect-connectors";
+const CONNECT_CONNECTOR_CONNECTIONS_ASSERTION = "x-nanocodex-connect-connector-connections";
 const CONNECT_MCP_IDS_ASSERTION = "x-nanocodex-connect-mcp-ids";
 const CONNECT_APP_TOOL_CATALOG_DIGEST_ASSERTION = "x-nanocodex-connect-app-tool-catalog-digest";
 const MEMORY_ORGANIZATION_ASSERTION = "x-nanocodex-organization-id";
@@ -560,9 +561,10 @@ function forwardedPrincipal(headers: Headers): Readonly<{
   try {
     const grantId = headers.get(CONNECT_GRANT_ID_ASSERTION);
     const encodedConnectors = headers.get(CONNECT_CONNECTORS_ASSERTION);
+    const encodedConnectorConnections = headers.get(CONNECT_CONNECTOR_CONNECTIONS_ASSERTION);
     const encodedMcpIds = headers.get(CONNECT_MCP_IDS_ASSERTION);
     const appToolCatalogDigest = headers.get(CONNECT_APP_TOOL_CATALOG_DIGEST_ASSERTION);
-    const connectAssertions = [grantId, encodedConnectors, encodedMcpIds];
+    const connectAssertions = [grantId, encodedConnectors, encodedConnectorConnections, encodedMcpIds];
     if (connectAssertions.some((value) => value !== null)
       && connectAssertions.some((value) => value === null)) return undefined;
     if (appToolCatalogDigest !== null && grantId === null) return undefined;
@@ -572,6 +574,7 @@ function forwardedPrincipal(headers: Headers): Readonly<{
         connectGrant: {
           grantId,
           connectors: JSON.parse(encodedConnectors!),
+          connectorConnections: JSON.parse(encodedConnectorConnections!),
           mcpIds: JSON.parse(encodedMcpIds!),
           ...(appToolCatalogDigest === null ? {} : { appToolCatalogDigest }),
         },
@@ -603,7 +606,7 @@ function isConnectGrantSlice(value: unknown): value is ConnectGrantSlice {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const grant = value as Partial<ConnectGrantSlice>;
   return Object.keys(value).every((key) => (
-    key === "grantId" || key === "connectors" || key === "mcpIds" || key === "appToolCatalogDigest"
+    key === "grantId" || key === "connectors" || key === "connectorConnections" || key === "mcpIds" || key === "appToolCatalogDigest"
   ))
     && typeof grant.grantId === "string" && /^0x[0-9a-f]{64}$/.test(grant.grantId)
     && isUniqueStringArray(grant.connectors)
@@ -611,10 +614,22 @@ function isConnectGrantSlice(value: unknown): value is ConnectGrantSlice {
       connector === "github" || connector === "gmail" || connector === "gdrive"
       || connector === "x" || connector === "chatgpt"
     ))
+    && isConnectorConnectionSlice(grant.connectorConnections, grant.connectors)
     && isUniqueStringArray(grant.mcpIds) && grant.mcpIds.length <= 16
     && grant.mcpIds.every((id) => /^[A-Za-z0-9_-]{43}$/.test(id))
     && (grant.appToolCatalogDigest === undefined
       || isAppToolCatalogDigest(grant.appToolCatalogDigest));
+}
+
+function isConnectorConnectionSlice(
+  value: unknown,
+  connectors: readonly string[],
+): value is Readonly<Record<string, readonly string[]>> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  return Object.entries(value).every(([connector, ids]) => connectors.includes(connector)
+    && Array.isArray(ids) && ids.length <= 32
+    && ids.every((id) => typeof id === "string" && /^[A-Za-z0-9_-]{43}$/.test(id))
+    && new Set(ids).size === ids.length);
 }
 
 function isUniqueStringArray(value: unknown): value is string[] {
@@ -4342,10 +4357,11 @@ export class DurableAgentSession extends DurableComputerSession {
     ).toArray()[0];
     if (!first) return undefined;
     let allowedConnectors: readonly ManagedEgressConnectorId[] = [];
+    let allowedConnectorConnections: ConnectGrantSlice["connectorConnections"] | undefined;
     try {
-      allowedConnectors = accountConnectorProjection(
-        parseTurnAuthorization(first.authorization_json),
-      ) ?? ["github", "gmail", "gdrive", "x"];
+      const authorization = parseTurnAuthorization(first.authorization_json);
+      allowedConnectors = accountConnectorProjection(authorization) ?? ["github", "gmail", "gdrive", "x"];
+      allowedConnectorConnections = authorization.connectGrant?.connectorConnections;
     } catch { /* Malformed authorization fails closed. */ }
     const retained = await this.ctx.storage.get<InitialAccountContext>(
       INITIAL_ACCOUNT_CONTEXT_KEY,
@@ -4353,7 +4369,7 @@ export class DurableAgentSession extends DurableComputerSession {
     if (retained) {
       return {
         ...retained,
-        account: projectAccountInfo(retained.account, allowedConnectors),
+        account: projectAccountInfo(retained.account, allowedConnectors, allowedConnectorConnections),
       };
     }
     const prepared = {
@@ -4363,6 +4379,7 @@ export class DurableAgentSession extends DurableComputerSession {
         session.owner_id,
         true,
         allowedConnectors,
+        allowedConnectorConnections,
       ),
     } satisfies InitialAccountContext;
     await this.ctx.storage.put(INITIAL_ACCOUNT_CONTEXT_KEY, prepared);
@@ -4516,7 +4533,7 @@ export class DurableAgentSession extends DurableComputerSession {
       computerProvider: configuredComputerProvider(this.env, this.ctx.id.toString()),
       egress: this.env.NANOCODEX,
       ...(multiplayer ? {} : { subject: this.ctx.id.toString() }),
-      connectorAllowed: (connector) => this.#activeTurnConnectorAllowed(connector),
+      connectorAllowed: (connector, connectionId) => this.#activeTurnConnectorAllowed(connector, connectionId),
       sshIdentityAllowed: (reference) => this.#activeTurnSshIdentityAllowed(reference),
     });
     const currentAccountInfo = () => {
@@ -4526,6 +4543,7 @@ export class DurableAgentSession extends DurableComputerSession {
         session.owner_id,
         !multiplayer,
         authorization === undefined ? [] : accountConnectorProjection(authorization),
+        authorization?.connectGrant?.connectorConnections,
       );
     };
     const internalRuntime = Symbol.for("nanocodex.cloudflare.internalRuntime");
@@ -4885,11 +4903,15 @@ export class DurableAgentSession extends DurableComputerSession {
     catch { return undefined; }
   }
 
-  #activeTurnConnectorAllowed(connector: ManagedEgressConnectorId): boolean {
+  #activeTurnConnectorAllowed(connector: ManagedEgressConnectorId, connectionId?: string): boolean | string {
     const authorization = this.#activeTurnAuthorization();
-    return authorization !== undefined
-      && (authorization.connectGrant === undefined
-        || authorization.connectGrant.connectors.includes(connector));
+    if (!authorization) return false;
+    if (authorization.connectGrant === undefined) return true;
+    if (!authorization.connectGrant.connectors.includes(connector)) return false;
+    if (connector !== "gmail" && connector !== "gdrive") return true;
+    const granted = authorization.connectGrant.connectorConnections[connector] ?? [];
+    if (connectionId) return granted.includes(connectionId) ? connectionId : false;
+    return granted.length === 1 ? granted[0]! : false;
   }
 
   #activeTurnMcpAllowed(connectionId: string): boolean {

--- a/services/managed/src/managed-egress.ts
+++ b/services/managed/src/managed-egress.ts
@@ -64,7 +64,7 @@ export async function handleManagedEgress(
   request: Request,
   binding: Fetcher,
   subject?: string,
-  connectorAllowed: (connector: ManagedEgressConnectorId) => boolean = () => true,
+  connectorAllowed: (connector: ManagedEgressConnectorId, connectionId?: string) => boolean | string = () => true,
 ): Promise<Response> {
   const method = request.method.toUpperCase();
   if (!ORDINARY_METHODS.has(method)) return failure(403, "method_denied");
@@ -76,12 +76,17 @@ export async function handleManagedEgress(
   const provider = providerFor(url);
   if (!provider && PROVIDERS.has(url.hostname)) return failure(403, "destination_denied");
   if (provider) {
-    if (!connectorAllowed(provider.connector)) return failure(403, "connector_forbidden");
+    const requestedConnection = request.headers.get("x-nanocodex-connector-connection") ?? undefined;
+    const allowedConnection = connectorAllowed(provider.connector, requestedConnection);
+    if (allowedConnection === false) return failure(403, "connector_forbidden");
     if (!subject || !SUBJECT.test(subject)) return failure(403, "requires_login");
     if (!canonicalProviderPath(provider, url.pathname) || !provider.path(url.pathname)) {
       return failure(403, "connector_path_denied");
     }
     const headers = new Headers(request.headers);
+    if (typeof allowedConnection === "string") {
+      headers.set("x-nanocodex-connector-connection", allowedConnection);
+    }
     headers.set("authorization", PROVIDER_PLACEHOLDER);
     headers.set("x-nanocodex-subject", subject);
     return projectResponse(await binding.fetch(new Request(request.url, {

--- a/services/managed/test/account-auth.test.ts
+++ b/services/managed/test/account-auth.test.ts
@@ -28,6 +28,7 @@ describe("Connect grant assertions", () => {
       headers: connectHeaders({
         capabilities: ["agents:read", "agents:write", "tools:use", "memory:read"],
         connectors: ["github", "chatgpt"],
+        connectorConnections: {},
         mcpIds: [CONNECT_MCP_ID],
         appToolCatalogDigest: APP_TOOL_CATALOG_DIGEST,
       }),
@@ -470,6 +471,7 @@ function connectHeaders(overrides: Readonly<{
   appToolCatalogDigest?: string;
   capabilities?: readonly string[];
   connectors?: readonly string[];
+  connectorConnections?: Readonly<Record<string, readonly string[]>>;
   mcpIds?: readonly string[];
 }> = {}): Headers {
   return new Headers({
@@ -479,6 +481,7 @@ function connectHeaders(overrides: Readonly<{
       overrides.capabilities ?? ["agents:read", "agents:write", "tools:use"],
     ),
     "x-nanocodex-connect-connectors": JSON.stringify(overrides.connectors ?? []),
+    "x-nanocodex-connect-connector-connections": JSON.stringify(overrides.connectorConnections ?? {}),
     "x-nanocodex-connect-mcp-ids": JSON.stringify(overrides.mcpIds ?? []),
     ...(overrides.appToolCatalogDigest === undefined
       ? {}

--- a/services/managed/test/account-info.test.ts
+++ b/services/managed/test/account-info.test.ts
@@ -112,7 +112,7 @@ describe("account info", () => {
       {
         type: "text",
         text: [
-          "The managed runtime already resolved the following non-secret accountInfo snapshot for this agent. Use it as the current connected-account context. Do not call accountInfo again unless the task requires state refreshed after this first prompt.",
+          "The managed runtime already resolved the following non-secret accountInfo snapshot for this agent. Use it as the current connected-account context. Do not call accountInfo again unless the task requires state refreshed after this first prompt. When multiple Gmail or Google Drive accounts are listed, choose the appropriate account by label and pass its id as X-Nanocodex-Connector-Connection on that provider request. Never invent an account id.",
           `<account_info>\n${JSON.stringify(info)}\n</account_info>`,
         ].join("\n\n"),
       },

--- a/services/managed/test/account-info.test.ts
+++ b/services/managed/test/account-info.test.ts
@@ -7,7 +7,10 @@ describe("account info", () => {
     const fetch = vi.fn(async () => Response.json({
       connectors: {
         github: { connected: true, account_id: "secret-account", label: "Nano Cat (nanocat)" },
-        gmail: { connected: false },
+        gmail: { connected: true, connections: [
+          { id: "a".repeat(43), account_id: "google-one", label: "one@example.test" },
+          { id: "b".repeat(43), account_id: "google-two", label: "two@example.test" },
+        ] },
         gdrive: { connected: true, access_token: "secret-token" },
         x: { connected: true, account_id: "secret-x-account", label: "Nano Cat (@nanocat)" },
       },
@@ -17,8 +20,12 @@ describe("account info", () => {
 
     expect(info).toEqual({
       status: "ready",
-      authenticated: ["github", "gdrive", "x"],
+      authenticated: ["github", "gmail", "gdrive", "x"],
       accounts: { github: "Nano Cat (nanocat)", x: "Nano Cat (@nanocat)" },
+      connectorAccounts: { gmail: [
+        { id: "a".repeat(43), label: "one@example.test" },
+        { id: "b".repeat(43), label: "two@example.test" },
+      ] },
       identity: {},
       stablecoins: [],
       authorizations: [],
@@ -33,12 +40,12 @@ describe("account info", () => {
     expect(await accountInfo({
       fetch: async () => Response.json({ error: "down" }, { status: 503 }),
     }, "user", true)).toEqual({
-      status: "unavailable", authenticated: [], accounts: {}, identity: {}, stablecoins: [], authorizations: [],
+      status: "unavailable", authenticated: [], accounts: {}, connectorAccounts: {}, identity: {}, stablecoins: [], authorizations: [],
     });
     expect(await accountInfo({
       fetch: async () => Response.json({ connectors: null }),
     }, "user", true)).toEqual({
-      status: "unavailable", authenticated: [], accounts: {}, identity: {}, stablecoins: [], authorizations: [],
+      status: "unavailable", authenticated: [], accounts: {}, connectorAccounts: {}, identity: {}, stablecoins: [], authorizations: [],
     });
   });
 
@@ -58,12 +65,31 @@ describe("account info", () => {
     expect(JSON.stringify(info)).not.toMatch(/Private Gmail|Private Drive|gmail|gdrive/);
   });
 
+  it("projects only Google accounts pinned into the Connect grant", async () => {
+    const first = "a".repeat(43);
+    const second = "b".repeat(43);
+    const info = await accountInfo({
+      fetch: async () => Response.json({ connectors: {
+        gmail: { connected: true, connections: [
+          { id: first, account_id: "google-one", label: "one@example.test" },
+          { id: second, account_id: "google-two", label: "two@example.test" },
+        ] },
+      } }),
+    }, "user", true, ["gmail"], { gmail: [second] });
+
+    expect(info.authenticated).toEqual(["gmail"]);
+    expect(info.accounts).toEqual({ gmail: "two@example.test" });
+    expect(info.connectorAccounts).toEqual({ gmail: [{ id: second, label: "two@example.test" }] });
+    expect(JSON.stringify(info)).not.toContain("one@example.test");
+  });
+
   it("does not query account connectors for shared rooms", async () => {
     const fetch = vi.fn(async () => Response.json({}));
     expect(await accountInfo({ fetch }, "owner", false)).toEqual({
       status: "disabled",
       authenticated: [],
       accounts: {},
+      connectorAccounts: {},
       identity: {},
       stablecoins: [],
       authorizations: [],
@@ -76,6 +102,7 @@ describe("account info", () => {
       status: "ready" as const,
       authenticated: ["github" as const],
       accounts: { github: "Nano Cat (nanocat)" },
+      connectorAccounts: {},
       identity: {},
       stablecoins: [] as const,
       authorizations: [] as const,

--- a/services/managed/test/managed-egress.test.ts
+++ b/services/managed/test/managed-egress.test.ts
@@ -91,6 +91,35 @@ describe("Computer egress gateway", () => {
     expect(publicFetch).not.toHaveBeenCalled();
   });
 
+  it("pins Google requests to an account allowed by the active Connect grant", async () => {
+    const selected = "a".repeat(43);
+    let seen: Request | undefined;
+    const binding = {
+      async fetch(input: RequestInfo | URL, init?: RequestInit) {
+        seen = new Request(input, init);
+        return Response.json({ ok: true });
+      },
+    } as Fetcher;
+    const allowed = await handleManagedEgress(
+      new Request("https://gmail.googleapis.com/gmail/v1/users/me/messages"),
+      binding,
+      SUBJECT,
+      (connector, requested) => connector === "gmail" && requested === undefined ? selected : false,
+    );
+    expect(allowed.status).toBe(200);
+    expect(seen?.headers.get("x-nanocodex-connector-connection")).toBe(selected);
+
+    const denied = await handleManagedEgress(
+      new Request("https://gmail.googleapis.com/gmail/v1/users/me/messages", {
+        headers: { "x-nanocodex-connector-connection": "b".repeat(43) },
+      }),
+      binding,
+      SUBJECT,
+      (_connector, requested) => requested === selected ? selected : false,
+    );
+    expect(denied.status).toBe(403);
+  });
+
   it("manually follows only revalidated public redirects", async () => {
     const requests: Request[] = [];
     vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {

--- a/web/connect-dialog/src/App.tsx
+++ b/web/connect-dialog/src/App.tsx
@@ -84,6 +84,8 @@ type ConnectorId = typeof connectorIds[number];
 type ConnectorStatus = Readonly<{
   connected: boolean;
   account_id?: string | undefined;
+  connection_id?: string | undefined;
+  connections?: readonly Readonly<{ id: string; account_id: string; label: string }>[] | undefined;
   label?: string | undefined;
 }>;
 type ConnectorStatuses = Partial<Record<ConnectorId, ConnectorStatus>>;

--- a/web/connect-dialog/src/connectPolicy.d.mts
+++ b/web/connect-dialog/src/connectPolicy.d.mts
@@ -88,6 +88,8 @@ export type McpCallbackContinuation = Readonly<{
   connectorStatuses: Readonly<Record<string, Readonly<{
     connected: boolean;
     account_id?: string | undefined;
+    connection_id?: string | undefined;
+    connections?: readonly Readonly<{ id: string; account_id: string; label: string }>[] | undefined;
     label?: string | undefined;
   }>>>;
   result: ReturnType<typeof sanitizeCliWalletResult>;

--- a/web/connect-dialog/src/connectPolicy.mjs
+++ b/web/connect-dialog/src/connectPolicy.mjs
@@ -498,15 +498,25 @@ function sanitizeConnectorStatuses(value) {
   const result = {};
   for (const [id, status] of Object.entries(value)) {
     if (!connectorIds.has(id) || !isRecord(status)
-      || Object.keys(status).some((key) => key !== "connected" && key !== "account_id" && key !== "label")
+      || Object.keys(status).some((key) => !["connected", "account_id", "connection_id", "connections", "label"].includes(key))
       || typeof status.connected !== "boolean"
       || (status.account_id !== undefined && typeof status.account_id !== "string")
+      || (status.connection_id !== undefined && !/^[A-Za-z0-9_-]{43}$/.test(status.connection_id))
+      || (status.connections !== undefined && (!Array.isArray(status.connections)
+        || status.connections.length > 32
+        || status.connections.some((connection) => !isRecord(connection)
+          || Object.keys(connection).some((key) => !["id", "account_id", "label"].includes(key))
+          || typeof connection.id !== "string" || !/^[A-Za-z0-9_-]{43}$/.test(connection.id)
+          || typeof connection.account_id !== "string"
+          || typeof connection.label !== "string")))
       || (status.label !== undefined && typeof status.label !== "string")) {
       throw new Error("Nanocodex Connect received invalid connector statuses.");
     }
     result[id] = Object.freeze({
       connected: status.connected,
       ...(status.account_id === undefined ? {} : { account_id: status.account_id }),
+      ...(status.connection_id === undefined ? {} : { connection_id: status.connection_id }),
+      ...(status.connections === undefined ? {} : { connections: Object.freeze(status.connections.map((connection) => Object.freeze({ ...connection }))) }),
       ...(status.label === undefined ? {} : { label: status.label }),
     });
   }

--- a/web/connect-dialog/test/connectPolicy.test.mjs
+++ b/web/connect-dialog/test/connectPolicy.test.mjs
@@ -478,11 +478,16 @@ test("device callback continuation is short-lived, exact, account-bound, and sec
     apiUrl: "http://demo.nanocodex.localhost:20735",
     accountAddress: "0x1111111111111111111111111111111111111111",
     token: "connect-session-token",
-    requestedConnectors: ["github"],
+    requestedConnectors: ["github", "gmail"],
     requestedMcpConnections: [
       { id: LINEAR_MCP, name: "Linear", status: "authorization_required" },
     ],
-    connectorStatuses: { github: { connected: true, label: "octocat" } },
+    connectorStatuses: {
+      github: { connected: true, label: "octocat" },
+      gmail: { connected: true, connections: [
+        { id: "g".repeat(43), account_id: "google-account", label: "mail@example.test" },
+      ] },
+    },
     result: {
       accounts: [{
         address: "0x1111111111111111111111111111111111111111",

--- a/web/src/ProfileConnectors.tsx
+++ b/web/src/ProfileConnectors.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { Fragment, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import {
   AccountConnectionCard,
   AccountConnectionGrid,
@@ -15,11 +15,13 @@ import {
 } from "@nanocodex-connect/connectorCompletion";
 
 type ConnectorId = "github" | "gmail" | "gdrive" | "x";
+type ConnectorConnection = Readonly<{ id: string; accountId: string; label: string }>;
 type ConnectorStatus = Readonly<{
   connected: boolean;
   accountId?: string;
   label?: string;
   unavailable?: string;
+  connections?: readonly ConnectorConnection[];
 }>;
 type McpConnectionStatus =
   | "authorization_required"
@@ -343,12 +345,15 @@ export function ProfileConnectors({
     }
   };
 
-  const disconnect = async (id: ConnectorId) => {
+  const disconnect = async (id: ConnectorId, connectionId?: string) => {
     if (operation) return;
-    setOperation(id);
+    setOperation(connectionId ?? id);
     setError(null);
     try {
-      const response = await connectorRequest(`/v1/connectors/${id}`, { method: "DELETE" });
+      const response = await connectorRequest(
+        `/v1/connectors/${id}${connectionId ? `/${encodeURIComponent(connectionId)}` : ""}`,
+        { method: "DELETE" },
+      );
       if (!response.ok) throw await responseFailure(response, `Couldn’t disconnect ${connectorLabel(id)}.`);
       await response.body?.cancel();
       await load();
@@ -531,22 +536,32 @@ export function ProfileConnectors({
           {connectors ? connectorDefinitions.map((definition) => {
             const status = connectors[definition.id];
             const unavailable = status.unavailable;
-            return <AccountConnectionCard
-              action={unavailable ? "Unavailable" : status.connected ? "Disconnect" : "Connect"}
-              connected={status.connected}
-              detail={unavailable
-                ? unavailable
-                : status.connected
-                  ? status.label || status.accountId || "Connected"
-                  : definition.description}
-              disabled={operation !== null || unavailable !== undefined}
-              key={definition.id}
-              logo={<ConnectionLogo id={definition.id} />}
-              onClick={() => void (status.connected
-                ? disconnect(definition.id)
-                : connect(definition.id))}
-              title={definition.label}
-            />;
+            const multi = isGoogleConnector(definition.id);
+            return <Fragment key={definition.id}>
+              <AccountConnectionCard
+                action={unavailable ? "Unavailable" : multi && status.connected ? "Add account" : status.connected ? "Disconnect" : "Connect"}
+                connected={status.connected}
+                detail={unavailable
+                  ? unavailable
+                  : multi && status.connected
+                    ? `${status.connections?.length ?? 0} account${status.connections?.length === 1 ? "" : "s"} connected`
+                    : status.connected ? status.label || status.accountId || "Connected" : definition.description}
+                disabled={operation !== null || unavailable !== undefined}
+                logo={<ConnectionLogo id={definition.id} />}
+                onClick={() => void (multi || !status.connected ? connect(definition.id) : disconnect(definition.id))}
+                title={definition.label}
+              />
+              {status.connections?.map((connection) => <AccountConnectionCard
+                action="Disconnect"
+                connected
+                detail={connection.label}
+                disabled={operation !== null}
+                key={connection.id}
+                logo={<ConnectionLogo id={definition.id} />}
+                onClick={() => void disconnect(definition.id, connection.id)}
+                title={connection.label}
+              />)}
+            </Fragment>;
           }) : null}
           {mcpError && !mcpConnections ? <AccountConnectionCard
             action="Retry"
@@ -608,20 +623,20 @@ export function ProfileConnectors({
       {connectors ? connectorDefinitions.map((definition) => {
         const status = connectors[definition.id];
         const unavailable = status.unavailable;
+        const multi = isGoogleConnector(definition.id);
         const detail = unavailable
           ? unavailable
+          : multi && status.connected
+            ? `${status.connections?.length ?? 0} account${status.connections?.length === 1 ? "" : "s"} connected`
           : status.connected
             ? status.label || status.accountId || "Connected"
             : definition.description;
-        return (
+        return (<Fragment key={definition.id}>
           <button
             className={`connection-card connector-row${status.connected ? " is-connected" : ""}${unavailable ? " is-unavailable" : ""}`}
-            key={definition.id}
             type="button"
             disabled={operation !== null || unavailable !== undefined}
-            onClick={() => void (status.connected
-              ? disconnect(definition.id)
-              : connect(definition.id))}
+            onClick={() => void (multi || !status.connected ? connect(definition.id) : disconnect(definition.id))}
           >
             <ConnectionLogo id={definition.id} />
             <span className="connection-card-copy">
@@ -629,10 +644,21 @@ export function ProfileConnectors({
               <span>{detail}</span>
             </span>
             <span className="connection-card-action">
-              {unavailable ? "Unavailable" : status.connected ? "Disconnect" : "Connect"}
+              {unavailable ? "Unavailable" : multi && status.connected ? "Add account" : status.connected ? "Disconnect" : "Connect"}
             </span>
           </button>
-        );
+          {status.connections?.map((connection) => <button
+            className="connection-card connector-row connector-account-row is-connected"
+            disabled={operation !== null}
+            key={connection.id}
+            onClick={() => void disconnect(definition.id, connection.id)}
+            type="button"
+          >
+            <ConnectionLogo id={definition.id} />
+            <span className="connection-card-copy"><strong>{connection.label}</strong><span>Google account</span></span>
+            <span className="connection-card-action">Disconnect</span>
+          </button>)}
+        </Fragment>);
       }) : null}
       {mcpConnections ? <McpConnectionAddCard
         disabled={operation !== null}
@@ -699,8 +725,23 @@ function decodeConnectorStatus(value: unknown): Record<ConnectorId, ConnectorSta
       connected: candidate.connected,
       ...(typeof candidate.account_id === "string" ? { accountId: candidate.account_id } : {}),
       ...(typeof candidate.label === "string" ? { label: candidate.label } : {}),
+      ...(Array.isArray(candidate.connections) ? {
+        connections: candidate.connections.map(decodeConnectorConnection),
+      } : {}),
     }];
   })) as Record<ConnectorId, ConnectorStatus>;
+}
+
+function decodeConnectorConnection(value: unknown): ConnectorConnection {
+  if (!isRecord(value) || typeof value.id !== "string" || !mcpConnectionId.test(value.id)
+    || typeof value.account_id !== "string" || typeof value.label !== "string") {
+    throw new Error("Invalid connector account response.");
+  }
+  return { id: value.id, accountId: value.account_id, label: value.label };
+}
+
+function isGoogleConnector(id: ConnectorId): id is "gmail" | "gdrive" {
+  return id === "gmail" || id === "gdrive";
 }
 
 function unavailableConnectorStatuses(message: string): Record<ConnectorId, ConnectorStatus> {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -696,6 +696,11 @@ body.agent-viewport-locked {
   min-width: 0;
 }
 
+.connector-account-row {
+  margin-left: 18px;
+  background: color-mix(in srgb, var(--surface) 72%, transparent);
+}
+
 .connector-row span {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/web/test/connectSharedSurface.test.ts
+++ b/web/test/connectSharedSurface.test.ts
@@ -59,6 +59,13 @@ test("Account owns MCP creation and in-place authorization without broadening em
   assert.doesNotMatch(app, /McpConnectionAddCard/);
 });
 
+test("Account supports adding and disconnecting individual Google accounts", () => {
+  assert.match(profileConnectors, /multi && status\.connected \? "Add account"/);
+  assert.match(profileConnectors, /status\.connections\?\.map/);
+  assert.match(profileConnectors, /disconnect\(definition\.id, connection\.id\)/);
+  assert.match(profileConnectors, /connectors\/\$\{id\}\$\{connectionId \? `\/\$\{encodeURIComponent\(connectionId\)\}` : ""\}/);
+});
+
 test("Account and embedded Connect share strict in-place OAuth completion", () => {
   assert.match(app, /connectorCompletionFor\(event/);
   assert.match(profileConnectors, /from "@nanocodex-connect\/connectorCompletion"/);


### PR DESCRIPTION
## Summary

- store multiple Gmail and Google Drive OAuth connections per Nanocodex account, including migration from the single-account broker state
- expose grant-approved account labels and opaque IDs so the agent can choose the right Google account per request
- route the choice through `X-Nanocodex-Connector-Connection`; the egress proxy validates it against the active grant before the private broker injects credentials
- support per-account disconnects while keeping OAuth tokens sealed inside the connector broker
- snapshot opaque Google connection IDs into Connect grants so later account additions cannot broaden an existing grant
- expose secret-free account metadata and add Account UI controls to add or disconnect individual Google accounts

## Testing

- `services/egress`: typecheck and 107 tests pass
- `services/managed`: typecheck passes; focused connector/account tests pass
- `services/connect-api`: typecheck passes; focused grant/import/policy tests pass
- `web/connect-dialog`: 52 tests pass
- `web`: typecheck and focused shared-surface test pass
- browser bindings: focused account-selection/egress tests and type declarations pass
- `git diff --check`

## Local environment limitations

The full managed/web and browser-package suites plus live browser QA require generated Rust/WASM bindings. This checkout has no installed Rust toolchain, so those generated-binding checks could not run locally.