### PR TITLE
fix(dev): stabilize Cloudflare WASM startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   while keeping explicit browser selection strict.
 - [web] Prepare the managed QuickJS WASM asset before starting Cloudflare Vite
   development workers.
-- [vite] Serialize concurrent Rust/WASM binding generation across dev workers.
+- [vite] Serialize concurrent Rust/WASM binding generation across dev workers and
+  reject incomplete generated glue caches.
 
 ## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [cli] Fall back to another installed Chromium-family browser when the default
   Brave installation is absent, or omit browser tools when none is available,
   while keeping explicit browser selection strict.
+- [web] Prepare the managed QuickJS WASM asset before starting Cloudflare Vite
+  development workers.
+- [vite] Serialize concurrent Rust/WASM binding generation across dev workers.
 
 ## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12
 

--- a/js/account/package.json
+++ b/js/account/package.json
@@ -8,11 +8,12 @@
   },
   "scripts": {
     "dev": "portless",
+    "predev:app": "pnpm --filter nanocodex-managed-service run prepare:code-evaluator",
     "dev:app": "CLOUDFLARE_ENV=development vite",
     "sync": "node scripts/sync-nanocodex.mjs",
     "publish:repository": "node scripts/publish-repository.mjs",
     "test": "npm run test:web",
-    "test:web": "node --experimental-strip-types --test worker/*.test.ts",
+    "test:web": "node --experimental-strip-types --test startup.test.mjs worker/*.test.ts",
     "typecheck": "tsc --noEmit",
     "check:docs": "node scripts/check-docs.mjs",
     "gen:types": "wrangler types",

--- a/js/account/startup.test.mjs
+++ b/js/account/startup.test.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const packageJson = JSON.parse(await readFile(
+  new URL("./package.json", import.meta.url),
+  "utf8",
+));
+
+test("web development prepares the managed QuickJS WASM asset before Vite", () => {
+  assert.match(
+    packageJson.scripts["predev:app"] ?? "",
+    /prepare:code-evaluator/,
+  );
+  assert.match(packageJson.scripts["dev:app"] ?? "", /vite/);
+});

--- a/js/nanocodex-vite/scripts/build-js-package.sh
+++ b/js/nanocodex-vite/scripts/build-js-package.sh
@@ -29,6 +29,8 @@ fi
 stamp_path="js/nanocodex/pkg-web/.nanocodex-bindgen-stamp"
 fingerprint="$(wasm-bindgen --version; "$binaryen" --version; printf 'worker-bundler-v1-simd\n'; cksum < "$wasm_artifact")"
 if [[ -f "$stamp_path" ]] \
+  && [[ -f js/nanocodex/pkg-web/nanocodex.js ]] \
+  && [[ -f js/nanocodex/pkg-web/nanocodex.d.ts ]] \
   && [[ -f js/nanocodex/pkg-web/nanocodex_bg.wasm ]] \
   && [[ -f js/nanocodex/pkg-web/nanocodex_bg.js ]] \
   && [[ -f js/nanocodex/pkg-web/nanocodex_worker.js ]] \

--- a/js/nanocodex-vite/scripts/build-js-package.sh
+++ b/js/nanocodex-vite/scripts/build-js-package.sh
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$repository_root"
+# Vite consumers start this builder in separate processes. Serialize the whole
+# generation so the cache check and in-place Node glue rewrite are atomic.
+if [[ "${NANOCODEX_WASM_BUILD_LOCK_HELD:-}" != "1" ]]; then
+  exec node "$repository_root/js/nanocodex-vite/scripts/build-lock.mjs" \
+    "$repository_root/js/nanocodex/pkg-web/.nanocodex-bindgen.lock" \
+    "$script_path" "$@"
+fi
+
 
 wasm_target=wasm32-unknown-unknown
 target_dir="${CARGO_TARGET_DIR:-$repository_root/target}"

--- a/js/nanocodex-vite/scripts/build-js-package.sh
+++ b/js/nanocodex-vite/scripts/build-js-package.sh
@@ -33,6 +33,8 @@ if [[ -f "$stamp_path" ]] \
   && [[ -f js/nanocodex/pkg-web/nanocodex_bg.js ]] \
   && [[ -f js/nanocodex/pkg-web/nanocodex_worker.js ]] \
   && [[ -f js/nanocodex/pkg-node/nanocodex.js ]] \
+  && [[ -f js/nanocodex/pkg-node/nanocodex.d.ts ]] \
+  && [[ -f js/nanocodex/pkg-node/package.json ]] \
   && [[ "$(<"$stamp_path")" == "$fingerprint" ]] \
   && node js/nanocodex/scripts/write-wasm-attestation.mjs --check-cache "$wasm_artifact" 2>/dev/null; then
   node js/nanocodex/scripts/write-wasm-attestation.mjs "$wasm_artifact"

--- a/js/nanocodex-vite/scripts/build-lock.mjs
+++ b/js/nanocodex-vite/scripts/build-lock.mjs
@@ -1,0 +1,123 @@
+import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
+import { mkdir, open, readFile, rename, rm, stat } from "node:fs/promises";
+import { dirname } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const POLL_INTERVAL_MS = 50;
+const STALE_LOCK_GRACE_MS = 5_000;
+
+export async function withBuildLock(lockPath, operation, {
+  pollIntervalMs = POLL_INTERVAL_MS,
+  staleLockGraceMs = STALE_LOCK_GRACE_MS,
+} = {}) {
+  const owner = await acquireBuildLock(lockPath, { pollIntervalMs, staleLockGraceMs });
+  try {
+    return await operation();
+  } finally {
+    await releaseBuildLock(lockPath, owner);
+  }
+}
+
+async function acquireBuildLock(lockPath, { pollIntervalMs, staleLockGraceMs }) {
+  await mkdir(dirname(lockPath), { recursive: true });
+  const owner = { pid: process.pid, token: randomUUID() };
+
+  for (;;) {
+    try {
+      const handle = await open(lockPath, "wx");
+      try {
+        await handle.writeFile(`${JSON.stringify(owner)}\n`, "utf8");
+      } finally {
+        await handle.close();
+      }
+      return owner;
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      if (await reclaimStaleBuildLock(lockPath, staleLockGraceMs)) continue;
+      await delay(pollIntervalMs);
+    }
+  }
+}
+
+async function releaseBuildLock(lockPath, owner) {
+  try {
+    const current = JSON.parse(await readFile(lockPath, "utf8"));
+    if (current.pid === owner.pid && current.token === owner.token) {
+      await rm(lockPath, { force: true });
+    }
+  } catch (error) {
+    if (error?.code !== "ENOENT" && !(error instanceof SyntaxError)) throw error;
+  }
+}
+
+async function reclaimStaleBuildLock(lockPath, graceMs) {
+  let current;
+  let metadata;
+  try {
+    [current, metadata] = await Promise.all([
+      readFile(lockPath, "utf8"),
+      stat(lockPath),
+    ]);
+  } catch (error) {
+    return error?.code === "ENOENT";
+  }
+
+  let owner;
+  try {
+    owner = JSON.parse(current);
+  } catch {
+    owner = undefined;
+  }
+  if (owner && processIsAlive(owner.pid)) return false;
+  if (!owner && Date.now() - metadata.mtimeMs < graceMs) return false;
+
+  const stalePath = `${lockPath}.stale-${process.pid}-${randomUUID()}`;
+  try {
+    await rename(lockPath, stalePath);
+  } catch (error) {
+    return error?.code === "ENOENT";
+  }
+  await rm(stalePath, { force: true });
+  return true;
+}
+
+function processIsAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function runCommand(lockPath, command, arguments_) {
+  await withBuildLock(lockPath, () => new Promise((resolve, reject) => {
+    const child = spawn(command, arguments_, {
+      env: { ...process.env, NANOCODEX_WASM_BUILD_LOCK_HELD: "1" },
+      stdio: "inherit",
+    });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${command} exited with ${code ?? signal}`));
+    });
+    for (const signal of ["SIGINT", "SIGTERM"]) {
+      process.once(signal, () => child.kill(signal));
+    }
+  }));
+}
+
+const invoked = process.argv[1]
+  ? pathToFileURL(process.argv[1]).href
+  : undefined;
+if (invoked === import.meta.url) {
+  const [lockPath, command, ...arguments_] = process.argv.slice(2);
+  if (!lockPath || !command) throw new Error("build lock requires a lock path and command");
+  await runCommand(lockPath, command, arguments_);
+}

--- a/js/nanocodex-vite/scripts/build-lock.mjs
+++ b/js/nanocodex-vite/scripts/build-lock.mjs
@@ -99,17 +99,44 @@ function delay(milliseconds) {
 async function runCommand(lockPath, command, arguments_) {
   await withBuildLock(lockPath, () => new Promise((resolve, reject) => {
     const child = spawn(command, arguments_, {
+      detached: process.platform !== "win32",
       env: { ...process.env, NANOCODEX_WASM_BUILD_LOCK_HELD: "1" },
       stdio: "inherit",
     });
-    child.once("error", reject);
+    const signals = process.platform === "win32"
+      ? ["SIGINT", "SIGTERM"]
+      : ["SIGINT", "SIGTERM", "SIGHUP", "SIGQUIT"];
+    const signalHandlers = new Map();
+    const removeSignalHandlers = () => {
+      for (const [signal, handler] of signalHandlers) {
+        process.removeListener(signal, handler);
+      }
+    };
+    const forwardSignal = (signal) => {
+      if (process.platform === "win32" || typeof child.pid !== "number") {
+        child.kill(signal);
+        return;
+      }
+      try {
+        process.kill(-child.pid, signal);
+      } catch (error) {
+        if (error?.code !== "ESRCH") child.kill(signal);
+      }
+    };
+    for (const signal of signals) {
+      const handler = () => forwardSignal(signal);
+      signalHandlers.set(signal, handler);
+      process.once(signal, handler);
+    }
+    child.once("error", (error) => {
+      removeSignalHandlers();
+      reject(error);
+    });
     child.once("exit", (code, signal) => {
+      removeSignalHandlers();
       if (code === 0) resolve();
       else reject(new Error(`${command} exited with ${code ?? signal}`));
     });
-    for (const signal of ["SIGINT", "SIGTERM"]) {
-      process.once(signal, () => child.kill(signal));
-    }
   }));
 }
 

--- a/js/nanocodex-vite/test/build-lock.test.mjs
+++ b/js/nanocodex-vite/test/build-lock.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+import { test } from "node:test";
+
+const buildLockModule = fileURLToPath(new URL("../scripts/build-lock.mjs", import.meta.url));
+
+test("the build lock serializes concurrent WASM generators", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "nanocodex-build-lock-"));
+  const lockPath = join(directory, "nanocodex.lock");
+  const eventsPath = join(directory, "events.log");
+  const workerPath = join(directory, "worker.mjs");
+  await writeFile(workerPath, `
+    import { appendFile } from "node:fs/promises";
+    import { withBuildLock } from ${JSON.stringify(buildLockModule)};
+
+    const [lockPath, eventsPath] = process.argv.slice(2);
+    await withBuildLock(lockPath, async () => {
+      await appendFile(eventsPath, "start\\n");
+      await new Promise((resolve) => setTimeout(resolve, 75));
+      await appendFile(eventsPath, "end\\n");
+    });
+  `);
+
+  try {
+    await Promise.all([
+      runWorker(workerPath, lockPath, eventsPath),
+      runWorker(workerPath, lockPath, eventsPath),
+    ]);
+    const events = (await readFile(eventsPath, "utf8")).trim().split("\n");
+    let active = 0;
+    let maximumActive = 0;
+    for (const event of events) {
+      if (event === "start") active += 1;
+      if (event === "end") active -= 1;
+      maximumActive = Math.max(maximumActive, active);
+    }
+    assert.deepEqual(events, ["start", "end", "start", "end"]);
+    assert.equal(maximumActive, 1);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+function runWorker(workerPath, lockPath, eventsPath) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [workerPath, lockPath, eventsPath], {
+      stdio: "ignore",
+    });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (code === 0) resolve();
+      else reject(new Error(`build-lock worker exited with ${code ?? signal}`));
+    });
+  });
+}

--- a/js/nanocodex-vite/test/build-lock.test.mjs
+++ b/js/nanocodex-vite/test/build-lock.test.mjs
@@ -89,8 +89,13 @@ test("signals terminate the whole generator process group", {
   }
 });
 
-test("the WASM cache requires every Node package artifact", async () => {
-  for (const missingArtifact of ["nanocodex.d.ts", "package.json"]) {
+test("the WASM cache requires every generated glue artifact", async () => {
+  for (const [missingPackage, missingArtifact] of [
+    ["pkg-web", "nanocodex.js"],
+    ["pkg-web", "nanocodex.d.ts"],
+    ["pkg-node", "nanocodex.d.ts"],
+    ["pkg-node", "package.json"],
+  ]) {
     const directory = await mkdtemp(join(tmpdir(), "nanocodex-build-cache-"));
     const repository = join(directory, "repository");
     const scripts = join(repository, "js/nanocodex-vite/scripts");
@@ -115,19 +120,16 @@ test("the WASM cache requires every Node package artifact", async () => {
       await chmod(builder, 0o755);
       await writeFile(wasmArtifact, "fake wasm\n");
       await Promise.all([
+        writeFile(join(webPackage, "nanocodex.js"), "web glue\n"),
+        writeFile(join(webPackage, "nanocodex.d.ts"), "web types\n"),
         writeFile(join(webPackage, "nanocodex_bg.wasm"), "web wasm\n"),
         writeFile(join(webPackage, "nanocodex_bg.js"), "web glue\n"),
         writeFile(join(webPackage, "nanocodex_worker.js"), "worker glue\n"),
         writeFile(join(nodePackage, "nanocodex.js"), "node glue\n"),
+        writeFile(join(nodePackage, "nanocodex.d.ts"), "node types\n"),
+        writeFile(join(nodePackage, "package.json"), '{"type":"commonjs"}\n'),
       ]);
-      if (missingArtifact !== "nanocodex.d.ts") {
-        await writeFile(join(nodePackage, "nanocodex.d.ts"), "node types\n");
-      } else {
-        await rm(join(nodePackage, missingArtifact), { force: true });
-      }
-      if (missingArtifact !== "package.json") {
-        await writeFile(join(nodePackage, "package.json"), '{"type":"commonjs"}\n');
-      }
+      await rm(join(repository, missingPackage, missingArtifact), { force: true });
       await writeFakeCommand(fakeBin, "cargo", "exit 0");
       await writeFakeCommand(
         fakeBin,

--- a/js/nanocodex-vite/test/build-lock.test.mjs
+++ b/js/nanocodex-vite/test/build-lock.test.mjs
@@ -1,13 +1,13 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { execFileSync, spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { spawn } from "node:child_process";
 import { test } from "node:test";
 
 const buildLockModule = fileURLToPath(new URL("../scripts/build-lock.mjs", import.meta.url));
-
+const buildScript = fileURLToPath(new URL("../scripts/build-js-package.sh", import.meta.url));
 test("the build lock serializes concurrent WASM generators", async () => {
   const directory = await mkdtemp(join(tmpdir(), "nanocodex-build-lock-"));
   const lockPath = join(directory, "nanocodex.lock");
@@ -44,6 +44,158 @@ test("the build lock serializes concurrent WASM generators", async () => {
     await rm(directory, { recursive: true, force: true });
   }
 });
+
+test("signals terminate the whole generator process group", {
+  skip: process.platform === "win32",
+}, async () => {
+  const directory = await mkdtemp(join(tmpdir(), "nanocodex-build-lock-signal-"));
+  const lockPath = join(directory, "nanocodex.lock");
+  const markerPath = join(directory, "marker.log");
+  const workerPath = join(directory, "worker.mjs");
+  await writeFile(workerPath, `
+    import { appendFile } from "node:fs/promises";
+    const [markerPath] = process.argv.slice(2);
+    await appendFile(markerPath, "started\\n");
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    await appendFile(markerPath, "survived\\n");
+  `);
+
+  const child = spawn(
+    process.execPath,
+    [
+      buildLockModule,
+      lockPath,
+      "sh",
+      "-c",
+      '"$1" "$2" "$3"',
+      "nanocodex-signal-test",
+      process.execPath,
+      workerPath,
+      markerPath,
+    ],
+    { stdio: "ignore" },
+  );
+  try {
+    await waitForFile(markerPath);
+    child.kill("SIGTERM");
+    const result = await waitForExit(child);
+    assert.notEqual(result.code, 0);
+    await new Promise((resolve) => setTimeout(resolve, 650));
+    assert.equal(await readFile(markerPath, "utf8"), "started\n");
+    await assert.rejects(readFile(lockPath), { code: "ENOENT" });
+  } finally {
+    child.kill("SIGKILL");
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("the WASM cache requires every Node package artifact", async () => {
+  for (const missingArtifact of ["nanocodex.d.ts", "package.json"]) {
+    const directory = await mkdtemp(join(tmpdir(), "nanocodex-build-cache-"));
+    const repository = join(directory, "repository");
+    const scripts = join(repository, "js/nanocodex-vite/scripts");
+    const webPackage = join(repository, "js/nanocodex/pkg-web");
+    const nodePackage = join(repository, "js/nanocodex/pkg-node");
+    const fakeBin = join(directory, "bin");
+    const markerPath = join(directory, "wasm-bindgen-called");
+    const builder = join(scripts, "build-js-package.sh");
+    const wasmArtifact = join(
+      repository,
+      "target/wasm32-unknown-unknown/wasm/nanocodex_wasm.wasm",
+    );
+    try {
+      await Promise.all([
+        mkdir(scripts, { recursive: true }),
+        mkdir(webPackage, { recursive: true }),
+        mkdir(nodePackage, { recursive: true }),
+        mkdir(fakeBin, { recursive: true }),
+        mkdir(join(repository, "target/wasm32-unknown-unknown/wasm"), { recursive: true }),
+      ]);
+      await copyFile(buildScript, builder);
+      await chmod(builder, 0o755);
+      await writeFile(wasmArtifact, "fake wasm\n");
+      await Promise.all([
+        writeFile(join(webPackage, "nanocodex_bg.wasm"), "web wasm\n"),
+        writeFile(join(webPackage, "nanocodex_bg.js"), "web glue\n"),
+        writeFile(join(webPackage, "nanocodex_worker.js"), "worker glue\n"),
+        writeFile(join(nodePackage, "nanocodex.js"), "node glue\n"),
+      ]);
+      if (missingArtifact !== "nanocodex.d.ts") {
+        await writeFile(join(nodePackage, "nanocodex.d.ts"), "node types\n");
+      } else {
+        await rm(join(nodePackage, missingArtifact), { force: true });
+      }
+      if (missingArtifact !== "package.json") {
+        await writeFile(join(nodePackage, "package.json"), '{"type":"commonjs"}\n');
+      }
+      await writeFakeCommand(fakeBin, "cargo", "exit 0");
+      await writeFakeCommand(
+        fakeBin,
+        "wasm-bindgen",
+        'if [ "$1" = "--version" ]; then echo wasm-bindgen-test; else printf called > "$NANOCODEX_WASM_BINDGEN_MARKER"; exit 17; fi',
+      );
+      await writeFakeCommand(fakeBin, "node", "exit 0");
+      await writeFakeCommand(
+        join(repository, "js/nanocodex/node_modules/.bin"),
+        "wasm-opt",
+        'if [ "$1" = "--version" ]; then echo wasm-opt-test; else exit 17; fi',
+      );
+      const checksum = execFileSync("cksum", [wasmArtifact], { encoding: "utf8" }).trim();
+      await writeFile(
+        join(webPackage, ".nanocodex-bindgen-stamp"),
+        `wasm-bindgen-test\nwasm-opt-test\nworker-bundler-v1-simd\n${checksum}\n`,
+      );
+      const result = await runProcess(builder, {
+        cwd: repository,
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH}`,
+          NANOCODEX_WASM_BUILD_LOCK_HELD: "1",
+          NANOCODEX_WASM_BINDGEN_MARKER: markerPath,
+          CARGO_TARGET_DIR: join(repository, "target"),
+        },
+      });
+      assert.notEqual(result.code, 0, `cache incorrectly accepted missing ${missingArtifact}`);
+      assert.equal(await readFile(markerPath, "utf8"), "called");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  }
+});
+
+async function writeFakeCommand(directory, name, body) {
+  await mkdir(directory, { recursive: true });
+  const path = join(directory, name);
+  await writeFile(path, `#!/bin/sh\n${body}\n`);
+  await chmod(path, 0o755);
+}
+
+async function waitForFile(path) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    try {
+      return await readFile(path, "utf8");
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+  throw new Error(`timed out waiting for ${path}`);
+}
+
+function waitForExit(child) {
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => resolve({ code, signal }));
+  });
+}
+
+function runProcess(command, { cwd, env }) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, [], { cwd, env, stdio: "ignore" });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => resolve({ code, signal }));
+  });
+}
 
 function runWorker(workerPath, lockPath, eventsPath) {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
### Summary

Fixes local Cloudflare development startup failures caused by concurrent WASM generation and missing generated QuickJS assets.

### Problems

- Multiple Cloudflare Vite workers could invoke the shared Rust/WASM builder concurrently.
- Concurrent builders could observe or write partially generated artifacts.
- The managed auxiliary Worker imported quickjs.wasm, but web development did not prepare that generated, gitignored asset before Vite startup.

### Changes

- Added an atomic cross-process lock around the complete Rust/WASM generation flow.
- Added stale-lock recovery and owner-token validation.
- Forwarded termination signals to the complete Unix generator process group.
- Ensured signal handlers are removed after the generator exits.
- Expanded the WASM cache check to require all generated Node package artifacts:
  - nanocodex.js
  - nanocodex.d.ts
  - package.json
- Added predev:app preparation for the managed QuickJS WASM asset.
- Added regression coverage for:
  - concurrent builders
  - nested-process termination
  - incomplete Node artifact caches
  - web development preparation wiring

### Verification

- nanocodex-web: 43 tests passed.
- nanocodex-web typecheck passed.
- nanocodex-vite: 11 tests passed.
- nanocodex-vite test typecheck passed.
- Concurrent WASM generation serialized successfully.
- Nested generator processes terminate with the wrapper.
- Incomplete Node artifacts correctly force regeneration.
- Clean web development startup regenerates QuickJS WASM and reaches Vite ready state.
- Standalone production web build succeeds without a pre-existing QuickJS asset.