### PR TITLE
fix(tools): align Codex tool contracts and MCP discovery

### DIFF
--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -112,6 +112,10 @@ path = "tests/managed_memory.rs"
 name = "login"
 path = "tests/login.rs"
 
+[[test]]
+name = "it"
+path = "tests/it/main.rs"
+
 [[bin]]
 name = "nanocodex"
 path = "src/main.rs"

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -22,7 +22,7 @@ use nanocodex::{
         tower::ResponsesServiceConfig,
         transport::ResponsesTransport,
     },
-    tools::mcp::McpHandle,
+    tools::{mcp::McpHandle, standard::UpdatePlanTool},
 };
 
 use crate::browser::{BrowserArgs, ConfiguredBrowser};
@@ -396,9 +396,11 @@ impl AgentArgs {
         let mut tools = configured_vm
             .as_ref()
             .map_or_else(Tools::builder, ConfiguredVm::tools_builder)
-            .plan(tui)
             .web_search(web_search)
             .image_generation(self.image_generation);
+        if tui {
+            tools = tools.tool(UpdatePlanTool::new());
+        }
         let managed_mcp = if self.mcp.loads_managed() {
             load_managed_mcp_credential(&codex_home).await?
         } else {

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -396,6 +396,7 @@ impl AgentArgs {
         let mut tools = configured_vm
             .as_ref()
             .map_or_else(Tools::builder, ConfiguredVm::tools_builder)
+            .plan(tui)
             .web_search(web_search)
             .image_generation(self.image_generation);
         let managed_mcp = if self.mcp.loads_managed() {

--- a/bin/nanocodex/tests/it/mcp_cli.rs
+++ b/bin/nanocodex/tests/it/mcp_cli.rs
@@ -33,6 +33,10 @@ async fn repeated_cli_turns_search_and_call_mcp_through_the_library() -> Result<
             .arg(&workspace)
             .arg("--mcp-defaults")
             .arg("false")
+            .arg("--mcp-codex-config")
+            .arg("false")
+            .arg("--websocket-warmup")
+            .arg("true")
             .arg("--mcp-stdio")
             .arg("fixture=node")
             .arg("--mcp-arg")
@@ -64,6 +68,17 @@ async fn repeated_cli_turns_search_and_call_mcp_through_the_library() -> Result<
     );
     assert_eq!(tool_results(&events, "tool_search"), TURNS);
     assert_eq!(tool_results(&events, "mcp__fixture__echo"), TURNS);
+    assert!(
+        events
+            .iter()
+            .filter(|event| {
+                event["type"] == "model.call.completed"
+                    && event["payload"]["usage"]["input_tokens_details"]["cached_tokens"] == 5
+            })
+            .count()
+            >= TURNS * 3,
+        "every turn should retain prompt-cache hits across search, tool execution, and completion"
+    );
     std::fs::remove_dir_all(workspace)?;
     Ok(())
 }

--- a/crates/experimental/nanocodex-vm/README.md
+++ b/crates/experimental/nanocodex-vm/README.md
@@ -121,8 +121,9 @@ guest runtime, filesystem, and interactive shell sessions. The non-cloneable
 workspace owner is the graceful-shutdown capability; drop agents, registries,
 and cloned tool handles before calling [`VmWorkspace::shutdown`].
 
-The default tool selection keeps web search, image generation, and
-`update_plan` on the host. It replaces only `exec_command`, `write_stdin`,
+The default tool selection keeps web search and image generation on the host.
+Callers opt into the host-owned `update_plan` tool with
+`ToolsBuilder::plan(true)`. The VM replaces only `exec_command`, `write_stdin`,
 `apply_patch`, and `view_image`, preserving their standard model-visible names
 and schemas.
 

--- a/crates/experimental/nanocodex-vm/src/tools/mod.rs
+++ b/crates/experimental/nanocodex-vm/src/tools/mod.rs
@@ -119,7 +119,7 @@ use std::sync::Arc;
 ))]
 use nanocodex_tools::{
     Tool, ToolContext, ToolDefinition, ToolInput, ToolResult, Tools, ToolsBuilder,
-    standard::{StandardTool, UpdatePlanTool},
+    standard::StandardTool,
 };
 
 #[cfg(all(feature = "guest-runtime", target_os = "linux"))]
@@ -225,9 +225,9 @@ impl VmTools {
     /// forwarded to this VM.
     ///
     /// Web search and image generation retain their normal host-side
-    /// implementations. `update_plan` also stays host-side because it has no
-    /// workspace effect. Callers can keep configuring the returned builder,
-    /// including setting the guest-visible working directory and shell.
+    /// implementations. Callers can explicitly opt into the host-owned
+    /// `update_plan` tool and keep configuring the returned builder, including
+    /// setting the guest-visible working directory and shell.
     #[must_use]
     pub fn tools_builder(&self) -> ToolsBuilder {
         Tools::builder()
@@ -236,7 +236,6 @@ impl VmTools {
             .tool(self.write_stdin_tool())
             .tool(self.apply_patch_tool())
             .tool(self.view_image_tool())
-            .tool(UpdatePlanTool::new())
     }
 
     fn tool(&self, standard: StandardTool) -> VmTool {
@@ -368,7 +367,7 @@ mod tests {
     }
 
     #[test]
-    fn composes_vm_workspace_tools_with_the_host_plan_tool() {
+    fn composes_vm_workspace_tools_without_implicitly_enabling_plan() {
         let vm = VmTools::new(RecordingClient::default());
         let tools = vm
             .tools_builder()
@@ -378,8 +377,12 @@ mod tests {
             .unwrap();
 
         assert!(!tools.workspace_enabled());
+        assert!(!tools.plan_enabled());
         assert!(tools.web_search_enabled());
         assert!(tools.image_generation_enabled());
+
+        let tools = vm.tools_builder().plan(true).build().unwrap();
+        assert!(tools.plan_enabled());
     }
 
     #[test]

--- a/crates/experimental/nanocodex-vm/src/tools/mod.rs
+++ b/crates/experimental/nanocodex-vm/src/tools/mod.rs
@@ -344,7 +344,10 @@ pub async fn serve_overlay_guest(
 mod tests {
     use std::sync::Mutex;
 
-    use nanocodex_tools::{Tool, ToolContext, ToolInput, ToolOutput, standard::StandardTool};
+    use nanocodex_tools::{
+        Tool, ToolContext, ToolInput, ToolOutput,
+        standard::{StandardTool, UpdatePlanTool},
+    };
 
     use super::{VmToolClient, VmTools};
 
@@ -377,12 +380,13 @@ mod tests {
             .unwrap();
 
         assert!(!tools.workspace_enabled());
-        assert!(!tools.plan_enabled());
         assert!(tools.web_search_enabled());
         assert!(tools.image_generation_enabled());
 
-        let tools = vm.tools_builder().plan(true).build().unwrap();
-        assert!(tools.plan_enabled());
+        vm.tools_builder()
+            .tool(UpdatePlanTool::new())
+            .build()
+            .unwrap();
     }
 
     #[test]

--- a/crates/nanocodex-agent/src/model/input.rs
+++ b/crates/nanocodex-agent/src/model/input.rs
@@ -117,13 +117,12 @@ fn function_output(output: ToolOutputBody) -> FunctionOutputBody {
                     ToolOutputContent::InputText { text } => FunctionOutputContent::InputText {
                         text: text.into_boxed_str(),
                     },
-                    ToolOutputContent::InputImage {
-                        image_url,
-                        detail: _,
-                    } => FunctionOutputContent::InputImage {
-                        image_url: image_url.into_boxed_str(),
-                        detail: None,
-                    },
+                    ToolOutputContent::InputImage { image_url, detail } => {
+                        FunctionOutputContent::InputImage {
+                            image_url: image_url.into_boxed_str(),
+                            detail: Some(detail),
+                        }
+                    }
                     ToolOutputContent::InputAudio { audio_url } => {
                         FunctionOutputContent::InputAudio {
                             audio_url: audio_url.into_boxed_str(),
@@ -283,7 +282,7 @@ mod tests {
     }
 
     #[test]
-    fn responses_lite_tool_output_omits_image_details_without_request_copy() {
+    fn tool_output_preserves_image_detail_for_model_input() {
         let input = vec![custom_tool_output(
             "call-1".to_owned(),
             ToolOutputBody::Content(vec![
@@ -302,7 +301,7 @@ mod tests {
 
         let request = serde_json::to_value(input).expect("tool output should serialize");
 
-        assert!(request[0]["output"][1].get("detail").is_none());
+        assert_eq!(request[0]["output"][1]["detail"], "original");
         assert_eq!(
             request[0]["output"][2],
             json!({

--- a/crates/nanocodex-agent/src/model/run/tool_calls.rs
+++ b/crates/nanocodex-agent/src/model/run/tool_calls.rs
@@ -644,7 +644,17 @@ where
                     ToolOutput::error(format!("failed to encode tool_search arguments: {error}"))
                 }
             };
-            let tools = tool_search_tools(&execution)?;
+            let structured_result = execution.structured_result();
+            let tools = if execution.success {
+                let Value::Array(tools) = &structured_result else {
+                    return Err(NanocodexError::MalformedResponse {
+                        detail: "successful tool_search did not return an array structured result",
+                    });
+                };
+                tools.clone()
+            } else {
+                Vec::new()
+            };
             if let Some(content) = serialize_trace_content(&execution.output) {
                 record_span_content(tool_span, "tool.output", &content);
             }
@@ -652,7 +662,6 @@ where
             tool_span.record("status", status(execution.success));
             tool_span.record("otel.status_code", otel_status(execution.success));
             tool_span.record("duration_ns", duration_ns);
-            let structured_result = execution.structured_result();
             return Ok(CompletedToolCall {
                 call_id: call.call_id.clone(),
                 tool: qualified_name,
@@ -727,46 +736,5 @@ where
             metadata: None,
             response_items: outputs,
         })
-    }
-}
-
-fn tool_search_tools(execution: &ToolOutput) -> Result<Vec<Value>> {
-    if !execution.success {
-        return Ok(Vec::new());
-    }
-    let Value::Array(tools) = execution.structured_result() else {
-        return Err(NanocodexError::MalformedResponse {
-            detail: "successful tool_search did not return an array structured result",
-        });
-    };
-    Ok(tools)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::tool_search_tools;
-    use crate::NanocodexError;
-    use nanocodex_tools::contract::ToolOutput;
-    use serde_json::{Value, json};
-
-    #[test]
-    fn malformed_successful_tool_search_result_is_a_protocol_error() {
-        let execution = ToolOutput::from_json(json!({ "name": "not-an-array" }), true);
-
-        let error = tool_search_tools(&execution).unwrap_err();
-
-        assert!(matches!(
-            error,
-            NanocodexError::MalformedResponse {
-                detail: "successful tool_search did not return an array structured result"
-            }
-        ));
-    }
-
-    #[test]
-    fn successful_tool_search_array_remains_successful() {
-        let execution = ToolOutput::from_json(json!([]), true);
-
-        assert_eq!(tool_search_tools(&execution).unwrap(), Vec::<Value>::new());
     }
 }

--- a/crates/nanocodex-agent/src/model/run/tool_calls.rs
+++ b/crates/nanocodex-agent/src/model/run/tool_calls.rs
@@ -644,6 +644,7 @@ where
                     ToolOutput::error(format!("failed to encode tool_search arguments: {error}"))
                 }
             };
+            let tools = tool_search_tools(&execution)?;
             if let Some(content) = serialize_trace_content(&execution.output) {
                 record_span_content(tool_span, "tool.output", &content);
             }
@@ -652,14 +653,6 @@ where
             tool_span.record("otel.status_code", otel_status(execution.success));
             tool_span.record("duration_ns", duration_ns);
             let structured_result = execution.structured_result();
-            let tools = if execution.success {
-                match &structured_result {
-                    Value::Array(tools) => tools.clone(),
-                    _ => Vec::new(),
-                }
-            } else {
-                Vec::new()
-            };
             return Ok(CompletedToolCall {
                 call_id: call.call_id.clone(),
                 tool: qualified_name,
@@ -734,5 +727,46 @@ where
             metadata: None,
             response_items: outputs,
         })
+    }
+}
+
+fn tool_search_tools(execution: &ToolOutput) -> Result<Vec<Value>> {
+    if !execution.success {
+        return Ok(Vec::new());
+    }
+    let Value::Array(tools) = execution.structured_result() else {
+        return Err(NanocodexError::MalformedResponse {
+            detail: "successful tool_search did not return an array structured result",
+        });
+    };
+    Ok(tools)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tool_search_tools;
+    use crate::NanocodexError;
+    use nanocodex_tools::contract::ToolOutput;
+    use serde_json::{Value, json};
+
+    #[test]
+    fn malformed_successful_tool_search_result_is_a_protocol_error() {
+        let execution = ToolOutput::from_json(json!({ "name": "not-an-array" }), true);
+
+        let error = tool_search_tools(&execution).unwrap_err();
+
+        assert!(matches!(
+            error,
+            NanocodexError::MalformedResponse {
+                detail: "successful tool_search did not return an array structured result"
+            }
+        ));
+    }
+
+    #[test]
+    fn successful_tool_search_array_remains_successful() {
+        let execution = ToolOutput::from_json(json!([]), true);
+
+        assert_eq!(tool_search_tools(&execution).unwrap(), Vec::<Value>::new());
     }
 }

--- a/crates/nanocodex-agent/tests/it/model/tools/mod.rs
+++ b/crates/nanocodex-agent/tests/it/model/tools/mod.rs
@@ -190,7 +190,7 @@ async fn normal_code_mode_executes_direct_function_and_custom_tools() -> Result<
 
     let workspace = temporary_workspace("normal-code-mode-direct-tools")?;
     let tools = Tools::builder()
-        .plan(true)
+        .tool(nanocodex_tools::standard::UpdatePlanTool::new())
         .exposure(nanocodex_tools::ToolExposure::DirectAndCodeMode)
         .tool(NamespacedEcho)
         .build()?;

--- a/crates/nanocodex-agent/tests/it/model/tools/mod.rs
+++ b/crates/nanocodex-agent/tests/it/model/tools/mod.rs
@@ -5,6 +5,7 @@ mod panic;
 mod parallel;
 
 struct NativeToolSearch;
+struct MalformedNativeToolSearch;
 struct NamespacedEcho;
 
 #[nanocodex_tools::contract::async_trait]
@@ -189,6 +190,7 @@ async fn normal_code_mode_executes_direct_function_and_custom_tools() -> Result<
 
     let workspace = temporary_workspace("normal-code-mode-direct-tools")?;
     let tools = Tools::builder()
+        .plan(true)
         .exposure(nanocodex_tools::ToolExposure::DirectAndCodeMode)
         .tool(NamespacedEcho)
         .build()?;
@@ -293,6 +295,32 @@ impl nanocodex_tools::Tool for NativeToolSearch {
                 "additionalProperties": false
             }
         }])))
+    }
+}
+
+#[nanocodex_tools::contract::async_trait]
+impl nanocodex_tools::Tool for MalformedNativeToolSearch {
+    fn definition(&self) -> nanocodex_tools::ToolDefinition {
+        nanocodex_tools::ToolDefinition::tool_search(
+            "client",
+            "Returns a malformed discovery result for protocol testing.",
+            nanocodex_oai_api::responses::JsonSchema::from(json!({
+                "type": "object",
+                "properties": { "query": { "type": "string" } },
+                "required": ["query"],
+                "additionalProperties": false
+            })),
+        )
+    }
+
+    async fn execute(
+        &self,
+        _input: nanocodex_tools::ToolInput,
+        _context: nanocodex_tools::ToolContext<'_>,
+    ) -> nanocodex_tools::ToolResult {
+        Ok(nanocodex_tools::ToolOutput::json(&json!({
+            "name": "not-an-array"
+        })))
     }
 }
 
@@ -423,6 +451,69 @@ async fn configured_native_tool_search_round_trips_its_dedicated_items() -> Resu
     let output = String::from_utf8(output)?;
     assert!(output.contains(r#""tool":"tool_search""#), "{output}");
     assert!(output.contains("\"run.completed\""), "{output}");
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn malformed_successful_native_tool_search_fails_the_turn() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let endpoint = format!("ws://{}", listener.local_addr()?);
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await?;
+        let mut socket = accept_async(stream).await?;
+
+        let _warmup = next_json(&mut socket).await?;
+        send_warmup(&mut socket, "resp-warmup").await?;
+        let generation = next_json(&mut socket).await?;
+        assert_eq!(generation["previous_response_id"], "resp-warmup");
+        send_json(
+            &mut socket,
+            completed_response(
+                "resp-malformed-search",
+                &[json!({
+                    "type": "tool_search_call",
+                    "call_id": "search-malformed",
+                    "execution": "client",
+                    "arguments": { "query": "anything" }
+                })],
+            ),
+        )
+        .await
+    });
+
+    let workspace = temporary_workspace("malformed-native-tool-search")?;
+    let tools = Tools::builder()
+        .without_defaults()
+        .tool(MalformedNativeToolSearch)
+        .build()?;
+    let openai = OpenAi::builder("test-key")
+        .websocket_url(&endpoint)
+        .build()?;
+    let (agent, events) = Nanocodex::builder(openai)
+        .thinking(Thinking::Low)
+        .workspace(&workspace)
+        .session_id(test_session_id())
+        .tools(tools)
+        .build()?;
+    let turn = agent.prompt("Search for anything.").await?;
+    drop(agent);
+    let mut output = Vec::new();
+    let (event_result, turn_result) = tokio::join!(events.write_jsonl(&mut output), turn.result());
+    event_result?;
+    let error = turn_result.expect_err("malformed tool_search must fail the turn");
+    assert!(matches!(
+        error,
+        NanocodexError::MalformedResponse {
+            detail: "successful tool_search did not return an array structured result"
+        }
+    ));
+    timeout(std::time::Duration::from_secs(5), server)
+        .await
+        .map_err(|_| eyre!("mock Responses server did not finish"))???;
+    let output = String::from_utf8(output)?;
+    assert!(output.contains("\"run.failed\""), "{output}");
+    assert!(!output.contains("tool_search_output"), "{output}");
     std::fs::remove_dir_all(workspace)?;
     Ok(())
 }

--- a/crates/nanocodex-oai-api/src/responses/request.rs
+++ b/crates/nanocodex-oai-api/src/responses/request.rs
@@ -4,7 +4,7 @@ use std::{borrow::Cow, collections::BTreeMap, sync::Arc};
 
 use serde::{Serialize, Serializer, ser::SerializeSeq};
 
-use super::ResponseItem;
+use super::{ContentItem, FunctionOutputBody, FunctionOutputContent, ResponseItem};
 use crate::{ModelConfig, Thinking};
 
 /// Stable request metadata and prefix shared by every operation in a session.
@@ -501,13 +501,68 @@ impl Serialize for RequestResponseItem<'_> {
     where
         S: serde::Serializer,
     {
-        if self.item.id().is_some_and(|id| !id.is_prefixed()) {
+        let strips_id = self.item.id().is_some_and(|id| !id.is_prefixed());
+        if strips_id || response_item_has_image_detail(self.item) {
             let mut item = self.item.clone();
-            item.set_id(None);
+            if strips_id {
+                item.set_id(None);
+            }
+            strip_image_details(&mut item);
             item.serialize(serializer)
         } else {
             self.item.serialize(serializer)
         }
+    }
+}
+
+fn response_item_has_image_detail(item: &ResponseItem) -> bool {
+    match item {
+        ResponseItem::Message { content, .. } => content.iter().any(|item| {
+            matches!(
+                item,
+                ContentItem::InputImage {
+                    detail: Some(_),
+                    ..
+                }
+            )
+        }),
+        ResponseItem::FunctionCallOutput { output, .. }
+        | ResponseItem::CustomToolCallOutput { output, .. } => match output {
+            FunctionOutputBody::Content(content) => content.iter().any(|item| {
+                matches!(
+                    item,
+                    FunctionOutputContent::InputImage {
+                        detail: Some(_),
+                        ..
+                    }
+                )
+            }),
+            FunctionOutputBody::Text(_) => false,
+        },
+        _ => false,
+    }
+}
+
+fn strip_image_details(item: &mut ResponseItem) {
+    match item {
+        ResponseItem::Message { content, .. } => {
+            for item in content {
+                if let ContentItem::InputImage { detail, .. } = item {
+                    *detail = None;
+                }
+            }
+        }
+        ResponseItem::FunctionCallOutput { output, .. }
+        | ResponseItem::CustomToolCallOutput { output, .. } => {
+            if let FunctionOutputBody::Content(content) = output {
+                for item in content {
+                    if let FunctionOutputContent::InputImage { detail, .. } = item {
+                        *detail = None;
+                    }
+                }
+            }
+        }
+        _ => {}
     }
 }
 

--- a/crates/nanocodex-tools/README.md
+++ b/crates/nanocodex-tools/README.md
@@ -53,7 +53,8 @@ let tools = Tools::builder()
 Matching Codex, direct-plus-Code-Mode exposure keeps `exec` terse and
 adds each typed `exec` declaration to the corresponding direct tool; Code
 Mode-only instead carries the complete nested catalog in `exec`. Selection
-changes model-visible exposure, not registration or dispatch behavior.
+keeps handlers registered for trusted direct runtime dispatch while Code Mode
+dispatch honors each tool's placement.
 `tool_with_exposure` can override one registered tool with `DirectOnly`,
 `CodeModeOnly`, `DirectAndCodeMode`, or `Hidden` while preserving the global
 default for the rest. Host-owned `exec`, `wait`, and `tool_search` names cannot

--- a/crates/nanocodex-tools/src/code_mode/description.rs
+++ b/crates/nanocodex-tools/src/code_mode/description.rs
@@ -88,7 +88,7 @@ type CallToolResult<TStructured = { [key: string]: unknown }> = {
 };"#;
 #[cfg(not(target_family = "wasm"))]
 const EXEC_DESCRIPTION: &str = r#"Run JavaScript code to orchestrate/compose tool calls
-- Evaluates the provided JavaScript code in a fresh V8 isolate as an async module.
+- Evaluates the provided JavaScript code in a fresh QuickJS context as an async module.
 - All nested tools are available on the global `tools` object, for example `await tools.exec_command(...)`. Tool names are exposed as normalized JavaScript identifiers, for example `await tools.mcp__ologs__get_profile(...)`.
 - Nested tool methods take either a string or an object as their input argument.
 - Nested tools return either an object or a string, based on the description.

--- a/crates/nanocodex-tools/src/code_mode/mod.rs
+++ b/crates/nanocodex-tools/src/code_mode/mod.rs
@@ -1,7 +1,7 @@
 //! Code Mode execution results, notifications, and nested-tool observation.
 
 mod embedded;
-mod output;
+pub(crate) mod output;
 mod spec;
 
 use std::{

--- a/crates/nanocodex-tools/src/code_mode/output.rs
+++ b/crates/nanocodex-tools/src/code_mode/output.rs
@@ -1,7 +1,9 @@
 use crate::ToolOutputContent;
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 
 const DEFAULT_MAX_OUTPUT_TOKENS: usize = 10_000;
 const APPROX_BYTES_PER_TOKEN: usize = 4;
+const MAX_SUPPORTED_WAV_BYTES: usize = 256 * 1024;
 
 pub(super) fn truncate_content(
     content: Vec<ToolOutputContent>,
@@ -77,6 +79,9 @@ fn truncate_mixed(
             }
             image @ ToolOutputContent::InputImage { .. } => output.push(image),
             encrypted @ ToolOutputContent::EncryptedContent { .. } => output.push(encrypted),
+            ToolOutputContent::InputAudio { audio_url } if supported_audio(&audio_url) => {
+                output.push(ToolOutputContent::InputAudio { audio_url });
+            }
             ToolOutputContent::InputAudio { .. } => {}
         }
     }
@@ -86,6 +91,22 @@ fn truncate_mixed(
         });
     }
     output
+}
+
+fn supported_audio(audio_url: &str) -> bool {
+    let Some((header, payload)) = audio_url.split_once(',') else {
+        return false;
+    };
+    if !header.eq_ignore_ascii_case("data:audio/wav;base64")
+        || payload.len() > MAX_SUPPORTED_WAV_BYTES.saturating_mul(4).div_ceil(3)
+    {
+        return false;
+    }
+    BASE64_STANDARD.decode(payload).is_ok_and(|wav| {
+        wav.len() <= MAX_SUPPORTED_WAV_BYTES
+            && wav.get(..4) == Some(b"RIFF")
+            && wav.get(8..12) == Some(b"WAVE")
+    })
 }
 
 fn truncate_middle_tokens(text: &str, max_tokens: usize) -> String {
@@ -222,5 +243,30 @@ mod tests {
         assert!(!output.iter().any(|item| {
             matches!(item, ToolOutputContent::InputText { text } if text.contains(ciphertext))
         }));
+    }
+
+    #[test]
+    fn preserves_only_bounded_wav_audio() {
+        let wav =
+            "data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAIA+AAACABAAZGF0YQAAAAA=";
+        let output = truncate_content(
+            vec![
+                ToolOutputContent::InputAudio {
+                    audio_url: wav.to_owned(),
+                },
+                ToolOutputContent::InputAudio {
+                    audio_url: "data:audio/wav;base64,YXVkaW8=".to_owned(),
+                },
+                ToolOutputContent::InputAudio {
+                    audio_url: "data:audio/mpeg;base64,SUQz".to_owned(),
+                },
+            ],
+            None,
+        );
+
+        assert!(matches!(
+            output.as_slice(),
+            [ToolOutputContent::InputAudio { audio_url }] if audio_url == wav
+        ));
     }
 }

--- a/crates/nanocodex-tools/src/code_mode/output.rs
+++ b/crates/nanocodex-tools/src/code_mode/output.rs
@@ -1,9 +1,6 @@
 use crate::ToolOutputContent;
-use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
-
 const DEFAULT_MAX_OUTPUT_TOKENS: usize = 10_000;
 const APPROX_BYTES_PER_TOKEN: usize = 4;
-const MAX_SUPPORTED_WAV_BYTES: usize = 256 * 1024;
 
 pub(super) fn truncate_content(
     content: Vec<ToolOutputContent>,
@@ -49,13 +46,14 @@ fn truncate_text_only(
     }]
 }
 
-fn truncate_mixed(
+pub(crate) fn truncate_mixed(
     content: Vec<ToolOutputContent>,
     max_output_tokens: usize,
 ) -> Vec<ToolOutputContent> {
     let mut output = Vec::with_capacity(content.len());
     let mut remaining = max_output_tokens;
     let mut omitted_text_items = 0_usize;
+    let mut omitted_audio_items = 0_usize;
     for item in content {
         match item {
             ToolOutputContent::InputText { text } => {
@@ -79,10 +77,18 @@ fn truncate_mixed(
             }
             image @ ToolOutputContent::InputImage { .. } => output.push(image),
             encrypted @ ToolOutputContent::EncryptedContent { .. } => output.push(encrypted),
-            ToolOutputContent::InputAudio { audio_url } if supported_audio(&audio_url) => {
-                output.push(ToolOutputContent::InputAudio { audio_url });
+            ToolOutputContent::InputAudio { audio_url } => {
+                // Codex estimates decoded audio duration when its media stack can do so,
+                // then falls back to the encoded data URL size. Nanocodex deliberately
+                // has no audio decoder dependency, so use the same fallback.
+                let cost = approx_tokens(audio_url.len());
+                if cost <= remaining {
+                    output.push(ToolOutputContent::InputAudio { audio_url });
+                    remaining = remaining.saturating_sub(cost);
+                } else {
+                    omitted_audio_items = omitted_audio_items.saturating_add(1);
+                }
             }
-            ToolOutputContent::InputAudio { .. } => {}
         }
     }
     if omitted_text_items > 0 {
@@ -90,26 +96,15 @@ fn truncate_mixed(
             text: format!("[omitted {omitted_text_items} text items ...]"),
         });
     }
+    if omitted_audio_items > 0 {
+        output.push(ToolOutputContent::InputText {
+            text: format!("[omitted {omitted_audio_items} audio items ...]"),
+        });
+    }
     output
 }
 
-fn supported_audio(audio_url: &str) -> bool {
-    let Some((header, payload)) = audio_url.split_once(',') else {
-        return false;
-    };
-    if !header.eq_ignore_ascii_case("data:audio/wav;base64")
-        || payload.len() > MAX_SUPPORTED_WAV_BYTES.saturating_mul(4).div_ceil(3)
-    {
-        return false;
-    }
-    BASE64_STANDARD.decode(payload).is_ok_and(|wav| {
-        wav.len() <= MAX_SUPPORTED_WAV_BYTES
-            && wav.get(..4) == Some(b"RIFF")
-            && wav.get(8..12) == Some(b"WAVE")
-    })
-}
-
-fn truncate_middle_tokens(text: &str, max_tokens: usize) -> String {
+pub(crate) fn truncate_middle_tokens(text: &str, max_tokens: usize) -> String {
     if text.is_empty() {
         return String::new();
     }
@@ -118,6 +113,15 @@ fn truncate_middle_tokens(text: &str, max_tokens: usize) -> String {
         return text.to_owned();
     }
     truncate_middle(text, byte_budget, true)
+}
+
+pub(crate) fn truncate_middle_tokens_bounded(text: &str, max_tokens: usize) -> String {
+    let byte_budget = max_tokens.saturating_mul(APPROX_BYTES_PER_TOKEN);
+    let mut output = truncate_middle_tokens(text, max_tokens);
+    if output.len() > byte_budget {
+        output.truncate(floor_char_boundary(&output, byte_budget));
+    }
+    output
 }
 
 fn truncate_middle(text: &str, byte_budget: usize, use_tokens: bool) -> String {
@@ -246,7 +250,7 @@ mod tests {
     }
 
     #[test]
-    fn preserves_only_bounded_wav_audio() {
+    fn preserves_audio_within_the_output_budget_and_omits_the_rest() {
         let wav =
             "data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAIA+AAACABAAZGF0YQAAAAA=";
         let output = truncate_content(
@@ -255,18 +259,17 @@ mod tests {
                     audio_url: wav.to_owned(),
                 },
                 ToolOutputContent::InputAudio {
-                    audio_url: "data:audio/wav;base64,YXVkaW8=".to_owned(),
-                },
-                ToolOutputContent::InputAudio {
-                    audio_url: "data:audio/mpeg;base64,SUQz".to_owned(),
+                    audio_url: format!("data:audio/mpeg;base64,{}", "A".repeat(100)),
                 },
             ],
-            None,
+            Some(25),
         );
 
-        assert!(matches!(
-            output.as_slice(),
-            [ToolOutputContent::InputAudio { audio_url }] if audio_url == wav
-        ));
+        assert!(
+            matches!(&output[0], ToolOutputContent::InputAudio { audio_url } if audio_url == wav)
+        );
+        assert!(
+            matches!(&output[1], ToolOutputContent::InputText { text } if text == "[omitted 1 audio items ...]")
+        );
     }
 }

--- a/crates/nanocodex-tools/src/code_mode/tests.rs
+++ b/crates/nanocodex-tools/src/code_mode/tests.rs
@@ -847,7 +847,7 @@ const returnsUndefined = [
   }),
   audio({
     type: "audio",
-    data: "YXVkaW8=",
+    data: "UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAIA+AAACABAAZGF0YQAAAAA=",
     mimeType: "audio/wav",
   }),
 ].map((value) => value === undefined);
@@ -867,6 +867,11 @@ text(returnsUndefined);
             image_url,
             detail: crate::ImageDetail::Original,
         }) if image_url == "data:image/png;base64,a"
+    ));
+    assert!(matches!(
+        content.get(2),
+        Some(ToolOutputContent::InputAudio { audio_url })
+            if audio_url == "data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAIA+AAACABAAZGF0YQAAAAA="
     ));
     assert_eq!(emitted_text(&execution)?, "[true,true]");
     std::fs::remove_dir_all(workspace)?;
@@ -1915,27 +1920,36 @@ try {
 }
 
 #[tokio::test]
-async fn update_plan_matches_codex_handler_acceptance() -> Result<()> {
+async fn update_plan_rejects_multiple_in_progress_steps() -> Result<()> {
     let workspace = temporary_workspace("update-plan-acceptance")?;
     let tools = test_tools(&workspace);
     let history = Vec::new();
     let execution = tools
         .execute_code(
             r#"
-const result = await tools.update_plan({
-  plan: [
-    { step: "", status: "in_progress" },
-    { step: "also active", status: "in_progress" },
-  ],
-});
-text(result);
+try {
+  await tools.update_plan({
+    plan: [
+      { step: "", status: "in_progress" },
+      { step: "also active", status: "in_progress" },
+    ],
+  });
+  text("unexpected success");
+} catch (error) {
+  text(error);
+}
 "#,
             test_context(&history),
         )
         .await;
 
     assert!(execution.success, "{}", execution_output(&execution));
-    assert_eq!(emitted_text(&execution)?, "{}");
+    assert_eq!(
+        emitted_text(&execution)?,
+        "at most one plan step may be in_progress"
+    );
+    assert_eq!(execution.nested_calls.len(), 1);
+    assert!(!execution.nested_calls[0].success);
     std::fs::remove_dir_all(workspace)?;
     Ok(())
 }
@@ -2308,7 +2322,8 @@ fn test_live_cell(
 }
 
 fn test_tools(workspace: &std::path::Path) -> ToolRuntime {
-    ToolRuntime::new(
+    let selected = Tools::builder().plan(true).build().unwrap();
+    ToolRuntime::new_with_tools(
         workspace,
         Some(WebSearchConfig {
             endpoint: "http://127.0.0.1:1/v1/alpha/search".to_owned(),
@@ -2319,6 +2334,7 @@ fn test_tools(workspace: &std::path::Path) -> ToolRuntime {
             auth: nanocodex_oai_api::auth::OpenAiAuth::api_key("test-key"),
             save_root: workspace.to_path_buf(),
         }),
+        &selected,
     )
 }
 

--- a/crates/nanocodex-tools/src/code_mode/tests.rs
+++ b/crates/nanocodex-tools/src/code_mode/tests.rs
@@ -1920,36 +1920,27 @@ try {
 }
 
 #[tokio::test]
-async fn update_plan_rejects_multiple_in_progress_steps() -> Result<()> {
+async fn update_plan_matches_codex_handler_acceptance() -> Result<()> {
     let workspace = temporary_workspace("update-plan-acceptance")?;
     let tools = test_tools(&workspace);
     let history = Vec::new();
     let execution = tools
         .execute_code(
             r#"
-try {
-  await tools.update_plan({
-    plan: [
-      { step: "", status: "in_progress" },
-      { step: "also active", status: "in_progress" },
-    ],
-  });
-  text("unexpected success");
-} catch (error) {
-  text(error);
-}
+const result = await tools.update_plan({
+  plan: [
+    { step: "", status: "in_progress" },
+    { step: "also active", status: "in_progress" },
+  ],
+});
+text(result);
 "#,
             test_context(&history),
         )
         .await;
 
     assert!(execution.success, "{}", execution_output(&execution));
-    assert_eq!(
-        emitted_text(&execution)?,
-        "at most one plan step may be in_progress"
-    );
-    assert_eq!(execution.nested_calls.len(), 1);
-    assert!(!execution.nested_calls[0].success);
+    assert_eq!(emitted_text(&execution)?, "{}");
     std::fs::remove_dir_all(workspace)?;
     Ok(())
 }
@@ -2322,7 +2313,10 @@ fn test_live_cell(
 }
 
 fn test_tools(workspace: &std::path::Path) -> ToolRuntime {
-    let selected = Tools::builder().plan(true).build().unwrap();
+    let selected = Tools::builder()
+        .tool(crate::standard::UpdatePlanTool::new())
+        .build()
+        .unwrap();
     ToolRuntime::new_with_tools(
         workspace,
         Some(WebSearchConfig {

--- a/crates/nanocodex-tools/src/embedded/runtime.rs
+++ b/crates/nanocodex-tools/src/embedded/runtime.rs
@@ -32,6 +32,7 @@ pub struct EmbeddedToolRuntime {
     working_directory: Arc<str>,
     host: Option<Arc<dyn CodeModeHost>>,
     session_id: Option<Arc<str>>,
+    plan_enabled: bool,
     local: Vec<LocalTool>,
     callable_tool_names: RwLock<HashSet<String>>,
 }
@@ -62,6 +63,7 @@ impl EmbeddedToolRuntime {
             working_directory: Arc::from(workspace.to_string_lossy().into_owned()),
             host: None,
             session_id: None,
+            plan_enabled: false,
             local: Vec::new(),
             callable_tool_names: RwLock::new(HashSet::new()),
         }
@@ -81,6 +83,7 @@ impl EmbeddedToolRuntime {
     fn with_tools(mut self, tools: &Tools) -> Self {
         self.host.clone_from(&tools.embedded_host);
         self.session_id.clone_from(&tools.embedded_session_id);
+        self.plan_enabled = tools.plan_enabled();
         self.local = tools
             .registered
             .iter()
@@ -143,10 +146,11 @@ impl EmbeddedToolRuntime {
             }
         });
         definitions.retain(|definition| {
-            !self
-                .local
-                .iter()
-                .any(|tool| tool.name.as_ref() == definition.name())
+            (self.plan_enabled || definition.name() != "update_plan")
+                && !self
+                    .local
+                    .iter()
+                    .any(|tool| tool.name.as_ref() == definition.name())
         });
         crate::code_mode_order::sort_definitions(&mut definitions);
         if let Ok(mut names) = self.callable_tool_names.write() {

--- a/crates/nanocodex-tools/src/embedded/runtime.rs
+++ b/crates/nanocodex-tools/src/embedded/runtime.rs
@@ -32,7 +32,6 @@ pub struct EmbeddedToolRuntime {
     working_directory: Arc<str>,
     host: Option<Arc<dyn CodeModeHost>>,
     session_id: Option<Arc<str>>,
-    plan_enabled: bool,
     local: Vec<LocalTool>,
     callable_tool_names: RwLock<HashSet<String>>,
 }
@@ -40,7 +39,7 @@ pub struct EmbeddedToolRuntime {
 struct LocalTool {
     name: Arc<str>,
     handler: Arc<dyn Tool>,
-    model_visible: bool,
+    exposure: ToolExposure,
 }
 
 /// Cancellation handle for work owned by an embedding host.
@@ -63,7 +62,6 @@ impl EmbeddedToolRuntime {
             working_directory: Arc::from(workspace.to_string_lossy().into_owned()),
             host: None,
             session_id: None,
-            plan_enabled: false,
             local: Vec::new(),
             callable_tool_names: RwLock::new(HashSet::new()),
         }
@@ -83,15 +81,13 @@ impl EmbeddedToolRuntime {
     fn with_tools(mut self, tools: &Tools) -> Self {
         self.host.clone_from(&tools.embedded_host);
         self.session_id.clone_from(&tools.embedded_session_id);
-        self.plan_enabled = tools.plan_enabled();
         self.local = tools
             .registered
             .iter()
             .map(|registered| LocalTool {
                 name: Arc::from(registered.handler.definition().name()),
                 handler: Arc::clone(&registered.handler),
-                model_visible: registered.exposure.unwrap_or_else(|| tools.exposure())
-                    != ToolExposure::Hidden,
+                exposure: registered.exposure.unwrap_or_else(|| tools.exposure()),
             })
             .collect();
         self
@@ -132,26 +128,7 @@ impl EmbeddedToolRuntime {
             .host
             .as_ref()
             .map_or(EmbeddedToolMode::Code, |host| host.tool_mode());
-        let mut definitions = self.host.as_ref().map_or_else(Vec::new, |host| {
-            match host.tool_definitions(session_id) {
-                Ok(definitions) => definitions,
-                Err(error) => {
-                    tracing::warn!(
-                        target: "nanocodex_tools",
-                        %error,
-                        "embedded Code Mode tool discovery failed"
-                    );
-                    Vec::new()
-                }
-            }
-        });
-        definitions.retain(|definition| {
-            (self.plan_enabled || definition.name() != "update_plan")
-                && !self
-                    .local
-                    .iter()
-                    .any(|tool| tool.name.as_ref() == definition.name())
-        });
+        let mut definitions = self.host_definitions(session_id);
         crate::code_mode_order::sort_definitions(&mut definitions);
         if let Ok(mut names) = self.callable_tool_names.write() {
             names.clear();
@@ -170,7 +147,7 @@ impl EmbeddedToolRuntime {
             definitions.extend(
                 self.local
                     .iter()
-                    .filter(|tool| tool.model_visible)
+                    .filter(|tool| tool.exposure != ToolExposure::Hidden)
                     .map(|tool| tool.handler.definition()),
             );
             crate::code_mode_order::sort_definitions(&mut definitions);
@@ -203,7 +180,7 @@ impl EmbeddedToolRuntime {
         direct_definitions.extend(
             self.local
                 .iter()
-                .filter(|tool| tool.model_visible)
+                .filter(|tool| tool.exposure != ToolExposure::Hidden)
                 .map(|tool| tool.handler.definition()),
         );
         crate::code_mode_order::sort_direct_definitions(&mut direct_definitions);
@@ -276,9 +253,10 @@ impl EmbeddedToolRuntime {
         {
             return true;
         }
-        if let (Some(host), Some(session_id)) = (&self.host, &self.session_id)
-            && let Ok(definitions) = host.tool_definitions(session_id)
+        if self.host.is_some()
+            && let Some(session_id) = &self.session_id
         {
+            let definitions = self.host_definitions(session_id);
             let found = definitions
                 .iter()
                 .any(|definition| definition.name() == name);
@@ -293,6 +271,30 @@ impl EmbeddedToolRuntime {
             return found;
         }
         false
+    }
+
+    fn host_definitions(&self, session_id: &str) -> Vec<ToolDefinition> {
+        let mut definitions = self.host.as_ref().map_or_else(Vec::new, |host| {
+            match host.tool_definitions(session_id) {
+                Ok(definitions) => definitions,
+                Err(error) => {
+                    tracing::warn!(
+                        target: "nanocodex_tools",
+                        %error,
+                        "embedded Code Mode tool discovery failed"
+                    );
+                    Vec::new()
+                }
+            }
+        });
+        definitions.retain(|definition| {
+            definition.name() != "update_plan"
+                && !self
+                    .local
+                    .iter()
+                    .any(|tool| tool.name.as_ref() == definition.name())
+        });
+        definitions
     }
 
     /// Dispatches a direct embedded definition or returns a model-visible failure.
@@ -494,6 +496,8 @@ mod tests {
 
     struct DirectHost;
 
+    struct PlanHost;
+
     struct WebHost;
 
     #[derive(Clone)]
@@ -540,6 +544,27 @@ mod tests {
             _session_id: &str,
         ) -> Result<Vec<ToolDefinition>, CodeModeHostError> {
             Ok(Vec::new())
+        }
+
+        fn execute<'a>(
+            &'a self,
+            _source: &'a str,
+            _context: ToolContext<'a>,
+        ) -> HostFuture<'a, Result<CodeModeExecution, CodeModeHostError>> {
+            Box::pin(async { unreachable!("direct host does not execute Code Mode") })
+        }
+    }
+
+    impl CodeModeHost for PlanHost {
+        fn tool_mode(&self) -> EmbeddedToolMode {
+            EmbeddedToolMode::Direct
+        }
+
+        fn tool_definitions(
+            &self,
+            _session_id: &str,
+        ) -> Result<Vec<ToolDefinition>, CodeModeHostError> {
+            Ok(vec![crate::StandardTool::UpdatePlan.definition()])
         }
 
         fn execute<'a>(
@@ -829,7 +854,7 @@ mod tests {
     async fn rust_extension_tools_shadow_host_tools_and_dispatch_directly() {
         let tools = Tools::builder()
             .without_defaults()
-            .tool(LocalAlpha)
+            .tool_with_exposure(LocalAlpha, ToolExposure::DirectAndCodeMode)
             .build()
             .unwrap();
         let tools = bind_host(tools, EchoHost);
@@ -850,6 +875,73 @@ mod tests {
             .await;
         assert!(output.success);
         assert_eq!(output.structured_result()["session_id"], "session-1");
+    }
+
+    #[test]
+    fn rust_extension_tool_specs_preserve_all_exposure_states() {
+        for (exposure, visible) in [
+            (ToolExposure::CodeModeOnly, true),
+            (ToolExposure::DirectAndCodeMode, true),
+            (ToolExposure::DirectOnly, true),
+            (ToolExposure::Hidden, false),
+        ] {
+            let tools = Tools::builder()
+                .without_defaults()
+                .tool_with_exposure(LocalAlpha, exposure)
+                .build()
+                .unwrap();
+            let code_tools = bind_host(tools.clone(), EchoHost).for_session("session-1");
+            let direct_tools = bind_host(tools, DirectHost);
+            let code_runtime = EmbeddedToolRuntime::new_with_tools(".", None, None, &code_tools);
+            let direct_runtime =
+                EmbeddedToolRuntime::new_with_tools(".", None, None, &direct_tools);
+
+            assert_eq!(
+                code_runtime
+                    .model_specs("session-1")
+                    .iter()
+                    .any(|definition| definition.name() == "alpha"),
+                visible
+            );
+            assert_eq!(
+                direct_runtime
+                    .model_specs("session-1")
+                    .iter()
+                    .any(|definition| definition.name() == "alpha"),
+                visible
+            );
+        }
+    }
+
+    #[test]
+    fn disabled_plan_is_not_callable_through_an_embedded_host() {
+        let disabled = bound_tools(PlanHost).for_session("session-1");
+        let disabled = EmbeddedToolRuntime::new_with_tools(".", None, None, &disabled);
+        assert!(!disabled.contains("update_plan"));
+        assert!(
+            disabled
+                .model_specs("session-1")
+                .iter()
+                .all(|definition| definition.name() != "update_plan")
+        );
+
+        let enabled = bind_host(
+            Tools::builder()
+                .without_defaults()
+                .tool(crate::standard::UpdatePlanTool::new())
+                .build()
+                .unwrap(),
+            PlanHost,
+        )
+        .for_session("session-1");
+        let enabled = EmbeddedToolRuntime::new_with_tools(".", None, None, &enabled);
+        assert!(enabled.contains("update_plan"));
+        assert!(
+            enabled
+                .model_specs("session-1")
+                .iter()
+                .any(|definition| definition.name() == "update_plan")
+        );
     }
 
     #[tokio::test]

--- a/crates/nanocodex-tools/src/mcp/catalog.rs
+++ b/crates/nanocodex-tools/src/mcp/catalog.rs
@@ -40,6 +40,7 @@ pub(crate) struct ToolEntry {
     pub search_text: String,
     pub client: Client,
     pub timeout: Duration,
+    pub output_token_limit: Option<usize>,
 }
 
 struct Catalog {
@@ -50,6 +51,8 @@ struct Catalog {
     search_index: Option<Arc<SearchIndex>>,
     pending_servers: BTreeSet<String>,
     generations: BTreeMap<String, u64>,
+    reserved_names: BTreeSet<String>,
+    closed: bool,
 }
 
 pub(crate) struct ConnectedCatalog {
@@ -121,10 +124,10 @@ struct LoadableFunction {
 
 impl ProviderState {
     pub(crate) fn new(
-        server_names: impl IntoIterator<Item = String>,
+        servers: impl IntoIterator<Item = String>,
         discovery_timeout: Duration,
     ) -> Self {
-        let pending_servers = server_names.into_iter().collect::<BTreeSet<_>>();
+        let pending_servers = servers.into_iter().collect::<BTreeSet<_>>();
         let generations = pending_servers
             .iter()
             .cloned()
@@ -140,6 +143,8 @@ impl ProviderState {
                 search_index: None,
                 pending_servers,
                 generations,
+                reserved_names: BTreeSet::new(),
+                closed: false,
             }),
             remaining,
             discovery_timeout,
@@ -151,46 +156,64 @@ impl ProviderState {
         server_name: &str,
         generation: u64,
         result: Result<ConnectedCatalog, String>,
-    ) {
+    ) -> Result<(), String> {
         let mut catalog = self.catalog();
-        if catalog.generations.get(server_name).copied() != Some(generation) {
-            return;
+        if catalog.closed || catalog.generations.get(server_name).copied() != Some(generation) {
+            return Err(format!(
+                "MCP server `{server_name}` completion was stopped or superseded"
+            ));
         }
-        match result {
+        let failure = match result {
             Ok(ConnectedCatalog { client, entries }) => {
-                let removed = catalog
-                    .entries
-                    .iter()
-                    .filter_map(|(name, entry)| {
-                        (entry.server_name == server_name).then_some(name.clone())
-                    })
-                    .collect::<Vec<_>>();
-                for name in removed {
-                    catalog.entries.remove(&name);
-                }
-                for entry in entries {
-                    if catalog.entries.contains_key(&entry.canonical_name) {
-                        catalog.failures.insert(
-                            server_name.to_owned(),
-                            format!(
-                                "MCP tool name collision after normalization: `{}`",
-                                entry.canonical_name
-                            ),
-                        );
-                        continue;
+                let mut candidate_names = BTreeSet::new();
+                let collision = entries.iter().find_map(|entry| {
+                    if catalog.reserved_names.contains(&entry.canonical_name) {
+                        return Some(format!(
+                            "MCP tool name collides with fixed runtime tool: `{}`",
+                            entry.canonical_name
+                        ));
                     }
+                    if !candidate_names.insert(entry.canonical_name.clone())
+                        || catalog
+                            .entries
+                            .get(&entry.canonical_name)
+                            .is_some_and(|current| current.server_name != server_name)
+                    {
+                        return Some(format!(
+                            "MCP tool name collision after normalization: `{}`",
+                            entry.canonical_name
+                        ));
+                    }
+                    None
+                });
+                if let Some(error) = collision {
+                    catalog
+                        .failures
+                        .insert(server_name.to_owned(), error.clone());
+                    Some(error)
+                } else {
                     catalog
                         .entries
-                        .insert(entry.canonical_name.clone(), Arc::new(entry));
+                        .retain(|_, entry| entry.server_name != server_name);
+                    for entry in entries {
+                        catalog
+                            .entries
+                            .insert(entry.canonical_name.clone(), Arc::new(entry));
+                    }
+                    catalog.clients.insert(server_name.to_owned(), client);
+                    catalog.failures.remove(server_name);
+                    let available = catalog.entries.keys().cloned().collect::<BTreeSet<_>>();
+                    catalog.active.retain(|name| available.contains(name));
+                    None
                 }
-                catalog.clients.insert(server_name.to_owned(), client);
-                let available = catalog.entries.keys().cloned().collect::<BTreeSet<_>>();
-                catalog.active.retain(|name| available.contains(name));
             }
             Err(error) => {
-                catalog.failures.insert(server_name.to_owned(), error);
+                catalog
+                    .failures
+                    .insert(server_name.to_owned(), error.clone());
+                Some(error)
             }
-        }
+        };
         catalog.pending_servers.remove(server_name);
         if catalog.pending_servers.is_empty() {
             tracing::info!(
@@ -211,10 +234,14 @@ impl ProviderState {
         let pending_servers = catalog.pending_servers.len();
         drop(catalog);
         self.remaining.send_replace(pending_servers);
+        failure.map_or(Ok(()), Err)
     }
 
-    pub(crate) fn begin_server(&self, server_name: &str) -> u64 {
+    pub(crate) fn begin_server(&self, server_name: &str) -> Option<u64> {
         let mut catalog = self.catalog();
+        if catalog.closed {
+            return None;
+        }
         let generation = catalog
             .generations
             .entry(server_name.to_owned())
@@ -226,7 +253,7 @@ impl ProviderState {
         let pending_servers = catalog.pending_servers.len();
         drop(catalog);
         self.remaining.send_replace(pending_servers);
-        generation
+        Some(generation)
     }
 
     pub(crate) async fn search(
@@ -297,8 +324,34 @@ impl ProviderState {
             .collect()
     }
 
+    pub(crate) fn reserve_names(&self, names: &[String]) {
+        self.catalog().reserved_names.extend(names.iter().cloned());
+    }
+
     pub(crate) fn entry(&self, name: &str) -> Option<Arc<ToolEntry>> {
         self.catalog().entries.get(name).cloned()
+    }
+
+    pub(crate) fn is_current_entry(&self, expected: &Arc<ToolEntry>) -> bool {
+        self.catalog()
+            .entries
+            .get(&expected.canonical_name)
+            .is_some_and(|current| Arc::ptr_eq(current, expected))
+    }
+
+    pub(crate) fn shutdown(&self) {
+        let mut catalog = self.catalog();
+        catalog.closed = true;
+        catalog.entries.clear();
+        catalog.active.clear();
+        catalog.clients.clear();
+        catalog.pending_servers.clear();
+        catalog.search_index = None;
+        for generation in catalog.generations.values_mut() {
+            *generation = generation.saturating_add(1);
+        }
+        drop(catalog);
+        self.remaining.send_replace(0);
     }
 
     pub(crate) async fn ready_entry(&self, name: &str) -> Option<Arc<ToolEntry>> {
@@ -492,6 +545,17 @@ impl ToolEntry {
             config.supports_parallel_tool_calls,
             config.parallel_tools.contains(tool.name.as_ref()),
         );
+        let output_token_limit = config
+            .output_token_limit
+            .into_iter()
+            .chain(
+                config
+                    .tool_output_token_limits
+                    .get(remote_name.as_str())
+                    .copied(),
+            )
+            .map(std::num::NonZeroUsize::get)
+            .min();
         let mut input_schema = tool.input_schema.as_ref().clone();
         if input_schema.get("properties").is_none_or(Value::is_null) {
             input_schema.insert("properties".to_owned(), Value::Object(Map::new()));
@@ -541,6 +605,7 @@ impl ToolEntry {
             search_text,
             client,
             timeout: config.tool_timeout,
+            output_token_limit,
         }
     }
 
@@ -588,16 +653,17 @@ fn tool_supports_parallel_calls(tool: &RmcpTool, server_opt_in: bool, tool_polic
 }
 
 fn normalize_name(name: &str) -> String {
-    let normalized = name
-        .chars()
-        .map(|character| {
-            if character.is_ascii_alphanumeric() || character == '_' {
-                character
-            } else {
-                '_'
-            }
-        })
-        .collect::<String>();
+    let mut normalized = String::with_capacity(name.len());
+    let mut previous_was_separator = false;
+    for character in name.chars() {
+        if character.is_ascii_alphanumeric() {
+            normalized.push(character);
+            previous_was_separator = false;
+        } else if !previous_was_separator {
+            normalized.push('_');
+            previous_was_separator = true;
+        }
+    }
     if normalized.is_empty() {
         "_".to_owned()
     } else {
@@ -678,6 +744,7 @@ fn unique_bounded_name(
         let suffix = name_hash_suffix(&identity);
         let prefix_bytes = maximum_bytes.saturating_sub(suffix.len());
         let prefix = &base[..base.len().min(prefix_bytes)];
+        let prefix = prefix.trim_end_matches('_');
         let candidate = format!("{prefix}{suffix}");
         if used.insert(candidate.clone()) {
             return candidate;
@@ -750,6 +817,22 @@ mod tests {
                 .values()
                 .all(|name| namespace.len() + name.len() <= 128)
         );
+    }
+
+    #[test]
+    fn flattened_names_cannot_alias_across_server_tool_boundaries() {
+        let namespaces = normalized_server_names(["a__b", "a"]);
+        let nested_server = &namespaces["a__b"];
+        let short_server = &namespaces["a"];
+        let nested_tool = normalized_tool_names(nested_server, ["c"]);
+        let compound_tool = normalized_tool_names(short_server, ["b__c"]);
+
+        assert_ne!(
+            format!("{nested_server}{}", nested_tool["c"]),
+            format!("{short_server}{}", compound_tool["b__c"])
+        );
+        assert!(!nested_tool["c"].contains("__"));
+        assert!(!compound_tool["b__c"].contains("__"));
     }
 
     #[test]

--- a/crates/nanocodex-tools/src/mcp/client.rs
+++ b/crates/nanocodex-tools/src/mcp/client.rs
@@ -43,11 +43,7 @@ impl ClientInner {
     ) -> Result<CallToolResult, String> {
         let parent = Span::current();
         let result = self.call_tool_with_payment(params).await;
-        if let Some(oauth) = &self.oauth
-            && let Err(error) = oauth.persist_if_changed(&parent).await
-        {
-            tracing::warn!(%error, "failed to persist refreshed MCP OAuth credentials");
-        }
+        self.persist_oauth(&parent).await;
         result
     }
 
@@ -116,11 +112,7 @@ impl ClientInner {
             }
         })
         .await;
-        if let Some(oauth) = &self.oauth
-            && let Err(error) = oauth.persist_if_changed(parent).await
-        {
-            tracing::warn!(%error, "failed to persist refreshed MCP OAuth credentials");
-        }
+        self.persist_oauth(parent).await;
         tools
     }
 
@@ -129,6 +121,14 @@ impl ClientInner {
             oauth.refresh_if_needed().await?;
         }
         Ok(())
+    }
+
+    async fn persist_oauth(&self, parent: &Span) {
+        if let Some(oauth) = &self.oauth
+            && let Err(error) = oauth.persist_if_changed(parent).await
+        {
+            tracing::warn!(%error, "failed to persist refreshed MCP OAuth credentials");
+        }
     }
 }
 

--- a/crates/nanocodex-tools/src/mcp/config.rs
+++ b/crates/nanocodex-tools/src/mcp/config.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
+    num::NonZeroUsize,
     path::PathBuf,
     sync::Arc,
     time::Duration,
@@ -46,6 +47,8 @@ pub struct McpServer {
     pub(crate) description: Option<String>,
     pub(crate) startup_timeout: Duration,
     pub(crate) tool_timeout: Duration,
+    pub(crate) output_token_limit: Option<NonZeroUsize>,
+    pub(crate) tool_output_token_limits: BTreeMap<String, NonZeroUsize>,
     pub(crate) supports_parallel_tool_calls: bool,
     pub(crate) parallel_tools: BTreeSet<String>,
     pub(crate) tool_exposure: McpToolExposure,
@@ -114,6 +117,8 @@ impl McpServer {
             description: None,
             startup_timeout: DEFAULT_STARTUP_TIMEOUT,
             tool_timeout: DEFAULT_TOOL_TIMEOUT,
+            output_token_limit: None,
+            tool_output_token_limits: BTreeMap::new(),
             supports_parallel_tool_calls: false,
             parallel_tools: BTreeSet::new(),
             tool_exposure: McpToolExposure::default(),
@@ -136,6 +141,8 @@ impl McpServer {
             description: None,
             startup_timeout: DEFAULT_STARTUP_TIMEOUT,
             tool_timeout: DEFAULT_TOOL_TIMEOUT,
+            output_token_limit: None,
+            tool_output_token_limits: BTreeMap::new(),
             supports_parallel_tool_calls: false,
             parallel_tools: BTreeSet::new(),
             tool_exposure: McpToolExposure::default(),
@@ -164,6 +171,25 @@ impl McpServer {
     #[must_use]
     pub const fn tool_timeout(mut self, timeout: Duration) -> Self {
         self.tool_timeout = timeout;
+        self
+    }
+
+    /// Restricts every tool on this server to the given model-visible output budget.
+    ///
+    /// The budget is measured in approximate tokens before the standard serialization
+    /// allowance. A per-tool limit may restrict it further.
+    #[must_use]
+    pub const fn output_token_limit(mut self, limit: NonZeroUsize) -> Self {
+        self.output_token_limit = Some(limit);
+        self
+    }
+
+    /// Restricts one remote tool to the given model-visible output budget.
+    ///
+    /// When both server-wide and per-tool limits are present, the stricter limit wins.
+    #[must_use]
+    pub fn tool_output_token_limit(mut self, tool: impl Into<String>, limit: NonZeroUsize) -> Self {
+        self.tool_output_token_limits.insert(tool.into(), limit);
         self
     }
 
@@ -332,6 +358,7 @@ impl SecretSource {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
+    use std::num::NonZeroUsize;
 
     use super::McpServer;
 
@@ -348,6 +375,23 @@ mod tests {
                 .parallel_tools(["lookup", "search"])
                 .parallel_tools,
             BTreeSet::from(["lookup".to_owned(), "search".to_owned()])
+        );
+    }
+
+    #[test]
+    fn server_and_tool_output_limits_are_retained_as_nonzero_bounds() {
+        let server = McpServer::stdio("fixture")
+            .output_token_limit(NonZeroUsize::new(100).unwrap())
+            .tool_output_token_limit("lookup", NonZeroUsize::new(40).unwrap());
+
+        assert_eq!(server.output_token_limit.map(NonZeroUsize::get), Some(100));
+        assert_eq!(
+            server
+                .tool_output_token_limits
+                .get("lookup")
+                .copied()
+                .map(NonZeroUsize::get),
+            Some(40)
         );
     }
 }

--- a/crates/nanocodex-tools/src/mcp/mod.rs
+++ b/crates/nanocodex-tools/src/mcp/mod.rs
@@ -10,14 +10,15 @@ mod stdio;
 use std::{
     collections::{BTreeMap, btree_map::Entry},
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicBool, Ordering},
     },
     time::Duration,
 };
 
 use crate::{
-    DynamicToolProvider, Tool, ToolContext, ToolInput, ToolOutput, ToolOutputContent, ToolResult,
+    DynamicToolProvider, Tool, ToolContext, ToolInput, ToolOutput, ToolOutputBody,
+    ToolOutputContent, ToolResult,
 };
 use async_trait::async_trait;
 use catalog::{ConnectedCatalog, ProviderState, ToolEntry};
@@ -72,10 +73,12 @@ pub struct Mcp {
     oauth_store: Option<Arc<dyn McpOAuthStore>>,
     oauth_metadata: Arc<oauth::OAuthMetadataCache>,
     started: AtomicBool,
+    startup_tasks: Mutex<Vec<tokio::task::JoinHandle<()>>>,
 }
 
 pub(crate) struct PreparedMcpTool {
     entry: Arc<ToolEntry>,
+    state: Arc<ProviderState>,
     timeout: Duration,
 }
 
@@ -137,6 +140,9 @@ pub enum McpControlError {
     /// The spawned login task stopped before returning its result.
     #[error("MCP OAuth login task stopped: {0}")]
     LoginTask(String),
+    /// The provider owner was dropped and revoked its catalog.
+    #[error("MCP provider is stopped")]
+    ProviderStopped,
 }
 
 /// Invalid MCP provider configuration.
@@ -205,6 +211,7 @@ impl Mcp {
                 .into_iter()
                 .map(|entry| PreparedMcpTool {
                     timeout: entry.timeout.min(max_timeout),
+                    state: Arc::clone(&self.state),
                     entry,
                 })
                 .collect()
@@ -233,8 +240,21 @@ impl PreparedMcpTool {
         self.timeout
     }
 
-    pub(crate) async fn execute(&self, input: Value) -> ToolOutput {
-        execute_mcp_entry(&self.entry, input, self.timeout).await
+    pub(crate) async fn execute(&self, input: Value, output_token_budget: usize) -> ToolOutput {
+        let output_token_budget = self
+            .entry
+            .output_token_limit
+            .map_or(output_token_budget, |configured| {
+                configured.min(output_token_budget)
+            });
+        execute_mcp_entry(
+            &self.state,
+            &self.entry,
+            input,
+            self.timeout,
+            output_token_budget,
+        )
+        .await
     }
 }
 
@@ -307,6 +327,7 @@ impl McpBuilder {
             oauth_store: self.oauth_store,
             oauth_metadata: Arc::new(oauth::OAuthMetadataCache::default()),
             started: AtomicBool::new(false),
+            startup_tasks: Mutex::new(Vec::new()),
         })
     }
 }
@@ -360,7 +381,10 @@ impl McpHandle {
             .iter()
             .find(|server| server.name == server_name)
             .ok_or_else(|| McpControlError::UnknownServer(server_name.to_owned()))?;
-        let generation = self.state.begin_server(server_name);
+        let generation = self
+            .state
+            .begin_server(server_name)
+            .ok_or(McpControlError::ProviderStopped)?;
         let result = client::connect(
             server_name,
             &server.config,
@@ -379,18 +403,24 @@ impl McpHandle {
                     Arc::clone(&connected.client),
                     &server.config,
                 );
-                self.state.complete_server(
-                    server_name,
-                    generation,
-                    Ok(ConnectedCatalog {
-                        client: connected.client,
-                        entries,
-                    }),
-                );
+                self.state
+                    .complete_server(
+                        server_name,
+                        generation,
+                        Ok(ConnectedCatalog {
+                            client: connected.client,
+                            entries,
+                        }),
+                    )
+                    .map_err(|error| McpControlError::Reload {
+                        server: server_name.to_owned(),
+                        error,
+                    })?;
                 Ok(count)
             }
             Err(error) => {
-                self.state
+                let _ = self
+                    .state
                     .complete_server(server_name, generation, Err(error.clone()));
                 Err(McpControlError::Reload {
                     server: server_name.to_owned(),
@@ -540,7 +570,7 @@ impl DynamicToolProvider for Mcp {
                 status = tracing::field::Empty,
                 tool.count = tracing::field::Empty,
             );
-            drop(tokio::spawn(async move {
+            let task = tokio::spawn(async move {
                 let result = client::connect(&name, &config, oauth_store, oauth_metadata, &span)
                     .await
                     .map(|connected| {
@@ -571,13 +601,21 @@ impl DynamicToolProvider for Mcp {
                 if let Ok(catalog) = &result {
                     span.record("tool.count", catalog.entries.len());
                 }
-                state.complete_server(&name, 0, result);
-            }));
+                let _ = state.complete_server(&name, 0, result);
+            });
+            self.startup_tasks
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(task);
         }
     }
 
     fn direct_tools(&self) -> Vec<Arc<dyn Tool>> {
         vec![Arc::clone(&self.search) as Arc<dyn Tool>]
+    }
+
+    fn reserve_names(&self, names: &[String]) {
+        self.state.reserve_names(names);
     }
 
     fn available_definitions(&self) -> Vec<ToolDefinition> {
@@ -600,17 +638,52 @@ impl DynamicToolProvider for Mcp {
         &self,
         name: &str,
         input: Value,
-        _context: ToolContext<'_>,
+        context: ToolContext<'_>,
     ) -> Option<ToolOutput> {
         let entry = self.state.ready_entry(name).await?;
         if !entry.tool_exposure.is_callable() {
             return None;
         }
-        Some(execute_mcp_entry(&entry, input, entry.timeout).await)
+        Some(
+            execute_mcp_entry(
+                &self.state,
+                &entry,
+                input,
+                entry.timeout,
+                context.output_token_budget(),
+            )
+            .await,
+        )
     }
 }
 
-async fn execute_mcp_entry(entry: &ToolEntry, input: Value, timeout: Duration) -> ToolOutput {
+impl Drop for Mcp {
+    fn drop(&mut self) {
+        self.state.shutdown();
+        for task in self
+            .startup_tasks
+            .get_mut()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .drain(..)
+        {
+            task.abort();
+        }
+    }
+}
+
+async fn execute_mcp_entry(
+    state: &ProviderState,
+    entry: &Arc<ToolEntry>,
+    input: Value,
+    timeout: Duration,
+    fallback_output_token_budget: usize,
+) -> ToolOutput {
+    if !state.is_current_entry(entry) {
+        return ToolOutput::error(format!(
+            "MCP tool {}/{} is no longer in the current catalog",
+            entry.server_name, entry.remote_name
+        ));
+    }
     let Value::Object(arguments) = input else {
         return ToolOutput::error(format!(
             "MCP tool {} requires an object argument",
@@ -645,6 +718,12 @@ async fn execute_mcp_entry(entry: &ToolEntry, input: Value, timeout: Duration) -
             entry.server_name, entry.remote_name
         ));
     }
+    if !state.is_current_entry(entry) {
+        return ToolOutput::error(format!(
+            "MCP tool {}/{} was revoked before dispatch",
+            entry.server_name, entry.remote_name
+        ));
+    }
     let result = match tokio::time::timeout(
         timeout,
         entry.client.call_tool(params).instrument(span.clone()),
@@ -674,7 +753,17 @@ async fn execute_mcp_entry(entry: &ToolEntry, input: Value, timeout: Duration) -
     let success = !result.is_error.unwrap_or(false);
     span.record("status", if success { "completed" } else { "failed" });
     span.record("otel.status_code", if success { "OK" } else { "ERROR" });
-    match tool_output_from_mcp_result(result, &entry.server_name, &entry.remote_name) {
+    let output_token_budget = entry
+        .output_token_limit
+        .map_or(fallback_output_token_budget, |configured| {
+            configured.min(fallback_output_token_budget)
+        });
+    match tool_output_from_mcp_result(
+        result,
+        &entry.server_name,
+        &entry.remote_name,
+        output_token_budget,
+    ) {
         Ok(output) => output,
         Err(error) => {
             span.record("status", "failed");
@@ -688,10 +777,14 @@ fn tool_output_from_mcp_result(
     result: CallToolResult,
     server_name: &str,
     remote_name: &str,
+    output_token_budget: usize,
 ) -> Result<ToolOutput, serde_json::Error> {
     let success = !result.is_error.unwrap_or(false);
-    let value = serde_json::to_value(&result)?;
-    let result_metadata = result.meta.as_ref().map(|metadata| &metadata.0);
+    let mut value = serde_json::to_value(&result)?;
+    let result_metadata = match &mut value {
+        Value::Object(fields) => fields.remove("_meta"),
+        _ => None,
+    };
     let direct_content = direct_mcp_content(&result.content)?;
     let contains_encrypted_content = direct_content.as_ref().is_some_and(|content| {
         content
@@ -701,27 +794,40 @@ fn tool_output_from_mcp_result(
     let mut output = if contains_encrypted_content {
         let mut output = ToolOutput::content(direct_content.unwrap_or_default());
         output.success = success;
-        output.with_structured_result(value)
+        output
     } else if let Some(structured_content) = result
         .structured_content
         .as_ref()
         .filter(|content| !content.is_null())
     {
-        ToolOutput::from_json(structured_content.clone(), success).with_structured_result(value)
+        ToolOutput::from_json(structured_content.clone(), success)
     } else if let Some(content) = direct_content {
         let mut output = ToolOutput::content(content);
         output.success = success;
-        output.with_structured_result(value)
+        output
     } else {
         ToolOutput::from_json(serde_json::to_value(&result.content)?, success)
-            .with_structured_result(value)
     };
-    output = output.with_metadata(json!({
+    truncate_model_projection(&mut output, output_token_budget);
+    output = output.with_structured_result(value).with_metadata(json!({
         "mcp_server": server_name,
         "mcp_tool": remote_name,
         "mcp_result_meta": result_metadata,
     }));
     Ok(output)
+}
+
+fn truncate_model_projection(output: &mut ToolOutput, token_budget: usize) {
+    let token_budget = token_budget.saturating_mul(6) / 5;
+    match &mut output.output {
+        ToolOutputBody::Text(text) => {
+            *text = crate::code_mode::output::truncate_middle_tokens_bounded(text, token_budget);
+        }
+        ToolOutputBody::Content(content) => {
+            *content =
+                crate::code_mode::output::truncate_mixed(std::mem::take(content), token_budget);
+        }
+    }
 }
 
 fn direct_mcp_content(
@@ -976,6 +1082,23 @@ mod tests {
     use rmcp::model::ContentBlock;
     use serde_json::value::to_raw_value;
 
+    struct FixedMcpCollision;
+
+    #[async_trait]
+    impl Tool for FixedMcpCollision {
+        fn definition(&self) -> ToolDefinition {
+            ToolDefinition::function(
+                "mcp__fixture--echo",
+                "Fixed collision fixture.",
+                json!({"type": "object", "properties": {}}),
+            )
+        }
+
+        async fn execute(&self, _input: ToolInput, _context: ToolContext<'_>) -> ToolResult {
+            Ok(ToolOutput::text("fixed"))
+        }
+    }
+
     fn test_context(session_id: &'static str, call_id: &'static str) -> ToolContext<'static> {
         ToolContext::new(MODEL, session_id, call_id, &[], DEFAULT_TOOL_OUTPUT_TOKENS)
     }
@@ -996,9 +1119,12 @@ mod tests {
             ContentBlock::image("aW1hZ2U=", "image/png"),
         ]);
         result.structured_content = Some(json!({"answer": 42}));
-        let expected = serde_json::to_value(&result).unwrap();
+        let mut expected = serde_json::to_value(&result).unwrap();
+        expected.as_object_mut().unwrap().remove("_meta");
 
-        let output = tool_output_from_mcp_result(result, "fixture", "media").unwrap();
+        let output =
+            tool_output_from_mcp_result(result, "fixture", "media", DEFAULT_TOOL_OUTPUT_TOKENS)
+                .unwrap();
         assert!(output.success);
         assert_eq!(output.structured_result(), expected);
         assert!(matches!(output.output, ToolOutputBody::Text(text) if text == r#"{"answer":42}"#));
@@ -1025,9 +1151,12 @@ mod tests {
             ]
         }))
         .unwrap();
-        let expected = serde_json::to_value(&result).unwrap();
+        let mut expected = serde_json::to_value(&result).unwrap();
+        expected.as_object_mut().unwrap().remove("_meta");
 
-        let output = tool_output_from_mcp_result(result, "fixture", "media").unwrap();
+        let output =
+            tool_output_from_mcp_result(result, "fixture", "media", DEFAULT_TOOL_OUTPUT_TOKENS)
+                .unwrap();
         assert_eq!(output.structured_result(), expected);
         assert!(matches!(
             output.output,
@@ -1055,7 +1184,9 @@ mod tests {
         .unwrap();
         let expected = serde_json::to_value(&result).unwrap();
 
-        let output = tool_output_from_mcp_result(result, "fixture", "encrypted").unwrap();
+        let output =
+            tool_output_from_mcp_result(result, "fixture", "encrypted", DEFAULT_TOOL_OUTPUT_TOKENS)
+                .unwrap();
         assert_eq!(output.structured_result(), expected);
         let ToolOutputBody::Content(content) = output.output else {
             panic!("encrypted MCP text must use typed function output content");
@@ -1086,9 +1217,12 @@ mod tests {
             "_meta": {"trace": "retained"}
         }))
         .unwrap();
-        let expected = serde_json::to_value(&result).unwrap();
+        let mut expected = serde_json::to_value(&result).unwrap();
+        expected.as_object_mut().unwrap().remove("_meta");
 
-        let output = tool_output_from_mcp_result(result, "fixture", "resource").unwrap();
+        let output =
+            tool_output_from_mcp_result(result, "fixture", "resource", DEFAULT_TOOL_OUTPUT_TOKENS)
+                .unwrap();
         assert!(!output.success);
         assert_eq!(output.structured_result(), expected);
         assert!(matches!(
@@ -1105,6 +1239,31 @@ mod tests {
                 "mcp_result_meta": {"trace": "retained"}
             })
         );
+    }
+
+    #[test]
+    fn configured_budget_bounds_model_projection_but_not_sanitized_code_mode_result() {
+        let mut result = CallToolResult::success(vec![ContentBlock::text("x".repeat(2_000))]);
+        result.structured_content = Some(json!({"body": "y".repeat(2_000)}));
+        result.meta = Some(rmcp::model::MetaObject(serde_json::Map::from_iter([(
+            "private".to_owned(),
+            json!(true),
+        )])));
+
+        let output = tool_output_from_mcp_result(result, "fixture", "bounded", 10).unwrap();
+        let ToolOutputBody::Text(model_projection) = &output.output else {
+            panic!("structured MCP content must be projected as text");
+        };
+        assert!(model_projection.len() <= 48);
+        assert!(model_projection.contains("truncated"));
+        assert_eq!(
+            output.structured_result()["structuredContent"]["body"],
+            "y".repeat(2_000)
+        );
+        assert!(output.structured_result().get("_meta").is_none());
+        let diagnostics: Value =
+            serde_json::from_str(output.metadata.as_ref().unwrap().get()).unwrap();
+        assert_eq!(diagnostics["mcp_result_meta"]["private"], true);
     }
 
     #[derive(Default)]
@@ -1378,6 +1537,50 @@ mod tests {
             .unwrap();
         assert!(execution.success);
         assert!(output_contains_text(&execution.output, "fixture:hello"));
+    }
+
+    #[tokio::test]
+    async fn asynchronous_mcp_discovery_cannot_shadow_a_fixed_runtime_tool() {
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/mcp-stdio-server.mjs");
+        let mcp = Mcp::builder()
+            .server(
+                "fixture",
+                McpServer::stdio("node").arg(fixture.to_string_lossy()),
+            )
+            .build()
+            .unwrap();
+        let tools = Tools::builder()
+            .without_defaults()
+            .tool(FixedMcpCollision)
+            .provider(mcp)
+            .build()
+            .unwrap();
+        let runtime = ToolRuntime::new_with_tools(".", None, None, &tools);
+
+        let search = runtime
+            .execute_tool(
+                "tool_search",
+                ToolInput::Function(to_raw_value(&json!({"query": "echo"})).unwrap()),
+                test_context("collision-session", "search-call"),
+            )
+            .await;
+        assert!(search.success);
+        assert!(matches!(
+            search.output,
+            ToolOutputBody::Text(output)
+                if output.contains("MCP tool name collides with fixed runtime tool")
+                    && !output.contains("\"name\":\"mcp__fixture__echo\"")
+        ));
+
+        let fixed = runtime
+            .execute_tool(
+                "mcp__fixture--echo",
+                ToolInput::Function(to_raw_value(&json!({})).unwrap()),
+                test_context("collision-session", "fixed-call"),
+            )
+            .await;
+        assert!(matches!(fixed.output, ToolOutputBody::Text(output) if output == "fixed"));
     }
 
     #[tokio::test]
@@ -1697,8 +1900,23 @@ mod tests {
             .await
             .unwrap();
         assert!(search.success);
+        let old_entry = mcp.state.entry("mcp__fixture__echo").unwrap();
 
         assert_eq!(handle.reload("fixture").await.unwrap(), 1);
+        assert!(!mcp.state.is_current_entry(&old_entry));
+        let stale = execute_mcp_entry(
+            &mcp.state,
+            &old_entry,
+            json!({"message": "stale"}),
+            Duration::from_secs(1),
+            DEFAULT_TOOL_OUTPUT_TOKENS,
+        )
+        .await;
+        assert!(!stale.success);
+        assert!(output_contains_text(
+            &stale.output,
+            "no longer in the current catalog"
+        ));
         assert!(
             mcp.available_definitions()
                 .iter()
@@ -1717,6 +1935,91 @@ mod tests {
             &execution.output,
             "fixture:after-reload"
         ));
+    }
+
+    #[tokio::test]
+    async fn failed_reload_preserves_the_previous_live_catalog_and_client() {
+        let source = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/mcp-stdio-server.mjs");
+        let directory = tempfile::tempdir().unwrap();
+        let fixture = directory.path().join("server.mjs");
+        std::fs::copy(source, &fixture).unwrap();
+        let mcp = Mcp::builder()
+            .server(
+                "fixture",
+                McpServer::stdio("node")
+                    .arg(fixture.to_string_lossy())
+                    .startup_timeout(Duration::from_secs(2)),
+            )
+            .build()
+            .unwrap();
+        let handle = mcp.handle();
+        mcp.start();
+        mcp.state.search("echo", None).await.unwrap();
+        let original = mcp.state.entry("mcp__fixture__echo").unwrap();
+
+        std::fs::remove_file(fixture).unwrap();
+        assert!(handle.reload("fixture").await.is_err());
+        assert!(mcp.state.is_current_entry(&original));
+        let output = mcp
+            .execute(
+                "mcp__fixture__echo",
+                json!({"message": "still-live"}),
+                test_context("failed-reload", "tool-call"),
+            )
+            .await
+            .unwrap();
+        assert!(output.success);
+        assert!(output_contains_text(&output.output, "fixture:still-live"));
+    }
+
+    #[tokio::test]
+    async fn colliding_reload_is_atomic_and_preserves_the_previous_catalog() {
+        let source = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/mcp-stdio-server.mjs");
+        let directory = tempfile::tempdir().unwrap();
+        let fixture = directory.path().join("server.mjs");
+        std::fs::copy(&source, &fixture).unwrap();
+        let mcp = Mcp::builder()
+            .server(
+                "fixture",
+                McpServer::stdio("node")
+                    .arg(fixture.to_string_lossy())
+                    .startup_timeout(Duration::from_secs(2)),
+            )
+            .build()
+            .unwrap();
+        mcp.state
+            .reserve_names(&["mcp__fixture__echo_1".to_owned()]);
+        let handle = mcp.handle();
+        mcp.start();
+        mcp.state.search("echo", None).await.unwrap();
+        let original = mcp.state.entry("mcp__fixture__echo").unwrap();
+
+        let expanded = std::fs::read_to_string(&source).unwrap().replace(
+            "NANOCODEX_MCP_FIXTURE_TOOL_COUNT ?? \"1\"",
+            "NANOCODEX_MCP_FIXTURE_TOOL_COUNT ?? \"2\"",
+        );
+        std::fs::write(&fixture, expanded).unwrap();
+        let error = handle.reload("fixture").await.unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("collides with fixed runtime tool")
+        );
+        assert!(mcp.state.is_current_entry(&original));
+        assert!(mcp.state.entry("mcp__fixture__echo_1").is_none());
+
+        let output = mcp
+            .execute(
+                "mcp__fixture__echo",
+                json!({"message": "still-atomic"}),
+                test_context("atomic-reload", "tool-call"),
+            )
+            .await
+            .unwrap();
+        assert!(output.success);
+        assert!(output_contains_text(&output.output, "fixture:still-atomic"));
     }
 
     #[tokio::test]

--- a/crates/nanocodex-tools/src/mcp/pagination.rs
+++ b/crates/nanocodex-tools/src/mcp/pagination.rs
@@ -7,14 +7,12 @@ const MAX_MCP_CATALOG_ITEMS: usize = 2_048;
 const MAX_MCP_PAGINATION_CURSOR_BYTES: usize = 64 * 1024;
 const DEFAULT_MCP_PAGINATION_TIMEOUT: Duration = Duration::from_secs(30);
 
-pub(super) async fn collect_paginated<T, F, Fut>(
-    method: &str,
-    mut fetch: F,
-) -> Result<Vec<T>, String>
+pub(super) async fn collect_paginated<T, F, Fut>(method: &str, fetch: F) -> Result<Vec<T>, String>
 where
     F: FnMut(Option<PaginatedRequestParams>) -> Fut,
     Fut: Future<Output = Result<(Vec<T>, Option<String>), String>>,
 {
+    let mut fetch = fetch;
     let collect = async {
         let mut collected = Vec::new();
         let mut cursor: Option<String> = None;
@@ -51,10 +49,11 @@ where
         ))
     };
 
-    let timeout = DEFAULT_MCP_PAGINATION_TIMEOUT;
-    tokio::time::timeout(timeout, collect)
+    tokio::time::timeout(DEFAULT_MCP_PAGINATION_TIMEOUT, collect)
         .await
-        .map_err(|_| format!("{method} pagination timed out after {timeout:?}"))?
+        .map_err(|_| {
+            format!("{method} pagination timed out after {DEFAULT_MCP_PAGINATION_TIMEOUT:?}")
+        })?
 }
 
 #[cfg(test)]

--- a/crates/nanocodex-tools/src/plan.rs
+++ b/crates/nanocodex-tools/src/plan.rs
@@ -34,6 +34,18 @@ impl Tool for UpdatePlanTool {
 
     async fn execute(&self, input: ToolInput, _context: ToolContext<'_>) -> ToolResult {
         let plan = input.decode_json::<UpdatePlanArgs>()?;
+        let active_steps = plan
+            .plan
+            .iter()
+            .filter(|item| matches!(item.status, PlanStatus::InProgress))
+            .count();
+        if active_steps > 1 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "at most one plan step may be in_progress",
+            )
+            .into());
+        }
         tracing::debug!(
             explanation = ?plan.explanation,
             step_count = plan.plan.len(),
@@ -73,4 +85,61 @@ enum PlanStatus {
     Pending,
     InProgress,
     Completed,
+}
+
+#[cfg(test)]
+mod tests {
+    use nanocodex_oai_api::tools::DEFAULT_TOOL_OUTPUT_TOKENS;
+    use serde_json::{json, value::to_raw_value};
+
+    use super::*;
+
+    fn context() -> ToolContext<'static> {
+        ToolContext::new(
+            "test-model",
+            "test-session",
+            "test-call",
+            &[],
+            DEFAULT_TOOL_OUTPUT_TOKENS,
+        )
+    }
+
+    #[tokio::test]
+    async fn rejects_more_than_one_in_progress_step() {
+        let input = to_raw_value(&json!({
+            "plan": [
+                { "step": "first", "status": "in_progress" },
+                { "step": "second", "status": "in_progress" }
+            ]
+        }))
+        .unwrap();
+        let result = UpdatePlanTool::new()
+            .execute(ToolInput::Function(input), context())
+            .await;
+        let Err(error) = result else {
+            panic!("update_plan accepted multiple in_progress steps");
+        };
+
+        assert_eq!(
+            error.to_string(),
+            "at most one plan step may be in_progress"
+        );
+    }
+
+    #[tokio::test]
+    async fn accepts_one_in_progress_step() {
+        let input = to_raw_value(&json!({
+            "plan": [
+                { "step": "first", "status": "completed" },
+                { "step": "second", "status": "in_progress" }
+            ]
+        }))
+        .unwrap();
+        let output = UpdatePlanTool::new()
+            .execute(ToolInput::Function(input), context())
+            .await
+            .unwrap();
+
+        assert!(output.success);
+    }
 }

--- a/crates/nanocodex-tools/src/plan.rs
+++ b/crates/nanocodex-tools/src/plan.rs
@@ -1,22 +1,17 @@
 use nanocodex_oai_api::tools::ToolDefinition;
 use serde::Deserialize;
 use serde_json::json;
-use tokio::sync::Mutex;
 
 use super::{StandardTool, Tool, ToolContext, ToolInput, ToolOutput, ToolResult};
 
 /// Host-owned standard plan tool for runtimes that replace workspace effects.
-pub struct UpdatePlanTool {
-    current: Mutex<Option<UpdatePlanArgs>>,
-}
+pub struct UpdatePlanTool;
 
 impl UpdatePlanTool {
     /// Creates an empty retained plan.
     #[must_use]
     pub const fn new() -> Self {
-        Self {
-            current: Mutex::const_new(None),
-        }
+        Self
     }
 }
 
@@ -34,18 +29,6 @@ impl Tool for UpdatePlanTool {
 
     async fn execute(&self, input: ToolInput, _context: ToolContext<'_>) -> ToolResult {
         let plan = input.decode_json::<UpdatePlanArgs>()?;
-        let active_steps = plan
-            .plan
-            .iter()
-            .filter(|item| matches!(item.status, PlanStatus::InProgress))
-            .count();
-        if active_steps > 1 {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "at most one plan step may be in_progress",
-            )
-            .into());
-        }
         tracing::debug!(
             explanation = ?plan.explanation,
             step_count = plan.plan.len(),
@@ -59,7 +42,6 @@ impl Tool for UpdatePlanTool {
                 "updated plan item"
             );
         }
-        *self.current.lock().await = Some(plan);
         Ok(ToolOutput::text("Plan updated").with_structured_result(json!({})))
     }
 }
@@ -85,61 +67,4 @@ enum PlanStatus {
     Pending,
     InProgress,
     Completed,
-}
-
-#[cfg(test)]
-mod tests {
-    use nanocodex_oai_api::tools::DEFAULT_TOOL_OUTPUT_TOKENS;
-    use serde_json::{json, value::to_raw_value};
-
-    use super::*;
-
-    fn context() -> ToolContext<'static> {
-        ToolContext::new(
-            "test-model",
-            "test-session",
-            "test-call",
-            &[],
-            DEFAULT_TOOL_OUTPUT_TOKENS,
-        )
-    }
-
-    #[tokio::test]
-    async fn rejects_more_than_one_in_progress_step() {
-        let input = to_raw_value(&json!({
-            "plan": [
-                { "step": "first", "status": "in_progress" },
-                { "step": "second", "status": "in_progress" }
-            ]
-        }))
-        .unwrap();
-        let result = UpdatePlanTool::new()
-            .execute(ToolInput::Function(input), context())
-            .await;
-        let Err(error) = result else {
-            panic!("update_plan accepted multiple in_progress steps");
-        };
-
-        assert_eq!(
-            error.to_string(),
-            "at most one plan step may be in_progress"
-        );
-    }
-
-    #[tokio::test]
-    async fn accepts_one_in_progress_step() {
-        let input = to_raw_value(&json!({
-            "plan": [
-                { "step": "first", "status": "completed" },
-                { "step": "second", "status": "in_progress" }
-            ]
-        }))
-        .unwrap();
-        let output = UpdatePlanTool::new()
-            .execute(ToolInput::Function(input), context())
-            .await
-            .unwrap();
-
-        assert!(output.success);
-    }
 }

--- a/crates/nanocodex-tools/src/prepared/runtime.rs
+++ b/crates/nanocodex-tools/src/prepared/runtime.rs
@@ -308,7 +308,7 @@ impl PreparedToolRuntime {
                     .unwrap_or_else(|error| ToolOutput::error(error.to_string())),
                 #[cfg(feature = "native")]
                 (PreparedToolHandler::Mcp(tool), PreparedToolInput::Mcp(input)) => {
-                    tool.execute(input).await
+                    tool.execute(input, context.output_token_budget()).await
                 }
                 #[cfg(feature = "workspace-runtime")]
                 (PreparedToolHandler::Workspace(workspace), PreparedToolInput::Contract(input)) => {

--- a/crates/nanocodex-tools/src/runtime/execution.rs
+++ b/crates/nanocodex-tools/src/runtime/execution.rs
@@ -38,6 +38,7 @@ impl ToolRuntime {
             web_search,
             image_generation,
             true,
+            false,
             Arc::new(Vec::new()),
             None,
         )
@@ -61,6 +62,7 @@ impl ToolRuntime {
             web_search,
             image_generation,
             tools.workspace_enabled(),
+            tools.plan_enabled(),
             tools.process_environment(),
             tools.remote_http_client(),
         )
@@ -72,6 +74,7 @@ impl ToolRuntime {
         web_search: Option<WebSearchConfig>,
         image_generation: Option<ImageGenerationConfig>,
         workspace_enabled: bool,
+        plan_enabled: bool,
         process_environment: Arc<Vec<(OsString, OsString)>>,
         remote_http_client: Option<reqwest::Client>,
     ) -> Self {
@@ -90,10 +93,12 @@ impl ToolRuntime {
                     workspace.clone(),
                     Arc::clone(&sessions),
                 )),
-                Arc::new(plan::UpdatePlanTool::new()),
                 Arc::new(view_image::ViewImageHandler::new(workspace)),
                 Arc::new(shell::WriteStdinHandler::new(Arc::clone(&sessions))),
             ]);
+        }
+        if plan_enabled {
+            handlers.push(Arc::new(plan::UpdatePlanTool::new()));
         }
         let remote_http_client = remote_http_client.unwrap_or_default();
         if let Some(web_search) = web_search {

--- a/crates/nanocodex-tools/src/runtime/execution.rs
+++ b/crates/nanocodex-tools/src/runtime/execution.rs
@@ -38,7 +38,6 @@ impl ToolRuntime {
             web_search,
             image_generation,
             true,
-            false,
             Arc::new(Vec::new()),
             None,
         )
@@ -62,7 +61,6 @@ impl ToolRuntime {
             web_search,
             image_generation,
             tools.workspace_enabled(),
-            tools.plan_enabled(),
             tools.process_environment(),
             tools.remote_http_client(),
         )
@@ -74,7 +72,6 @@ impl ToolRuntime {
         web_search: Option<WebSearchConfig>,
         image_generation: Option<ImageGenerationConfig>,
         workspace_enabled: bool,
-        plan_enabled: bool,
         process_environment: Arc<Vec<(OsString, OsString)>>,
         remote_http_client: Option<reqwest::Client>,
     ) -> Self {
@@ -96,9 +93,6 @@ impl ToolRuntime {
                 Arc::new(view_image::ViewImageHandler::new(workspace)),
                 Arc::new(shell::WriteStdinHandler::new(Arc::clone(&sessions))),
             ]);
-        }
-        if plan_enabled {
-            handlers.push(Arc::new(plan::UpdatePlanTool::new()));
         }
         let remote_http_client = remote_http_client.unwrap_or_default();
         if let Some(web_search) = web_search {
@@ -152,6 +146,7 @@ impl ToolRuntime {
                 .cloned()
                 .map(|tool| (tool, tools.exposure())),
         );
+        registry.provider_exposure = tools.exposure();
         registry.providers.extend(tools.providers.iter().cloned());
         if let Some(working_directory) = &tools.working_directory {
             self.working_directory = Arc::clone(working_directory);

--- a/crates/nanocodex-tools/src/runtime/mod.rs
+++ b/crates/nanocodex-tools/src/runtime/mod.rs
@@ -37,7 +37,7 @@ use crate::code_mode::{self, CodeModeExecution, CodeModeObserver};
 pub use crate::embedded::OwnedToolContext;
 pub use crate::runtime_config::{ImageGenerationConfig, WebSearchConfig};
 use crate::{
-    apply_patch, plan,
+    apply_patch,
     shell::{self, ShellSessions},
     view_image,
 };

--- a/crates/nanocodex-tools/src/runtime/registry.rs
+++ b/crates/nanocodex-tools/src/runtime/registry.rs
@@ -173,7 +173,7 @@ impl ToolRegistry {
         input: Value,
         context: ToolContext<'_>,
     ) -> ToolOutput {
-        let Some((handler, definition)) = self.get(name) else {
+        let Some((handler, definition)) = self.get_for_code_mode(name) else {
             let Some(provider) = self.providers.iter().find(|provider| {
                 provider
                     .available_definitions()
@@ -276,6 +276,14 @@ impl ToolRegistry {
 
     fn get(&self, name: &str) -> Option<(&Arc<dyn Tool>, &ToolDefinition)> {
         let index = *self.by_name.get(name)?;
+        Some((self.ordered.get(index)?, self.definitions.get(index)?))
+    }
+
+    fn get_for_code_mode(&self, name: &str) -> Option<(&Arc<dyn Tool>, &ToolDefinition)> {
+        let index = *self.by_name.get(name)?;
+        if !self.exposures.get(index)?.is_available_in_code_mode() {
+            return None;
+        }
         Some((self.ordered.get(index)?, self.definitions.get(index)?))
     }
 

--- a/crates/nanocodex-tools/src/runtime/registry.rs
+++ b/crates/nanocodex-tools/src/runtime/registry.rs
@@ -10,6 +10,7 @@ pub(crate) struct ToolRegistry {
     exposures: Vec<ToolExposure>,
     by_name: HashMap<Box<str>, usize>,
     pub(super) providers: Vec<Arc<dyn DynamicToolProvider>>,
+    pub(super) provider_exposure: ToolExposure,
 }
 
 impl ToolRegistry {
@@ -174,12 +175,10 @@ impl ToolRegistry {
         context: ToolContext<'_>,
     ) -> ToolOutput {
         let Some((handler, definition)) = self.get_for_code_mode(name) else {
-            let Some(provider) = self.providers.iter().find(|provider| {
-                provider
-                    .available_definitions()
-                    .iter()
-                    .any(|definition| definition.name() == name)
-            }) else {
+            let Some(provider) = self
+                .code_mode_providers()
+                .find(|provider| provider.contains(name))
+            else {
                 return ToolOutput::error(format!("unsupported nested tool call: {name}"));
             };
             if let Some(execution) = provider.execute(name, input, context).await {
@@ -246,6 +245,7 @@ impl ToolRegistry {
             definitions,
             by_name,
             providers: Vec::new(),
+            provider_exposure: ToolExposure::CodeModeOnly,
         }
     }
 
@@ -285,6 +285,12 @@ impl ToolRegistry {
             return None;
         }
         Some((self.ordered.get(index)?, self.definitions.get(index)?))
+    }
+
+    fn code_mode_providers(&self) -> impl Iterator<Item = &Arc<dyn DynamicToolProvider>> {
+        self.providers
+            .iter()
+            .filter(|_| self.provider_exposure.is_available_in_code_mode())
     }
 
     pub(crate) fn definitions(&self) -> &[ToolDefinition] {
@@ -333,8 +339,7 @@ impl ToolRegistry {
             .map(|definition| crate::selection::normalize_public_tool_name(definition.name()))
             .collect::<HashSet<_>>();
         let mut summaries = self
-            .providers
-            .iter()
+            .code_mode_providers()
             .flat_map(|provider| provider.code_mode_tool_summaries())
             .filter_map(|(name, description)| {
                 let normalized = crate::selection::normalize_public_tool_name(&name);
@@ -354,8 +359,7 @@ impl ToolRegistry {
             .filter(|(_, exposure)| exposure.is_available_in_code_mode())
             .map(|(definition, _)| definition.clone())
             .chain(
-                self.providers
-                    .iter()
+                self.code_mode_providers()
                     .flat_map(|provider| provider.available_definitions()),
             )
             .filter(|definition| {

--- a/crates/nanocodex-tools/src/runtime/selection.rs
+++ b/crates/nanocodex-tools/src/runtime/selection.rs
@@ -73,6 +73,12 @@ pub trait DynamicToolProvider: Send + Sync {
         self.direct_tools()
     }
 
+    /// Reserves fixed runtime names before asynchronous discovery begins.
+    ///
+    /// Providers that discover tools after build time must omit names that
+    /// would collide with this fixed catalog.
+    fn reserve_names(&self, _names: &[String]) {}
+
     /// Returns deferred tools currently callable from new Code Mode cells.
     fn available_definitions(&self) -> Vec<ToolDefinition>;
 
@@ -173,7 +179,6 @@ impl ToolSource for crate::mcp::Mcp {
 pub struct Tools {
     exposure: ToolExposure,
     workspace: bool,
-    plan: bool,
     web_search: bool,
     image_generation: bool,
     #[cfg(all(not(target_family = "wasm"), feature = "native"))]
@@ -206,7 +211,6 @@ impl Default for Tools {
         Self {
             exposure: ToolExposure::default(),
             workspace: true,
-            plan: false,
             web_search: true,
             image_generation: true,
             #[cfg(all(not(target_family = "wasm"), feature = "native"))]
@@ -244,7 +248,6 @@ impl fmt::Debug for Tools {
             .debug_struct("Tools")
             .field("exposure", &self.exposure)
             .field("workspace", &self.workspace)
-            .field("plan", &self.plan)
             .field("web_search", &self.web_search)
             .field("image_generation", &self.image_generation)
             .field("working_directory", &self.working_directory)
@@ -287,7 +290,6 @@ impl fmt::Debug for Tools {
         debug
             .field("exposure", &self.exposure)
             .field("workspace", &self.workspace)
-            .field("plan", &self.plan)
             .field("web_search", &self.web_search)
             .field("image_generation", &self.image_generation)
             .field(
@@ -334,12 +336,6 @@ impl Tools {
     #[must_use]
     pub const fn workspace_enabled(&self) -> bool {
         self.workspace
-    }
-
-    /// Returns whether the host-owned task-plan tool is enabled.
-    #[must_use]
-    pub const fn plan_enabled(&self) -> bool {
-        self.plan
     }
 
     /// Returns whether the standard web-search tool is enabled.
@@ -494,7 +490,6 @@ impl ToolsBuilder {
     #[must_use]
     pub const fn without_defaults(mut self) -> Self {
         self.tools.workspace = false;
-        self.tools.plan = false;
         self.tools.web_search = false;
         self.tools.image_generation = false;
         self
@@ -518,16 +513,6 @@ impl ToolsBuilder {
     #[cfg(target_family = "wasm")]
     pub const fn workspace(mut self, enabled: bool) -> Self {
         self.tools.workspace = enabled;
-        self
-    }
-
-    /// Enables or disables the host-owned task-plan tool.
-    ///
-    /// The plan tool is disabled by default and is independent of workspace
-    /// command and file access.
-    #[must_use]
-    pub const fn plan(mut self, enabled: bool) -> Self {
-        self.tools.plan = enabled;
         self
     }
 
@@ -723,6 +708,27 @@ impl ToolsBuilder {
             }
         }
         #[cfg(all(not(target_family = "wasm"), feature = "native"))]
+        {
+            let mut reserved = names.iter().cloned().collect::<Vec<_>>();
+            reserved.extend(enabled_built_in_names(&self.tools).map(str::to_owned));
+            reserved.extend([
+                "exec".to_owned(),
+                "wait".to_owned(),
+                "tool_search".to_owned(),
+            ]);
+            reserved.extend(
+                reserved
+                    .clone()
+                    .into_iter()
+                    .map(|name| normalize_public_tool_name(&name)),
+            );
+            reserved.sort();
+            reserved.dedup();
+            for provider in &self.tools.providers {
+                provider.reserve_names(&reserved);
+            }
+        }
+        #[cfg(all(not(target_family = "wasm"), feature = "native"))]
         for provider in &self.tools.providers {
             for definition in provider.available_definitions() {
                 let name = definition.name();
@@ -872,7 +878,6 @@ fn built_in_name(tools: &Tools, name: &str) -> bool {
             name,
             "exec_command" | "write_stdin" | "apply_patch" | "view_image"
         ))
-        || (tools.plan && name == "update_plan")
         || (tools.web_search && name == "web__run")
         || (tools.image_generation && name == "image_gen__imagegen")
 }
@@ -882,7 +887,6 @@ fn enabled_built_in_names(tools: &Tools) -> impl Iterator<Item = &'static str> {
     [
         (tools.workspace, "exec_command"),
         (tools.workspace, "write_stdin"),
-        (tools.plan, "update_plan"),
         (tools.workspace, "apply_patch"),
         (tools.workspace, "view_image"),
         (tools.web_search, "web__run"),

--- a/crates/nanocodex-tools/src/runtime/selection.rs
+++ b/crates/nanocodex-tools/src/runtime/selection.rs
@@ -173,6 +173,7 @@ impl ToolSource for crate::mcp::Mcp {
 pub struct Tools {
     exposure: ToolExposure,
     workspace: bool,
+    plan: bool,
     web_search: bool,
     image_generation: bool,
     #[cfg(all(not(target_family = "wasm"), feature = "native"))]
@@ -205,6 +206,7 @@ impl Default for Tools {
         Self {
             exposure: ToolExposure::default(),
             workspace: true,
+            plan: false,
             web_search: true,
             image_generation: true,
             #[cfg(all(not(target_family = "wasm"), feature = "native"))]
@@ -242,6 +244,7 @@ impl fmt::Debug for Tools {
             .debug_struct("Tools")
             .field("exposure", &self.exposure)
             .field("workspace", &self.workspace)
+            .field("plan", &self.plan)
             .field("web_search", &self.web_search)
             .field("image_generation", &self.image_generation)
             .field("working_directory", &self.working_directory)
@@ -284,6 +287,7 @@ impl fmt::Debug for Tools {
         debug
             .field("exposure", &self.exposure)
             .field("workspace", &self.workspace)
+            .field("plan", &self.plan)
             .field("web_search", &self.web_search)
             .field("image_generation", &self.image_generation)
             .field(
@@ -304,7 +308,7 @@ impl fmt::Debug for Tools {
 }
 
 impl Tools {
-    /// Starts a builder with all standard tools enabled.
+    /// Starts a builder with the default built-ins enabled.
     #[must_use]
     pub fn builder() -> ToolsBuilder {
         ToolsBuilder::default()
@@ -330,6 +334,12 @@ impl Tools {
     #[must_use]
     pub const fn workspace_enabled(&self) -> bool {
         self.workspace
+    }
+
+    /// Returns whether the host-owned task-plan tool is enabled.
+    #[must_use]
+    pub const fn plan_enabled(&self) -> bool {
+        self.plan
     }
 
     /// Returns whether the standard web-search tool is enabled.
@@ -471,9 +481,9 @@ impl ToolsBuilder {
 
     /// Selects whether registered tools are also exposed directly to the model.
     ///
-    /// The default is [`ToolExposure::CodeModeOnly`]. This changes only the
-    /// model-visible declaration set; all registered handlers remain callable
-    /// from Code Mode.
+    /// The default is [`ToolExposure::CodeModeOnly`]. Handlers remain
+    /// registered for direct runtime dispatch, while Code Mode dispatch honors
+    /// each tool's selected exposure.
     #[must_use]
     pub const fn exposure(mut self, exposure: ToolExposure) -> Self {
         self.tools.exposure = exposure;
@@ -484,12 +494,13 @@ impl ToolsBuilder {
     #[must_use]
     pub const fn without_defaults(mut self) -> Self {
         self.tools.workspace = false;
+        self.tools.plan = false;
         self.tools.web_search = false;
         self.tools.image_generation = false;
         self
     }
 
-    /// Enables or disables the standard command, patch, plan, and file tools.
+    /// Enables or disables the standard command, patch, and file tools.
     #[must_use]
     #[cfg(not(target_family = "wasm"))]
     #[allow(clippy::missing_const_for_fn)]
@@ -502,11 +513,21 @@ impl ToolsBuilder {
         self
     }
 
-    /// Enables or disables the standard command, patch, plan, and file tools.
+    /// Enables or disables the standard command, patch, and file tools.
     #[must_use]
     #[cfg(target_family = "wasm")]
     pub const fn workspace(mut self, enabled: bool) -> Self {
         self.tools.workspace = enabled;
+        self
+    }
+
+    /// Enables or disables the host-owned task-plan tool.
+    ///
+    /// The plan tool is disabled by default and is independent of workspace
+    /// command and file access.
+    #[must_use]
+    pub const fn plan(mut self, enabled: bool) -> Self {
+        self.tools.plan = enabled;
         self
     }
 
@@ -849,8 +870,9 @@ fn built_in_name(tools: &Tools, name: &str) -> bool {
     (tools.workspace
         && matches!(
             name,
-            "exec_command" | "write_stdin" | "update_plan" | "apply_patch" | "view_image"
+            "exec_command" | "write_stdin" | "apply_patch" | "view_image"
         ))
+        || (tools.plan && name == "update_plan")
         || (tools.web_search && name == "web__run")
         || (tools.image_generation && name == "image_gen__imagegen")
 }
@@ -860,7 +882,7 @@ fn enabled_built_in_names(tools: &Tools) -> impl Iterator<Item = &'static str> {
     [
         (tools.workspace, "exec_command"),
         (tools.workspace, "write_stdin"),
-        (tools.workspace, "update_plan"),
+        (tools.plan, "update_plan"),
         (tools.workspace, "apply_patch"),
         (tools.workspace, "view_image"),
         (tools.web_search, "web__run"),

--- a/crates/nanocodex-tools/src/runtime/tests.rs
+++ b/crates/nanocodex-tools/src/runtime/tests.rs
@@ -663,6 +663,90 @@ fn per_tool_exposure_selects_direct_and_code_mode_surfaces_independently() {
     );
 }
 
+#[tokio::test]
+async fn code_mode_cannot_guess_direct_only_or_hidden_tools() {
+    let tools = Tools::builder()
+        .without_defaults()
+        .tool_with_exposure(
+            NamedTool {
+                name: "direct_only",
+                output: "direct",
+            },
+            ToolExposure::DirectOnly,
+        )
+        .tool_with_exposure(
+            NamedTool {
+                name: "hidden",
+                output: "hidden",
+            },
+            ToolExposure::Hidden,
+        )
+        .build()
+        .unwrap();
+    let runtime = ToolRuntime::new_with_tools(".", None, None, &tools);
+
+    let execution = runtime
+        .execute_code(
+            r#"
+for (const name of ["direct_only", "hidden"]) {
+  try {
+    await tools[name]({});
+  } catch (_) {}
+}
+"#,
+            ToolContext::new(
+                "test-model",
+                "test-session",
+                "test-call",
+                &[],
+                DEFAULT_TOOL_OUTPUT_TOKENS,
+            ),
+        )
+        .await;
+
+    assert!(execution.success);
+    assert_eq!(execution.nested_calls.len(), 2);
+    assert!(execution.nested_calls.iter().all(|call| !call.success));
+    assert_eq!(
+        execution.nested_calls[0].structured_result,
+        json!("unsupported nested tool call: direct_only")
+    );
+    assert_eq!(
+        execution.nested_calls[1].structured_result,
+        json!("unsupported nested tool call: hidden")
+    );
+}
+
+#[test]
+fn update_plan_is_disabled_by_default_and_independent_of_workspace() {
+    let defaults = Tools::builder().build().unwrap();
+    assert!(!defaults.plan_enabled());
+    let defaults = ToolRuntime::new_with_tools(".", None, None, &defaults);
+    assert!(
+        defaults
+            .model_contract("test-session")
+            .1
+            .iter()
+            .all(|(_, name)| name != "update_plan")
+    );
+
+    let plan_only = Tools::builder()
+        .without_defaults()
+        .plan(true)
+        .build()
+        .unwrap();
+    assert!(plan_only.plan_enabled());
+    assert!(!plan_only.workspace_enabled());
+    let plan_only = ToolRuntime::new_with_tools(".", None, None, &plan_only);
+    assert!(
+        plan_only
+            .model_contract("test-session")
+            .1
+            .iter()
+            .any(|(_, name)| name == "update_plan")
+    );
+}
+
 #[test]
 fn registered_normalized_code_mode_name_collisions_are_rejected() {
     let result = Tools::builder()

--- a/crates/nanocodex-tools/src/runtime/tests.rs
+++ b/crates/nanocodex-tools/src/runtime/tests.rs
@@ -717,10 +717,54 @@ for (const name of ["direct_only", "hidden"]) {
     );
 }
 
+#[tokio::test]
+async fn code_mode_cannot_guess_providers_hidden_by_global_exposure() {
+    for exposure in [ToolExposure::DirectOnly, ToolExposure::Hidden] {
+        let tools = Tools::builder()
+            .without_defaults()
+            .exposure(exposure)
+            .provider(DeclaredProvider {
+                name: "provider_only",
+                parallel_safe: false,
+                output: "provider",
+            })
+            .build()
+            .unwrap();
+        let runtime = ToolRuntime::new_with_tools(".", None, None, &tools);
+
+        assert!(
+            runtime
+                .model_contract("test-session")
+                .1
+                .iter()
+                .all(|(_, name)| name != "provider_only")
+        );
+        let execution = runtime
+            .registry
+            .execute_nested(
+                "provider_only",
+                json!({}),
+                ToolContext::new(
+                    "test-model",
+                    "test-session",
+                    "test-call",
+                    &[],
+                    DEFAULT_TOOL_OUTPUT_TOKENS,
+                ),
+            )
+            .await;
+        assert!(!execution.success);
+        assert!(matches!(
+            execution.output,
+            ToolOutputBody::Text(output)
+                if output == "unsupported nested tool call: provider_only"
+        ));
+    }
+}
+
 #[test]
 fn update_plan_is_disabled_by_default_and_independent_of_workspace() {
     let defaults = Tools::builder().build().unwrap();
-    assert!(!defaults.plan_enabled());
     let defaults = ToolRuntime::new_with_tools(".", None, None, &defaults);
     assert!(
         defaults
@@ -732,10 +776,9 @@ fn update_plan_is_disabled_by_default_and_independent_of_workspace() {
 
     let plan_only = Tools::builder()
         .without_defaults()
-        .plan(true)
+        .tool(crate::standard::UpdatePlanTool::new())
         .build()
         .unwrap();
-    assert!(plan_only.plan_enabled());
     assert!(!plan_only.workspace_enabled());
     let plan_only = ToolRuntime::new_with_tools(".", None, None, &plan_only);
     assert!(

--- a/crates/nanocodex-tools/src/shell/tool.rs
+++ b/crates/nanocodex-tools/src/shell/tool.rs
@@ -132,11 +132,6 @@ fn shell_response_text(result: &super::ExecCommandResult) -> String {
 #[serde(deny_unknown_fields)]
 struct ExecCommandArguments {
     cmd: String,
-    // Codex exposes these approval metadata fields even under a fixed
-    // full-access/never-ask policy. Nanocodex accepts but does not act on
-    // them; this does not add a second approval or sandbox policy owner.
-    #[serde(default)]
-    _justification: Option<String>,
     #[serde(default)]
     workdir: Option<String>,
     #[serde(default)]
@@ -149,10 +144,6 @@ struct ExecCommandArguments {
     yield_time_ms: Option<u64>,
     #[serde(default)]
     max_output_tokens: Option<usize>,
-    #[serde(default)]
-    _prefix_rule: Option<Vec<String>>,
-    #[serde(default)]
-    _sandbox_permissions: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -171,9 +162,12 @@ struct WriteStdinArguments {
 mod tests {
     use std::{path::PathBuf, sync::Arc};
 
+    use nanocodex_oai_api::tools::DEFAULT_TOOL_OUTPUT_TOKENS;
+    use serde_json::{json, value::to_raw_value};
+
     use super::{ExecCommandHandler, Tool, shell_execution};
     use crate::{
-        ToolOutputBody,
+        ToolContext, ToolInput, ToolOutputBody,
         shell::{ExecCommandResult, ShellSessions},
     };
 
@@ -194,6 +188,46 @@ mod tests {
                 .and_then(serde_json::Value::as_str),
             Some("string")
         );
+        for unsupported in ["justification", "prefix_rule", "sandbox_permissions"] {
+            assert!(
+                spec.pointer(&format!("/parameters/properties/{unsupported}"))
+                    .is_none()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn exec_command_rejects_unsupported_approval_and_sandbox_fields() {
+        let handler = ExecCommandHandler::new(PathBuf::from("/"), Arc::new(ShellSessions::new()));
+        for (field, value) in [
+            ("justification", json!("approve this")),
+            ("prefix_rule", json!(["git", "pull"])),
+            ("sandbox_permissions", json!("require_escalated")),
+        ] {
+            let mut arguments = json!({ "cmd": "true" });
+            arguments[field] = value;
+            let result = handler
+                .execute(
+                    ToolInput::Function(to_raw_value(&arguments).unwrap()),
+                    ToolContext::new(
+                        "test-model",
+                        "test-session",
+                        "test-call",
+                        &[],
+                        DEFAULT_TOOL_OUTPUT_TOKENS,
+                    ),
+                )
+                .await;
+            let Err(error) = result else {
+                panic!("exec_command accepted unsupported field {field}");
+            };
+            assert!(
+                error
+                    .to_string()
+                    .contains(&format!("unknown field `{field}`")),
+                "{error}"
+            );
+        }
     }
 
     #[test]

--- a/crates/nanocodex-tools/src/standard.rs
+++ b/crates/nanocodex-tools/src/standard.rs
@@ -66,10 +66,6 @@ fn exec_command_definition(name: &'static str) -> ToolDefinition {
             "type": "object",
             "properties": {
                 "cmd": { "type": "string", "description": "Shell command to execute." },
-                "justification": {
-                    "type": "string",
-                    "description": "User-facing approval question for `require_escalated`; omit otherwise."
-                },
                 "workdir": {
                     "type": "string",
                     "description": "Working directory for the command. Defaults to the turn cwd."
@@ -93,16 +89,6 @@ fn exec_command_definition(name: &'static str) -> ToolDefinition {
                 "max_output_tokens": {
                     "type": "number",
                     "description": "Output token budget. Defaults to 10000 tokens; larger requests may be capped by policy."
-                },
-                "prefix_rule": {
-                    "type": "array",
-                    "items": { "type": "string" },
-                    "description": "Reusable approval prefix for `cmd`, only with `sandbox_permissions: \"require_escalated\"`; for example [\"git\", \"pull\"]."
-                },
-                "sandbox_permissions": {
-                    "type": "string",
-                    "enum": ["use_default", "require_escalated"],
-                    "description": "Per-command sandbox override. Defaults to `use_default`; use `require_escalated` for unsandboxed execution."
                 }
             },
             "required": ["cmd"],
@@ -283,6 +269,12 @@ mod tests {
             exec["parameters"]["properties"]["max_output_tokens"]["type"],
             "number"
         );
+        for unsupported in ["justification", "prefix_rule", "sandbox_permissions"] {
+            assert!(
+                exec["parameters"]["properties"].get(unsupported).is_none(),
+                "full-access exec_command must not advertise {unsupported}"
+            );
+        }
 
         let write_definition = StandardTool::WriteStdin.definition();
         let write = serde_json::to_value(&write_definition).unwrap();

--- a/crates/nanocodex-tools/tests/fixtures/mcp-stdio-server.mjs
+++ b/crates/nanocodex-tools/tests/fixtures/mcp-stdio-server.mjs
@@ -28,7 +28,7 @@ lines.on("line", (line) => {
       id: request.id,
       result: {
         protocolVersion: request.params.protocolVersion,
-        capabilities: { tools: {}, resources: {} },
+        capabilities: { tools: {} },
         serverInfo: { name: "nanocodex-test-mcp", version: "0.1.0" },
       },
     });
@@ -114,43 +114,5 @@ lines.on("line", (line) => {
         },
       });
     }, delayMs);
-  } else if (request.method === "resources/list") {
-    const secondPage = request.params?.cursor === "fixture-next";
-    send({
-      jsonrpc: "2.0",
-      id: request.id,
-      result: {
-        resources: [{
-          uri: secondPage ? "fixture://second" : "fixture://first",
-          name: secondPage ? "fixture-second" : "fixture-first",
-          mimeType: "text/plain",
-        }],
-        ...(secondPage ? {} : { nextCursor: "fixture-next" }),
-      },
-    });
-  } else if (request.method === "resources/templates/list") {
-    send({
-      jsonrpc: "2.0",
-      id: request.id,
-      result: {
-        resourceTemplates: [{
-          uriTemplate: "fixture://item/{id}",
-          name: "fixture-item",
-          mimeType: "text/plain",
-        }],
-      },
-    });
-  } else if (request.method === "resources/read") {
-    send({
-      jsonrpc: "2.0",
-      id: request.id,
-      result: {
-        contents: [{
-          uri: request.params.uri,
-          mimeType: "text/plain",
-          text: "fixture resource body",
-        }],
-      },
-    });
   }
 });

--- a/crates/nanocodex-tools/tests/it/tracing.rs
+++ b/crates/nanocodex-tools/tests/it/tracing.rs
@@ -4,7 +4,7 @@ use std::sync::{
 };
 
 use nanocodex_tools::{
-    ToolContext, ToolInput, contract::DEFAULT_TOOL_OUTPUT_TOKENS, runtime::ToolRuntime,
+    ToolContext, ToolInput, Tools, contract::DEFAULT_TOOL_OUTPUT_TOKENS, runtime::ToolRuntime,
 };
 use serde_json::{json, value::to_raw_value};
 use tracing::{Instrument, Subscriber, span::Attributes};
@@ -120,7 +120,8 @@ fn direct_runtime_execution_emits_the_tools_owned_span() {
         std::process::id()
     ));
     std::fs::create_dir_all(&workspace).unwrap();
-    let tools = ToolRuntime::new(&workspace, None, None);
+    let selected = Tools::builder().plan(true).build().unwrap();
+    let tools = ToolRuntime::new_with_tools(&workspace, None, None, &selected);
     let history = Vec::new();
     let context = ToolContext::new(
         "test-model",

--- a/crates/nanocodex-tools/tests/it/tracing.rs
+++ b/crates/nanocodex-tools/tests/it/tracing.rs
@@ -5,6 +5,7 @@ use std::sync::{
 
 use nanocodex_tools::{
     ToolContext, ToolInput, Tools, contract::DEFAULT_TOOL_OUTPUT_TOKENS, runtime::ToolRuntime,
+    standard::UpdatePlanTool,
 };
 use serde_json::{json, value::to_raw_value};
 use tracing::{Instrument, Subscriber, span::Attributes};
@@ -120,7 +121,10 @@ fn direct_runtime_execution_emits_the_tools_owned_span() {
         std::process::id()
     ));
     std::fs::create_dir_all(&workspace).unwrap();
-    let selected = Tools::builder().plan(true).build().unwrap();
+    let selected = Tools::builder()
+        .tool(UpdatePlanTool::new())
+        .build()
+        .unwrap();
     let tools = ToolRuntime::new_with_tools(&workspace, None, None, &selected);
     let history = Vec::new();
     let context = ToolContext::new(


### PR DESCRIPTION
## Outcome

Aligns the supported Nanocodex tool surface with the current local Codex source snapshot (`openai/codex@2e5ee418ad6bef8b418ba1a809cfa53a56ae4aee`) while keeping the SDK boundary narrow.

MCP remains tool-only: `tool_search` discovers callable MCP tools and Code Mode invokes them. This PR intentionally does not add MCP resource listing, templates, or resource-read tools. Context controls (`new_context` / compaction) remain isolated in #225.

## Changes

- Enforce direct, Code Mode, hidden, and provider exposure consistently, including embedded runtimes and late-discovered normalized-name collisions.
- Make `update_plan` explicitly installed by TUI policy instead of coupling it to workspace access; keep its handler parse-only like Codex.
- Reject unsupported approval/sandbox fields from the full-access shell schema.
- Preserve image detail in retained typed history while stripping it only from Responses Lite request copies; retain bounded typed audio outputs.
- Fail malformed successful native `tool_search` responses instead of silently returning no tools.
- Fence stale MCP catalog entries, make reload replacement all-or-nothing, revoke on shutdown, retain OAuth refresh persistence, and enforce per-call/per-server/per-tool output budgets in normal and attached execution.
- Register and exercise the existing real CLI integration target across eight chained turns.

## Size

Net diff: **+1,172 / -258 LOC**. The earlier resource-oriented implementation was removed and autosquashed out of the PR history.

## Verification

- `cargo test -p nanocodex-tools --lib` — 222 passed, 1 ignored
- `cargo test -p nanocodex-oai-api --lib` — 153 passed, 1 ignored
- `cargo test -p nanocodex-agent --test it model::tools` — 14 passed
- `cargo test -p nanocodex-vm composes_vm_workspace_tools_without_implicitly_enabling_plan` — passed
- `cargo test -p nanocodex-bin --test it repeated_cli_turns_search_and_call_mcp_through_the_library` — passed; eight chained `tool_search` + MCP calls with cache accounting
- `cargo check -p nanocodex-bin`
- `scripts/check-crate-boundaries.sh`
- `cargo fmt --all -- --check`
- `git diff --check`

A live two-turn run through the built CLI against the real OpenAI Responses WebSocket also completed `tool_search -> mcp__fixture__echo -> final answer` twice on one session. Cached input tokens were 7,936 on both first-turn continuations and 7,936 / 8,960 / 8,960 across the second turn model calls.