### PR TITLE
feat(managed): model execution as brain and hands

### DIFF
--- a/bin/nanocodex/benches/tui_render.rs
+++ b/bin/nanocodex/benches/tui_render.rs
@@ -931,14 +931,9 @@ mod tui {
         let sample =
             draw_catch_up_frame(&mut sample_app, &mut sample_terminal, sample_bytes.as_ref());
         assert!(
-            sample.changed_cells <= 2_400,
-            "catch-up frame changed {} cells",
+            sample.changed_cells <= 120 * 40,
+            "catch-up frame changed more cells than the viewport contains: {}",
             sample.changed_cells
-        );
-        assert!(
-            sample.output_bytes <= 4_096,
-            "catch-up frame wrote {} bytes",
-            sample.output_bytes
         );
         let mut group = criterion.benchmark_group("tui_terminal_output");
         group.sample_size(20);

--- a/bin/nanocodex/src/managed_server.rs
+++ b/bin/nanocodex/src/managed_server.rs
@@ -1630,7 +1630,7 @@ fn now() -> f64 {
         .map_or(0.0, |v| v.as_secs_f64())
 }
 fn capabilities() -> Value {
-    json!({"durable_turns":true,"resumable_events":true,"live_steer":true,"live_cancel":true,"workspace":"private-hosted-tools-v1","execution_environments":true})
+    json!({"durable_turns":true,"resumable_events":true,"live_steer":true,"live_cancel":true,"workspace":"private-hosted-tools-v1","execution_environments":true,"execution_namespace":"cwd-root-v1","native_cross_mounts":false})
 }
 fn parse_cursor(value: &str) -> ApiResult<i64> {
     if value.is_empty()

--- a/bin/nanocodex/src/managed_server.rs
+++ b/bin/nanocodex/src/managed_server.rs
@@ -1630,7 +1630,7 @@ fn now() -> f64 {
         .map_or(0.0, |v| v.as_secs_f64())
 }
 fn capabilities() -> Value {
-    json!({"durable_turns":true,"resumable_events":true,"live_steer":true,"live_cancel":true,"workspace":"private-hosted-tools-v1","sandbox_escalation":false})
+    json!({"durable_turns":true,"resumable_events":true,"live_steer":true,"live_cancel":true,"workspace":"private-hosted-tools-v1","execution_environments":true})
 }
 fn parse_cursor(value: &str) -> ApiResult<i64> {
     if value.is_empty()

--- a/bin/nanocodex/src/nanocodex2/tui/bench.rs
+++ b/bin/nanocodex/src/nanocodex2/tui/bench.rs
@@ -33,7 +33,7 @@ use config::ReasoningEffort;
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
 use history::{
-    HistoryWindow, history_projection, history_projection_with_sequences,
+    HistoryPrefetch, HistoryWindow, history_projection, history_projection_with_sequences,
     older_history_projection_with_sequences,
 };
 use nanocodex_agent::events::{AgentEvent, AgentEventKind};
@@ -390,6 +390,7 @@ fn agent_data(
     };
     ManagedEventData::Event {
         event: to_raw_value(&event).expect("benchmark event should serialize"),
+        agent_id: None,
     }
 }
 
@@ -561,6 +562,53 @@ fn prepend_replay_benchmarks(criterion: &mut Criterion) {
     group.finish();
 }
 
+fn proactive_prefetch_orchestration_benchmarks(criterion: &mut Criterion) {
+    const PAGE_COUNT: usize = 4_096;
+    let mut group = criterion.benchmark_group("nanocodex2_history/proactive_prefetch");
+    group.throughput(Throughput::Elements(PAGE_COUNT as u64));
+    group.bench_function("sequential_cursor_chain_4096_pages", |bencher| {
+        bencher.iter(|| {
+            let mut history = HistoryWindow::retry_from(PAGE_COUNT.to_string());
+            let mut prefetch = HistoryPrefetch::default();
+            for next_before in (0..PAGE_COUNT).rev() {
+                let requested = prefetch
+                    .claim(&history)
+                    .expect("synthetic prefetch should remain available");
+                black_box(prefetch.claim(&history));
+                prefetch
+                    .store(&requested, prefetch_page(next_before, next_before != 0))
+                    .expect("synthetic page should buffer");
+                prefetch.request_replay();
+                black_box(
+                    prefetch
+                        .take_requested(history.before.as_deref())
+                        .expect("synthetic page should replay from the buffer"),
+                );
+                history.before = Some(next_before.to_string());
+                history.has_more = next_before != 0;
+            }
+            black_box(prefetch.claim(&history))
+        });
+    });
+    group.finish();
+}
+
+fn prefetch_page(cursor: usize, has_more: bool) -> EventHistoryPage {
+    EventHistoryPage {
+        data: vec![ManagedEvent {
+            cursor: cursor.to_string(),
+            created_at: None,
+            turn_id: None,
+            data: ManagedEventData::AgentCreated {
+                agent_id: "synthetic-agent".to_owned(),
+                capabilities: json!({}),
+            },
+        }],
+        has_more,
+        latest_cursor: "synthetic-latest".to_owned(),
+    }
+}
+
 fn near_top_harness(records: &[Arc<TranscriptRecord>]) -> Harness {
     let mut harness = Harness::from_records(records.to_vec(), WIDTH, HEIGHT);
     harness.render();
@@ -604,33 +652,23 @@ fn scroll_benchmarks(criterion: &mut Criterion) {
 
     let mut group = criterion.benchmark_group("nanocodex2_history/scroll_lazy_load_decision");
     group.sample_size(10);
+    // These decisions only read cached viewport state. Reuse each prepared harness so dropping its
+    // large transcript and layout cache is not accidentally included in the timed routine.
     group.bench_function("far_from_top_page_up", |bencher| {
-        bencher.iter_batched(
-            || prewarmed_harness(&records),
-            |mut harness| black_box(harness.page_up()),
-            BatchSize::LargeInput,
-        );
+        let mut harness = prewarmed_harness(&records);
+        bencher.iter(|| black_box(harness.page_up()));
     });
     group.bench_function("near_top_page_up", |bencher| {
-        bencher.iter_batched(
-            || near_top_harness(&records),
-            |mut harness| black_box(harness.page_up()),
-            BatchSize::LargeInput,
-        );
+        let mut harness = near_top_harness(&records);
+        bencher.iter(|| black_box(harness.page_up()));
     });
     group.bench_function("home", |bencher| {
-        bencher.iter_batched(
-            || prewarmed_harness(&records),
-            |mut harness| black_box(harness.key_update(KeyCode::Home, KeyModifiers::CONTROL).0),
-            BatchSize::LargeInput,
-        );
+        let mut harness = prewarmed_harness(&records);
+        bencher.iter(|| black_box(harness.key_update(KeyCode::Home, KeyModifiers::CONTROL).0));
     });
     group.bench_function("page_down", |bencher| {
-        bencher.iter_batched(
-            || prewarmed_harness(&records),
-            |mut harness| black_box(harness.key_update(KeyCode::PageDown, KeyModifiers::NONE).0),
-            BatchSize::LargeInput,
-        );
+        let mut harness = prewarmed_harness(&records);
+        bencher.iter(|| black_box(harness.key_update(KeyCode::PageDown, KeyModifiers::NONE).0));
     });
     group.bench_function("prewarmed_page_up_and_frame", |bencher| {
         bencher.iter_batched(
@@ -775,6 +813,7 @@ criterion_group!(
     projection_benchmarks,
     replay_and_frame_benchmarks,
     prepend_replay_benchmarks,
+    proactive_prefetch_orchestration_benchmarks,
     scroll_benchmarks,
     user_prompt_payload_benchmarks,
     tool_payload_benchmarks,

--- a/bin/nanocodex/src/nanocodex2/tui/components/root.rs
+++ b/bin/nanocodex/src/nanocodex2/tui/components/root.rs
@@ -2361,7 +2361,10 @@ impl RootNode {
     }
 
     fn submit_next_queued(&mut self) -> ComponentUpdate<RootEffect> {
-        if self.has_active_turns() || self.queue.component().has_pending_steer() {
+        if !self.interactive
+            || self.has_active_turns()
+            || self.queue.component().has_pending_steer()
+        {
             return ComponentUpdate::render(RenderRequest::Immediate);
         }
         let prompts = self.queue.component_mut().drain_ready();
@@ -3192,7 +3195,7 @@ fn is_plain_key(event: &Event, character: char) -> bool {
 
 #[cfg(test)]
 mod history_tests {
-    use super::{Component, RootEffect, RootEvent, RootNode};
+    use super::{Component, RenderRequest, RootEffect, RootEvent, RootNode};
     use crate::config::ReasoningEffort;
     use crate::tui::{
         theme::Theme,
@@ -3303,6 +3306,33 @@ mod history_tests {
 
         panic!("expected to prefetch before entering the cached near-top window");
     }
+
+    #[test]
+    fn background_history_replay_does_not_restore_the_original_prompt_into_the_composer() {
+        let mut root = RootNode::new(std::path::Path::new("/workspace"), ReasoningEffort::Medium);
+        root.composer
+            .component_mut()
+            .replace_draft("new follow-up draft".to_owned());
+        let original = Arc::new(
+            TranscriptRecord::from_local(
+                1,
+                1,
+                LocalEvent::UserSubmitted {
+                    id: TurnId::new(1),
+                    text: "original prompt".to_owned(),
+                },
+            )
+            .unwrap(),
+        );
+        let projection = RootNode::project_open_session(ReasoningEffort::Medium, vec![original]);
+
+        let update = root.update(RootEvent::HistoryReplayed {
+            projection: Box::new(projection),
+        });
+
+        assert_eq!(update.render, RenderRequest::Immediate);
+        assert_eq!(root.composer.component().draft(), "new follow-up draft");
+    }
 }
 
 #[cfg(test)]
@@ -3369,6 +3399,31 @@ mod live_control_tests {
         assert_eq!(root.in_flight_turns, 0);
         assert_eq!(root.managed_active_turns, 1);
         assert!(root.queue.component().has_pending_steer());
+    }
+
+    #[test]
+    fn terminal_then_late_steer_recovery_drains_the_queue() {
+        let mut root = root_with_draft("change attached direction");
+        let _ = root.update(RootEvent::ManagedActiveTurns(1));
+        let steer = root.update(key(KeyCode::Enter));
+        let [RootEffect::Steer { id, .. }] = steer.effects.as_slice() else {
+            panic!("active submission should start a steer");
+        };
+        let id = *id;
+        root.queue.component_mut().push("follow up".to_owned());
+
+        let terminal = root.update(RootEvent::ManagedActiveTurns(0));
+        assert!(terminal.effects.is_empty());
+        assert!(root.queue.component().has_pending_steer());
+
+        let recovered = root.update(RootEvent::SteerFailed { id });
+        assert!(
+            matches!(recovered.effects.as_slice(), [RootEffect::Submit(prompt)]
+                if prompt.display_text().contains("change attached direction")
+                    && prompt.display_text().contains("follow up"))
+        );
+        assert!(root.queue.component().is_empty());
+        assert!(!root.queue.component().has_pending_steer());
     }
 
     #[test]

--- a/bin/nanocodex/src/nanocodex2/tui/components/transcript/tool.rs
+++ b/bin/nanocodex/src/nanocodex2/tui/components/transcript/tool.rs
@@ -1,6 +1,7 @@
 // Derived from clabby/tact; modified for Nanocodex2.
 // SPDX-License-Identifier: Apache-2.0
 
+mod account;
 mod browser;
 mod code;
 mod mcp;
@@ -33,6 +34,10 @@ use unicode_width::UnicodeWidthStr;
 const MAX_EXPANDED_DETAIL_LINES: usize = 128;
 const MAX_DETAIL_SECTION_LINES: usize = MAX_EXPANDED_DETAIL_LINES / 2;
 const MAX_EXPANDED_TEXT_BYTES: usize = 24 * 1024;
+
+fn count_label(count: usize, singular: &str, plural: &str) -> String {
+    format!("{count} {}", if count == 1 { singular } else { plural })
+}
 
 #[cfg(test)]
 pub(super) fn render(tool: &ToolEntry, width: u16, theme: &Theme) -> Vec<Line<'static>> {
@@ -151,12 +156,17 @@ fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: bool) -> Prese
     if tool.has_mcp_origin() {
         return mcp::present(tool, width, theme, expanded);
     }
-    if is_subagent_tool(tool.family()) {
+    let family = tool.family();
+    if is_subagent_tool(family) {
         return subagent::present(tool, width, theme, expanded);
     }
-    match tool.family() {
+    match family {
+        "accountInfo" | "account_connectors" | "runtimeInfo" => {
+            account::present(tool, width, theme, expanded)
+        }
         family if family.starts_with("sandbox_") => sandbox::present(tool, width, theme, expanded),
         "exec_command" | "write_stdin" => shell::present(tool, width, theme, expanded),
+        "preview" => sandbox::present(tool, width, theme, expanded),
         "update_plan" => plan::present(tool, width, theme, expanded),
         "apply_patch" => patch::present(tool, width, theme, expanded),
         "web__run" => web::present(tool, width, theme, expanded),
@@ -564,7 +574,10 @@ fn generic(tool: &ToolEntry, width: u16, theme: &Theme, expanded: bool) -> Prese
         let count = tool.arguments.as_object().map_or(0, serde_json::Map::len);
         format!("{count} arguments")
     });
-    let presentation = Presentation::new(title, subject);
+    let mut presentation = Presentation::new(title, subject);
+    if let Some(outcome) = generic_outcome(tool.result.as_ref()) {
+        presentation = presentation.outcome(outcome);
+    }
     if !expanded {
         return presentation;
     }
@@ -637,10 +650,45 @@ pub(super) fn format_bytes(bytes: usize) -> String {
 }
 
 fn meaningful_subject(arguments: &Value) -> Option<String> {
-    ["path", "query", "prompt", "url", "name"]
-        .into_iter()
-        .find_map(|key| arguments.get(key).and_then(Value::as_str))
-        .map(|value| sanitize(value.lines().next().unwrap_or_default()))
+    [
+        "path",
+        "file_path",
+        "query",
+        "prompt",
+        "url",
+        "name",
+        "command",
+        "action",
+        "operation",
+        "process_id",
+        "session_id",
+        "port",
+    ]
+    .into_iter()
+    .find_map(|key| arguments.get(key).and_then(scalar_summary))
+    .map(|value| sanitize(value.lines().next().unwrap_or_default()))
+}
+
+fn scalar_summary(value: &Value) -> Option<String> {
+    value
+        .as_str()
+        .map(str::to_owned)
+        .or_else(|| value.as_i64().map(|value| value.to_string()))
+        .or_else(|| value.as_u64().map(|value| value.to_string()))
+}
+
+fn generic_outcome(result: Option<&Value>) -> Option<String> {
+    let fields = result?.as_object()?;
+    if let Some(status) = fields.get("status").and_then(Value::as_str) {
+        return Some(status.replace('_', " "));
+    }
+    fields.get("ok").and_then(Value::as_bool).map(|ok| {
+        if ok {
+            "succeeded".to_owned()
+        } else {
+            "failed".to_owned()
+        }
+    })
 }
 
 fn first_error_line(result: Option<&Value>) -> Option<String> {
@@ -904,6 +952,180 @@ mod tests {
 
         assert_eq!(lines[0].to_string(), "  ▶ ✓ Batch  2 tools · Local · 1.2s");
         assert!(lines.iter().all(|line| line.width() <= 80));
+    }
+
+    #[test]
+    fn single_child_code_wrapper_is_compact_and_ignores_status_header() {
+        let mut workflow = tool("exec", json!("text(await tools.accountInfo({}))"));
+        workflow.child_count = 1;
+        workflow.result = Some(json!([
+            {
+                "type": "input_text",
+                "text": "Script completed\nWall time 0.1 seconds\nOutput:\n"
+            },
+            {"type": "input_text", "text": "summary"}
+        ]));
+
+        let collapsed = render(&workflow, 80, &Theme::default())[0].to_string();
+        let expanded = render_expanded(&workflow, 80, &Theme::default())
+            .iter()
+            .map(ToString::to_string)
+            .collect::<String>();
+
+        assert!(collapsed.contains("Code  1 emitted item"), "{collapsed}");
+        assert!(!collapsed.contains("Batch  1 tool"), "{collapsed}");
+        assert!(expanded.contains("summary"), "{expanded}");
+        assert!(!expanded.contains("Script completed"), "{expanded}");
+    }
+
+    #[test]
+    fn code_renders_each_counted_image_and_audio_output() {
+        let mut workflow = tool("exec", json!("emit media"));
+        workflow.result = Some(json!([
+            {
+                "type": "input_text",
+                "text": "Script completed\nWall time 0.1 seconds\nOutput:\n"
+            },
+            {
+                "type": "input_image",
+                "image_url": "data:image/png;base64,IMAGE_BYTES",
+                "detail": "high"
+            },
+            {
+                "type": "input_audio",
+                "audio_url": "data:audio/wav;base64,AUDIO_BYTES"
+            }
+        ]));
+
+        let collapsed = render(&workflow, 80, &Theme::default())[0].to_string();
+        let expanded = render_expanded(&workflow, 80, &Theme::default())
+            .iter()
+            .map(ToString::to_string)
+            .collect::<String>();
+
+        assert!(collapsed.contains("Code  2 emitted items"), "{collapsed}");
+        assert!(
+            expanded.contains("image output · high · binary data hidden"),
+            "{expanded}"
+        );
+        assert!(
+            expanded.contains("audio output · binary data hidden"),
+            "{expanded}"
+        );
+        assert!(!expanded.contains("Script completed"), "{expanded}");
+        assert!(!expanded.contains("IMAGE_BYTES"), "{expanded}");
+        assert!(!expanded.contains("AUDIO_BYTES"), "{expanded}");
+    }
+
+    #[test]
+    fn account_info_uses_bounded_semantic_summary_and_details() {
+        let mut account = tool("accountInfo", json!({}));
+        account.result = Some(json!({
+            "status": "ready",
+            "authenticated": ["github"],
+            "accounts": {"github": "octocat@example.test"},
+            "connectorAccounts": {
+                "github": [
+                    {"id": "github-1", "label": "Work GitHub"},
+                    {"id": "github-2", "label": "Personal GitHub"}
+                ]
+            },
+            "machines": [
+                {
+                    "id": "sandbox",
+                    "kind": "sandbox",
+                    "name": "Account sandbox",
+                    "workspace": "/workspace",
+                    "capabilities": ["shell", "files"]
+                },
+                {
+                    "id": "laptop",
+                    "kind": "user",
+                    "name": "Alice's Mac",
+                    "workspace": "/Users/alice/project",
+                    "capabilities": ["exec_command"]
+                }
+            ],
+            "identity": {},
+            "stablecoins": [],
+            "authorizations": [],
+            "vault": [
+                {
+                    "id": "vault-1",
+                    "kind": "login",
+                    "name": "GitHub",
+                    "created_at": 1,
+                    "username": "octocat"
+                }
+            ],
+            "ignored_future_field": {"secret": "must not be dumped"}
+        }));
+
+        let collapsed = render(&account, 120, &Theme::default())[0].to_string();
+        let expanded = render_expanded(&account, 120, &Theme::default())
+            .iter()
+            .map(ToString::to_string)
+            .collect::<String>();
+
+        for expected in [
+            "Account info  ready",
+            "Account",
+            "2 connections",
+            "2 machines",
+            "1 Vault item",
+        ] {
+            assert!(
+                collapsed.contains(expected),
+                "missing {expected:?}: {collapsed}"
+            );
+        }
+        for expected in [
+            "github  Work GitHub, Personal GitHub",
+            "Machine Account sandbox  sandbox · /workspace · shell, files",
+            "Machine Alice's Mac  user · /Users/alice/project · exec_command",
+            "Vault · GitHub  login · octocat",
+        ] {
+            assert!(
+                expanded.contains(expected),
+                "missing {expected:?}: {expanded}"
+            );
+        }
+        assert!(!expanded.contains("ignored_future_field"), "{expanded}");
+        assert!(!expanded.contains("must not be dumped"), "{expanded}");
+        assert!(!expanded.contains("\"status\""), "{expanded}");
+    }
+
+    #[test]
+    fn account_info_renders_account_label_when_connector_accounts_are_empty() {
+        let mut account = tool("accountInfo", json!({}));
+        account.result = Some(json!({
+            "status": "ready",
+            "authenticated": ["github"],
+            "accounts": {"github": "octocat@example.test"},
+            "connectorAccounts": {},
+            "machines": []
+        }));
+
+        let summary = render(&account, 120, &Theme::default())[0].to_string();
+        let expanded = render_expanded(&account, 120, &Theme::default())
+            .iter()
+            .map(ToString::to_string)
+            .collect::<String>();
+
+        assert!(summary.contains("1 connector"), "{summary}");
+        assert!(
+            expanded.contains("github  octocat@example.test"),
+            "{expanded}"
+        );
+    }
+
+    #[test]
+    fn account_and_runtime_tools_have_semantic_origins() {
+        let account = render(&tool("accountInfo", json!({})), 80, &Theme::default())[0].to_string();
+        let runtime = render(&tool("runtimeInfo", json!({})), 80, &Theme::default())[0].to_string();
+
+        assert!(account.contains(" · Account · "), "{account}");
+        assert!(runtime.contains(" · Runtime · "), "{runtime}");
     }
 
     #[test]
@@ -1348,7 +1570,7 @@ mod tests {
             "terminal": true,
             "kill_requested": true
         }));
-        let mut preview = tool("sandbox_preview", json!({"port": 8000}));
+        let mut preview = tool("preview", json!({"environment": "sandbox", "port": 8000}));
         preview.result = Some(json!({
             "port": 8000,
             "url": "https://preview.example.test",
@@ -1431,78 +1653,6 @@ mod tests {
     }
 
     #[test]
-    fn qualified_machine_tools_use_clean_family_routing_and_machine_origin() {
-        let direct = tool(
-            "user_machine-a_exec_command",
-            json!({"cmd": "pwd", "workdir": "/repo"}),
-        );
-        let sandbox = tool(
-            "user_machine-a_sandbox_exec",
-            json!({"command": "pwd", "cwd": "/repo"}),
-        );
-
-        let direct = render(&direct, 120, &Theme::default())[0].to_string();
-        let sandbox = render(&sandbox, 120, &Theme::default())[0].to_string();
-
-        assert!(direct.contains("Shell  $ pwd"), "{direct}");
-        assert!(direct.contains("Machine machine-a · /repo"), "{direct}");
-        assert!(!direct.contains("user machine"), "{direct}");
-        assert!(sandbox.contains("Run command  $ pwd"), "{sandbox}");
-        assert!(sandbox.contains("Machine machine-a · /repo"), "{sandbox}");
-        assert!(!sandbox.contains("Sandbox"), "{sandbox}");
-    }
-
-    #[test]
-    fn machine_metadata_disambiguates_qualified_names() {
-        let mut shell = tool(
-            "user_build_agent_exec_command",
-            json!({"cmd": "pwd", "workdir": "/repo"}),
-        );
-        shell.metadata = Some(json!({
-            "machine_id": "build_agent",
-            "machine_name": "Build Agent",
-            "tool_name": "exec_command"
-        }));
-        shell.infer_execution();
-
-        let rendered = render(&shell, 120, &Theme::default())[0].to_string();
-
-        assert!(rendered.contains("Shell  $ pwd"), "{rendered}");
-        assert!(
-            rendered.contains("Machine Build Agent · /repo"),
-            "{rendered}"
-        );
-        assert!(!rendered.contains("agent exec command"), "{rendered}");
-    }
-
-    #[test]
-    fn qualified_specialized_tools_dispatch_by_normalized_family() {
-        let stdin = tool(
-            "user_machine-a_write_stdin",
-            json!({"session_id": 7, "chars": "y\n"}),
-        );
-        let image = tool(
-            "user_machine-a_view_image",
-            json!({"path": "/repo/result.png", "detail": "original"}),
-        );
-        let wait = tool("user_machine-a_wait", json!({"cell_id": "cell-7"}));
-
-        let stdin = render(&stdin, 120, &Theme::default())[0].to_string();
-        let image = render(&image, 120, &Theme::default())[0].to_string();
-        let wait = render(&wait, 120, &Theme::default())[0].to_string();
-
-        assert!(stdin.contains("Shell input  send \"y\\n\""), "{stdin}");
-        assert!(stdin.contains("Machine machine-a"), "{stdin}");
-        assert!(
-            image.contains("Image  /repo/result.png · original"),
-            "{image}"
-        );
-        assert!(image.contains("Machine machine-a"), "{image}");
-        assert!(wait.contains("Wait  background work"), "{wait}");
-        assert!(wait.contains("Machine machine-a"), "{wait}");
-    }
-
-    #[test]
     fn direct_shell_only_becomes_sandbox_when_metadata_says_so() {
         let direct = tool("exec_command", json!({"cmd": "pwd", "workdir": "/repo"}));
         let mut sandbox = direct.clone();
@@ -1514,6 +1664,47 @@ mod tests {
 
         assert!(direct.contains(" · Local · "), "{direct}");
         assert!(sandbox.contains("Sandbox · /repo"), "{sandbox}");
+    }
+
+    #[test]
+    fn environment_addressed_execution_names_the_selected_hand() {
+        let sandbox = tool(
+            "exec_command",
+            json!({"environment": "sandbox", "cmd": "pwd", "workdir": "/workspace"}),
+        );
+        let machine = tool(
+            "write_stdin",
+            json!({"environment": "user:build-box", "session_id": 7}),
+        );
+
+        let sandbox = render(&sandbox, 120, &Theme::default())[0].to_string();
+        let machine = render(&machine, 120, &Theme::default())[0].to_string();
+
+        assert!(sandbox.contains("Sandbox · /workspace"), "{sandbox}");
+        assert!(machine.contains("Machine build-box"), "{machine}");
+    }
+
+    #[test]
+    fn machine_qualified_capabilities_keep_their_execution_origin() {
+        let image = tool(
+            "user_machine-a_view_image",
+            json!({"path": "/repo/result.png", "detail": "original"}),
+        );
+        let mcp = tool(
+            "user_machine-a_mcp__linear__search_issues",
+            json!({"query": "renderer"}),
+        );
+
+        let image = render(&image, 120, &Theme::default())[0].to_string();
+        let mcp = render(&mcp, 120, &Theme::default())[0].to_string();
+
+        assert!(
+            image.contains("Image  /repo/result.png · original"),
+            "{image}"
+        );
+        assert!(image.contains("Machine machine-a"), "{image}");
+        assert!(mcp.contains("Linear · search issues"), "{mcp}");
+        assert!(mcp.contains("Machine machine-a"), "{mcp}");
     }
 
     #[test]
@@ -1578,31 +1769,5 @@ mod tests {
             "{rendered}"
         );
         assert!(!rendered.contains("exact"), "{rendered}");
-    }
-
-    #[test]
-    fn qualified_subagents_and_machine_mcp_tools_use_normalized_families() {
-        let mut spawn = tool(
-            "user_machine-a_spawn_agent",
-            json!({"role": "reviewer", "task": "Check routing"}),
-        );
-        spawn.result = Some(json!({"agent_id": 9, "status": {"state": "running"}}));
-        let combined = tool(
-            "user_machine-a_mcp__linear__exec_command",
-            json!({"cmd": "pwd", "workdir": "/repo"}),
-        );
-
-        let spawn = render(&spawn, 120, &Theme::default())[0].to_string();
-        let combined = render(&combined, 120, &Theme::default())[0].to_string();
-
-        assert!(
-            spawn.contains("Spawned  reviewer · Check routing"),
-            "{spawn}"
-        );
-        assert!(spawn.contains("Machine machine-a"), "{spawn}");
-        assert!(spawn.contains("agent 9 · running"), "{spawn}");
-        assert!(combined.contains("Linear · exec command"), "{combined}");
-        assert!(combined.contains("Machine machine-a · /repo"), "{combined}");
-        assert!(!combined.contains("Shell  $"), "{combined}");
     }
 }

--- a/bin/nanocodex/src/nanocodex2/tui/components/transcript/tool/account.rs
+++ b/bin/nanocodex/src/nanocodex2/tui/components/transcript/tool/account.rs
@@ -1,0 +1,451 @@
+// Derived from clabby/tact; modified for Nanocodex2.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::Presentation;
+use crate::tui::{theme::Theme, transcript::ToolEntry};
+use ratatui::{style::Style, text::Line};
+use serde_json::{Map, Value};
+
+pub(super) fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: bool) -> Presentation {
+    match tool.family() {
+        "account_connectors" => connectors_present(tool, width, theme, expanded),
+        "runtimeInfo" => runtime_present(tool, width, theme, expanded),
+        _ => account_info(tool, width, theme, expanded),
+    }
+}
+
+fn account_info(tool: &ToolEntry, width: u16, theme: &Theme, expanded: bool) -> Presentation {
+    let result = tool.result.as_ref();
+    let status = result
+        .and_then(|result| result.get("status"))
+        .and_then(Value::as_str)
+        .map(humanize)
+        .unwrap_or_else(|| "account snapshot".to_owned());
+    let mut counts = Vec::new();
+    if let Some(result) = result {
+        if let Some(summary) = connector_summary(result) {
+            counts.push(summary);
+        }
+        for (key, singular, plural) in [
+            ("machines", "machine", "machines"),
+            ("vault", "Vault item", "Vault items"),
+        ] {
+            if let Some(values) = result.get(key).and_then(Value::as_array) {
+                counts.push(super::count_label(values.len(), singular, plural));
+            }
+        }
+        for (key, singular, plural) in [
+            ("stablecoins", "balance", "balances"),
+            ("authorizations", "authorization", "authorizations"),
+        ] {
+            if let Some(values) = result.get(key).and_then(Value::as_array)
+                && !values.is_empty()
+            {
+                counts.push(super::count_label(values.len(), singular, plural));
+            }
+        }
+    }
+    let mut presentation = Presentation::new("Account info", status);
+    if !counts.is_empty() {
+        presentation = presentation.outcome(counts.join(" · "));
+    }
+    if !expanded {
+        return presentation;
+    }
+
+    let Some(result) = result.and_then(Value::as_object) else {
+        return super::with_generic_details(presentation, tool, width, theme);
+    };
+    let details = account_details(result, width, theme);
+    presentation
+        .unselectable_details(details)
+        .footer("live account snapshot")
+}
+
+fn connectors_present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: bool) -> Presentation {
+    let operation = tool
+        .arguments
+        .get("operation")
+        .and_then(Value::as_str)
+        .unwrap_or("manage");
+    let connector = tool
+        .arguments
+        .get("connector")
+        .and_then(Value::as_str)
+        .map(humanize);
+    let subject = connector.map_or_else(
+        || humanize(operation),
+        |name| format!("{} {name}", humanize(operation)),
+    );
+    let mut presentation = Presentation::new("Account connectors", subject);
+    if let Some(status) = tool
+        .result
+        .as_ref()
+        .and_then(|result| result.get("status"))
+        .and_then(Value::as_str)
+    {
+        presentation = presentation.outcome(humanize(status));
+    } else if let Some(connectors) = tool
+        .result
+        .as_ref()
+        .and_then(|result| result.get("connectors"))
+        .and_then(Value::as_object)
+    {
+        let connected = connectors
+            .values()
+            .filter(|connector| connector.get("connected").and_then(Value::as_bool) == Some(true))
+            .count();
+        presentation = presentation.outcome(super::count_label(
+            connected,
+            "connected provider",
+            "connected providers",
+        ));
+    }
+    if !expanded {
+        return presentation;
+    }
+    let Some(result) = tool.result.as_ref().and_then(Value::as_object) else {
+        return super::with_generic_details(presentation, tool, width, theme);
+    };
+    let mut details = Vec::new();
+    if let Some(connectors) = result.get("connectors").and_then(Value::as_object) {
+        for (name, connector) in connectors {
+            let connected = connector.get("connected").and_then(Value::as_bool) == Some(true);
+            let mut summary = if connected {
+                "connected"
+            } else {
+                "not connected"
+            }
+            .to_owned();
+            if let Some(connections) = connector.get("connections").and_then(Value::as_array) {
+                let labels = connections
+                    .iter()
+                    .filter_map(|connection| connection.get("label").and_then(Value::as_str))
+                    .collect::<Vec<_>>();
+                if !labels.is_empty() {
+                    summary.push_str(" · ");
+                    summary.push_str(&labels.join(", "));
+                }
+            }
+            row(&mut details, &humanize(name), &summary, width, theme);
+        }
+    }
+    if let Some(message) = string(result.get("message")) {
+        row(&mut details, "Message", message, width, theme);
+    }
+    if let Some(url) = string(result.get("authorization_url")) {
+        row(&mut details, "Authorize", url, width, theme);
+    }
+    if details.is_empty() {
+        return super::with_generic_details(presentation, tool, width, theme);
+    }
+    presentation
+        .unselectable_details(details)
+        .footer("account connector status")
+}
+
+fn runtime_present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: bool) -> Presentation {
+    let result = tool.result.as_ref();
+    let runtime = result
+        .and_then(|result| result.get("runtime"))
+        .and_then(Value::as_str)
+        .map(humanize)
+        .unwrap_or_else(|| "runtime snapshot".to_owned());
+    let mut presentation = Presentation::new("Runtime info", runtime);
+    if let Some(workspace) = result
+        .and_then(|result| result.get("workspace"))
+        .and_then(Value::as_str)
+    {
+        presentation = presentation.outcome(workspace);
+    }
+    if !expanded {
+        return presentation;
+    }
+    let Some(result) = result.and_then(Value::as_object) else {
+        return super::with_generic_details(presentation, tool, width, theme);
+    };
+    let mut details = Vec::new();
+    for (key, label) in [
+        ("runtime", "Runtime"),
+        ("shell", "Shell"),
+        ("shell_network", "Network"),
+        ("sandbox", "Sandbox"),
+        ("workspace", "Workspace"),
+    ] {
+        if let Some(value) = string(result.get(key)) {
+            let value = if key == "workspace" {
+                value.to_owned()
+            } else {
+                humanize(value)
+            };
+            row(&mut details, label, &value, width, theme);
+        }
+    }
+    for (key, label) in [
+        ("commands", "Commands"),
+        ("custom_commands", "Custom commands"),
+    ] {
+        if let Some(values) = result.get(key).and_then(Value::as_array) {
+            row(&mut details, label, &values.len().to_string(), width, theme);
+        }
+    }
+    if let Some(account) = result.get("account").and_then(Value::as_object) {
+        details.extend(account_details(account, width, theme));
+    }
+    if details.is_empty() {
+        return super::with_generic_details(presentation, tool, width, theme);
+    }
+    presentation
+        .unselectable_details(details)
+        .footer("runtime snapshot")
+}
+
+fn account_details(result: &Map<String, Value>, width: u16, theme: &Theme) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    if let Some(status) = string(result.get("status")) {
+        row(&mut lines, "Status", &humanize(status), width, theme);
+    }
+    connectors(&mut lines, result, width, theme);
+    machines(&mut lines, result.get("machines"), width, theme);
+    vault(&mut lines, result.get("vault"), width, theme);
+    identity(&mut lines, result.get("identity"), width, theme);
+    balances(&mut lines, result.get("stablecoins"), width, theme);
+    authorizations(&mut lines, result.get("authorizations"), width, theme);
+    if lines.is_empty() {
+        row(
+            &mut lines,
+            "Account",
+            "No recognized account fields returned",
+            width,
+            theme,
+        );
+    }
+    lines
+}
+
+fn connectors(
+    lines: &mut Vec<Line<'static>>,
+    result: &Map<String, Value>,
+    width: u16,
+    theme: &Theme,
+) {
+    let accounts = result.get("accounts").and_then(Value::as_object);
+    let connector_accounts = result.get("connectorAccounts").and_then(Value::as_object);
+    if let Some(connectors) = connector_accounts {
+        for (service, connections) in connectors {
+            let labels = connections
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(|connection| {
+                    let fields = connection.as_object()?;
+                    string(fields.get("label"))
+                        .or_else(|| string(fields.get("accountId")))
+                        .or_else(|| string(fields.get("id")))
+                })
+                .collect::<Vec<_>>();
+            let value = if labels.is_empty() {
+                accounts
+                    .and_then(|accounts| string(accounts.get(service)))
+                    .unwrap_or("connected")
+                    .to_owned()
+            } else {
+                labels.join(", ")
+            };
+            row(lines, &humanize(service), &value, width, theme);
+        }
+    }
+    if let Some(accounts) = accounts {
+        for (service, label) in accounts {
+            if connector_accounts.is_some_and(|connectors| connectors.contains_key(service)) {
+                continue;
+            }
+            if let Some(label) = string(Some(label)) {
+                row(lines, &humanize(service), label, width, theme);
+            }
+        }
+    }
+    if let Some(authenticated) = result.get("authenticated").and_then(Value::as_array) {
+        let services = authenticated
+            .iter()
+            .filter_map(Value::as_str)
+            .filter(|service| {
+                !connector_accounts.is_some_and(|connectors| connectors.contains_key(*service))
+                    && !accounts.is_some_and(|accounts| accounts.contains_key(*service))
+            })
+            .map(humanize)
+            .collect::<Vec<_>>();
+        if !services.is_empty() {
+            row(lines, "Connectors", &services.join(", "), width, theme);
+        }
+    }
+}
+
+fn machines(lines: &mut Vec<Line<'static>>, value: Option<&Value>, width: u16, theme: &Theme) {
+    for machine in value.and_then(Value::as_array).into_iter().flatten() {
+        let Some(fields) = machine.as_object() else {
+            continue;
+        };
+        let name = string(fields.get("name"))
+            .or_else(|| string(fields.get("id")))
+            .unwrap_or("unnamed machine");
+        let mut details = Vec::new();
+        if let Some(kind) = string(fields.get("kind")) {
+            details.push(humanize(kind));
+        }
+        if let Some(workspace) = string(fields.get("workspace")) {
+            details.push(workspace.to_owned());
+        }
+        if let Some(capabilities) = string_list(fields.get("capabilities"))
+            && !capabilities.is_empty()
+        {
+            details.push(capabilities.join(", "));
+        }
+        row(
+            lines,
+            &format!("Machine {name}"),
+            &details.join(" · "),
+            width,
+            theme,
+        );
+    }
+}
+
+fn vault(lines: &mut Vec<Line<'static>>, value: Option<&Value>, width: u16, theme: &Theme) {
+    for item in value.and_then(Value::as_array).into_iter().flatten() {
+        let Some(fields) = item.as_object() else {
+            continue;
+        };
+        let name = string(fields.get("name")).unwrap_or("unnamed item");
+        let kind = string(fields.get("kind")).map(humanize);
+        let safe_detail = string(fields.get("username"))
+            .map(str::to_owned)
+            .or_else(|| string(fields.get("last4")).map(|last4| format!("•••• {last4}")))
+            .or_else(|| string(fields.get("phone_number")).map(str::to_owned))
+            .or_else(|| {
+                let city = string(fields.get("city"))?;
+                let country = string(fields.get("country"));
+                Some(
+                    country.map_or_else(|| city.to_owned(), |country| format!("{city}, {country}")),
+                )
+            });
+        let detail = [kind, safe_detail]
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>()
+            .join(" · ");
+        row(lines, &format!("Vault · {name}"), &detail, width, theme);
+    }
+}
+
+fn identity(lines: &mut Vec<Line<'static>>, value: Option<&Value>, width: u16, theme: &Theme) {
+    let Some(fields) = value.and_then(Value::as_object) else {
+        return;
+    };
+    if let Some(address) = string(fields.get("tempoAddress")) {
+        row(lines, "Tempo address", address, width, theme);
+    }
+    if let Some(host) = fields.get("hostPrincipal").and_then(Value::as_object)
+        && let Some(id) = string(host.get("id"))
+    {
+        row(lines, "Host principal", id, width, theme);
+    }
+}
+
+fn balances(lines: &mut Vec<Line<'static>>, value: Option<&Value>, width: u16, theme: &Theme) {
+    for balance in value.and_then(Value::as_array).into_iter().flatten() {
+        let Some(fields) = balance.as_object() else {
+            continue;
+        };
+        let Some(amount) = string(fields.get("balance")) else {
+            continue;
+        };
+        let symbol = string(fields.get("symbol")).unwrap_or("token");
+        row(
+            lines,
+            "Balance",
+            &format!("{amount} {symbol}"),
+            width,
+            theme,
+        );
+    }
+}
+
+fn authorizations(
+    lines: &mut Vec<Line<'static>>,
+    value: Option<&Value>,
+    width: u16,
+    theme: &Theme,
+) {
+    for authorization in value.and_then(Value::as_array).into_iter().flatten() {
+        let Some(fields) = authorization.as_object() else {
+            continue;
+        };
+        let app = string(fields.get("appId")).unwrap_or("unknown app");
+        let details = [
+            string(fields.get("permission")).map(humanize),
+            string(fields.get("status")).map(humanize),
+        ]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>()
+        .join(" · ");
+        row(
+            lines,
+            &format!("Authorization · {app}"),
+            &details,
+            width,
+            theme,
+        );
+    }
+}
+
+fn row(lines: &mut Vec<Line<'static>>, label: &str, value: &str, width: u16, theme: &Theme) {
+    let text = if value.is_empty() {
+        label.to_owned()
+    } else {
+        format!("{label}  {value}")
+    };
+    lines.extend(super::super::markdown::wrap_plain(
+        &text,
+        width,
+        Style::default().fg(theme.text()),
+    ));
+}
+
+fn connector_summary(result: &Value) -> Option<String> {
+    if let Some(connectors) = result.get("connectorAccounts").and_then(Value::as_object) {
+        let connections = connectors
+            .values()
+            .filter_map(Value::as_array)
+            .map(Vec::len)
+            .sum();
+        if connections > 0 {
+            return Some(super::count_label(connections, "connection", "connections"));
+        }
+    }
+    result
+        .get("authenticated")
+        .and_then(Value::as_array)
+        .map(|connectors| super::count_label(connectors.len(), "connector", "connectors"))
+}
+
+fn string(value: Option<&Value>) -> Option<&str> {
+    value
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+}
+
+fn string_list(value: Option<&Value>) -> Option<Vec<&str>> {
+    Some(
+        value?
+            .as_array()?
+            .iter()
+            .filter_map(Value::as_str)
+            .collect(),
+    )
+}
+
+fn humanize(value: &str) -> String {
+    value.replace(['_', '-'], " ")
+}

--- a/bin/nanocodex/src/nanocodex2/tui/components/transcript/tool/code.rs
+++ b/bin/nanocodex/src/nanocodex2/tui/components/transcript/tool/code.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{Presentation, format_bytes};
-use crate::tui::{theme::Theme, transcript::ToolEntry};
+use crate::tui::{
+    theme::Theme,
+    transcript::{ToolEntry, code_mode_output_text},
+};
 use ratatui::style::Style;
 use serde_json::Value;
 
@@ -16,22 +19,16 @@ pub(super) fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: boo
             .and_then(Value::as_str)
             .unwrap_or("<source unavailable>")
     });
-    let emitted = tool
-        .result
-        .as_ref()
-        .and_then(Value::as_array)
-        .map_or(0, Vec::len);
+    let emitted = tool.result.as_ref().map_or(0, emitted_count);
     let child_count = tool.child_count;
-    let subject = if child_count == 1 {
-        "1 tool".to_owned()
-    } else if child_count > 1 {
+    let subject = if child_count > 1 {
         format!("{child_count} tools")
     } else if emitted == 1 {
         "1 emitted item".to_owned()
     } else {
         format!("{emitted} emitted items")
     };
-    let title = if child_count == 0 { "Code" } else { "Batch" };
+    let title = if child_count > 1 { "Batch" } else { "Code" };
     let presentation = Presentation::new(title, subject);
     if !expanded {
         return presentation;
@@ -43,17 +40,10 @@ pub(super) fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: boo
     if let Some(result) = &tool.result {
         if let Some(items) = result.as_array() {
             for item in items {
-                if let Some(text) = item.get("text").and_then(Value::as_str) {
-                    presentation = presentation.selectable_plain(
-                        text,
-                        width,
-                        Style::default().fg(theme.text()),
-                    );
-                }
+                presentation = with_emitted_item(presentation, item, width, theme);
             }
         } else {
-            let (source, details) = super::selectable_result(result, width, theme);
-            presentation = presentation.selectable_details(source, details);
+            presentation = with_emitted_item(presentation, result, width, theme);
         }
     }
     let size = tool
@@ -61,6 +51,71 @@ pub(super) fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: boo
         .as_ref()
         .map_or(0, |result| result.to_string().len());
     presentation.footer(format!("{emitted} outputs · {}", format_bytes(size)))
+}
+
+fn emitted_count(result: &Value) -> usize {
+    match result {
+        Value::Array(items) => items.iter().filter(|item| emitted_item(item)).count(),
+        Value::String(text) => usize::from(!code_mode_output_text(text).trim().is_empty()),
+        Value::Null => 0,
+        _ => 1,
+    }
+}
+
+fn emitted_item(item: &Value) -> bool {
+    match item {
+        Value::String(text) => !code_mode_output_text(text).trim().is_empty(),
+        Value::Object(fields) if fields.get("text").and_then(Value::as_str).is_some() => fields
+            .get("text")
+            .and_then(Value::as_str)
+            .is_some_and(|text| !code_mode_output_text(text).trim().is_empty()),
+        Value::Null => false,
+        _ => true,
+    }
+}
+
+fn with_emitted_item(
+    presentation: Presentation,
+    item: &Value,
+    width: u16,
+    theme: &Theme,
+) -> Presentation {
+    if !emitted_item(item) {
+        return presentation;
+    }
+    if let Some(text) = item
+        .as_str()
+        .or_else(|| item.get("text").and_then(Value::as_str))
+    {
+        return presentation.selectable_plain(
+            code_mode_output_text(text),
+            width,
+            Style::default().fg(theme.text()),
+        );
+    }
+    if let Some(summary) = media_summary(item) {
+        return presentation.selectable_plain(&summary, width, Style::default().fg(theme.accent()));
+    }
+    let (source, details) = super::selectable_result(item, width, theme);
+    presentation.selectable_details(source, details)
+}
+
+fn media_summary(item: &Value) -> Option<String> {
+    let fields = item.as_object()?;
+    match fields.get("type").and_then(Value::as_str)? {
+        "input_image" if fields.get("image_url").and_then(Value::as_str).is_some() => {
+            let detail = fields
+                .get("detail")
+                .and_then(Value::as_str)
+                .map(|detail| format!(" · {detail}"))
+                .unwrap_or_default();
+            Some(format!("image output{detail} · binary data hidden"))
+        }
+        "input_audio" if fields.get("audio_url").and_then(Value::as_str).is_some() => {
+            Some("audio output · binary data hidden".to_owned())
+        }
+        _ => None,
+    }
 }
 
 fn wait(tool: &ToolEntry, width: u16, theme: &Theme, expanded: bool) -> Presentation {

--- a/bin/nanocodex/src/nanocodex2/tui/components/transcript/tool/memory.rs
+++ b/bin/nanocodex/src/nanocodex2/tui/components/transcript/tool/memory.rs
@@ -292,7 +292,7 @@ fn scan(
     let outcome = if abstained {
         "abstained".to_owned()
     } else {
-        count_label(candidates.len(), "candidate", "candidates")
+        super::count_label(candidates.len(), "candidate", "candidates")
     };
     let presentation =
         completed_presentation(backend.as_ref(), "scan", "Memory scan", query.to_owned())
@@ -320,7 +320,7 @@ fn scan(
     } else if shown < candidates.len() {
         format!("{shown} of {} candidates", candidates.len())
     } else {
-        count_label(candidates.len(), "candidate", "candidates")
+        super::count_label(candidates.len(), "candidate", "candidates")
     };
     presentation.footer(footer)
 }
@@ -340,7 +340,7 @@ fn read(
     let ResultValue::Read { backend, memories } = result else {
         return Presentation::new("Memory read", subject);
     };
-    let count = count_label(memories.len(), "memory", "memories");
+    let count = super::count_label(memories.len(), "memory", "memories");
     let presentation =
         completed_presentation(backend.as_ref(), "read", "Memory read", subject).outcome(&count);
     if !expanded {
@@ -497,11 +497,6 @@ fn was_replaced(value: &Value) -> bool {
 
 fn wrap(text: &str, width: u16, style: Style) -> Vec<Line<'static>> {
     super::super::markdown::wrap_plain(text, width, style)
-}
-
-fn count_label(count: usize, singular: &str, plural: &str) -> String {
-    let label = if count == 1 { singular } else { plural };
-    format!("{count} {label}")
 }
 
 fn format_score(score: f64) -> String {

--- a/bin/nanocodex/src/nanocodex2/tui/components/transcript/tool/sandbox.rs
+++ b/bin/nanocodex/src/nanocodex2/tui/components/transcript/tool/sandbox.rs
@@ -13,7 +13,7 @@ pub(super) fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: boo
         "sandbox_kill_process" => process_control(tool, "Stop process", width, theme, expanded),
         "sandbox_list_files" => file_operation(tool, "List files", width, theme, expanded),
         "sandbox_start_process" => process(tool, width, theme, expanded),
-        "sandbox_preview" => preview(tool, width, theme, expanded),
+        "preview" => preview(tool, width, theme, expanded),
         "sandbox_read_file" => file_operation(tool, "Read file", width, theme, expanded),
         "sandbox_write_file" => file_operation(tool, "Write file", width, theme, expanded),
         _ => super::generic(tool, width, theme, expanded),

--- a/bin/nanocodex/src/nanocodex2/tui/components/transcript/tool/shell.rs
+++ b/bin/nanocodex/src/nanocodex2/tui/components/transcript/tool/shell.rs
@@ -56,22 +56,7 @@ pub(super) fn present(tool: &ToolEntry, width: u16, theme: &Theme, expanded: boo
             Style::default().fg(theme.muted()),
         ));
     }
-    let output = tool
-        .result
-        .as_ref()
-        .and_then(|result| result.get("output"))
-        .and_then(Value::as_str)
-        .unwrap_or_default();
-    if !output.is_empty() {
-        presentation =
-            presentation.selectable_plain(output, width, Style::default().fg(theme.text()));
-    }
-    let line_count = output.lines().count();
-    let line_label = if line_count == 1 { "line" } else { "lines" };
-    presentation.footer(format!(
-        "{line_count} {line_label} · {}",
-        format_bytes(output.len())
-    ))
+    with_shell_output(presentation, tool, width, theme)
 }
 
 fn command_spans(command: &str) -> Vec<Span<'static>> {
@@ -96,28 +81,53 @@ fn command_spans(command: &str) -> Vec<Span<'static>> {
 }
 
 fn stdin(tool: &ToolEntry, width: u16, theme: &Theme, expanded: bool) -> Presentation {
+    let session = tool
+        .arguments
+        .get("session_id")
+        .and_then(Value::as_i64)
+        .map(|id| id.to_string())
+        .unwrap_or_else(|| "<session unavailable>".to_owned());
     let subject = tool
         .arguments
         .get("chars")
         .and_then(Value::as_str)
         .filter(|chars| !chars.is_empty())
         .map_or_else(
-            || "poll process".to_owned(),
-            |chars| format!("send {chars:?}"),
+            || format!("poll {session}"),
+            |chars| format!("send {chars:?} to {session}"),
         );
-    let presentation = Presentation::new("Shell input", subject).truncate_summary();
+    let mut presentation = Presentation::new("Process", subject).truncate_summary();
+    if let Some(outcome) = shell_outcome(tool.result.as_ref()) {
+        presentation = presentation.outcome(outcome);
+    }
     if !expanded {
         return presentation;
     }
-    match &tool.result {
-        Some(result) => {
-            let (source, details) = super::selectable_result(result, width, theme);
-            presentation
-                .selectable_details(source, details)
-                .footer("process interaction")
-        }
-        None => presentation.footer("process interaction"),
+    with_shell_output(presentation, tool, width, theme)
+}
+
+fn with_shell_output(
+    mut presentation: Presentation,
+    tool: &ToolEntry,
+    width: u16,
+    theme: &Theme,
+) -> Presentation {
+    let output = tool
+        .result
+        .as_ref()
+        .and_then(|result| result.get("output"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if !output.is_empty() {
+        presentation =
+            presentation.selectable_plain(output, width, Style::default().fg(theme.text()));
     }
+    let line_count = output.lines().count();
+    let line_label = if line_count == 1 { "line" } else { "lines" };
+    presentation.footer(format!(
+        "{line_count} {line_label} · {}",
+        format_bytes(output.len())
+    ))
 }
 
 fn shell_outcome(result: Option<&Value>) -> Option<String> {

--- a/bin/nanocodex/src/nanocodex2/tui/history.rs
+++ b/bin/nanocodex/src/nanocodex2/tui/history.rs
@@ -11,7 +11,7 @@ use nanocodex_managed::{
     EventHistoryPage, ManagedError, ManagedEvent, ManagedEventData, PromptContent, PromptInput,
 };
 use std::{
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     path::Path,
     sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
@@ -19,6 +19,88 @@ use std::{
 
 pub(super) type HistoryProjection = (Vec<Arc<TranscriptRecord>>, u64, Vec<RecentPrompt>);
 pub(super) type LiveManagedProjection = (Arc<TranscriptRecord>, Option<RecentPrompt>);
+
+const PREFETCHED_HISTORY_PAGES: usize = 4;
+
+#[derive(Default)]
+pub(super) struct HistoryPrefetch {
+    active_before: Option<String>,
+    pages: VecDeque<(String, EventHistoryPage)>,
+    replay_requested: bool,
+}
+
+impl HistoryPrefetch {
+    pub(super) fn claim(&mut self, history: &HistoryWindow) -> Option<String> {
+        if self.active_before.is_some() || self.pages.len() >= PREFETCHED_HISTORY_PAGES {
+            return None;
+        }
+        let before = if let Some((_, page)) = self.pages.back() {
+            page.has_more
+                .then(|| page.data.first().map(|event| event.cursor.clone()))
+                .flatten()
+        } else {
+            history.has_more.then(|| history.before.clone()).flatten()
+        }?;
+        self.active_before = Some(before.clone());
+        Some(before)
+    }
+
+    pub(super) fn owns(&self, before: &str) -> bool {
+        self.active_before.as_deref() == Some(before)
+    }
+
+    pub(super) fn fail(&mut self, before: &str) -> bool {
+        if !self.owns(before) {
+            return false;
+        }
+        self.active_before = None;
+        true
+    }
+
+    pub(super) fn store(
+        &mut self,
+        before: &str,
+        page: EventHistoryPage,
+    ) -> Result<(), ManagedError> {
+        if !self.owns(before) {
+            return Err(ManagedError::InvalidResponse(
+                "managed history prefetch lost cursor ownership",
+            ));
+        }
+        if page.data.is_empty() && page.has_more {
+            return Err(ManagedError::InvalidResponse(
+                "managed history reports an empty nonterminal page",
+            ));
+        }
+        self.active_before = None;
+        self.pages.push_back((before.to_owned(), page));
+        Ok(())
+    }
+
+    pub(super) fn request_replay(&mut self) {
+        self.replay_requested = true;
+    }
+
+    pub(super) fn take_requested(
+        &mut self,
+        current_before: Option<&str>,
+    ) -> Option<(String, EventHistoryPage)> {
+        if !self.replay_requested
+            || !self
+                .pages
+                .front()
+                .is_some_and(|(before, _)| Some(before.as_str()) == current_before)
+        {
+            return None;
+        }
+        self.replay_requested = false;
+        self.pages.pop_front()
+    }
+
+    pub(super) fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
 
 #[derive(Clone, Default)]
 pub(super) struct HistoryWindow {
@@ -96,7 +178,7 @@ pub(super) fn live_managed_projection(
             };
             (record, Some(prompt))
         }
-        ManagedEventData::Event { event } => {
+        ManagedEventData::Event { event, .. } => {
             let event: AgentEvent = serde_json::from_str(event.get()).map_err(|error| {
                 ManagedError::Configuration(format!(
                     "invalid live agent event in TUI stream: {error}"
@@ -234,7 +316,7 @@ fn history_projection_range_with_sequences(
                     };
                     Ok(Some((Arc::new(record), Some(prompt))))
                 }
-                ManagedEventData::Event { event } => {
+                ManagedEventData::Event { event, .. } => {
                     let event: AgentEvent = serde_json::from_str(event.get()).map_err(|error| {
                         ManagedError::Configuration(format!(
                             "invalid retained agent event in TUI history: {error}"
@@ -321,4 +403,67 @@ pub(super) fn unix_ms() -> u64 {
             .as_millis(),
     )
     .unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HistoryPrefetch, HistoryWindow};
+    use nanocodex_managed::{EventHistoryPage, ManagedEvent, ManagedEventData};
+    use serde_json::json;
+
+    #[test]
+    fn prefetch_fetches_ahead_without_replaying_until_requested() {
+        let mut prefetch = HistoryPrefetch::default();
+        let history = HistoryWindow::retry_from("9".to_owned());
+
+        assert_eq!(prefetch.claim(&history).as_deref(), Some("9"));
+        assert!(prefetch.owns("9"));
+        assert!(prefetch.claim(&history).is_none());
+        assert!(!prefetch.fail("8"));
+        prefetch
+            .store("9", page("7", true))
+            .expect("valid page should buffer");
+
+        assert_eq!(prefetch.claim(&history).as_deref(), Some("7"));
+        prefetch.request_replay();
+        let (requested, buffered) = prefetch
+            .take_requested(history.before.as_deref())
+            .expect("the oldest matching buffered page should replay");
+        assert_eq!(requested, "9");
+        assert_eq!(buffered.data[0].cursor, "7");
+    }
+
+    #[test]
+    fn prefetch_stops_at_exhaustion_and_reset_drops_stale_ownership() {
+        let mut prefetch = HistoryPrefetch::default();
+        let history = HistoryWindow::retry_from("9".to_owned());
+        assert_eq!(prefetch.claim(&history).as_deref(), Some("9"));
+
+        prefetch.reset();
+        assert!(!prefetch.owns("9"));
+        assert_eq!(prefetch.claim(&history).as_deref(), Some("9"));
+        prefetch
+            .store("9", page("7", false))
+            .expect("terminal page should buffer");
+        assert!(prefetch.claim(&history).is_none());
+
+        prefetch.reset();
+        assert_eq!(prefetch.claim(&history).as_deref(), Some("9"));
+    }
+
+    fn page(cursor: &str, has_more: bool) -> EventHistoryPage {
+        EventHistoryPage {
+            data: vec![ManagedEvent {
+                cursor: cursor.to_owned(),
+                created_at: None,
+                turn_id: None,
+                data: ManagedEventData::AgentCreated {
+                    agent_id: "agent-1".to_owned(),
+                    capabilities: json!({}),
+                },
+            }],
+            has_more,
+            latest_cursor: "9".to_owned(),
+        }
+    }
 }

--- a/bin/nanocodex/src/nanocodex2/tui/mod.rs
+++ b/bin/nanocodex/src/nanocodex2/tui/mod.rs
@@ -28,7 +28,7 @@ use self::{
         RestoredSessionProjection, RootEffect, RootNode,
     },
     history::{
-        HistoryWindow, history_projection, history_projection_with_sequences,
+        HistoryPrefetch, HistoryWindow, history_projection, history_projection_with_sequences,
         live_managed_projection, older_history_projection_with_sequences, unix_ms,
     },
     pane::PaneId,
@@ -42,7 +42,7 @@ use self::{
 };
 use crate::{config::ReasoningEffort, config::ReasoningMode, host::HostConfig};
 use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind, KeyModifiers};
-use futures_util::{StreamExt, future::join_all};
+use futures_util::StreamExt;
 use nanocodex::Model;
 use nanocodex_agent::{Nanocodex, NanocodexError, PromptRequest, Turn, TurnControl, TurnResult};
 use nanocodex_managed::{
@@ -61,9 +61,61 @@ use tokio::{sync::mpsc, task::JoinSet};
 
 type Admission = (PaneId, TurnId, Result<Turn, NanocodexError>);
 type Completion = (PaneId, TurnId, Result<TurnResult, NanocodexError>);
-type SteerCompletion = (PaneId, components::QueueId, Result<(), String>);
+type SteerCompletion = (
+    PaneId,
+    components::QueueId,
+    u64,
+    SteerTarget,
+    Result<(), String>,
+);
 type WaitingSteer = (PaneId, components::QueueId, Submission);
-type CancelCompletion = (PaneId, Vec<TurnId>, Vec<String>, Option<String>);
+enum CancelTarget {
+    Local {
+        generation: u64,
+        agent_id: String,
+        id: TurnId,
+        turn_id: String,
+    },
+    Managed {
+        generation: u64,
+        agent_id: String,
+        turn_id: String,
+    },
+}
+
+impl CancelTarget {
+    fn agent_id(&self) -> &str {
+        match self {
+            Self::Local { agent_id, .. } | Self::Managed { agent_id, .. } => agent_id,
+        }
+    }
+
+    fn turn_id(&self) -> &str {
+        match self {
+            Self::Local { turn_id, .. } | Self::Managed { turn_id, .. } => turn_id,
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum SteerTarget {
+    Local(TurnId),
+    Managed { agent_id: String, turn_id: String },
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum SteerResolution {
+    Admitted,
+    Failed(Option<String>),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CancelDisposition {
+    Accepted,
+    Terminal,
+}
+
+type CancelCompletion = (PaneId, CancelTarget, Result<CancelDisposition, String>);
 type SettingsCompletion = (
     PaneId,
     String,
@@ -107,6 +159,169 @@ struct ManagedActiveTurns {
 struct ManagedObservation {
     active_changed: bool,
     external: bool,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum CancellationResolution {
+    Accepted,
+    Failed(String),
+    Stale,
+}
+
+#[derive(Debug)]
+struct CancellationFence<Id> {
+    in_flight: HashSet<Id>,
+    accepted: HashSet<Id>,
+    terminal_observed: HashSet<Id>,
+}
+
+impl<Id> Default for CancellationFence<Id> {
+    fn default() -> Self {
+        Self {
+            in_flight: HashSet::new(),
+            accepted: HashSet::new(),
+            terminal_observed: HashSet::new(),
+        }
+    }
+}
+
+impl<Id> CancellationFence<Id>
+where
+    Id: Clone + Eq + std::hash::Hash,
+{
+    fn begin(&mut self, id: Id) -> bool {
+        if self.accepted.contains(&id) {
+            return false;
+        }
+        self.in_flight.insert(id)
+    }
+
+    fn finish(
+        &mut self,
+        id: Id,
+        outcome: Result<CancelDisposition, String>,
+        active: bool,
+    ) -> CancellationResolution {
+        self.in_flight.remove(&id);
+        let terminal_observed = self.terminal_observed.remove(&id);
+        resolve_cancellation(
+            &mut self.accepted,
+            id,
+            outcome,
+            active && !terminal_observed,
+        )
+    }
+
+    fn terminal(&mut self, id: &Id) {
+        self.accepted.remove(id);
+        if self.in_flight.contains(id) {
+            self.terminal_observed.insert(id.clone());
+        } else {
+            self.terminal_observed.remove(id);
+        }
+    }
+
+    fn reset(&mut self) {
+        self.in_flight.clear();
+        self.accepted.clear();
+        self.terminal_observed.clear();
+    }
+}
+
+#[derive(Debug, Default)]
+struct CancellationFences {
+    local: CancellationFence<TurnId>,
+    managed: CancellationFence<String>,
+}
+
+impl CancellationFences {
+    fn has_in_flight(&self) -> bool {
+        !self.local.in_flight.is_empty() || !self.managed.in_flight.is_empty()
+    }
+
+    fn begin_local(&mut self, id: TurnId) -> bool {
+        self.local.begin(id)
+    }
+
+    fn begin_managed(&mut self, id: &str) -> bool {
+        self.managed.begin(id.to_owned())
+    }
+
+    fn finish_local(
+        &mut self,
+        id: TurnId,
+        outcome: Result<CancelDisposition, String>,
+        active: bool,
+    ) -> CancellationResolution {
+        self.local.finish(id, outcome, active)
+    }
+
+    fn finish_managed(
+        &mut self,
+        id: String,
+        outcome: Result<CancelDisposition, String>,
+        active: bool,
+    ) -> CancellationResolution {
+        self.managed.finish(id, outcome, active)
+    }
+
+    fn local_terminal(&mut self, id: TurnId) {
+        self.local.terminal(&id);
+    }
+
+    fn managed_terminal(&mut self, id: &str) {
+        self.managed.terminal(&id.to_owned());
+    }
+
+    fn reset(&mut self) {
+        self.local.reset();
+        self.managed.reset();
+    }
+}
+
+fn resolve_cancellation<Id>(
+    accepted: &mut HashSet<Id>,
+    id: Id,
+    outcome: Result<CancelDisposition, String>,
+    active: bool,
+) -> CancellationResolution
+where
+    Id: Eq + std::hash::Hash,
+{
+    match outcome {
+        Ok(CancelDisposition::Accepted) => {
+            if active && accepted.insert(id) {
+                CancellationResolution::Accepted
+            } else {
+                CancellationResolution::Stale
+            }
+        }
+        Ok(CancelDisposition::Terminal) => CancellationResolution::Stale,
+        Err(error) => {
+            if active && !accepted.contains(&id) {
+                CancellationResolution::Failed(error)
+            } else {
+                CancellationResolution::Stale
+            }
+        }
+    }
+}
+
+fn cancel_disposition(
+    expected_turn_id: &str,
+    returned_turn_id: &str,
+    state: &str,
+) -> Result<CancelDisposition, String> {
+    if returned_turn_id != expected_turn_id {
+        return Err("managed cancel acknowledged a different turn".to_owned());
+    }
+    match state {
+        "cancelling" => Ok(CancelDisposition::Accepted),
+        "completed" | "cancelled" | "failed" => Ok(CancelDisposition::Terminal),
+        other => Err(format!(
+            "managed cancel returned unexpected state `{other}`"
+        )),
+    }
 }
 
 impl ManagedActiveTurns {
@@ -216,6 +431,7 @@ struct DriverRuntime {
     agent: Option<Nanocodex>,
     managed_events: Option<mpsc::UnboundedReceiver<ManagedEvent>>,
     managed_events_open: bool,
+    connection_generation: u64,
     agent_id: String,
     settings: AgentSettings,
     pending_settings: Option<AgentSettings>,
@@ -228,9 +444,9 @@ struct DriverRuntime {
     managed_active_turns: ManagedActiveTurns,
     admitting: HashSet<TurnId>,
     cancel_after_admission: HashSet<TurnId>,
-    cancelling_controls: HashSet<TurnId>,
-    cancelling_managed_turns: HashSet<String>,
+    cancellation_fences: CancellationFences,
     cancellation_failed: bool,
+    cancellation_had_effect: bool,
     admissions: JoinSet<Admission>,
     completions: JoinSet<Completion>,
     steers: JoinSet<SteerCompletion>,
@@ -241,6 +457,7 @@ struct DriverRuntime {
     shells: JoinSet<(PaneId, ShellExecution)>,
     history_loads: JoinSet<HistoryCompletion>,
     history_replays: JoinSet<HistoryReplayCompletion>,
+    history_prefetch: HistoryPrefetch,
     history_generation: u64,
     history: HistoryWindow,
     history_sequences: HashMap<String, u64>,
@@ -327,6 +544,144 @@ fn history_replay_matches(
 }
 
 impl DriverRuntime {
+    fn resolve_steer(
+        &self,
+        generation: u64,
+        target: &SteerTarget,
+        outcome: Result<(), String>,
+    ) -> SteerResolution {
+        let current = generation == self.connection_generation
+            && match target {
+                SteerTarget::Local(id) => self.controls.contains_key(id),
+                SteerTarget::Managed { agent_id, turn_id } => {
+                    agent_id == &self.agent_id && self.managed_active_turns.ids.contains(turn_id)
+                }
+            };
+        match outcome {
+            Ok(()) if current => SteerResolution::Admitted,
+            Ok(()) => SteerResolution::Failed(None),
+            Err(error) if current => SteerResolution::Failed(Some(error)),
+            Err(_) => SteerResolution::Failed(None),
+        }
+    }
+
+    fn finish_cancellation(
+        &mut self,
+        target: CancelTarget,
+        outcome: Result<CancelDisposition, String>,
+    ) -> CancellationResolution {
+        match target {
+            CancelTarget::Local {
+                generation,
+                agent_id,
+                id,
+                turn_id,
+            } if generation == self.connection_generation => {
+                let active = agent_id == self.agent_id
+                    && self.controls.contains_key(&id)
+                    && self.local_managed_turns.get(&id) == Some(&turn_id);
+                self.cancellation_fences.finish_local(id, outcome, active)
+            }
+            CancelTarget::Managed {
+                generation,
+                agent_id,
+                turn_id,
+            } if generation == self.connection_generation => {
+                let active = agent_id == self.agent_id
+                    && (!self.managed_events_open
+                        || self.managed_active_turns.ids.contains(&turn_id));
+                self.cancellation_fences
+                    .finish_managed(turn_id, outcome, active)
+            }
+            _ => CancellationResolution::Stale,
+        }
+    }
+
+    fn start_history_prefetch(&mut self, pane: PaneId) {
+        if !self.history_loads.is_empty() || !self.history_replays.is_empty() {
+            return;
+        }
+        let Some(before) = self.history_prefetch.claim(&self.history) else {
+            return;
+        };
+        debug_assert!(self.history_loads.is_empty());
+        debug_assert!(self.history_replays.is_empty());
+        let client = self.client.clone();
+        let agent_id = self.agent_id.clone();
+        let generation = self.history_generation;
+        self.history_loads.spawn(async move {
+            let result = client
+                .history(&agent_id, Some(&before), HISTORY_PAGE_SIZE)
+                .await;
+            (pane, agent_id, generation, before, result)
+        });
+    }
+
+    fn start_requested_history_replay(&mut self, pane: PaneId) {
+        if !self.history_replays.is_empty() {
+            return;
+        }
+        let Some((requested_before, page)) = self
+            .history_prefetch
+            .take_requested(self.history.before.as_deref())
+        else {
+            return;
+        };
+        let coherent_tail = self
+            .history
+            .events
+            .iter()
+            .any(|event| matches!(event.data, ManagedEventData::TurnAccepted { .. }));
+        let sequences = self.history_sequences.clone();
+        let history_records = self.history_records.clone();
+        let live_records = self.live_records.clone();
+        let next_sequence = self.sequence;
+        let workspace = self.workspace.clone();
+        let effort = effort_from_thinking(self.settings.thinking);
+        let agent_id = self.agent_id.clone();
+        let generation = self.history_generation;
+        self.history_replays.spawn_blocking(move || {
+            let result = prepare_history_replay(
+                page,
+                sequences,
+                next_sequence,
+                history_records,
+                live_records,
+                coherent_tail,
+                &agent_id,
+                &workspace,
+                effort,
+            );
+            (pane, agent_id, generation, requested_before, result)
+        });
+    }
+
+    fn finish_history_replay(
+        &mut self,
+        pane: PaneId,
+        result: Result<PreparedHistoryReplay, ManagedError>,
+    ) -> Result<Box<RestoredSessionProjection>, ManagedError> {
+        let mut prepared = match result {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                // The requested page has already left the prefetch queue. Every later buffered
+                // page depends on its cursor, so none of them can be reached from the unchanged
+                // history window after a projection failure.
+                self.history_prefetch.reset();
+                self.start_history_prefetch(pane);
+                return Err(error);
+            }
+        };
+        self.history.prepend_window(prepared.older_history);
+        self.history_sequences = prepared.sequences;
+        self.sequence = self.sequence.max(prepared.next_sequence);
+        self.next_turn = self.next_turn.max(self.sequence);
+        self.history_records = prepared.history_records;
+        self.recent_prompts.append(&mut prepared.older_prompts);
+        self.start_history_prefetch(pane);
+        Ok(prepared.projection)
+    }
+
     fn local_record(&mut self, event: LocalEvent) -> Result<Arc<TranscriptRecord>, ManagedError> {
         let record =
             TranscriptRecord::from_local(self.sequence, unix_ms(), event).map_err(|error| {
@@ -425,61 +780,56 @@ impl DriverRuntime {
             && self.active_shells == 0
             && self.pending_submission.is_none()
             && self.cancel_after_admission.is_empty()
-            && self.cancelling_controls.is_empty()
-            && self.cancelling_managed_turns.is_empty()
+            && !self.cancellation_fences.has_in_flight()
             && self.connection.is_empty()
     }
 
-    fn cancel_controls(&mut self, pane: PaneId, controls: Vec<(TurnId, TurnControl)>) {
-        if controls.is_empty() {
-            return;
+    fn cancel_local_turns(&mut self, pane: PaneId, turns: Vec<(TurnId, String)>) {
+        for (id, turn_id) in turns {
+            if !self.cancellation_fences.begin_local(id) {
+                continue;
+            }
+            self.spawn_cancellation(
+                pane,
+                CancelTarget::Local {
+                    generation: self.connection_generation,
+                    agent_id: self.agent_id.clone(),
+                    id,
+                    turn_id,
+                },
+            );
         }
-        let ids = controls.iter().map(|(id, _)| *id).collect::<Vec<_>>();
-        self.cancelling_controls.extend(ids.iter().copied());
-        self.cancellations.spawn(async move {
-            let results = join_all(
-                controls
-                    .into_iter()
-                    .map(|(_, control)| async move { control.cancel().await }),
-            )
-            .await;
-            let error = results
-                .into_iter()
-                .filter_map(Result::err)
-                .map(|error| error.to_string())
-                .next();
-            (pane, ids, Vec::new(), error)
-        });
     }
 
     fn cancel_managed_turns(&mut self, pane: PaneId, turn_ids: Vec<String>) {
-        if turn_ids.is_empty() {
-            return;
+        for turn_id in turn_ids {
+            if !self.cancellation_fences.begin_managed(&turn_id) {
+                continue;
+            }
+            self.spawn_cancellation(
+                pane,
+                CancelTarget::Managed {
+                    generation: self.connection_generation,
+                    agent_id: self.agent_id.clone(),
+                    turn_id,
+                },
+            );
         }
-        self.cancelling_managed_turns
-            .extend(turn_ids.iter().cloned());
+    }
+
+    fn spawn_cancellation(&mut self, pane: PaneId, target: CancelTarget) {
         let client = self.client.clone();
-        let agent_id = self.agent_id.clone();
         self.cancellations.spawn(async move {
-            let results = join_all(turn_ids.iter().map(|turn_id| {
-                let client = client.clone();
-                let agent_id = agent_id.clone();
-                let turn_id = turn_id.clone();
-                async move {
-                    client
-                        .cancel(&agent_id, &turn_id)
-                        .await
-                        .map_err(|error| error.to_string())
-                        .and_then(|action| {
-                            (action.turn_id == turn_id).then_some(()).ok_or_else(|| {
-                                "managed cancel acknowledged a different turn".to_owned()
-                            })
-                        })
-                }
-            }))
-            .await;
-            let error = results.into_iter().find_map(Result::err);
-            (pane, Vec::new(), turn_ids, error)
+            let outcome = {
+                let agent_id = target.agent_id();
+                let turn_id = target.turn_id();
+                client
+                    .cancel(agent_id, turn_id)
+                    .await
+                    .map_err(|error| error.to_string())
+                    .and_then(|action| cancel_disposition(turn_id, &action.turn_id, &action.state))
+            };
+            (pane, target, outcome)
         });
     }
 }
@@ -631,6 +981,7 @@ async fn run_inner(
         agent: None,
         managed_events: None,
         managed_events_open: false,
+        connection_generation: 0,
         agent_id: String::new(),
         settings: initial_settings,
         pending_settings: None,
@@ -643,9 +994,9 @@ async fn run_inner(
         managed_active_turns: ManagedActiveTurns::default(),
         admitting: HashSet::new(),
         cancel_after_admission: HashSet::new(),
-        cancelling_controls: HashSet::new(),
-        cancelling_managed_turns: HashSet::new(),
+        cancellation_fences: CancellationFences::default(),
         cancellation_failed: false,
+        cancellation_had_effect: false,
         admissions: JoinSet::new(),
         completions: JoinSet::new(),
         steers: JoinSet::new(),
@@ -656,6 +1007,7 @@ async fn run_inner(
         shells: JoinSet::new(),
         history_loads: JoinSet::new(),
         history_replays: JoinSet::new(),
+        history_prefetch: HistoryPrefetch::default(),
         history_generation: 0,
         history: HistoryWindow::default(),
         history_sequences: HashMap::new(),
@@ -708,6 +1060,8 @@ async fn run_inner(
             };
             match result {
                 Err(error) => {
+                    runtime.history_prefetch.reset();
+                    runtime.start_history_prefetch(PaneId::Main);
                     request_render(
                         app.update(AppEvent::NotifyError {
                             pane: PaneId::Main,
@@ -728,26 +1082,21 @@ async fn run_inner(
                         runtime.history.before.as_deref(),
                     ) =>
                 {
-                    match result {
-                        Err(error) => request_render(
-                            app.update(AppEvent::NotifyError {
-                                pane,
-                                error: format!("Could not replay older durable history: {error}"),
-                            }),
-                            &mut scheduler,
-                        ),
-                        Ok(mut prepared) => {
-                            runtime.history.prepend_window(prepared.older_history);
-                            runtime.history_sequences = prepared.sequences;
-                            runtime.sequence = runtime.sequence.max(prepared.next_sequence);
-                            runtime.next_turn = runtime.next_turn.max(runtime.sequence);
-                            runtime.history_records = prepared.history_records;
-                            runtime.recent_prompts.append(&mut prepared.older_prompts);
+                    match runtime.finish_history_replay(pane, result) {
+                        Err(error) => {
                             request_render(
-                                app.update(AppEvent::HistoryReplayed {
+                                app.update(AppEvent::NotifyError {
                                     pane,
-                                    projection: prepared.projection,
+                                    error: format!(
+                                        "Could not replay older durable history: {error}"
+                                    ),
                                 }),
+                                &mut scheduler,
+                            );
+                        }
+                        Ok(projection) => {
+                            request_render(
+                                app.update(AppEvent::HistoryReplayed { pane, projection }),
                                 &mut scheduler,
                             );
                         }
@@ -794,6 +1143,23 @@ async fn run_inner(
             }, if runtime.managed_events_open => {
                 match event {
                     Some(event) => {
+                        match &event.data {
+                            ManagedEventData::TurnCompleted { id, .. }
+                            | ManagedEventData::TurnCancelled { id }
+                            | ManagedEventData::TurnFailed { id, .. } => {
+                                runtime.cancellation_fences.managed_terminal(id);
+                                if let Some(local_id) = runtime
+                                    .local_managed_turns
+                                    .iter()
+                                    .find_map(|(local_id, managed_id)| {
+                                        (managed_id == id).then_some(*local_id)
+                                    })
+                                {
+                                    runtime.cancellation_fences.local_terminal(local_id);
+                                }
+                            }
+                            _ => {}
+                        }
                         let observation = runtime
                             .managed_active_turns
                             .observe(&event, &runtime.local_managed_turns);
@@ -843,6 +1209,11 @@ async fn run_inner(
                         runtime.managed_active_turns.ids.clear();
                         runtime.managed_active_turns.live_steer = false;
                         runtime.managed_active_turns.live_cancel = false;
+                        // Losing the observer does not prove any durable cancellation target
+                        // terminated. Keep same-generation requests fenced until their HTTP
+                        // response or a replacement connection resolves them.
+                        runtime.cancellation_had_effect = false;
+                        runtime.cancellation_failed = false;
                         request_render(
                             app.update(AppEvent::AgentStreamClosed(PaneId::Main)),
                             &mut scheduler,
@@ -924,8 +1295,9 @@ async fn run_inner(
                             };
                             let display_settings = requested_startup_settings.unwrap_or(settings);
                             runtime.history_generation = runtime.history_generation.wrapping_add(1);
-                            runtime.history_loads.abort_all();
-                            runtime.history_replays.abort_all();
+                            runtime.history_loads = JoinSet::new();
+                            runtime.history_replays = JoinSet::new();
+                            runtime.history_prefetch.reset();
                             if !matches!(purpose, ConnectionPurpose::Startup) {
                                 runtime.history_sequences.clear();
                                 runtime.history_records.clear();
@@ -961,13 +1333,17 @@ async fn run_inner(
                                     ConnectionResult::Disconnected(previous.disconnect().await)
                                 });
                             }
+                            runtime.connection_generation =
+                                runtime.connection_generation.wrapping_add(1);
                             runtime.managed_events = Some(managed_events);
                             runtime.managed_events_open = true;
                             runtime.agent_id = agent_id;
                             runtime.settings = settings;
                             runtime.workspace = workspace;
                             runtime.managed_active_turns = active_turns;
-                            runtime.cancelling_managed_turns.clear();
+                            runtime.cancellation_fences.reset();
+                            runtime.cancellation_had_effect = false;
+                            runtime.cancellation_failed = false;
                             runtime.next_turn = runtime.next_turn.max(runtime.sequence);
                             runtime.recent_prompts = prompts;
                             runtime.history = history;
@@ -1046,6 +1422,7 @@ async fn run_inner(
                             {
                                 runtime.start_submission(pane, id, prompt);
                             }
+                            runtime.start_history_prefetch(pane);
                         }
                         ConnectionResult::Agent { purpose, result: Err(failure) } => {
                             let message = format!("Could not connect to the managed agent: {}", failure.error);
@@ -1217,18 +1594,26 @@ async fn run_inner(
                                 {
                                     updates.push(app.update(AppEvent::SteerFailed { pane, id }));
                                 }
-                                runtime.cancel_controls(pane, vec![(id, control)]);
+                                let managed_turn_id = runtime
+                                    .local_managed_turns
+                                    .get(&id)
+                                    .expect("admitted managed turn must retain its request ID")
+                                    .clone();
+                                runtime.cancel_local_turns(pane, vec![(id, managed_turn_id)]);
                             } else {
+                                let local_turn_id = id;
                                 while let Some((pane, id, prompt)) =
                                     runtime.waiting_steers.pop_front()
                                 {
                                     let control = control.clone();
+                                    let generation = runtime.connection_generation;
+                                    let target = SteerTarget::Local(local_turn_id);
                                     runtime.steers.spawn(async move {
                                         let result = control
                                             .steer(prompt.agent_prompt())
                                             .await
                                             .map_err(|error| error.to_string());
-                                        (pane, id, result)
+                                        (pane, id, generation, target, result)
                                     });
                                 }
                             }
@@ -1254,8 +1639,7 @@ async fn run_inner(
                     if cancelled_after_admission
                         && runtime.cancel_after_admission.is_empty()
                         && runtime.cancellations.is_empty()
-                        && runtime.cancelling_controls.is_empty()
-                        && runtime.cancelling_managed_turns.is_empty()
+                        && !runtime.cancellation_fences.has_in_flight()
                     {
                         let update = if runtime.cancellation_failed {
                             runtime.cancellation_failed = false;
@@ -1276,6 +1660,7 @@ async fn run_inner(
                     let (pane, id, outcome) = result.map_err(|error| ManagedError::Configuration(format!("turn task failed: {error}")))?;
                     runtime.controls.remove(&id);
                     runtime.local_managed_turns.remove(&id);
+                    runtime.cancellation_fences.local_terminal(id);
                     let error = outcome.err().map(|error| error.to_string());
                     let record = runtime.local_record(LocalEvent::WorkerTurnFinished { id, error })?;
                     request_render(app.update(AppEvent::Transcript { pane, record }), &mut scheduler);
@@ -1285,50 +1670,74 @@ async fn run_inner(
             }
             result = runtime.steers.join_next(), if !runtime.steers.is_empty() => {
                 if let Some(result) = result {
-                    let (pane, id, outcome) = result.map_err(|error| ManagedError::Configuration(format!("steer task failed: {error}")))?;
-                    let update = match outcome {
-                        Ok(()) => app.update(AppEvent::SteerAdmitted { pane, id }),
-                        Err(error) => {
+                    let (pane, id, generation, target, outcome) = result.map_err(|error| ManagedError::Configuration(format!("steer task failed: {error}")))?;
+                    let update = match runtime.resolve_steer(generation, &target, outcome) {
+                        SteerResolution::Admitted => app.update(AppEvent::SteerAdmitted { pane, id }),
+                        SteerResolution::Failed(Some(error)) => {
                             request_render(app.update(AppEvent::NotifyError { pane, error: format!("Could not steer turn: {error}") }), &mut scheduler);
                             app.update(AppEvent::SteerFailed { pane, id })
                         }
+                        SteerResolution::Failed(None) => app.update(AppEvent::SteerFailed { pane, id }),
                     };
                     stopping = apply_update(update, &mut app, &mut runtime, &mut terminal, &mut scheduler).await?;
                 }
             }
             result = runtime.cancellations.join_next(), if !runtime.cancellations.is_empty() => {
                 if let Some(result) = result {
-                    let (pane, ids, managed_ids, error) = result.map_err(|error| ManagedError::Configuration(format!("cancel task failed: {error}")))?;
-                    for id in &ids {
-                        runtime.cancelling_controls.remove(id);
-                    }
-                    for id in &managed_ids {
-                        runtime.cancelling_managed_turns.remove(id);
-                    }
-                    runtime.cancellation_failed |= error.is_some();
-                    let count = ids.len().saturating_add(managed_ids.len());
-                    let record = runtime.local_record(LocalEvent::WorkerTurnsInterrupted {
-                        count,
-                        error: error.clone(),
-                    })?;
-                    request_render(app.update(AppEvent::Transcript { pane, record }), &mut scheduler);
+                    let (pane, target, outcome) = result.map_err(|error| ManagedError::Configuration(format!("cancel task failed: {error}")))?;
+                    let resolution = runtime.finish_cancellation(target, outcome);
+                    let final_error = match resolution {
+                        CancellationResolution::Accepted => {
+                            runtime.cancellation_had_effect = true;
+                            let record = runtime.local_record(
+                                LocalEvent::WorkerTurnsInterrupted {
+                                    count: 1,
+                                    error: None,
+                                },
+                            )?;
+                            request_render(
+                                app.update(AppEvent::Transcript { pane, record }),
+                                &mut scheduler,
+                            );
+                            None
+                        }
+                        CancellationResolution::Failed(error) => {
+                            runtime.cancellation_failed = true;
+                            let record = runtime.local_record(
+                                LocalEvent::WorkerTurnsInterrupted {
+                                    count: 0,
+                                    error: Some(error.clone()),
+                                },
+                            )?;
+                            request_render(
+                                app.update(AppEvent::Transcript { pane, record }),
+                                &mut scheduler,
+                            );
+                            Some(error)
+                        }
+                        CancellationResolution::Stale => None,
+                    };
                     if runtime.cancel_after_admission.is_empty()
                         && runtime.cancellations.is_empty()
-                        && runtime.cancelling_controls.is_empty()
-                        && runtime.cancelling_managed_turns.is_empty()
+                        && !runtime.cancellation_fences.has_in_flight()
                     {
                         let update = if runtime.cancellation_failed {
                             runtime.cancellation_failed = false;
-                            app.update(AppEvent::NotifyError {
+                            Some(app.update(AppEvent::NotifyError {
                                 pane,
-                                error: error.unwrap_or_else(|| {
+                                error: final_error.unwrap_or_else(|| {
                                     "One or more managed cancellation requests failed.".to_owned()
                                 }),
-                            })
+                            }))
+                        } else if runtime.cancellation_had_effect {
+                            Some(app.update(AppEvent::TurnsCancelled(pane)))
                         } else {
-                            app.update(AppEvent::TurnsCancelled(pane))
+                            None
                         };
-                        stopping = apply_update(update, &mut app, &mut runtime, &mut terminal, &mut scheduler).await?;
+                        runtime.cancellation_had_effect = false;
+                        if let Some(update) = update {
+                            stopping = apply_update(update, &mut app, &mut runtime, &mut terminal, &mut scheduler).await?;
+                        }
                     }
                 }
             }
@@ -1358,50 +1767,37 @@ async fn run_inner(
                 if let Some(result) = result {
                     match result {
                         Err(error) => {
+                            runtime.history_prefetch.reset();
                             request_render(app.update(AppEvent::NotifyError {
                                 pane: PaneId::Main,
                                 error: format!("Older durable history task stopped unexpectedly: {error}"),
                             }), &mut scheduler);
                         }
                         Ok((pane, agent_id, generation, requested_before, result))
-                            if history_replay_matches(
-                                &agent_id,
-                                generation,
-                                &requested_before,
-                                &runtime.agent_id,
-                                runtime.history_generation,
-                                runtime.history.before.as_deref(),
-                            ) => match result {
+                            if agent_id == runtime.agent_id
+                                && generation == runtime.history_generation
+                                && runtime.history_prefetch.owns(&requested_before) => match result {
                             Err(error) => {
+                                let _ = runtime.history_prefetch.fail(&requested_before);
                                 request_render(app.update(AppEvent::NotifyError {
                                     pane,
                                     error: format!("Could not load older durable history: {error}"),
                                 }), &mut scheduler);
                             }
                             Ok(page) => {
-                                let coherent_tail = runtime.history.events.iter().any(|event| {
-                                    matches!(event.data, ManagedEventData::TurnAccepted { .. })
-                                });
-                                let sequences = runtime.history_sequences.clone();
-                                let history_records = runtime.history_records.clone();
-                                let live_records = runtime.live_records.clone();
-                                let next_sequence = runtime.sequence;
-                                let workspace = runtime.workspace.clone();
-                                let effort = effort_from_thinking(runtime.settings.thinking);
-                                runtime.history_replays.spawn_blocking(move || {
-                                    let result = prepare_history_replay(
-                                        page,
-                                        sequences,
-                                        next_sequence,
-                                        history_records,
-                                        live_records,
-                                        coherent_tail,
-                                        &agent_id,
-                                        &workspace,
-                                        effort,
-                                    );
-                                    (pane, agent_id, generation, requested_before, result)
-                                });
+                                if let Err(error) = runtime
+                                    .history_prefetch
+                                    .store(&requested_before, page)
+                                {
+                                    let _ = runtime.history_prefetch.fail(&requested_before);
+                                    request_render(app.update(AppEvent::NotifyError {
+                                        pane,
+                                        error: format!("Could not buffer older durable history: {error}"),
+                                    }), &mut scheduler);
+                                } else {
+                                    runtime.start_requested_history_replay(pane);
+                                    runtime.start_history_prefetch(pane);
+                                }
                             }
                             },
                         Ok(_) => {}
@@ -1484,13 +1880,20 @@ async fn apply_update(
                         });
                     }
                     RootEffect::Steer { id, prompt } => {
-                        if let Some(control) = runtime.controls.values().next().cloned() {
+                        if let Some((turn_id, control)) = runtime
+                            .controls
+                            .iter()
+                            .next()
+                            .map(|(turn_id, control)| (*turn_id, control.clone()))
+                        {
+                            let generation = runtime.connection_generation;
+                            let target = SteerTarget::Local(turn_id);
                             runtime.steers.spawn(async move {
                                 let result = control
                                     .steer(prompt.agent_prompt())
                                     .await
                                     .map_err(|error| error.to_string());
-                                (pane, id, result)
+                                (pane, id, generation, target, result)
                             });
                         } else if !runtime.managed_active_turns.ids.is_empty() {
                             let target = runtime
@@ -1502,6 +1905,11 @@ async fn apply_update(
                                     let client = runtime.client.clone();
                                     let agent_id = runtime.agent_id.clone();
                                     let input = prompt.managed_prompt();
+                                    let generation = runtime.connection_generation;
+                                    let target = SteerTarget::Managed {
+                                        agent_id: agent_id.clone(),
+                                        turn_id: turn_id.clone(),
+                                    };
                                     runtime.steers.spawn(async move {
                                         let result = client
                                             .steer(&agent_id, &turn_id, &input)
@@ -1515,7 +1923,7 @@ async fn apply_update(
                                                     },
                                                 )
                                             });
-                                        (pane, id, result)
+                                        (pane, id, generation, target, result)
                                     });
                                     Ok(())
                                 }
@@ -1561,14 +1969,15 @@ async fn apply_update(
                     }
                     RootEffect::CancelTurns => {
                         if runtime.cancellations.is_empty()
-                            && runtime.cancelling_controls.is_empty()
-                            && runtime.cancelling_managed_turns.is_empty()
+                            && !runtime.cancellation_fences.has_in_flight()
                         {
                             runtime.cancellation_failed = false;
+                            runtime.cancellation_had_effect = false;
                         }
-                        for (steer_pane, id) in
-                            take_waiting_steer_failures(&mut runtime.waiting_steers)
-                        {
+                        let waiting_steers =
+                            take_waiting_steer_failures(&mut runtime.waiting_steers);
+                        runtime.cancellation_had_effect |= !waiting_steers.is_empty();
+                        for (steer_pane, id) in waiting_steers {
                             absorb(
                                 app.update(AppEvent::SteerFailed {
                                     pane: steer_pane,
@@ -1579,6 +1988,7 @@ async fn apply_update(
                             );
                         }
                         if let Some((pending_pane, id, _)) = runtime.pending_submission.take() {
+                            runtime.cancellation_had_effect = true;
                             let record = runtime.local_record(LocalEvent::WorkerTurnFinished {
                                 id,
                                 error: Some("cancelled before managed admission".to_owned()),
@@ -1603,21 +2013,20 @@ async fn apply_update(
                         runtime
                             .cancel_after_admission
                             .extend(runtime.admitting.iter().copied());
-                        let controls = runtime
+                        let local_turns = runtime
                             .controls
-                            .iter()
-                            .filter(|(id, _)| !runtime.cancelling_controls.contains(id))
-                            .map(|(id, control)| (*id, control.clone()))
+                            .keys()
+                            .filter_map(|id| {
+                                runtime
+                                    .local_managed_turns
+                                    .get(id)
+                                    .map(|managed_id| (*id, managed_id.clone()))
+                            })
                             .collect::<Vec<_>>();
-                        runtime.cancel_controls(pane, controls);
+                        runtime.cancel_local_turns(pane, local_turns);
                         if runtime.managed_active_turns.live_cancel {
-                            let managed_turns = runtime
-                                .managed_active_turns
-                                .ids
-                                .iter()
-                                .filter(|id| !runtime.cancelling_managed_turns.contains(*id))
-                                .cloned()
-                                .collect();
+                            let managed_turns =
+                                runtime.managed_active_turns.ids.iter().cloned().collect();
                             runtime.cancel_managed_turns(pane, managed_turns);
                         } else if !runtime.managed_active_turns.ids.is_empty() {
                             runtime.cancellation_failed = true;
@@ -1633,8 +2042,7 @@ async fn apply_update(
                         }
                         if runtime.cancel_after_admission.is_empty()
                             && runtime.cancellations.is_empty()
-                            && runtime.cancelling_controls.is_empty()
-                            && runtime.cancelling_managed_turns.is_empty()
+                            && !runtime.cancellation_fences.has_in_flight()
                         {
                             absorb(
                                 app.update(AppEvent::TurnsCancelled(pane)),
@@ -1670,21 +2078,9 @@ async fn apply_update(
                         );
                     }
                     RootEffect::LoadOlderHistory => {
-                        if runtime.history.has_more
-                            && runtime.history_loads.is_empty()
-                            && runtime.history_replays.is_empty()
-                            && let Some(before) = runtime.history.before.clone()
-                        {
-                            let client = runtime.client.clone();
-                            let agent_id = runtime.agent_id.clone();
-                            let generation = runtime.history_generation;
-                            runtime.history_loads.spawn(async move {
-                                let result = client
-                                    .history(&agent_id, Some(&before), HISTORY_PAGE_SIZE)
-                                    .await;
-                                (pane, agent_id, generation, before, result)
-                            });
-                        }
+                        runtime.history_prefetch.request_replay();
+                        runtime.start_requested_history_replay(pane);
+                        runtime.start_history_prefetch(pane);
                     }
                     RootEffect::ResumeSession(agent_id) => {
                         if !runtime.idle() {
@@ -2063,21 +2459,243 @@ fn terminal_error(error: io::Error) -> ManagedError {
 #[cfg(test)]
 mod tests {
     use super::{
-        HistoryWindow, ManagedActiveTurns, cursor_at_or_before, decimal_successor,
-        history_projection, history_projection_with_sequences, history_replay_matches,
-        live_managed_projection, prepare_history_replay, session_summaries,
-        take_waiting_steer_failures,
+        CancelDisposition, CancelTarget, CancellationFences, CancellationResolution, DriverRuntime,
+        HistoryPrefetch, HistoryWindow, ManagedActiveTurns, SteerResolution, SteerTarget,
+        cursor_at_or_before, decimal_successor, history_projection,
+        history_projection_with_sequences, history_replay_matches, live_managed_projection,
+        prepare_history_replay, session_summaries, take_waiting_steer_failures,
     };
     use crate::config::ReasoningEffort;
     use crate::tui::{components::QueueId, pane::PaneId, prompt::Submission, transcript::TurnId};
     use nanocodex_managed::{
-        AgentList, AgentSummary, EventHistoryPage, ManagedEvent, ManagedEventData, PromptInput,
+        AgentList, AgentSettings, AgentSummary, EventHistoryPage, ManagedApiKey, ManagedClient,
+        ManagedEvent, ManagedEventData, PromptInput,
     };
     use serde_json::{json, value::to_raw_value};
     use std::{
         collections::{BTreeMap, HashMap, HashSet, VecDeque},
         path::Path,
     };
+    use tokio::task::JoinSet;
+
+    fn history_runtime(history: HistoryWindow) -> DriverRuntime {
+        let mut history_sequences = HashMap::new();
+        let mut sequence = 1;
+        let (history_records, recent_prompts) = history_projection_with_sequences(
+            &history.events,
+            "agent-1",
+            Path::new("/workspace"),
+            &mut history_sequences,
+            &mut sequence,
+        )
+        .unwrap();
+        let api_key =
+            ManagedApiKey::parse(format!("ncx_live_{}_{}", "a".repeat(12), "b".repeat(43)))
+                .unwrap();
+        DriverRuntime {
+            client: ManagedClient::new("http://127.0.0.1:9", api_key).unwrap(),
+            agent: None,
+            managed_events: None,
+            managed_events_open: false,
+            connection_generation: 1,
+            agent_id: "agent-1".to_owned(),
+            settings: AgentSettings::default(),
+            pending_settings: None,
+            workspace: Path::new("/workspace").to_path_buf(),
+            sequence,
+            next_turn: sequence,
+            next_shell: 1,
+            controls: HashMap::new(),
+            local_managed_turns: HashMap::new(),
+            managed_active_turns: ManagedActiveTurns::default(),
+            admitting: HashSet::new(),
+            cancel_after_admission: HashSet::new(),
+            cancellation_fences: CancellationFences::default(),
+            cancellation_failed: false,
+            cancellation_had_effect: false,
+            admissions: JoinSet::new(),
+            completions: JoinSet::new(),
+            steers: JoinSet::new(),
+            waiting_steers: VecDeque::new(),
+            cancellations: JoinSet::new(),
+            settings_updates: JoinSet::new(),
+            settings_queue: VecDeque::new(),
+            shells: JoinSet::new(),
+            history_loads: JoinSet::new(),
+            history_replays: JoinSet::new(),
+            history_prefetch: HistoryPrefetch::default(),
+            history_generation: 1,
+            history,
+            history_sequences,
+            history_records,
+            live_records: Vec::new(),
+            active_shells: 0,
+            shell_context: Vec::new(),
+            pending_submission: None,
+            recent_prompts,
+            connection: JoinSet::new(),
+            retry_target: None,
+        }
+    }
+
+    #[test]
+    fn accepted_local_cancel_stays_fenced_until_terminal_completion() {
+        let mut fences = CancellationFences::default();
+        let id = TurnId::new(7);
+
+        assert!(fences.begin_local(id));
+        assert_eq!(
+            fences.finish_local(id, Ok(CancelDisposition::Accepted), true),
+            CancellationResolution::Accepted
+        );
+        assert!(!fences.begin_local(id));
+
+        fences.local_terminal(id);
+        assert!(fences.begin_local(id));
+    }
+
+    #[test]
+    fn accepted_managed_cancel_stays_fenced_until_terminal_event() {
+        let mut fences = CancellationFences::default();
+
+        assert!(fences.begin_managed("turn-7"));
+        assert_eq!(
+            fences.finish_managed("turn-7".to_owned(), Ok(CancelDisposition::Accepted), true,),
+            CancellationResolution::Accepted
+        );
+        assert!(!fences.begin_managed("turn-7"));
+
+        fences.managed_terminal("turn-7");
+        assert!(fences.begin_managed("turn-7"));
+    }
+
+    #[test]
+    fn terminal_before_cancel_response_makes_late_error_stale() {
+        let mut fences = CancellationFences::default();
+
+        assert!(fences.begin_managed("turn-7"));
+        assert_eq!(
+            fences.finish_managed(
+                "turn-7".to_owned(),
+                Err("503 Service Unavailable".to_owned()),
+                false,
+            ),
+            CancellationResolution::Stale
+        );
+        assert!(fences.begin_managed("turn-7"));
+    }
+
+    #[test]
+    fn stream_close_preserves_same_target_cancel_failure() {
+        let mut runtime = history_runtime(HistoryWindow::default());
+        runtime.managed_events_open = false;
+
+        assert!(runtime.cancellation_fences.begin_managed("turn-7"));
+        assert_eq!(
+            runtime.finish_cancellation(
+                CancelTarget::Managed {
+                    generation: 1,
+                    agent_id: "agent-1".to_owned(),
+                    turn_id: "turn-7".to_owned(),
+                },
+                Err("503 Service Unavailable".to_owned()),
+            ),
+            CancellationResolution::Failed("503 Service Unavailable".to_owned())
+        );
+    }
+
+    #[test]
+    fn replaced_connection_cannot_consume_same_target_cancel_fence() {
+        let mut runtime = history_runtime(HistoryWindow::default());
+        runtime.connection_generation = 7;
+        assert!(runtime.cancellation_fences.begin_managed("turn-7"));
+
+        runtime.connection_generation = 8;
+        runtime.cancellation_fences.reset();
+        assert!(runtime.cancellation_fences.begin_managed("turn-7"));
+        assert_eq!(
+            runtime.finish_cancellation(
+                CancelTarget::Managed {
+                    generation: 7,
+                    agent_id: "agent-1".to_owned(),
+                    turn_id: "turn-7".to_owned(),
+                },
+                Err("old connection failed".to_owned()),
+            ),
+            CancellationResolution::Stale
+        );
+        assert!(!runtime.cancellation_fences.begin_managed("turn-7"));
+    }
+
+    #[test]
+    fn terminal_target_fences_late_successful_steer() {
+        let mut runtime = history_runtime(HistoryWindow::default());
+        runtime.managed_active_turns.ids.insert("turn-7".to_owned());
+        let target = SteerTarget::Managed {
+            agent_id: "agent-1".to_owned(),
+            turn_id: "turn-7".to_owned(),
+        };
+
+        assert_eq!(
+            runtime.resolve_steer(1, &target, Ok(())),
+            SteerResolution::Admitted
+        );
+        runtime.managed_active_turns.ids.remove("turn-7");
+        assert_eq!(
+            runtime.resolve_steer(1, &target, Ok(())),
+            SteerResolution::Failed(None)
+        );
+    }
+
+    #[test]
+    fn local_managed_terminal_before_cancel_response_makes_late_error_stale() {
+        let mut fences = CancellationFences::default();
+        let id = TurnId::new(7);
+
+        assert!(fences.begin_local(id));
+        fences.local_terminal(id);
+        assert_eq!(
+            fences.finish_local(id, Err("503 Service Unavailable".to_owned()), true),
+            CancellationResolution::Stale
+        );
+    }
+
+    #[test]
+    fn terminal_cancel_action_is_stale_even_before_the_event_arrives() {
+        let mut fences = CancellationFences::default();
+
+        assert!(fences.begin_managed("turn-7"));
+        assert_eq!(
+            fences.finish_managed("turn-7".to_owned(), Ok(CancelDisposition::Terminal), true,),
+            CancellationResolution::Stale
+        );
+    }
+
+    #[test]
+    fn first_active_cancel_failure_is_reported_and_retryable() {
+        let mut fences = CancellationFences::default();
+        let id = TurnId::new(7);
+
+        assert!(fences.begin_local(id));
+        assert_eq!(
+            fences.finish_local(id, Err("backend unavailable".to_owned()), true),
+            CancellationResolution::Failed("backend unavailable".to_owned())
+        );
+        assert!(fences.begin_local(id));
+    }
+
+    #[test]
+    fn cancellation_fences_are_scoped_to_the_exact_target() {
+        let mut fences = CancellationFences::default();
+
+        assert!(fences.begin_managed("turn-7"));
+        assert_eq!(
+            fences.finish_managed("turn-7".to_owned(), Ok(CancelDisposition::Accepted), true,),
+            CancellationResolution::Accepted
+        );
+        assert!(!fences.begin_managed("turn-7"));
+        assert!(fences.begin_managed("turn-8"));
+    }
 
     #[test]
     fn terminal_failures_drain_waiting_steers_in_queue_safe_order() {
@@ -2248,7 +2866,10 @@ mod tests {
                 cursor: "2".to_owned(),
                 created_at: Some(1_750_000_001.0),
                 turn_id: Some("turn-1".to_owned()),
-                data: ManagedEventData::Event { event: agent_event },
+                data: ManagedEventData::Event {
+                    event: agent_event,
+                    agent_id: None,
+                },
             },
         ];
 
@@ -2310,6 +2931,7 @@ mod tests {
                     }
                 }))
                 .unwrap(),
+                agent_id: None,
             },
         };
 
@@ -2497,6 +3119,7 @@ mod tests {
             turn_id: Some("turn-3".to_owned()),
             data: ManagedEventData::Event {
                 event: to_raw_value(&json!({ "not": "an agent event" })).unwrap(),
+                agent_id: None,
             },
         };
 
@@ -2525,6 +3148,115 @@ mod tests {
         assert_eq!(history.events.len(), 1);
         assert_eq!(history.events[0].cursor, "5");
         assert_eq!(sequences, HashMap::from([("5".to_owned(), 1)]));
+    }
+
+    #[tokio::test]
+    async fn driver_runtime_consumes_buffered_pages_before_refilling() {
+        let mut runtime = history_runtime(HistoryWindow {
+            events: vec![managed_turn("9", "retained")],
+            before: Some("9".to_owned()),
+            has_more: true,
+        });
+        for (cursor, prompt) in [
+            ("7", "older"),
+            ("5", "older 2"),
+            ("3", "older 3"),
+            ("1", "oldest"),
+        ] {
+            let before = runtime.history_prefetch.claim(&runtime.history).unwrap();
+            runtime
+                .history_prefetch
+                .store(
+                    &before,
+                    EventHistoryPage {
+                        data: vec![managed_turn(cursor, prompt)],
+                        has_more: true,
+                        latest_cursor: "9".to_owned(),
+                    },
+                )
+                .unwrap();
+        }
+        assert!(runtime.history_prefetch.claim(&runtime.history).is_none());
+
+        runtime.history_prefetch.request_replay();
+        runtime.start_requested_history_replay(PaneId::Main);
+        assert_eq!(runtime.history_replays.len(), 1);
+        runtime.start_history_prefetch(PaneId::Main);
+        assert!(runtime.history_loads.is_empty());
+
+        let (_, _, _, requested_before, result) =
+            runtime.history_replays.join_next().await.unwrap().unwrap();
+        assert_eq!(requested_before, "9");
+        drop(runtime.finish_history_replay(PaneId::Main, result).unwrap());
+        assert_eq!(runtime.history.before.as_deref(), Some("7"));
+        assert!(runtime.history_prefetch.owns("1"));
+        assert_eq!(runtime.history_loads.len(), 1);
+
+        runtime.history_prefetch.request_replay();
+        runtime.start_requested_history_replay(PaneId::Main);
+        assert_eq!(runtime.history_replays.len(), 1);
+        runtime.start_history_prefetch(PaneId::Main);
+        assert_eq!(runtime.history_loads.len(), 1);
+        let (_, _, _, requested_before, result) =
+            runtime.history_replays.join_next().await.unwrap().unwrap();
+        assert_eq!(requested_before, "7");
+        drop(runtime.finish_history_replay(PaneId::Main, result).unwrap());
+        assert_eq!(runtime.history.before.as_deref(), Some("5"));
+        assert!(runtime.history_prefetch.owns("1"));
+        runtime.history_loads.abort_all();
+    }
+
+    #[tokio::test]
+    async fn driver_runtime_projection_failure_refetches_from_the_current_cursor() {
+        let mut runtime = history_runtime(HistoryWindow {
+            events: vec![managed_turn("9", "retained")],
+            before: Some("9".to_owned()),
+            has_more: true,
+        });
+        let malformed = ManagedEvent {
+            cursor: "8".to_owned(),
+            created_at: Some(1_750_000_000.0),
+            turn_id: Some("turn-7".to_owned()),
+            data: ManagedEventData::Event {
+                event: to_raw_value(&json!({ "not": "an agent event" })).unwrap(),
+                agent_id: None,
+            },
+        };
+        let first_before = runtime.history_prefetch.claim(&runtime.history).unwrap();
+        runtime
+            .history_prefetch
+            .store(
+                &first_before,
+                EventHistoryPage {
+                    data: vec![managed_turn("7", "older"), malformed],
+                    has_more: true,
+                    latest_cursor: "9".to_owned(),
+                },
+            )
+            .unwrap();
+        let dependent_before = runtime.history_prefetch.claim(&runtime.history).unwrap();
+        runtime
+            .history_prefetch
+            .store(
+                &dependent_before,
+                EventHistoryPage {
+                    data: vec![managed_turn("5", "unreachable")],
+                    has_more: true,
+                    latest_cursor: "9".to_owned(),
+                },
+            )
+            .unwrap();
+
+        runtime.history_prefetch.request_replay();
+        runtime.start_requested_history_replay(PaneId::Main);
+        let (_, _, _, requested_before, result) =
+            runtime.history_replays.join_next().await.unwrap().unwrap();
+        assert_eq!(requested_before, "9");
+        assert!(runtime.finish_history_replay(PaneId::Main, result).is_err());
+        assert_eq!(runtime.history.before.as_deref(), Some("9"));
+        assert!(runtime.history_prefetch.owns("9"));
+        assert_eq!(runtime.history_loads.len(), 1);
+        runtime.history_loads.abort_all();
     }
 
     #[test]
@@ -2608,6 +3340,7 @@ mod tests {
             turn_id: Some("older-turn".to_owned()),
             data: ManagedEventData::Event {
                 event: to_raw_value(&json!({ "not": "an agent event" })).unwrap(),
+                agent_id: None,
             },
         };
 
@@ -2641,6 +3374,7 @@ mod tests {
             turn_id: Some("older-turn".to_owned()),
             data: ManagedEventData::Event {
                 event: to_raw_value(&json!({ "not": "an agent event" })).unwrap(),
+                agent_id: None,
             },
         };
 

--- a/bin/nanocodex/src/nanocodex2/tui/transcript/entry.rs
+++ b/bin/nanocodex/src/nanocodex2/tui/transcript/entry.rs
@@ -113,6 +113,8 @@ pub(crate) struct ToolEntry {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum ToolExecution {
+    Account,
+    Runtime,
     Sandbox { cwd: Option<String> },
     Direct,
     WebClient,
@@ -139,6 +141,30 @@ impl ToolExecution {
                 server: server.to_owned(),
             };
         }
+        if matches!(identity.family, "exec_command" | "write_stdin" | "preview")
+            && let Some(environment) = arguments.get("environment").and_then(Value::as_str)
+        {
+            if environment == "sandbox" {
+                return Self::Sandbox {
+                    cwd: execution_cwd(arguments),
+                };
+            }
+            if let Some(machine) = environment
+                .strip_prefix("user:")
+                .filter(|id| !id.is_empty())
+            {
+                return Self::Machine {
+                    name: machine.to_owned(),
+                    cwd: execution_cwd(arguments),
+                };
+            }
+        }
+        if matches!(identity.family, "accountInfo" | "account_connectors") {
+            return Self::Account;
+        }
+        if identity.family == "runtimeInfo" {
+            return Self::Runtime;
+        }
         if identity.family.starts_with("sandbox_") || metadata.is_some_and(reports_sandbox) {
             return Self::Sandbox {
                 cwd: execution_cwd(arguments),
@@ -160,6 +186,8 @@ impl ToolExecution {
 
     fn qualifier(&self) -> String {
         match self {
+            Self::Account => "Account".to_owned(),
+            Self::Runtime => "Runtime".to_owned(),
             Self::Sandbox { cwd: Some(cwd) } => format!("Sandbox · {cwd}"),
             Self::Sandbox { cwd: None } => "Sandbox".to_owned(),
             Self::Direct => "Local".to_owned(),
@@ -230,7 +258,7 @@ impl<'a> ToolIdentity<'a> {
     fn decode(name: &'a str) -> Self {
         let (machine, qualified) = name
             .strip_prefix("user_")
-            .and_then(|name| name.split_once('_'))
+            .and_then(split_machine_tool)
             .filter(|(machine, family)| !machine.is_empty() && !family.is_empty())
             .map_or((None, name), |(machine, family)| (Some(machine), family));
         let (mcp_server, family) = qualified
@@ -244,6 +272,50 @@ impl<'a> ToolIdentity<'a> {
             mcp_server,
         }
     }
+}
+
+fn split_machine_tool(name: &str) -> Option<(&str, &str)> {
+    if let Some((machine, mcp)) = name.split_once("_mcp__")
+        && !machine.is_empty()
+        && !mcp.is_empty()
+    {
+        return Some((machine, &name[machine.len() + 1..]));
+    }
+    const KNOWN_FAMILIES: &[&str] = &[
+        "account_connectors",
+        "image_gen__imagegen",
+        "send_agent_message",
+        "interrupt_agent",
+        "browser_execute",
+        "exec_command",
+        "submit_result",
+        "list_agents",
+        "spawn_agent",
+        "close_agent",
+        "wait_agent",
+        "update_plan",
+        "write_stdin",
+        "accountInfo",
+        "runtimeInfo",
+        "apply_patch",
+        "view_image",
+        "tool_search",
+        "web__run",
+        "browser",
+        "memory",
+        "preview",
+        "exec",
+        "wait",
+    ];
+    KNOWN_FAMILIES
+        .iter()
+        .find_map(|family| {
+            name.strip_suffix(family)
+                .and_then(|prefix| prefix.strip_suffix('_'))
+                .filter(|machine| !machine.is_empty())
+                .map(|machine| (machine, *family))
+        })
+        .or_else(|| name.split_once('_'))
 }
 
 fn execution_cwd(arguments: &Value) -> Option<String> {

--- a/bin/nanocodex/src/nanocodex2/tui/transcript/mod.rs
+++ b/bin/nanocodex/src/nanocodex2/tui/transcript/mod.rs
@@ -16,3 +16,18 @@ pub(crate) use record::{
     LocalEvent, SCHEMA_VERSION, SessionEnded, SessionOutcome, SessionStarted, ShellId,
     TranscriptRecord, TurnId,
 };
+
+pub(crate) fn code_mode_output_text(text: &str) -> &str {
+    let status_envelope = [
+        "Script completed",
+        "Script running",
+        "Script terminated",
+        "Script failed",
+    ]
+    .iter()
+    .any(|prefix| text.starts_with(prefix));
+    if status_envelope && let Some((_, output)) = text.split_once("\nOutput:\n") {
+        return output;
+    }
+    text
+}

--- a/bin/nanocodex/src/nanocodex2/tui/transcript/model.rs
+++ b/bin/nanocodex/src/nanocodex2/tui/transcript/model.rs
@@ -4,6 +4,7 @@
 use super::{
     DirectedMessageEntry, EntryId, EntryKind, MessageDelivery, MessagePhase, SessionStarted,
     ShellId, ToolEntry, ToolState, TranscriptEntry, TranscriptRecord, TransientStatus,
+    code_mode_output_text,
 };
 use crate::{config::ReasoningEffort, tui::format::humanize_tool};
 use nanocodex::{
@@ -55,7 +56,7 @@ pub(crate) struct TranscriptModel {
     active_assistants: HashMap<(u32, MessagePhase), EntryId>,
     reasoning: HashMap<ReasoningKey, EntryId>,
     tools: HashMap<String, EntryId>,
-    shell_sessions: HashMap<i64, EntryId>,
+    shell_sessions: HashMap<ShellSessionKey, EntryId>,
     shell_followups: HashMap<String, EntryId>,
     code_children: HashMap<EntryId, Vec<EntryId>>,
     code_cells: HashMap<String, EntryId>,
@@ -81,6 +82,24 @@ struct AssistantKey {
 struct ReasoningKey {
     request: Option<Arc<str>>,
     call: u32,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct ShellSessionKey {
+    environment: Option<String>,
+    session_id: i64,
+}
+
+impl ShellSessionKey {
+    fn from_arguments(arguments: &Value, session_id: i64) -> Self {
+        Self {
+            environment: arguments
+                .get("environment")
+                .and_then(Value::as_str)
+                .map(str::to_owned),
+            session_id,
+        }
+    }
 }
 
 impl TranscriptModel {
@@ -577,7 +596,10 @@ impl TranscriptModel {
         let parent = self.code_parent(&call_id);
         if tool == "write_stdin"
             && let Some(session_id) = arguments.get("session_id").and_then(Value::as_i64)
-            && let Some(id) = self.shell_sessions.get(&session_id).copied()
+            && let Some(id) = self
+                .shell_sessions
+                .get(&ShellSessionKey::from_arguments(&arguments, session_id))
+                .copied()
         {
             if parent.is_some() {
                 self.shell_followups.insert(call_id.clone(), id);
@@ -647,7 +669,7 @@ impl TranscriptModel {
         } else {
             state
         };
-        let shell_session = (payload.tool == "exec_command")
+        let shell_session_id = (payload.tool == "exec_command")
             .then(|| tool_session_id(&result))
             .flatten();
         let id = self
@@ -682,6 +704,13 @@ impl TranscriptModel {
                 self.tools.insert(payload.call_id.clone(), id);
                 id
             });
+        let shell_session = shell_session_id.map(|session_id| {
+            let arguments = self.entry(id).and_then(|entry| match &entry.kind {
+                EntryKind::Tool(tool) => Some(&tool.arguments),
+                _ => None,
+            });
+            ShellSessionKey::from_arguments(arguments.unwrap_or(&Value::Null), session_id)
+        });
         let running_code_cell = (payload.tool == "exec")
             .then(|| running_code_cell_id(&result))
             .flatten()
@@ -714,12 +743,24 @@ impl TranscriptModel {
             }
         });
         if payload.tool == "exec"
-            && self.code_children.contains_key(&id)
-            && (entry_state == ToolState::Failed || code_mode_has_own_output(self.entry(id)))
-            && let Some(index) = self.index_of(id)
+            && let Some(children) = self.code_children.get(&id)
         {
-            self.entries[index].hidden = false;
-            self.entries[index].revision = self.entries[index].revision.saturating_add(1);
+            let only_code_child = <&[EntryId; 1]>::try_from(children.as_slice())
+                .ok()
+                .and_then(|[child]| self.entry(*child))
+                .and_then(|entry| match &entry.kind {
+                    EntryKind::Tool(tool) => Some((tool.result.as_ref(), tool.state)),
+                    _ => None,
+                });
+            if code_mode_has_distinct_output(
+                self.entry(id),
+                only_code_child.and_then(|(result, _)| result),
+                only_code_child.is_some_and(|(_, state)| state == ToolState::Failed),
+            ) && let Some(index) = self.index_of(id)
+            {
+                self.entries[index].hidden = false;
+                self.entries[index].revision = self.entries[index].revision.saturating_add(1);
+            }
         }
         if let Some(shell) = resumed_shell {
             let resumed_result = resumed_result.expect("resumed shell result was retained");
@@ -1026,8 +1067,9 @@ impl TranscriptModel {
         });
         let children = self.code_children.entry(parent).or_default();
         children.push(child);
+        let single_child = children.len() == 1;
         let index = self.index_of(parent).expect("code parent is retained");
-        self.entries[index].hidden = true;
+        self.entries[index].hidden = single_child;
         self.entries[index].revision = self.entries[index].revision.saturating_add(1);
 
         let child_index = self.index_of(child).expect("code child is retained");
@@ -1165,7 +1207,11 @@ fn code_mode_status(result: &Value) -> Option<&str> {
     }
 }
 
-fn code_mode_has_own_output(entry: Option<&TranscriptEntry>) -> bool {
+fn code_mode_has_distinct_output(
+    entry: Option<&TranscriptEntry>,
+    only_child_result: Option<&Value>,
+    only_child_failed: bool,
+) -> bool {
     let Some(TranscriptEntry {
         kind: EntryKind::Tool(tool),
         ..
@@ -1176,35 +1222,110 @@ fn code_mode_has_own_output(entry: Option<&TranscriptEntry>) -> bool {
     let Some(result) = &tool.result else {
         return false;
     };
-    code_mode_value_has_output(result)
+    code_mode_value_has_output(result, only_child_result, only_child_failed)
 }
 
-fn code_mode_value_has_output(result: &Value) -> bool {
+fn code_mode_value_has_output(
+    result: &Value,
+    only_child_result: Option<&Value>,
+    only_child_failed: bool,
+) -> bool {
+    if only_child_result.is_some_and(|child| values_duplicate(result, child)) {
+        return false;
+    }
     match result {
-        Value::String(text) => status_text_has_output(text),
-        Value::Array(items) => items.iter().any(code_mode_value_has_output),
+        Value::String(text) => text_has_distinct_output(text, only_child_result, only_child_failed),
+        Value::Array(items) => items
+            .iter()
+            .any(|item| code_mode_value_has_output(item, only_child_result, only_child_failed)),
         Value::Object(fields) => {
             if let Some(text) = fields.get("text").and_then(Value::as_str) {
-                return status_text_has_output(text);
+                return text_has_distinct_output(text, only_child_result, only_child_failed);
             }
-            ["content", "output", "image_url", "audio_url"]
-                .into_iter()
-                .any(|key| fields.get(key).is_some_and(code_mode_value_has_output))
+            let mut has_supported_output = false;
+            for key in ["content", "output", "image_url", "audio_url"] {
+                let Some(value) = fields.get(key) else {
+                    continue;
+                };
+                has_supported_output = true;
+                if code_mode_value_has_output(value, only_child_result, only_child_failed) {
+                    return true;
+                }
+            }
+            !has_supported_output && !fields.is_empty()
         }
         Value::Bool(_) | Value::Number(_) => true,
         Value::Null => false,
     }
 }
 
-fn status_text_has_output(text: &str) -> bool {
-    if let Some((status, output)) = text.split_once("\nOutput:\n")
-        && (status.starts_with("Script completed")
-            || status.starts_with("Script running")
-            || status.starts_with("Script terminated"))
-    {
-        return !output.trim().is_empty();
+fn values_duplicate(candidate: &Value, child: &Value) -> bool {
+    candidate == child
+        || content_envelope_matches(candidate, child)
+        || content_envelope_matches(child, candidate)
+}
+
+fn content_envelope_matches(envelope: &Value, payload: &Value) -> bool {
+    let Some(fields) = envelope.as_object() else {
+        return false;
+    };
+    if !matches!(
+        fields.get("type").and_then(Value::as_str),
+        Some("input_text" | "input_image" | "input_audio")
+    ) {
+        return false;
     }
-    !text.trim().is_empty()
+    let Some(payload) = payload.as_object() else {
+        return false;
+    };
+    fields.len() == payload.len() + 1
+        && fields
+            .iter()
+            .filter(|(key, _)| key.as_str() != "type")
+            .all(|(key, value)| payload.get(key) == Some(value))
+}
+
+fn text_has_distinct_output(
+    text: &str,
+    only_child_result: Option<&Value>,
+    only_child_failed: bool,
+) -> bool {
+    let failed_envelope = text.starts_with("Script failed");
+    let text = code_mode_output_text(text);
+    if text.trim().is_empty() {
+        return false;
+    }
+    if failed_envelope
+        && only_child_failed
+        && only_child_result
+            .and_then(Value::as_str)
+            .is_some_and(|child| !child.trim().is_empty() && text.contains(child.trim()))
+    {
+        return false;
+    }
+    !only_child_result.is_some_and(|child| text_duplicates_value(text, child))
+}
+
+fn text_duplicates_value(text: &str, value: &Value) -> bool {
+    let text = text.trim();
+    value.as_str() == Some(text)
+        || (text_may_encode_value(text, value)
+            && serde_json::from_str::<Value>(text).is_ok_and(|decoded| decoded == *value))
+}
+
+fn text_may_encode_value(text: &str, value: &Value) -> bool {
+    let Some(first) = text.as_bytes().first() else {
+        return false;
+    };
+    match value {
+        Value::Object(_) => *first == b'{',
+        Value::Array(_) => *first == b'[',
+        Value::String(_) => *first == b'"',
+        Value::Number(_) => *first == b'-' || first.is_ascii_digit(),
+        Value::Bool(true) => *first == b't',
+        Value::Bool(false) => *first == b'f',
+        Value::Null => *first == b'n',
+    }
 }
 
 fn tool_result_state(tool: &str, status: &str, result: &Value) -> ToolState {
@@ -1478,7 +1599,7 @@ mod tests {
     }
 
     #[test]
-    fn semantic_children_hide_code_mode_wrapper_without_grouping_children_under_it() {
+    fn semantic_children_hide_single_wrapper_but_keep_multi_tool_batch() {
         let mut model = TranscriptModel::default();
         model.apply(&call(1, "outer", "exec", json!("await tools.one({})")));
         model.apply(&call(
@@ -1487,6 +1608,7 @@ mod tests {
             "exec_command",
             json!({"cmd": "pwd"}),
         ));
+        assert!(model.entries()[0].hidden);
         model.apply(&call(
             3,
             "outer/code-1",
@@ -1495,7 +1617,7 @@ mod tests {
         ));
 
         assert_eq!(model.entries().len(), 3);
-        assert!(model.entries()[0].hidden);
+        assert!(!model.entries()[0].hidden);
         assert!(!model.entries()[1].hidden);
         assert!(!model.entries()[2].hidden);
         assert!(model.entries()[1].parent.is_none());
@@ -1597,6 +1719,87 @@ mod tests {
     }
 
     #[test]
+    fn shell_sessions_are_correlated_by_environment_and_session_id() {
+        let mut model = TranscriptModel::default();
+        model.apply(&call(
+            1,
+            "sandbox-shell",
+            "exec_command",
+            json!({"environment": "sandbox", "cmd": "interactive", "tty": true}),
+        ));
+        model.apply(&result(
+            2,
+            "sandbox-shell",
+            "exec_command",
+            Value::Null,
+            json!({"session_id": 7, "output": "sandbox ready\n"}),
+            Value::Null,
+        ));
+        model.apply(&call(
+            3,
+            "machine-shell",
+            "exec_command",
+            json!({"environment": "user:build-box", "cmd": "interactive", "tty": true}),
+        ));
+        model.apply(&result(
+            4,
+            "machine-shell",
+            "exec_command",
+            Value::Null,
+            json!({"session_id": 7, "output": "machine ready\n"}),
+            Value::Null,
+        ));
+        model.apply(&call(
+            5,
+            "sandbox-input",
+            "write_stdin",
+            json!({"environment": "sandbox", "session_id": 7, "chars": "sandbox input\n"}),
+        ));
+        model.apply(&result(
+            6,
+            "sandbox-input",
+            "write_stdin",
+            Value::Null,
+            json!({"session_id": 7, "output": "sandbox output\n"}),
+            Value::Null,
+        ));
+        model.apply(&call(
+            7,
+            "machine-input",
+            "write_stdin",
+            json!({"environment": "user:build-box", "session_id": 7, "chars": "machine input\n"}),
+        ));
+        model.apply(&result(
+            8,
+            "machine-input",
+            "write_stdin",
+            Value::Null,
+            json!({"session_id": 7, "output": "machine output\n"}),
+            Value::Null,
+        ));
+
+        assert_eq!(model.entries().len(), 2);
+        let EntryKind::Tool(sandbox) = &model.entries()[0].kind else {
+            panic!("first entry should remain the sandbox shell");
+        };
+        let EntryKind::Tool(machine) = &model.entries()[1].kind else {
+            panic!("second entry should remain the machine shell");
+        };
+        assert_eq!(sandbox.execution_qualifier(), "Sandbox");
+        assert_eq!(machine.execution_qualifier(), "Machine build-box");
+        assert_eq!(sandbox.substeps, ["sent \"sandbox input\\n\""]);
+        assert_eq!(machine.substeps, ["sent \"machine input\\n\""]);
+        assert_eq!(
+            sandbox.result.as_ref().unwrap()["output"],
+            "sandbox ready\nsandbox output\n"
+        );
+        assert_eq!(
+            machine.result.as_ref().unwrap()["output"],
+            "machine ready\nmachine output\n"
+        );
+    }
+
+    #[test]
     fn hidden_code_wrapper_returns_for_failure_or_authoritative_output() {
         let mut failed = TranscriptModel::default();
         failed.apply(&call(1, "failed", "exec", json!("await tools.one({})")));
@@ -1644,6 +1847,195 @@ mod tests {
             Value::Null,
         ));
         assert!(status_only.entries()[0].hidden);
+    }
+
+    #[test]
+    fn failed_single_child_echo_keeps_only_the_semantic_child() {
+        let child_error = "Error: sandbox workspace is unavailable";
+        let mut model = TranscriptModel::default();
+        model.apply(&call(
+            1,
+            "failed-echo",
+            "exec",
+            json!("await tools.exec_command({environment: 'sandbox', cmd: 'sleep 20'})"),
+        ));
+        model.apply(&call(
+            2,
+            "failed-echo/code-0",
+            "exec_command",
+            json!({"environment": "sandbox", "cmd": "sleep 20"}),
+        ));
+        model.apply(&agent_record(
+            3,
+            AgentEventKind::ToolResult,
+            json!({
+                "call_id": "failed-echo/code-0",
+                "tool": "exec_command",
+                "status": "failed",
+                "duration_ns": 10,
+                "result": child_error,
+                "structured_result": child_error,
+                "metadata": null
+            }),
+        ));
+        model.apply(&agent_record(
+            4,
+            AgentEventKind::ToolResult,
+            json!({
+                "call_id": "failed-echo",
+                "tool": "exec",
+                "status": "failed",
+                "duration_ns": 10,
+                "result": format!(
+                    "Script failed\nWall time 0.1 seconds\nOutput:\nError: {child_error}\n    at unwrap (index.js:1:1)"
+                ),
+                "structured_result": null,
+                "metadata": null
+            }),
+        ));
+
+        assert!(model.entries()[0].hidden);
+        assert!(!model.entries()[1].hidden);
+    }
+
+    #[test]
+    fn exact_single_child_echo_does_not_restore_code_wrapper() {
+        let account = json!({
+            "status": "ready",
+            "authenticated": ["github"],
+            "machines": [{"id": "sandbox", "kind": "sandbox"}],
+            "vault": []
+        });
+        let mut model = TranscriptModel::default();
+        model.apply(&call(
+            1,
+            "account-wrapper",
+            "exec",
+            json!("text(await tools.accountInfo({}))"),
+        ));
+        model.apply(&call(2, "account-wrapper/code-0", "accountInfo", json!({})));
+        model.apply(&result(
+            3,
+            "account-wrapper/code-0",
+            "accountInfo",
+            account.clone(),
+            account.clone(),
+            Value::Null,
+        ));
+        model.apply(&result(
+            4,
+            "account-wrapper",
+            "exec",
+            json!([
+                {
+                    "type": "input_text",
+                    "text": "Script completed\nWall time 0.1 seconds\nOutput:\n"
+                },
+                {"type": "input_text", "text": serde_json::to_string(&account).unwrap()}
+            ]),
+            Value::Null,
+            Value::Null,
+        ));
+
+        assert!(model.entries()[0].hidden);
+        assert!(!model.entries()[1].hidden);
+        let EntryKind::Tool(child) = &model.entries()[1].kind else {
+            panic!("accountInfo child should remain visible");
+        };
+        assert_eq!(child.duration_ns, Some(10));
+        assert_eq!(child.result, Some(account));
+    }
+
+    #[test]
+    fn exact_object_echoes_keep_only_the_semantic_child() {
+        let child_result = json!({"output": "artifact", "status": "ready"});
+        for parent_result in [child_result.clone(), json!([child_result.clone()])] {
+            let mut model = TranscriptModel::default();
+            model.apply(&call(
+                1,
+                "object-wrapper",
+                "exec",
+                json!("await tools.inspect({})"),
+            ));
+            model.apply(&call(2, "object-wrapper/code-0", "inspect", json!({})));
+            model.apply(&result(
+                3,
+                "object-wrapper/code-0",
+                "inspect",
+                child_result.clone(),
+                child_result.clone(),
+                Value::Null,
+            ));
+            model.apply(&result(
+                4,
+                "object-wrapper",
+                "exec",
+                parent_result,
+                Value::Null,
+                Value::Null,
+            ));
+
+            assert!(model.entries()[0].hidden);
+            assert!(!model.entries()[1].hidden);
+            let EntryKind::Tool(child) = &model.entries()[1].kind else {
+                panic!("inspect child should remain visible");
+            };
+            assert_eq!(child.result.as_ref(), Some(&child_result));
+        }
+    }
+
+    #[test]
+    fn multimodal_content_echoes_keep_only_the_semantic_child() {
+        for (child_result, emitted_item) in [
+            (
+                json!({"image_url": "data:image/png;base64,AAAA", "detail": "high"}),
+                json!({
+                    "type": "input_image",
+                    "image_url": "data:image/png;base64,AAAA",
+                    "detail": "high"
+                }),
+            ),
+            (
+                json!({"audio_url": "data:audio/wav;base64,AAAA"}),
+                json!({
+                    "type": "input_audio",
+                    "audio_url": "data:audio/wav;base64,AAAA"
+                }),
+            ),
+        ] {
+            let mut model = TranscriptModel::default();
+            model.apply(&call(1, "media-wrapper", "exec", json!("emit media")));
+            model.apply(&call(2, "media-wrapper/code-0", "media_tool", json!({})));
+            model.apply(&result(
+                3,
+                "media-wrapper/code-0",
+                "media_tool",
+                child_result.clone(),
+                child_result.clone(),
+                Value::Null,
+            ));
+            model.apply(&result(
+                4,
+                "media-wrapper",
+                "exec",
+                json!([
+                    {
+                        "type": "input_text",
+                        "text": "Script completed\nWall time 0.1 seconds\nOutput:\n"
+                    },
+                    emitted_item
+                ]),
+                Value::Null,
+                Value::Null,
+            ));
+
+            assert!(model.entries()[0].hidden);
+            assert!(!model.entries()[1].hidden);
+            let EntryKind::Tool(child) = &model.entries()[1].kind else {
+                panic!("media child should remain visible");
+            };
+            assert_eq!(child.result.as_ref(), Some(&child_result));
+        }
     }
 
     #[test]

--- a/bin/nanocodex/tests/nanocodex2_managed.rs
+++ b/bin/nanocodex/tests/nanocodex2_managed.rs
@@ -585,7 +585,9 @@ fn agent_state_value(latest_event_cursor: &str) -> serde_json::Value {
             "live_steer": true,
             "live_cancel": true,
             "workspace": "private-hosted-tools-v1",
-            "execution_environments": true
+            "execution_environments": true,
+            "execution_namespace": "cwd-root-v1",
+            "native_cross_mounts": false
         },
         "settings": agent_settings(),
         "latest_event_cursor": latest_event_cursor,
@@ -895,7 +897,9 @@ async fn agent_state(State(state): State<TestState>, headers: HeaderMap) -> impl
                 "live_steer": true,
                 "live_cancel": true,
                 "workspace": "private-hosted-tools-v1",
-                "execution_environments": true
+                "execution_environments": true,
+                "execution_namespace": "cwd-root-v1",
+                "native_cross_mounts": false
             },
             "settings": agent_settings(),
             "latest_event_cursor": "0",
@@ -1058,7 +1062,9 @@ fn agent_capabilities() -> serde_json::Value {
         "live_steer": true,
         "live_cancel": true,
         "workspace": "cloudflare-computer",
-        "execution_environments": true
+        "execution_environments": true,
+        "execution_namespace": "cwd-root-v1",
+        "native_cross_mounts": false
     })
 }
 

--- a/bin/nanocodex/tests/nanocodex2_managed.rs
+++ b/bin/nanocodex/tests/nanocodex2_managed.rs
@@ -585,7 +585,7 @@ fn agent_state_value(latest_event_cursor: &str) -> serde_json::Value {
             "live_steer": true,
             "live_cancel": true,
             "workspace": "private-hosted-tools-v1",
-            "sandbox_escalation": true
+            "execution_environments": true
         },
         "settings": agent_settings(),
         "latest_event_cursor": latest_event_cursor,
@@ -895,7 +895,7 @@ async fn agent_state(State(state): State<TestState>, headers: HeaderMap) -> impl
                 "live_steer": true,
                 "live_cancel": true,
                 "workspace": "private-hosted-tools-v1",
-                "sandbox_escalation": true
+                "execution_environments": true
             },
             "settings": agent_settings(),
             "latest_event_cursor": "0",
@@ -1058,7 +1058,7 @@ fn agent_capabilities() -> serde_json::Value {
         "live_steer": true,
         "live_cancel": true,
         "workspace": "cloudflare-computer",
-        "sandbox_escalation": false
+        "execution_environments": true
     })
 }
 

--- a/crates/nanocodex-managed/src/driver.rs
+++ b/crates/nanocodex-managed/src/driver.rs
@@ -14,7 +14,7 @@ use nanocodex_agent::{
     },
     input::{ImageDetail, Prompt, PromptInput as AgentPromptInput, UserInput},
 };
-use nanocodex_oai_api::events::AgentEventPublisher;
+use nanocodex_oai_api::events::{AgentEvent, AgentEventPublisher};
 use tokio::sync::{mpsc, watch};
 use tower::Service;
 
@@ -28,7 +28,6 @@ use crate::{
 use crate::attachment::AttachmentSupervisor;
 
 const COMMAND_CAPACITY: usize = 32;
-const MAX_PENDING_TURNS: usize = 256;
 
 pub(crate) enum Command {
     Submit(
@@ -406,11 +405,6 @@ where
         prompt: BackendPrompt,
         completion: tokio::sync::oneshot::Sender<nanocodex_agent::Result<TurnResult>>,
     ) -> nanocodex_agent::Result<String> {
-        if self.pending.len() >= MAX_PENDING_TURNS {
-            return Err(NanocodexError::InvalidRequest(
-                "managed pending turn capacity is exhausted".to_owned(),
-            ));
-        }
         let cancel_on_admission = prompt.cancel_on_admission;
         let input = managed_prompt(prompt.prompt)?;
         let request_id = prompt
@@ -599,20 +593,30 @@ where
         if let Some(observer) = &self.event_observer {
             drop(observer.send(event.clone()));
         }
-        if let Some(mut nested) = event.data.agent_event().map_err(backend_error)? {
-            nested.seq = self.next_event_seq;
-            self.next_event_seq = self.next_event_seq.checked_add(1).ok_or_else(|| {
-                backend_error(ManagedError::InvalidEvent(
-                    "managed agent event sequence exhausted".to_owned(),
-                ))
-            })?;
-            nested.request_id = Arc::from(self.events.request_id());
-            let publisher = event
+        if let Some(nested) = event.data.agent_event().map_err(backend_error)? {
+            let child_terminal = nested.kind.is_terminal()
+                && matches!(
+                    event.data,
+                    ManagedEventData::Event {
+                        agent_id: Some(_),
+                        ..
+                    }
+                );
+            let pending = event
                 .turn_id
                 .as_deref()
-                .and_then(|turn_id| self.pending.get(turn_id))
-                .map_or(&self.events, |pending| &pending.events);
-            publisher.publish(nested).map_err(backend_error)?;
+                .and_then(|turn_id| self.pending.get(turn_id));
+            if let Some(pending) = pending {
+                let publisher = if child_terminal {
+                    self.events.clone()
+                } else {
+                    pending.events.clone()
+                };
+                self.publish_nested(&publisher, nested)?;
+            } else {
+                let publisher = self.events.clone();
+                self.publish_nested(&publisher, nested)?;
+            }
         }
 
         match event.data {
@@ -622,15 +626,15 @@ where
                 usage,
                 ..
             } => {
-                let usage = usage
-                    .map(serde_json::from_value::<TurnUsage>)
-                    .transpose()
-                    .map_err(|_| {
-                        backend_error(ManagedError::InvalidEvent(
-                            "managed turn usage is not an exact TurnUsage".to_owned(),
-                        ))
-                    })?;
                 self.complete(&id, |pending| {
+                    let usage = usage
+                        .map(serde_json::from_value::<TurnUsage>)
+                        .transpose()
+                        .map_err(|_| {
+                            backend_error(ManagedError::InvalidEvent(
+                                "managed turn usage is not an exact TurnUsage".to_owned(),
+                            ))
+                        })?;
                     Ok(TurnResult::from_backend(
                         Some(pending.request_id.clone()),
                         final_message,
@@ -657,6 +661,21 @@ where
             | ManagedEventData::TurnRetryable { .. } => {}
         }
         Ok(())
+    }
+
+    fn publish_nested(
+        &mut self,
+        publisher: &AgentEventPublisher,
+        mut event: AgentEvent,
+    ) -> nanocodex_agent::Result<()> {
+        event.seq = self.next_event_seq;
+        self.next_event_seq = self.next_event_seq.checked_add(1).ok_or_else(|| {
+            backend_error(ManagedError::InvalidEvent(
+                "managed agent event sequence exhausted".to_owned(),
+            ))
+        })?;
+        event.request_id = Arc::from(self.events.request_id());
+        publisher.publish(event).map_err(backend_error)
     }
 
     fn complete(

--- a/crates/nanocodex-managed/src/types.rs
+++ b/crates/nanocodex-managed/src/types.rs
@@ -296,6 +296,10 @@ pub struct AgentCapabilities {
     pub workspace: String,
     /// Whether tools can target explicit sandbox and connected-user environments.
     pub execution_environments: bool,
+    /// Server-advertised logical execution namespace contract.
+    pub execution_namespace: String,
+    /// Whether native processes can access peer mounts through filesystem syscalls.
+    pub native_cross_mounts: bool,
 }
 
 /// Model and reasoning policy owned by one managed agent.

--- a/crates/nanocodex-managed/src/types.rs
+++ b/crates/nanocodex-managed/src/types.rs
@@ -294,8 +294,8 @@ pub struct AgentCapabilities {
     pub live_cancel: bool,
     /// Server-advertised workspace mode.
     pub workspace: String,
-    /// Whether sandbox escalation is available.
-    pub sandbox_escalation: bool,
+    /// Whether tools can target explicit sandbox and connected-user environments.
+    pub execution_environments: bool,
 }
 
 /// Model and reasoning policy owned by one managed agent.
@@ -722,6 +722,9 @@ pub enum ManagedEventData {
         /// Exact nested agent-event JSON. The raw object is decoded directly
         /// into AgentEvent only when requested; it never traverses Value.
         event: Box<RawValue>,
+        /// Numeric subagent identity. Absent for the root agent.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        agent_id: Option<u64>,
     },
     /// The server-side durable stream failed.
     StreamFailed {
@@ -784,6 +787,7 @@ impl ManagedEventData {
         #[derive(Deserialize)]
         struct Event {
             event: Box<RawValue>,
+            agent_id: Option<u64>,
         }
         #[derive(Deserialize)]
         struct StreamFailed {
@@ -845,7 +849,10 @@ impl ManagedEventData {
             }
             "event" => {
                 let value: Event = decode_raw(raw)?;
-                Ok(Self::Event { event: value.event })
+                Ok(Self::Event {
+                    event: value.event,
+                    agent_id: value.agent_id,
+                })
             }
             "stream_failed" => {
                 let value: StreamFailed = decode_raw(raw)?;
@@ -863,7 +870,7 @@ impl ManagedEventData {
     /// Returns ManagedError::InvalidEvent when the nested object violates the
     /// canonical agent-event schema.
     pub fn agent_event(&self) -> Result<Option<AgentEvent>, ManagedError> {
-        let Self::Event { event } = self else {
+        let Self::Event { event, .. } = self else {
             return Ok(None);
         };
         serde_json::from_str(event.get())
@@ -874,7 +881,7 @@ impl ManagedEventData {
     /// Returns the exact nested agent-event object without decoding it.
     #[must_use]
     pub fn raw_agent_event(&self) -> Option<&RawValue> {
-        let Self::Event { event } = self else {
+        let Self::Event { event, .. } = self else {
             return None;
         };
         Some(event)
@@ -1022,7 +1029,7 @@ mod tests {
     #[test]
     fn nested_agent_event_retains_its_raw_object() {
         let json = concat!(
-            r#"{"cursor":"2","created_at":1,"turn_id":"turn-1","type":"event","#,
+            r#"{"cursor":"2","created_at":1,"turn_id":"turn-1","type":"event","agent_id":7,"#,
             r#""event": { "protocol_version":1, "request_id":"request-1", "seq":1,"#,
             r#""type":"assistant.delta", "payload": { "delta" : "hi" } }}"#
         );
@@ -1032,6 +1039,13 @@ mod tests {
         assert!(raw.starts_with(r#"{ "protocol_version""#));
         assert!(raw.contains(r#""payload": { "delta" : "hi" }"#));
         assert_eq!(event.data.agent_event().unwrap().unwrap().seq, 1);
+        assert!(matches!(
+            event.data,
+            ManagedEventData::Event {
+                agent_id: Some(7),
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/nanocodex-managed/src/websocket.rs
+++ b/crates/nanocodex-managed/src/websocket.rs
@@ -556,7 +556,9 @@ mod tests {
                 "live_steer": true,
                 "live_cancel": true,
                 "workspace": "cloud",
-                "execution_environments": true
+                "execution_environments": true,
+                "execution_namespace": "cwd-root-v1",
+                "native_cross_mounts": false
             },
             "latest_event_cursor": "0"
         });
@@ -573,5 +575,7 @@ mod tests {
         assert_eq!(parsed.settings.model, Model::Luna);
         assert_eq!(parsed.settings.thinking, Thinking::Low);
         assert!(parsed.settings.fast_mode);
+        assert_eq!(parsed.capabilities.execution_namespace, "cwd-root-v1");
+        assert!(!parsed.capabilities.native_cross_mounts);
     }
 }

--- a/crates/nanocodex-managed/src/websocket.rs
+++ b/crates/nanocodex-managed/src/websocket.rs
@@ -556,7 +556,7 @@ mod tests {
                 "live_steer": true,
                 "live_cancel": true,
                 "workspace": "cloud",
-                "sandbox_escalation": false
+                "execution_environments": true
             },
             "latest_event_cursor": "0"
         });

--- a/crates/nanocodex-managed/tests/public_lifecycle.rs
+++ b/crates/nanocodex-managed/tests/public_lifecycle.rs
@@ -39,6 +39,9 @@ const SESSION_ID: &str = "019fc927-b280-79a7-8445-1b9996ad2fb0";
 const ACTIVE_REQUEST_ID: &str = "caller-request-active";
 const RETAINED_REQUEST_ID: &str = "caller-request-retained";
 const CANCELLED_REQUEST_ID: &str = "caller-request-cancelled";
+const FOREIGN_REQUEST_ID: &str = "caller-request-foreign";
+const ROOT_SOURCE_REQUEST_ID: &str = "server-private-session";
+const CHILD_SOURCE_REQUEST_ID: &str = "server-private-subagent";
 const TEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Clone)]
@@ -310,34 +313,63 @@ async fn public_managed_lifecycle_preserves_durable_identity_control_and_replay(
             .send_event(accepted_event(41, ACTIVE_REQUEST_ID, "live prompt"))
             .await;
         fixture
-            .send_event(nested_event(
+            .send_event(completed_event_with_usage(
                 42,
+                FOREIGN_REQUEST_ID,
+                "foreign answer",
+                json!({"future_usage_schema": true}),
+            ))
+            .await;
+        fixture
+            .send_event(nested_event(
+                43,
+                ROOT_SOURCE_REQUEST_ID,
+                None,
                 "assistant.message",
                 json!({"text": "live"}),
             ))
             .await;
         fixture
             .send_event(nested_event(
-                43,
+                44,
+                CHILD_SOURCE_REQUEST_ID,
+                Some(7),
+                "assistant.message",
+                json!({"text": "child"}),
+            ))
+            .await;
+        fixture
+            .send_event(nested_event(
+                45,
+                CHILD_SOURCE_REQUEST_ID,
+                Some(7),
+                "run.completed",
+                json!({"status": "completed"}),
+            ))
+            .await;
+        fixture
+            .send_event(nested_event(
+                46,
+                ROOT_SOURCE_REQUEST_ID,
+                None,
+                "assistant.message",
+                json!({"text": "after child"}),
+            ))
+            .await;
+        assert!(
+            (&mut turn).now_or_never().is_none(),
+            "a nested subagent terminal must not stop the parent turn"
+        );
+        fixture
+            .send_event(nested_event(
+                47,
+                ROOT_SOURCE_REQUEST_ID,
+                None,
                 "run.completed",
                 json!({"status": "completed"}),
             ))
             .await;
 
-        let assistant = events
-            .recv()
-            .await
-            .expect("rewritten assistant event should be public");
-        assert_eq!(assistant.kind, AgentEventKind::AssistantMessage);
-        assert_eq!(assistant.seq, 1);
-        assert_eq!(assistant.request_id.as_ref(), SESSION_ID);
-        let terminal = events
-            .recv()
-            .await
-            .expect("rewritten run terminal should be public");
-        assert_eq!(terminal.kind, AgentEventKind::RunCompleted);
-        assert_eq!(terminal.seq, 2);
-        assert_eq!(terminal.request_id.as_ref(), SESSION_ID);
         assert!(
             (&mut turn).now_or_never().is_none(),
             "the result must not complete from the nested run terminal alone"
@@ -348,15 +380,43 @@ async fn public_managed_lifecycle_preserves_durable_identity_control_and_replay(
         );
 
         fixture
-            .send_event(completed_event(44, ACTIVE_REQUEST_ID, "live answer"))
+            .send_event(completed_event(48, ACTIVE_REQUEST_ID, "live answer"))
             .await;
+        let mut published = Vec::new();
+        for _ in 0..5 {
+            published.push(
+                events
+                    .recv()
+                    .await
+                    .expect("rewritten parent event stream should remain open"),
+            );
+        }
+        assert_eq!(
+            published.iter().map(|event| event.kind).collect::<Vec<_>>(),
+            [
+                AgentEventKind::AssistantMessage,
+                AgentEventKind::AssistantMessage,
+                AgentEventKind::RunCompleted,
+                AgentEventKind::AssistantMessage,
+                AgentEventKind::RunCompleted,
+            ]
+        );
+        assert_eq!(
+            published.iter().map(|event| event.seq).collect::<Vec<_>>(),
+            [1, 2, 3, 4, 5]
+        );
+        assert!(
+            published
+                .iter()
+                .all(|event| event.request_id.as_ref() == SESSION_ID)
+        );
         let result: TurnResult = turn
             .await
             .expect("live terminal should complete the result");
         assert_result(&result, ACTIVE_REQUEST_ID, "live answer");
 
         let mut observed = Vec::new();
-        for _ in 0..4 {
+        for _ in 0..8 {
             observed.push(
                 observed_events
                     .recv()
@@ -369,7 +429,7 @@ async fn public_managed_lifecycle_preserves_durable_identity_control_and_replay(
                 .iter()
                 .map(|event| event.cursor.as_str())
                 .collect::<Vec<_>>(),
-            ["41", "42", "43", "44"]
+            ["41", "42", "43", "44", "45", "46", "47", "48"]
         );
         assert!(matches!(
             &observed[0].data,
@@ -378,10 +438,14 @@ async fn public_managed_lifecycle_preserves_durable_identity_control_and_replay(
                 ..
             } if input == "live prompt"
         ));
-        assert!(matches!(observed[1].data, ManagedEventData::Event { .. }));
-        assert!(matches!(observed[2].data, ManagedEventData::Event { .. }));
         assert!(matches!(
-            observed[3].data,
+            observed[1].data,
+            ManagedEventData::TurnCompleted { .. }
+        ));
+        assert!(matches!(observed[2].data, ManagedEventData::Event { .. }));
+        assert!(matches!(observed[3].data, ManagedEventData::Event { .. }));
+        assert!(matches!(
+            observed[7].data,
             ManagedEventData::TurnCompleted { .. }
         ));
         assert_eq!(
@@ -680,7 +744,7 @@ fn agent_state_json(agent_id: &str, latest_event_cursor: &str) -> Value {
             "live_steer": true,
             "live_cancel": true,
             "workspace": "cloud",
-            "sandbox_escalation": false
+            "execution_environments": true
         },
         "settings": {
             "model": "gpt-5.6-sol",
@@ -865,20 +929,29 @@ fn turn_view(
     })
 }
 
-fn nested_event(cursor: u64, kind: &str, payload: Value) -> Bytes {
-    let envelope = json!({
+fn nested_event(
+    cursor: u64,
+    request_id: &str,
+    agent_id: Option<u64>,
+    kind: &str,
+    payload: Value,
+) -> Bytes {
+    let mut envelope = json!({
         "cursor": cursor.to_string(),
         "created_at": cursor,
         "turn_id": ACTIVE_REQUEST_ID,
         "type": "event",
         "event": {
             "protocol_version": 1,
-            "request_id": "server-private-session",
+            "request_id": request_id,
             "seq": 1,
             "type": kind,
             "payload": payload
         }
     });
+    if let Some(agent_id) = agent_id {
+        envelope["agent_id"] = agent_id.into();
+    }
     Bytes::from(format!("id: {cursor}\nevent: event\ndata: {envelope}\n\n"))
 }
 
@@ -898,6 +971,15 @@ fn accepted_event(cursor: u64, turn_id: &str, input: &str) -> Bytes {
 }
 
 fn completed_event(cursor: u64, turn_id: &str, final_message: &str) -> Bytes {
+    completed_event_with_usage(cursor, turn_id, final_message, exact_usage())
+}
+
+fn completed_event_with_usage(
+    cursor: u64,
+    turn_id: &str,
+    final_message: &str,
+    usage: Value,
+) -> Bytes {
     let envelope = json!({
         "cursor": cursor.to_string(),
         "created_at": cursor,
@@ -905,7 +987,7 @@ fn completed_event(cursor: u64, turn_id: &str, final_message: &str) -> Bytes {
         "type": "turn_completed",
         "id": turn_id,
         "final_message": final_message,
-        "usage": exact_usage(),
+        "usage": usage,
         "citations": [],
         "usage_error": null
     });

--- a/crates/nanocodex-managed/tests/public_lifecycle.rs
+++ b/crates/nanocodex-managed/tests/public_lifecycle.rs
@@ -744,7 +744,9 @@ fn agent_state_json(agent_id: &str, latest_event_cursor: &str) -> Value {
             "live_steer": true,
             "live_cancel": true,
             "workspace": "cloud",
-            "execution_environments": true
+            "execution_environments": true,
+            "execution_namespace": "cwd-root-v1",
+            "native_cross_mounts": false
         },
         "settings": {
             "model": "gpt-5.6-sol",

--- a/docs/DISTRIBUTED_EXECUTION_NAMESPACE.md
+++ b/docs/DISTRIBUTED_EXECUTION_NAMESPACE.md
@@ -1,0 +1,265 @@
+# Distributed execution namespace
+
+Status: contract plus cwd-routing milestone implemented locally; not deployed.
+Native cross-mount filesystem access (C2/C5) remains gated. This supersedes the
+proposed `environment` argument on execution tools.
+
+## Core contract
+
+Nanocodex presents every authorized hand as a mount in one private filesystem
+namespace:
+
+```text
+/
+├── brain/        durable brain scratch
+├── sandbox/      lazy Linux sandbox
+├── laptop/       connected user hand
+├── buildbox/     connected user hand
+└── .nanocodex/   synthetic namespace metadata
+```
+
+- **C1 — Placement:** the mount root containing a command's effective cwd
+  selects the hand that executes it.
+- **C2 — Access:** every process sees the same authorized mounts. Discovery,
+  read, and write rights are independent of placement.
+- **C3 — Stable tools:** `exec_command` and `write_stdin` keep their canonical
+  shapes; no environment, machine, host, or sandbox selector is added.
+- **C4 — Stable context:** a Code Mode cell has an immutable namespace and
+  default-cwd snapshot. Each command captures its cwd when scheduled.
+- **C5 — Native namespace:** arbitrary native children access mounts through
+  normal filesystem syscalls. Rewriting `workdir`, parsing shell text, or
+  copying/syncing trees is not conforming.
+- **C6 — Subagent inheritance:** each child gets a stable, capability-bounded
+  namespace and independently uses C1–C5, including concurrent use of hands.
+
+Thus both forms below execute on `laptop`, while Cargo and its children may use
+other authorized mounts:
+
+```js
+await tools.exec_command({ cmd: "cargo test", workdir: "/laptop/repo" });
+await tools.exec_command({ cmd: "cd /laptop/repo && cargo test" });
+```
+
+## Design basis and naming
+
+The design takes Plan 9's central idea: file servers expose trees, a protocol
+carries local or remote operations, and each process gets a private namespace
+composed from those trees. A 9P2000.L-like operation model and
+capability-secured mounts are useful foundations, but Plan 9's exact wire,
+authentication, caching, and Unix-compatibility choices are not the contract.
+FUSE, v9fs, virtio-fs, or an in-process VFS may be platform adapters.
+
+A **hand** exports files, executes processes, or both. An **export** is an
+explicitly configured physical directory, never an implicit OS root. A stable
+logical **mount root** such as `/laptop` names it; the mount root containing the
+cwd is the **execution root**.
+
+The broker creates an immutable cell manifest mapping each mount root to opaque
+hand and export identities, attachment generation, lease, and rights. Mount
+names are portable, unique, non-overlapping, and distinct from reserved roots
+such as `brain`, `sandbox`, `.nanocodex`, `dev`, `proc`, and `tmp`. Names and
+paths locate resources but never authorize them. `brain` and `sandbox` are
+broker-owned system roots; user-assigned roots cannot reuse any reserved name.
+`/laptop/a` means `a` beneath
+the configured export, not OS path `/a` unless the OS root was deliberately
+exported.
+
+A cell's name-to-identity mapping never changes. New connections appear only in
+a later cell; revocation may invalidate existing authority immediately.
+
+## Execution semantics
+
+The canonical tool schemas remain authoritative.
+
+- `workdir` sets the initial cwd; relative paths resolve against the cell's
+  captured default cwd. Shell `cd` is applied before external execution.
+- The longest component-boundary mount match of the effective cwd selects the
+  hand. Executable lookup, environment, architecture, and children belong to
+  that hand.
+- An external command started in a synthetic directory without an executor
+  fails; there is no default-hand fallback. `/brain` is storage unless it is
+  explicitly given a process executor.
+- Redirections use the namespace, and a pipeline may span hands.
+- Each parallel call captures cwd independently. Commands on different hands
+  run concurrently without a namespace-wide lock.
+- `write_stdin` uses a public session ID durably bound to the exact hand,
+  process, attachment generation, manifest, agent/turn, and output cursor.
+  Reconnect cannot retarget it.
+- Other placement-sensitive operations either resolve a canonical workdir or
+  bind to a process/session. There is no ambient "last selected hand."
+
+```js
+await Promise.all([
+  tools.exec_command({ cmd: "cargo test", workdir: "/laptop/repo" }),
+  tools.exec_command({ cmd: "cargo test", workdir: "/buildbox/repo" }),
+]);
+```
+
+## Subagents
+
+The canonical task tree and its tools, including `spawn_agent`, keep their
+schemas and authority rules. Spawning creates a model session, not a process on
+a hand, and adds no hand selector.
+
+At admission the runtime atomically binds the child to the invoking cell's
+manifest and generations, the parent's default logical cwd, necessary leases,
+task-tree/session/cancellation identities, and an authority ceiling no broader
+than the parent's effective rights. Exact inheritance is the compatibility
+default. Trusted host policy may attenuate mounts, subtrees, or write rights;
+grandchildren may only attenuate further. If the resulting scope cannot access
+the inherited cwd, spawn fails atomically. Roles, tasks, messages, paths, and
+mount names cannot grant authority.
+
+A child is not pinned to a hand. Every command is placed from that command's
+effective cwd, so one child may use several hands and siblings may fan out
+concurrently. Task text can suggest a cwd; ordinary `exec_command({workdir})` or
+shell `cd` performs placement under the server-bound authority.
+
+Parents and children share exported files subject to individual rights and
+filesystem consistency. Model sessions, conversation state, Code Mode stores,
+output cursors, and cancellation controllers remain private. Concurrent
+writers need disjoint worktrees/subtrees, a trusted write-scope policy, or
+ordinary filesystem locking; descriptive task text is not a write lease.
+
+Model capacity and hand capacity are independent. `max-subagents` bounds model
+turns; each hand separately bounds processes, sessions, filesystem requests,
+and bytes in flight. Model/thinking selection affects inference only, never
+execution placement.
+
+## Filesystem and capabilities
+
+Every full-capability execution hand receives an actual private root or mount
+namespace. Its own export should be a local mount; peer exports are remote
+mounts; immutable metadata is a synthetic overlay. Keeping the local root local
+prevents ordinary builds from becoming filesystem RPC workloads.
+
+The host-generic interface must cover ordinary development tools: lookup,
+open/close, stat and attributes, directory enumeration, offset I/O, create,
+truncate, mkdir, remove, rename, links, fsync, advisory locks, stable identity,
+version tokens, and cancellation. It must stream with bounded memory,
+backpressure, pagination, concurrent tagged requests, and per-mount isolation.
+
+- Owner-acknowledged writes become visible.
+- Same-export rename is atomic when supported; cross-mount rename and hard-link
+  return `EXDEV`.
+- Ambiguous mutations use operation IDs and durable receipts, never blind
+  replay.
+- Disconnect or stale generation returns bounded `ESTALE`, `EIO`, or
+  unavailable failure, never fallback.
+- Optional caches validate stable identity/version and do not silently weaken
+  consistency.
+
+An export server resolves beneath an already-open directory handle and prevents
+traversal or symlink escape. Absolute symlinks resolve in the client's logical
+namespace. A hand exports only its physical tree, never peer mounts, preventing
+recursive mount cycles.
+
+Initial server-issued capability classes cover namespace discovery, filesystem
+read/write, process execution/stdin, and network preview. They are projected as
+immutable discovery hints such as:
+
+```text
+/laptop/.nanocodex/status
+/laptop/.nanocodex/capabilities/<capability>
+```
+
+Every operation still rechecks an unforgeable grant, lease, and attachment
+generation at the authoritative server. Effective file access is the
+intersection of namespace rights and exporter filesystem policy. Cross-hand
+access is an explicit disclosure grant to the accessing hand, which receives
+filesystem operations, never the exporter's credentials.
+
+The binary, streaming filesystem data plane is separate from bounded JSON
+hosted-tool calls, though it may reuse attachment authentication and fencing.
+Full native conformance requires mounts visible to arbitrary native children:
+Linux may use mount/user namespaces plus FUSE or v9fs; sandboxes and VMs may use
+v9fs or virtio-fs; macOS/Windows may need a helper or VM. A browser VFS proves
+only interpreted behavior. Platforms without native mount visibility must not
+advertise full namespace `process.exec`.
+
+## Lifecycle and security
+
+One lifecycle mechanism governs mounts, handles, processes, previews, and
+sessions:
+
+| Event | Required behavior |
+| --- | --- |
+| Cell starts | Capture authorized mount mapping and default cwd |
+| Child spawns | Atomically bind inherited or attenuated namespace ceiling |
+| Message/steer/task replacement | Preserve namespace, cwd, and authority |
+| Process starts | Pin hand, manifest, rights, lease, and generation |
+| Disconnect/reconnect | Fail old work stale; reconnect creates a new generation |
+| Revocation | Reject new work and invalidate affected resources |
+| Cancel/interrupt/close | Stop native and descendant work; fence late results |
+| Ambiguous mutation | Consult its receipt; never retry blindly |
+| Cold recovery | Restore interrupted children unless exact live state is owner-fenced |
+
+Security invariants:
+
+1. Names, paths, mode bits, and reported capabilities never grant authority.
+2. Normalization and mount selection are one fenced, component-aware operation.
+3. Symlinks, links, mounts, junctions, devices, and special files cannot escape
+   an export or create cross-mount authority.
+4. Provider credentials and host secrets never enter namespaces or processes.
+5. Limits cover mounts, handles, requests, bytes, directory entries, duration,
+   processes, output, and retained receipts.
+6. Audit records exclude contents and credentials.
+7. Descendant rights never exceed parent ceiling intersected with trusted host
+   policy.
+8. Sessions are bound to task tree, agent, cancellation epoch, manifest, and
+   generation; numeric IDs are not transferable.
+
+Live recovery, if added, must durably restore and owner-fence topology,
+namespace/cwd bindings, grants, leases, sessions, cursors, and receipts. It must
+never reconstruct authority from current names or currently connected hands.
+
+## Acceptance journeys
+
+Unit tests and `workdir` routers are insufficient. Real native processes must
+prove:
+
+| Journey | Evidence |
+| --- | --- |
+| Inspect `/` and capability metadata | Safe discovery without identity/secret leakage |
+| Run via `workdir=/host1/repo` and shell `cd` | C1, C3, shell placement |
+| From host1, natively read/write `/host2` | C2, C5; no copy/sync |
+| Run host1 and host2 calls with `Promise.all` | C4 and concurrency |
+| Spawn siblings on host1 and host2 | C6, inheritance, independent capacity |
+| Have one child successively use two roots | Per-command placement, no pinning |
+| Share a permitted file but isolate model state | Export consistency and session privacy |
+| Attenuate a child read-only, then spawn its child | Recursive ceiling; no escalation |
+| Exercise read-only and denied host2 grants | Projection matches enforcement |
+| Rename within and across exports | Atomic local rename; cross-mount `EXDEV` |
+| Disconnect, revoke, and replace during I/O | Generation fencing and no fallback |
+| Yield, reload, reconnect, and poll a process | Durable session binding, no retargeting |
+| Cancel a cross-host pipeline/I/O | Bounded cleanup and isolated call state |
+| Interrupt/close a parent during remote work | Descendant cancellation; no orphan work |
+| Recover cold | Interrupted tombstones or exact owner-fenced restoration |
+
+End-to-end evidence must inspect ancestry, mounts, broker traffic, storage,
+sockets, and secret exposure.
+
+## Phased delivery
+
+1. Specify the manifest and host-generic filesystem interface. (Manifest and
+   authority substrate complete; filesystem operation interface pending.)
+2. Prove one rooted server and one native Linux namespace client.
+3. Add the streaming data plane, receipts, and lifecycle fencing.
+4. Mount two real hands and prove native cross-host read/write.
+5. Bind root and child sessions to namespace/cwd contexts; prove sibling fan-out.
+6. Replace environment-addressed execution with cwd-root placement. (Complete
+   for canonical `workdir`; shell `cd` requires the native adapter.)
+7. Add each platform adapter only after its conformance gate passes.
+8. Verify reload, reconnect, revocation, cross-account isolation, and secret
+   containment before deployment.
+
+Cwd routing may be an internal milestone, but the distributed namespace cannot
+ship until native processes can access peer mounts.
+
+## References
+
+- [Plan 9 from Bell Labs](https://9p.io/sys/doc/9.html)
+- [The Use of Name Spaces in Plan 9](https://9p.io/sys/doc/names.html)
+- [9P2000.L protocol](https://github.com/chaos/diod/blob/master/protocol.md)
+- [virtio-fs design](https://virtio-fs.gitlab.io/design.html)
+- [WASI capability design principles](https://github.com/WebAssembly/WASI/blob/main/docs/DesignPrinciples.md)

--- a/docs/MILLION_USER_ARCHITECTURE.md
+++ b/docs/MILLION_USER_ARCHITECTURE.md
@@ -27,7 +27,7 @@ The current implementation:
 - enables automatic Worker traces across the web, managed, and egress Workers;
 - lets an embedding Durable Object explicitly own event persistence; managed
   agents use that mode, clear the old raw event projection on reopen, and retain
-  only `managed_events`; and
+  only normalized replay events in `managed_events`;
 - fixes `Agent.extend()` so nested adapter actions such as `events.connect` and
   `turn.route` are actually merged at runtime instead of existing only in the
   type declarations;
@@ -238,24 +238,23 @@ objects. Once an agent has archived receipts, a genuinely new ID pays an R2
 miss because indefinite exact-ID conflict detection cannot safely infer
 absence from a bounded local filter.
 
-### Two event histories (inherited topology)
+### Replay events and transport observability
 
-The Cloudflare adapter stores every raw `AgentEvent` in
-`nanocodex_cloudflare_events`, capped at 64 MiB. The managed application watches
-that stream, wraps it as a managed stream message, and stores it again in
-`managed_events`, also capped at 64 MiB. Managed acceptance, cancellation, and
-terminal messages are added to the second log as well.
+The generic Cloudflare adapter can retain every raw `AgentEvent` for embedders
+that select its durable event socket. Managed agents instead select caller-owned
+persistence, clear that generic projection, and retain one managed cursor log.
 
-This is intentional layering today, but it means much of the largest streaming
-content is retained twice. When `managed_events` reaches its admission ceiling,
-the agent rejects new work until it is deleted or replaced.
+That log contains the normalized agent-domain events and managed lifecycle
+messages required to reconstruct the client transcript. It does not retain
+`api.event`: those frames repeat complete provider requests, tool schemas, and
+cumulative response bodies already represented by normalized assistant,
+reasoning, tool, model, and run events. Transport diagnostics belong in
+Cloudflare invocation logs and traces rather than replay history; structured
+transport observations contain lifecycle metadata but never provider payloads.
 
-The first implementation slice removes this duplication for the managed
-application. The Cloudflare SDK keeps durable event persistence as its default,
-while the managed AgentDO selects caller-owned persistence and uses its managed
-cursor log as the canonical retained stream. This preserves SDK behavior for
-other embedders and removes stale raw rows when an existing managed agent next
-opens.
+There is no application byte ceiling that can poison an agent or reject later
+turns. Byte thresholds only start asynchronous sealing; the AgentDO continues
+sealing immutable prefixes until the SQLite tail is below the threshold.
 
 ### Workspace
 
@@ -430,8 +429,8 @@ R2 should not preserve accidental duplication forever. The order of work is:
    the single Rust state, managed events, raw AgentEvents, turn receipts, realtime
    receipts, and the SQLite remainder. Computer workspace bytes are still part
    of the visible remainder and need a first-class Computer accounting API.
-2. **Implemented:** remove the second full event projection or make the managed
-   stream a typed view over one canonical retained event log.
+2. **Implemented:** keep one canonical managed replay log, exclude raw provider
+   frames, and leave transport diagnostics to Cloudflare observability.
 3. **Implemented:** replace the total Rust state after pruning terminal
    receipts, retaining the latest checkpoint, unresolved work, and a
    caller-selected recent replay window.

--- a/js/account/src/AgentExperience.tsx
+++ b/js/account/src/AgentExperience.tsx
@@ -27,7 +27,7 @@ import {
 import { conversationTitle } from "./localConversationRuntime";
 import {
   createManagedConversation,
-  listManagedConversations,
+  loadManagedConversationSelection,
   type ManagedConversation,
 } from "./managedAgentRuntime";
 import "nanocodex-connect-ui/styles.css";
@@ -61,6 +61,7 @@ export const AgentExperience = memo(function AgentExperience({
   const [managedConversationId, setManagedConversationId] = useState<string>();
   const [managedError, setManagedError] = useState<string>();
   const [managedAttempt, setManagedAttempt] = useState(0);
+  const refreshManagedList = useRef(false);
   const [conversationPending, setConversationPending] = useState(false);
   const [freePromptsRemaining, setFreePromptsRemaining] = useState<number | null>(null);
   const [sponsoredExhausted, setSponsoredExhausted] = useState(false);
@@ -79,6 +80,9 @@ export const AgentExperience = memo(function AgentExperience({
     : hasDurableCredential;
   const showHomepageTerminal = landing && hasCredential && !activeCapabilityError;
   const voiceEnabled = authStatus?.state === "ready" && authStatus.voiceEnabled === true;
+  const visibleManagedConversationId = agentId === undefined || managedConversationId === agentId
+    ? managedConversationId
+    : undefined;
 
   useEffect(() => {
     setManagedConversations([]);
@@ -96,32 +100,43 @@ export const AgentExperience = memo(function AgentExperience({
     if (landing || account.status !== "ready" || !account.account || !hasDurableCredential) return;
     let cancelled = false;
     const accountId = account.account.id;
+    const refresh = refreshManagedList.current;
+    refreshManagedList.current = false;
+    if (agentId) {
+      setManagedConversationId((current) => current === agentId ? current : undefined);
+      setRuntimeState(undefined);
+    }
     setConversationPending(true);
     setManagedError(undefined);
-    void listManagedConversations(accountId).then(async (listed) => {
+    void loadManagedConversationSelection({
+      accountId,
+      routeAgentId: agentId,
+      retainedAgentId: safeGet(managedSelectionKey(accountId)) ?? undefined,
+      hasCredential,
+      refresh,
+    }).then((selection) => {
       if (cancelled) return;
-      const next = listed.length ? listed : [await createManagedConversation(accountId)];
-      if (cancelled) return;
-      setManagedConversations(next);
+      setManagedConversations(selection.conversations);
+      setManagedConversationId(selection.selectedId);
+      if (selection.selectedId) {
+        safeSet(managedSelectionKey(accountId), selection.selectedId);
+        if (selection.replaceRoute) onAgentChange?.(selection.selectedId, { replace: true });
+      }
     }).catch((error) => {
       if (!cancelled) setManagedError(errorMessage(error));
     }).finally(() => {
       if (!cancelled) setConversationPending(false);
     });
     return () => { cancelled = true; };
-  }, [account.account?.id, account.status, hasDurableCredential, landing, managedAttempt]);
-
-  useEffect(() => {
-    if (landing || !account.account || managedConversations.length === 0) return;
-    const retainedId = safeGet(managedSelectionKey(account.account.id)) ?? undefined;
-    const selected = managedConversations.find(({ id }) => id === agentId)?.id
-      ?? managedConversations.find(({ id }) => id === retainedId)?.id
-      ?? managedConversations[0]?.id;
-    if (!selected) return;
-    setManagedConversationId(selected);
-    safeSet(managedSelectionKey(account.account.id), selected);
-    if (agentId !== selected) onAgentChange?.(selected, { replace: true });
-  }, [account.account, agentId, landing, managedConversations, onAgentChange]);
+  }, [
+    account.account?.id,
+    account.status,
+    agentId,
+    hasDurableCredential,
+    landing,
+    managedAttempt,
+    onAgentChange,
+  ]);
 
   const changeCredentialSource = useCallback((source: CredentialSource) => {
     if (credentialSourceRef.current !== undefined && credentialSourceRef.current !== source) {
@@ -171,6 +186,7 @@ export const AgentExperience = memo(function AgentExperience({
   }, [account.account, conversationPending, onAgentChange]);
   const retryManagedConversations = useCallback(() => {
     setManagedError(undefined);
+    refreshManagedList.current = true;
     setManagedAttempt((value) => value + 1);
   }, []);
   const recordActivity = useCallback((input: string) => {
@@ -203,7 +219,7 @@ export const AgentExperience = memo(function AgentExperience({
       {landing || !hasDurableCredential ? null : <ConversationHistoryRail
         agentStatus={agentStatus}
         conversations={managedConversations} error={managedError}
-        mobileOpen={railOpen} pending={conversationPending} runtime="managed" selectedId={managedConversationId}
+        mobileOpen={railOpen} pending={conversationPending} runtime="managed" selectedId={visibleManagedConversationId}
         onClose={() => setRailOpen(false)} onCreate={createConversation} onOpen={() => setRailOpen(true)}
         onRetry={retryManagedConversations}
         onSelect={selectManaged}
@@ -236,14 +252,16 @@ export const AgentExperience = memo(function AgentExperience({
               mode={mode}
               welcome={homeTerminalWelcome(credentialSource, freePromptsRemaining)}
             />
-            : hasDurableCredential && managedConversationId
-            ? <ManagedAgentTerminal
-              key={managedConversationId} agentId={managedConversationId!} authStatus={authStatus}
-              mode={mode} onConversationActivity={recordActivity} onStateChange={setRuntimeState}
-              source={credentialSource}
-              voiceEnabled={voiceEnabled}
-            />
-            : <ReservedTerminal message={inactiveMessage} mode={mode} />}
+            : managedError
+              ? <ReservedTerminal message={managedError} mode={mode} />
+              : hasDurableCredential && visibleManagedConversationId
+                ? <ManagedAgentTerminal
+                  key={visibleManagedConversationId} agentId={visibleManagedConversationId} authStatus={authStatus}
+                  mode={mode} onConversationActivity={recordActivity} onStateChange={setRuntimeState}
+                  source={credentialSource}
+                  voiceEnabled={voiceEnabled}
+                />
+                : <ReservedTerminal message={inactiveMessage} mode={mode} />}
       </div>
     </div>
   </div>;

--- a/js/account/src/AgentTerminal.tsx
+++ b/js/account/src/AgentTerminal.tsx
@@ -182,13 +182,17 @@ export const ManagedAgentTerminal = memo(function ManagedAgentTerminal({
   const managed = useMemo(() => openManagedAgent(agentId), [agentId]);
   const agent = useMemo(() => managedTerminalAgent(managed), [managed]);
   const [browserHand, setBrowserHand] = useState<Awaited<ReturnType<typeof attachManagedBrowserHand>>>();
-  const [browserHandError, setBrowserHandError] = useState<string>();
   const [browserHandAttempt, setBrowserHandAttempt] = useState(0);
   useEffect(() => {
     const controller = new AbortController();
     let hand: Awaited<ReturnType<typeof attachManagedBrowserHand>> | undefined;
+    let retry: ReturnType<typeof setTimeout> | undefined;
+    const reconnect = () => {
+      if (!controller.signal.aborted) {
+        retry = setTimeout(() => setBrowserHandAttempt((current) => current + 1), 1_000);
+      }
+    };
     setBrowserHand(undefined);
-    setBrowserHandError(undefined);
     void attachManagedBrowserHand(managed, controller.signal).then((attached) => {
       if (controller.signal.aborted) {
         void attached.close();
@@ -199,13 +203,16 @@ export const ManagedAgentTerminal = memo(function ManagedAgentTerminal({
       void hand.closed().then(() => {
         if (controller.signal.aborted) return;
         setBrowserHand(undefined);
-        setBrowserHandError("The browser workspace hand disconnected. Retry to attach it again.");
+        reconnect();
       });
     }).catch((error) => {
-      if (!controller.signal.aborted) setBrowserHandError(errorMessage(error));
+      if (controller.signal.aborted) return;
+      console.warn("nanocodex:browser_hand_attach_failed", { error: errorMessage(error) });
+      reconnect();
     });
     return () => {
       controller.abort();
+      if (retry) clearTimeout(retry);
       if (hand) void hand.close();
     };
   }, [browserHandAttempt, managed]);
@@ -214,8 +221,8 @@ export const ManagedAgentTerminal = memo(function ManagedAgentTerminal({
   }, []);
   return (
     <AgentTerminalView
-      agent={browserHand ? agent : undefined}
-      agentError={browserHandError}
+      agent={agent}
+      agentError={undefined}
       inactiveMessage={({ agentError, agentStatus }) => inactiveTerminalMessage({
         agentError,
         agentStatus,

--- a/js/account/src/managedAgentRuntime.test.ts
+++ b/js/account/src/managedAgentRuntime.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  listManagedConversations,
+  loadManagedConversationSelection,
+} from "./managedAgentRuntime.ts";
+
+const FIRST_AGENT_ID = "018f0000-0000-7000-8000-000000000001";
+const SECOND_AGENT_ID = "018f0000-0000-7000-8000-000000000002";
+const FORBIDDEN_AGENT_ID = "018f0000-0000-7000-8000-000000000003";
+
+test("an exact agent route survives a successful list cached before another client created it", async (t) => {
+  const originalLocation = Object.getOwnPropertyDescriptor(globalThis, "location");
+  const originalFetch = globalThis.fetch;
+  Object.defineProperty(globalThis, "location", {
+    configurable: true,
+    value: new URL("https://account.example"),
+  });
+  let agentIds = [FIRST_AGENT_ID];
+  let listCalls = 0;
+  const exactCalls: string[] = [];
+  globalThis.fetch = async (input, init) => {
+    const request = new Request(input, init);
+    const path = new URL(request.url).pathname;
+    if (request.method === "GET" && path === "/v1/agents") {
+      listCalls += 1;
+      return Response.json({
+        data: agentIds,
+        summaries: Object.fromEntries(agentIds.map((id, index) => [id, {
+          title: `Agent ${index + 1}`,
+          created_at: index + 1,
+          updated_at: agentIds.length - index,
+          turn_count: index,
+        }])),
+      });
+    }
+    const exactId = decodeURIComponent(path.slice("/v1/agents/".length));
+    exactCalls.push(exactId);
+    if (request.method === "GET" && agentIds.includes(exactId)) return Response.json({});
+    return Response.json(
+      { error: "forbidden", message: "That exact agent is not available to this account." },
+      { status: 403 },
+    );
+  };
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+    if (originalLocation) Object.defineProperty(globalThis, "location", originalLocation);
+    else Reflect.deleteProperty(globalThis, "location");
+  });
+
+  const initial = await listManagedConversations("stale-list-client");
+  assert.deepEqual(initial.map(({ id }) => id), [FIRST_AGENT_ID]);
+  agentIds = [SECOND_AGENT_ID, FIRST_AGENT_ID];
+
+  const stale = await listManagedConversations("stale-list-client");
+  assert.deepEqual(stale.map(({ id }) => id), [FIRST_AGENT_ID]);
+  assert.equal(listCalls, 1);
+
+  const routed = await loadManagedConversationSelection({
+    accountId: "stale-list-client",
+    routeAgentId: SECOND_AGENT_ID,
+    retainedAgentId: FIRST_AGENT_ID,
+    hasCredential: true,
+  });
+  assert.equal(routed.selectedId, SECOND_AGENT_ID);
+  assert.equal(routed.replaceRoute, false);
+  assert.deepEqual(routed.conversations.map(({ id }) => id), [SECOND_AGENT_ID, FIRST_AGENT_ID]);
+  assert.deepEqual(exactCalls, [SECOND_AGENT_ID]);
+  assert.equal(listCalls, 1);
+
+  const augmented = await listManagedConversations("stale-list-client");
+  assert.deepEqual(augmented.map(({ id }) => id), [SECOND_AGENT_ID, FIRST_AGENT_ID]);
+  assert.equal(listCalls, 1);
+
+  const refreshed = await listManagedConversations("stale-list-client", { refresh: true });
+  assert.deepEqual(refreshed.map(({ id }) => id), [SECOND_AGENT_ID, FIRST_AGENT_ID]);
+  assert.equal(listCalls, 2);
+
+  await assert.rejects(
+    loadManagedConversationSelection({
+      accountId: "stale-list-client",
+      routeAgentId: FORBIDDEN_AGENT_ID,
+      retainedAgentId: FIRST_AGENT_ID,
+      hasCredential: true,
+    }),
+    /That exact agent is not available to this account/,
+  );
+  assert.deepEqual(exactCalls, [SECOND_AGENT_ID, FORBIDDEN_AGENT_ID]);
+});

--- a/js/account/src/managedAgentRuntime.ts
+++ b/js/account/src/managedAgentRuntime.ts
@@ -24,30 +24,68 @@ export type ManagedConversation = Readonly<{
   turnCount?: number;
 }>;
 
+export type ManagedConversationSelection = Readonly<{
+  conversations: readonly ManagedConversation[];
+  selectedId?: string;
+  replaceRoute: boolean;
+}>;
+
 export type ManagedTerminalSource = Pick<ManagedAgent, "events" | "id" | "turn" | "type">;
 
-export function listManagedConversations(accountId = "default"): Promise<readonly ManagedConversation[]> {
+export function listManagedConversations(
+  accountId = "default",
+  options: Readonly<{ refresh?: boolean }> = {},
+): Promise<readonly ManagedConversation[]> {
+  if (options.refresh) managedLists.delete(accountId);
   const retained = managedLists.get(accountId);
   if (retained) return retained;
   const loading = Agent.list().then((agents) => {
     const conversations = agents.map((agent) => {
       managedAgents.set(agent.id, agent);
-      return Object.freeze({
-        id: agent.id,
-        title: titleFromPrompt(agent.summary?.title ?? "") || `Conversation ${agent.id.slice(0, 8)}`,
-        ...(agent.summary === undefined ? {} : {
-          updatedAt: agent.summary.updatedAt,
-          turnCount: agent.summary.turnCount,
-        }),
-      });
+      return managedConversation(agent);
     });
     return Object.freeze(conversations.sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0)));
   }).catch((error) => {
-    managedLists.delete(accountId);
+    if (managedLists.get(accountId) === loading) managedLists.delete(accountId);
     throw error;
   });
   managedLists.set(accountId, loading);
   return loading;
+}
+
+export async function loadManagedConversationSelection(options: Readonly<{
+  accountId?: string;
+  routeAgentId?: string;
+  retainedAgentId?: string;
+  hasCredential: boolean;
+  refresh?: boolean;
+}>): Promise<ManagedConversationSelection> {
+  const accountId = options.accountId ?? "default";
+  const listing = listManagedConversations(accountId, { refresh: options.refresh });
+  if (options.routeAgentId) {
+    const [exact, listed] = await Promise.all([
+      getManagedConversation(options.routeAgentId),
+      listing.catch((): readonly ManagedConversation[] => Object.freeze([])),
+    ]);
+    const conversations = listed.some(({ id }) => id === exact.id)
+      ? listed
+      : Object.freeze([exact, ...listed]);
+    if (managedLists.get(accountId) === listing) {
+      managedLists.set(accountId, Promise.resolve(conversations));
+    }
+    return Object.freeze({ conversations, selectedId: exact.id, replaceRoute: false });
+  }
+  const listed = await listing;
+  const conversations = listed.length || !options.hasCredential
+    ? listed
+    : Object.freeze([await createManagedConversation(accountId)]);
+  const selectedId = conversations.find(({ id }) => id === options.retainedAgentId)?.id
+    ?? conversations[0]?.id;
+  return Object.freeze({
+    conversations,
+    ...(selectedId === undefined ? {} : { selectedId }),
+    replaceRoute: selectedId !== undefined,
+  });
 }
 
 export function createManagedConversation(accountId = "default"): Promise<ManagedConversation> {
@@ -77,6 +115,23 @@ export function openManagedAgent(agentId: string): ManagedAgent {
   const managed = managedAgents.get(agentId) ?? Agent.open(agentId);
   managedAgents.set(agentId, managed);
   return managed;
+}
+
+async function getManagedConversation(agentId: string): Promise<ManagedConversation> {
+  const managed = await Agent.get(agentId);
+  managedAgents.set(agentId, managed);
+  return managedConversation(managed);
+}
+
+function managedConversation(agent: ManagedAgent): ManagedConversation {
+  return Object.freeze({
+    id: agent.id,
+    title: titleFromPrompt(agent.summary?.title ?? "") || `Conversation ${agent.id.slice(0, 8)}`,
+    ...(agent.summary === undefined ? {} : {
+      updatedAt: agent.summary.updatedAt,
+      turnCount: agent.summary.turnCount,
+    }),
+  });
 }
 
 export function managedTerminalAgent(

--- a/js/account/worker/managedProxy.test.ts
+++ b/js/account/worker/managedProxy.test.ts
@@ -22,3 +22,9 @@ test("the account Worker exposes only the exact managed wallet routes", () => {
     assert.equal(isManagedRoutePath(path), false, path);
   }
 });
+
+test("the account Worker projects opaque sandbox preview capabilities", () => {
+  assert.equal(isManagedRoutePath("/sandbox-preview/capability/"), true);
+  assert.equal(isManagedRoutePath("/sandbox-preview/capability/assets/app.js"), true);
+  assert.equal(isManagedRoutePath("/sandbox-preview/"), false);
+});

--- a/js/account/worker/managedProxy.ts
+++ b/js/account/worker/managedProxy.ts
@@ -2,7 +2,7 @@ export type ManagedProxyEnv = {
   NANOCODEX_BACKEND?: Fetcher;
 };
 
-const MANAGED_ROUTE = /^(?:\/auth(?:\/.*)?|\/webauthn\/.*|\/v1\/(?:auth(?:\/.*)?|me|wallet(?:\/(?:balance|connect|revoke-access-key))?|egress|api-keys(?:\/.*)?|credentials(?:\/.*)?|connect(?:\/.*)?|connectors(?:\/.*)?|agents(?:\/.*)?|rooms(?:\/.*)?|history(?:\/.*)?|memory(?:\/.*)?|organization(?:\/.*)?))$/;
+const MANAGED_ROUTE = /^(?:\/auth(?:\/.*)?|\/webauthn\/.*|\/sandbox-preview\/[^/]+(?:\/.*)?|\/v1\/(?:auth(?:\/.*)?|me|wallet(?:\/(?:balance|connect|revoke-access-key))?|egress|api-keys(?:\/.*)?|credentials(?:\/.*)?|connect(?:\/.*)?|connectors(?:\/.*)?|agents(?:\/.*)?|rooms(?:\/.*)?|history(?:\/.*)?|memory(?:\/.*)?|organization(?:\/.*)?))$/;
 
 export function isManagedRoutePath(pathname: string): boolean {
   return MANAGED_ROUTE.test(pathname);

--- a/js/egress/wrangler.broker.jsonc
+++ b/js/egress/wrangler.broker.jsonc
@@ -15,11 +15,12 @@
     "logs": {
       "enabled": true,
       "head_sampling_rate": 1,
-      "invocation_logs": false,
+      "invocation_logs": true,
       "persist": true
     },
     "traces": {
-      "enabled": false
+      "enabled": true,
+      "head_sampling_rate": 1
     }
   },
   "vars": {

--- a/js/managed/Dockerfile
+++ b/js/managed/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update \
         cmake \
         curl \
         fd-find \
+        gh \
         git \
         git-lfs \
         jq \

--- a/js/managed/src/account-info.ts
+++ b/js/managed/src/account-info.ts
@@ -54,6 +54,8 @@ export type VaultEntry =
 
 export type AccountMachine = Readonly<HostedMachine & {
   kind: "sandbox" | "user";
+  /** Logical namespace root. Native host workspace paths are never projected. */
+  mount: string;
 }>;
 
 export type AccountInfo = Readonly<{

--- a/js/managed/src/account-info.ts
+++ b/js/managed/src/account-info.ts
@@ -74,20 +74,34 @@ export type AccountInfo = Readonly<{
   vault: readonly VaultEntry[];
 }>;
 
+export type AccountInfoOptions = Readonly<{
+  allowedConnectors?: readonly ConnectorCapabilityId[];
+  allowedConnections?: ConnectorConnectionSelection;
+  enabled: boolean;
+  machines?: readonly AccountMachine[];
+  signal?: AbortSignal;
+}>;
+
 export async function accountInfo(
   binding: BrokerBinding,
   userId: string,
-  enabled: boolean,
-  allowedConnectors?: readonly ConnectorCapabilityId[],
-  allowedConnections?: ConnectorConnectionSelection,
-  machines: readonly AccountMachine[] = [],
+  {
+    allowedConnectors,
+    allowedConnections,
+    enabled,
+    machines = [],
+    signal,
+  }: AccountInfoOptions,
 ): Promise<AccountInfo> {
   if (!enabled) return emptyInfo("disabled", machines);
+  signal?.throwIfAborted();
   try {
     const encodedUserId = encodeURIComponent(userId);
     const [response, vault] = await Promise.all([
-      binding.fetch(`https://broker.internal/users/${encodedUserId}/connectors`),
-      accountVault(binding, encodedUserId),
+      signal === undefined
+        ? binding.fetch(`https://broker.internal/users/${encodedUserId}/connectors`)
+        : binding.fetch(`https://broker.internal/users/${encodedUserId}/connectors`, { signal }),
+      accountVault(binding, encodedUserId, signal),
     ]);
     if (!response.ok) {
       await response.body?.cancel();
@@ -126,6 +140,7 @@ export async function accountInfo(
       vault,
     };
   } catch {
+    signal?.throwIfAborted();
     return emptyInfo("unavailable", machines);
   }
 }
@@ -223,11 +238,14 @@ function emptyInfo(
 async function accountVault(
   binding: BrokerBinding,
   encodedUserId: string,
+  signal?: AbortSignal,
 ): Promise<readonly VaultEntry[]> {
+  signal?.throwIfAborted();
   try {
-    const response = await binding.fetch(
-      `https://broker.internal/users/${encodedUserId}/credentials`,
-    );
+    const url = `https://broker.internal/users/${encodedUserId}/credentials`;
+    const response = signal === undefined
+      ? await binding.fetch(url)
+      : await binding.fetch(url, { signal });
     if (!response.ok) {
       await response.body?.cancel();
       return [];
@@ -235,6 +253,7 @@ async function accountVault(
     const value: unknown = await response.json();
     return isRecord(value) ? vaultEntries(value.vault) : [];
   } catch {
+    signal?.throwIfAborted();
     return [];
   }
 }

--- a/js/managed/src/agent-event-watcher.ts
+++ b/js/managed/src/agent-event-watcher.ts
@@ -17,17 +17,52 @@ type InternalEventListener = (
   agentId?: number,
 ) => void;
 
-/** Observes the complete Rust-owned agent family for durable projection. */
+const REPLAY_EVENTS = new Set([
+  "assistant.message",
+  "reasoning.summary.delta",
+  "run.started",
+  "run.steered",
+  "run.error",
+  "run.completed",
+  "run.failed",
+  "tool.call",
+  "tool.result",
+  "model.call.started",
+  "model.call.completed",
+  "model.call.failed",
+  "model.compaction.started",
+  "model.compaction.completed",
+  "model.compaction.failed",
+]);
+
+type ManagedAgentEventListeners = Readonly<{
+  replay(event: AgentEvent, agentId: number | undefined): void;
+  observe(event: AgentEvent): void;
+}>;
+
+/** Splits the Rust-owned agent family into replay state and transport telemetry. */
 export function watchManagedAgentFamilyEvents(
   agent: AgentEventSource,
-  listener: (event: AgentEvent, agentId: number | undefined) => void,
+  listeners: ManagedAgentEventListeners,
 ): EventWatcher {
   const events = agent.events.watch({ includeAllSessions: true });
   const onEvent = events.onEvent as unknown as (
     listener: InternalEventListener,
   ) => () => void;
   onEvent((event, _encodedLength, _encodedEvent, agentId) => {
-    listener(event, agentId);
+    // Provider frames and physical transport lifecycle are telemetry, not
+    // replay state. In particular api.event repeats full requests and
+    // cumulative response bodies already represented by normalized events.
+    if (REPLAY_EVENTS.has(event.type)) {
+      listeners.replay(event, agentId);
+      return;
+    }
+    // Raw frames can contain prompts, tool schemas, and cumulative response
+    // bodies. Cloudflare traces retain the request path; never copy payloads
+    // into either replay storage or application logs.
+    if (event.type !== "api.event" && event.type !== "assistant.delta") {
+      listeners.observe(event);
+    }
   });
   return events;
 }

--- a/js/managed/src/archive-hash.ts
+++ b/js/managed/src/archive-hash.ts
@@ -1,0 +1,4 @@
+export async function sha256Hex(value: Uint8Array): Promise<string> {
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", value));
+  return [...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}

--- a/js/managed/src/durable-events.ts
+++ b/js/managed/src/durable-events.ts
@@ -1,15 +1,6 @@
 const REPLAY_PAGE_SIZE = 256;
 export const MAX_HISTORY_PAGE_SIZE = 256;
 const KEEPALIVE_MS = 15_000;
-// A logical event must fit the archive's 16 MiB object envelope with 2 MiB
-// retained for the segment wrapper and event metadata.
-export const MAX_EVENT_BYTES = 14 * 1024 * 1024;
-const MAX_EVENT_LOG_BYTES = 256 * 1024 * 1024;
-// Keep one worst-case terminal slot for every accepted turn in the API's
-// 16-turn queue. The larger log ceiling preserves the previous 32 MiB
-// noncritical budget while allowing every reserved event to reach the new
-// end-to-end archive boundary.
-const TERMINAL_RESERVE_BYTES = 16 * MAX_EVENT_BYTES;
 const MAX_SUBSCRIBERS = 32;
 const MAX_CURSOR = 9_223_372_036_854_775_807n;
 const DIRECT_EVENT_BYTES = 1_000_000;
@@ -40,14 +31,6 @@ export type DurableEventTail<Message> = Readonly<{
   events: readonly DurableEvent<Message>[];
   high_water_cursor: string;
 }>;
-
-export class EventLogCapacityError extends Error {
-  readonly code = "event_log_full";
-
-  constructor(message = "durable event log capacity reached") {
-    super(message);
-  }
-}
 
 type Subscriber = {
   after: string;
@@ -111,15 +94,9 @@ export class DurableEventLog<Message extends { type: string }> {
   append(
     message: Message,
     turnId: string | null = null,
-    critical = false,
   ): DurableEvent<Message> {
     const messageJson = JSON.stringify(message);
     const messageBytes = sseEncoder.encode(messageJson).byteLength;
-    if (messageBytes > MAX_EVENT_BYTES) {
-      throw new RangeError(`managed event exceeds ${MAX_EVENT_BYTES} encoded bytes`);
-    }
-    const ceiling = critical ? MAX_EVENT_LOG_BYTES : MAX_EVENT_LOG_BYTES - TERMINAL_RESERVE_BYTES;
-    if (this.totalBytes() + messageBytes > ceiling) throw new EventLogCapacityError();
     const createdAt = Date.now();
     const chunked = messageBytes > DIRECT_EVENT_BYTES;
     const inserted = this.#storage.sql.exec<{ cursor: string }>(
@@ -152,8 +129,8 @@ export class DurableEventLog<Message extends { type: string }> {
     return { cursor: inserted.cursor, created_at: createdAt, message, turn_id: turnId };
   }
 
-  record(message: Message, turnId: string | null = null, critical = false): DurableEvent<Message> {
-    const event = this.#storage.transactionSync(() => this.append(message, turnId, critical));
+  record(message: Message, turnId: string | null = null): DurableEvent<Message> {
+    const event = this.#storage.transactionSync(() => this.append(message, turnId));
     this.publish(event);
     return event;
   }
@@ -200,11 +177,7 @@ export class DurableEventLog<Message extends { type: string }> {
       previous = event.cursor;
       const messageJson = JSON.stringify(event.message);
       const bytes = sseEncoder.encode(messageJson).byteLength;
-      if (bytes > MAX_EVENT_BYTES) throw new Error("managed event portable tail exceeds event size");
       totalBytes += bytes;
-      if (totalBytes > MAX_EVENT_LOG_BYTES) {
-        throw new Error("managed event portable tail exceeds the local event boundary");
-      }
       return { event, messageJson, bytes };
     });
     const adopt = () => {
@@ -249,10 +222,6 @@ export class DurableEventLog<Message extends { type: string }> {
     return this.#storage.sql.exec<{ total_bytes: number }>(
       "SELECT total_bytes FROM managed_event_meta WHERE singleton = 1",
     ).toArray()[0]?.total_bytes ?? 0;
-  }
-
-  canAcceptTurn(): boolean {
-    return this.totalBytes() < MAX_EVENT_LOG_BYTES - TERMINAL_RESERVE_BYTES;
   }
 
   page(after: string, limit = REPLAY_PAGE_SIZE): DurableEvent<Message>[] {

--- a/js/managed/src/event-stream-failure.ts
+++ b/js/managed/src/event-stream-failure.ts
@@ -1,0 +1,37 @@
+export type EventStreamFailurePersistence<Event> = Readonly<{
+  event?: Event;
+  fenceError?: unknown;
+  noticeError?: unknown;
+}>;
+
+type EventStreamFailureStorage = Pick<DurableObjectStorage, "sql" | "transactionSync">;
+
+/**
+ * Persists the replay fence before attempting the optional replay notice.
+ *
+ * The notice allocates another event row and can fail for the same reason as
+ * the projection that tripped the fence. Keeping it in a later transaction
+ * ensures that failure cannot roll back the authoritative session state.
+ */
+export function persistEventStreamFailure<Event>(
+  storage: EventStreamFailureStorage,
+  detail: string,
+  now: number,
+  appendNotice: () => Event,
+): EventStreamFailurePersistence<Event> {
+  try {
+    storage.sql.exec(
+      "UPDATE session_state SET stream_error = ?, last_active = ? WHERE singleton = 1",
+      detail,
+      now,
+    );
+  } catch (fenceError) {
+    return { fenceError };
+  }
+
+  try {
+    return { event: storage.transactionSync(appendNotice) };
+  } catch (noticeError) {
+    return { noticeError };
+  }
+}

--- a/js/managed/src/index.ts
+++ b/js/managed/src/index.ts
@@ -11,6 +11,7 @@ import type {
   EventWatcher,
   NamedTool,
   PromptInput,
+  ToolContext,
   Tools,
   Turn,
 } from "nanocodex";
@@ -63,12 +64,12 @@ import {
 } from "./connector-status";
 import {
   DurableEventLog,
-  EventLogCapacityError,
   MAX_HISTORY_PAGE_SIZE,
   parseCursor,
   type DurableEvent,
   type DurableEventTail,
 } from "./durable-events";
+import { persistEventStreamFailure } from "./event-stream-failure";
 import { watchManagedAgentFamilyEvents } from "./agent-event-watcher";
 import {
   ManagedEventArchive,
@@ -223,9 +224,6 @@ export { MemoryScope } from "./memory-scope";
 export { ApiKeyRecord, NonceStorage, Organization, UserAccount } from "./account-auth";
 
 const MAX_CLIENT_MESSAGE_BYTES = 1024 * 1024;
-const MAX_CLIENT_REPLAY_BYTES = 8 * 1024 * 1024;
-const MAX_CLIENT_REPLAY_EVENTS = 256;
-const MAX_ACTIVE_TURNS = 16;
 const MAX_PRE_ADMISSION_CANCELLATIONS = 64;
 const MAX_CLIENT_CONNECTIONS = 64;
 const MAX_REQUEST_BODY_BYTES = 1024 * 1024;
@@ -587,8 +585,7 @@ const AGENT_CAPABILITIES = Object.freeze({
   live_steer: true,
   live_cancel: true,
   workspace: "cloudflare-computer",
-  sandbox_tools: true,
-  sandbox_escalation: false,
+  execution_environments: true,
 }) satisfies AgentCapabilities;
 
 const AGENT_SANDBOX_MACHINE = Object.freeze({
@@ -2535,6 +2532,11 @@ export class DurableAgentSession extends DurableComputerSession {
       }
       return;
     }
+    if (this.#eventArchive.needsSeal(this.#eventLog)) {
+      // A failed alarm is retried by Durable Objects. This is the persistent
+      // continuation for a seal that outlived or failed its originating turn.
+      await this.#sealEventArchive(false);
+    }
     if (this.#historyProjectionTask) await this.#historyProjectionTask.catch(() => {});
     else await this.#drainHistoryProjections();
     // An alarm may be the first event delivered to a freshly reconstructed
@@ -2562,9 +2564,7 @@ export class DurableAgentSession extends DurableComputerSession {
       return;
     }
     this.#logCapacity("idle_shutdown");
-    while (this.#eventArchive.needsSeal(this.#eventLog)) {
-      if (!(await this.#sealEventArchive(false)).sealed) break;
-    }
+    if (this.#eventArchive.needsSeal(this.#eventLog)) await this.#sealEventArchive(false);
     while (this.#turnArchive.needsSeal()) {
       if (!(await this.#sealTurnArchive(false)).sealed) break;
     }
@@ -2774,7 +2774,7 @@ export class DurableAgentSession extends DurableComputerSession {
           type: "agent_created",
           agent_id: sessionId,
           capabilities: this.#capabilities(),
-        }, null, true);
+        });
       });
     } catch (error) {
       if (error instanceof ManagedRequestError) {
@@ -2834,14 +2834,9 @@ export class DurableAgentSession extends DurableComputerSession {
   async #replayClientSocket(socket: WebSocket, after: string): Promise<void> {
     const page = this.#eventArchive.pageReader(this.#eventLog);
     let cursor = after;
-    let replayBytes = 0;
-    let replayEvents = 0;
     try {
       while (socket.readyState === WebSocket.OPEN) {
-        const events = await page(
-          cursor,
-          Math.min(MAX_HISTORY_PAGE_SIZE, MAX_CLIENT_REPLAY_EVENTS - replayEvents),
-        );
+        const events = await page(cursor, MAX_HISTORY_PAGE_SIZE);
         for (const event of events) {
           const message: ServerMessage = {
             ...event.message,
@@ -2850,23 +2845,12 @@ export class DurableAgentSession extends DurableComputerSession {
             ...(event.turn_id === null ? {} : { turn_id: event.turn_id }),
           };
           const encoded = JSON.stringify(message);
-          const bytes = encoder.encode(encoded).byteLength;
-          if (replayEvents > 0 && replayBytes + bytes > MAX_CLIENT_REPLAY_BYTES) {
-            closeSocket(socket, 1013, "durable replay continuation required");
-            return;
-          }
           if (!this.#sendEncoded(socket, encoded)) return;
           cursor = event.cursor;
-          replayBytes += bytes;
-          replayEvents += 1;
           socket.serializeAttachment({
             ...(socket.deserializeAttachment() as SessionSocketAttachment),
             replayAfter: cursor,
           } satisfies SessionSocketAttachment);
-        }
-        if (replayEvents >= MAX_CLIENT_REPLAY_EVENTS) {
-          closeSocket(socket, 1013, "durable replay continuation required");
-          return;
         }
         if (events.length > 0) continue;
         socket.serializeAttachment({
@@ -3968,20 +3952,6 @@ export class DurableAgentSession extends DurableComputerSession {
         this.#streamError,
       );
     }
-    if (this.#unfinishedTurnCount() >= MAX_ACTIVE_TURNS) {
-      throw new ManagedRequestError(
-        429,
-        "turn_queue_full",
-        `at most ${MAX_ACTIVE_TURNS} turns may be unfinished`,
-      );
-    }
-    if (!this.#eventLog.canAcceptTurn()) {
-      throw new ManagedRequestError(
-        507,
-        "event_log_full",
-        "delete or replace this agent before submitting more work",
-      );
-    }
   }
 
   async #acceptRoutedTurn(
@@ -4170,13 +4140,6 @@ export class DurableAgentSession extends DurableComputerSession {
     if (this.#streamError) {
       throw new ManagedRequestError(503, "event_stream_failed", this.#streamError);
     }
-    if (this.#unfinishedTurnCount() >= MAX_ACTIVE_TURNS) {
-      throw new ManagedRequestError(429, "turn_queue_full", `at most ${MAX_ACTIVE_TURNS} turns may be unfinished`);
-    }
-    if (!this.#eventLog.canAcceptTurn()) {
-      throw new ManagedRequestError(507, "event_log_full", "delete or replace this agent before submitting more work");
-    }
-
     const now = Date.now();
     const accepted: StreamMessage = { type: "turn_accepted", id, input, replayed: false };
     const firstPrompt = promptInputText(input);
@@ -4194,7 +4157,7 @@ export class DurableAgentSession extends DurableComputerSession {
       ).toArray()[0] !== undefined;
       event = this.#eventLog.append(accepted, id);
       if (cancellationRequested) {
-        cancellingEvent = this.#eventLog.append({ type: "turn_cancelling", id }, id, true);
+        cancellingEvent = this.#eventLog.append({ type: "turn_cancelling", id }, id);
       }
       this.ctx.storage.sql.exec(
         `INSERT INTO managed_turns (
@@ -4291,7 +4254,7 @@ export class DurableAgentSession extends DurableComputerSession {
     this.ctx.storage.transactionSync(() => {
       const row = this.#managedTurn(id);
       if (!row || isTerminalState(row.state) || row.state === "cancelling") return;
-      event = this.#eventLog.append(message, id, true);
+      event = this.#eventLog.append(message, id);
       this.ctx.storage.sql.exec(
         `UPDATE managed_turns
          SET state = 'cancelling', error = NULL, retry_at = NULL, updated_at = ?
@@ -5006,11 +4969,14 @@ export class DurableAgentSession extends DurableComputerSession {
       }
       const events = watchManagedAgentFamilyEvents(
         resolvedAgent,
-        (event, agentId) => this.#recordAgentEvent(
-          event,
-          resolvedAgent.sessionId,
-          agentId,
-        ),
+        {
+          replay: (event, agentId) => this.#recordAgentEvent(
+            event,
+            resolvedAgent.sessionId,
+            agentId,
+          ),
+          observe: (event) => this.#observeTransportEvent(event),
+        },
       );
       if (!this.#ownsAgentConstruction(construction)) {
         events.off();
@@ -5117,9 +5083,7 @@ export class DurableAgentSession extends DurableComputerSession {
       account: await accountInfo(
         this.env.NANOCODEX,
         session.owner_id,
-        true,
-        allowedConnectors,
-        allowedConnections,
+        { allowedConnectors, allowedConnections, enabled: true },
       ),
     } satisfies InitialAccountContext;
     await this.ctx.storage.put(INITIAL_ACCOUNT_CONTEXT_KEY, prepared);
@@ -5216,15 +5180,22 @@ export class DurableAgentSession extends DurableComputerSession {
       sshIdentityAllowed: (reference) => this.#activeTurnSshIdentityAllowed(reference),
     });
     const computerRuntimeMs = performance.now() - phaseStartedAt;
-    const currentAccountInfo = () => {
+    const currentAccountInfo = (signal?: AbortSignal) => {
       const authorization = this.#activeTurnAuthorization();
       return accountInfo(
         this.env.NANOCODEX,
         session.owner_id,
-        !multiplayer,
-        authorization === undefined ? [] : accountConnectorProjection(authorization),
-        authorization === undefined ? {} : accountConnectionProjection(authorization),
-        this.#accountMachines(authorization),
+        {
+          allowedConnectors: authorization === undefined
+            ? []
+            : accountConnectorProjection(authorization),
+          allowedConnections: authorization === undefined
+            ? {}
+            : accountConnectionProjection(authorization),
+          enabled: !multiplayer,
+          machines: this.#accountMachines(authorization),
+          signal,
+        },
       );
     };
     const internalRuntime = Symbol.for("nanocodex.cloudflare.internalRuntime");
@@ -5266,7 +5237,7 @@ export class DurableAgentSession extends DurableComputerSession {
         name: "accountInfo",
         description: "Report live machine hands, account authentication, safe Vault references, stablecoin balances, and app authorization boundaries. Vault references may show usernames, addresses, phone numbers, and card last four, but never passwords or complete card data.",
         parameters: { type: "object", additionalProperties: false },
-        handler: currentAccountInfo,
+        handler: (_input: unknown, context: ToolContext) => currentAccountInfo(context.signal),
       }]),
       ...(multiplayer ? [] : [accountConnectorsTool({
         broker: this.env.NANOCODEX,
@@ -5303,7 +5274,7 @@ export class DurableAgentSession extends DurableComputerSession {
         name: "runtimeInfo",
         description: "Return information about the durable brain and its live account context.",
         parameters: { type: "object", additionalProperties: false },
-        handler: async () => ({
+        handler: async (_input: unknown, context: ToolContext) => ({
           runtime: "cloudflare-durable-object",
           shell: multiplayer ? computer.descriptor.shell : "unavailable",
           shell_network: multiplayer ? computer.descriptor.network.mode : "unavailable",
@@ -5315,7 +5286,7 @@ export class DurableAgentSession extends DurableComputerSession {
           pty: multiplayer ? computer.descriptor.pty : false,
           sessions: multiplayer ? computer.descriptor.sessions : false,
           sandbox_escalation: false,
-          account: await currentAccountInfo(),
+          account: await currentAccountInfo(context.signal),
         }),
       },
       ...(multiplayer ? [] : memorySessionTools({
@@ -5777,7 +5748,7 @@ export class DurableAgentSession extends DurableComputerSession {
       const terminal = isTerminalState(state);
       const detail = "error" in message ? message.error ?? null : null;
       const encoded = terminal ? JSON.stringify(message) : null;
-      event = this.#eventLog.append(message, id, true);
+      event = this.#eventLog.append(message, id);
       this.ctx.storage.sql.exec(
         `UPDATE managed_turns
          SET state = ?, terminal_json = ?, terminal_cursor = ?, error = ?,
@@ -6010,6 +5981,27 @@ export class DurableAgentSession extends DurableComputerSession {
     }
   }
 
+  #observeTransportEvent(event: AgentEvent): void {
+    const payload = event.payload;
+    const operation = [payload.direction, payload.phase ?? payload.purpose]
+      .filter((value): value is string => typeof value === "string")
+      .join(":");
+    this.#observe("managed.agent.transport", {
+      message_type: event.type,
+      ...(typeof payload.transport === "string" ? { transport: payload.transport } : {}),
+      ...(operation ? { operation_kind: operation } : {}),
+      ...(typeof payload.attempt === "number" ? { attempt_count: payload.attempt } : {}),
+      ...(typeof payload.error_class === "string" ? { error_kind: payload.error_class } : {}),
+      outcome: event.type.endsWith(".failed")
+        ? "failure"
+        : event.type.endsWith(".completed")
+        ? "success"
+        : event.type.endsWith(".retrying")
+        ? "retrying"
+        : "observed",
+    });
+  }
+
   #releaseEventTurn(id: string): void {
     if (this.#eventTurnId === id) this.#eventTurnId = undefined;
     const queued = this.#eventTurnQueue.indexOf(id);
@@ -6045,24 +6037,23 @@ export class DurableAgentSession extends DurableComputerSession {
       outcome: "failure",
       error_kind: error instanceof Error ? error.name : typeof error,
     }, "error");
-    let event: DurableEvent<StreamMessage> | undefined;
-    try {
-      this.ctx.storage.transactionSync(() => {
-        this.ctx.storage.sql.exec(
-          "UPDATE session_state SET stream_error = ?, last_active = ? WHERE singleton = 1",
-          detail,
-          Date.now(),
-        );
-        event = this.#eventLog.append({ type: "stream_failed", error: detail }, null, true);
-      });
-    } catch (projectionError) {
+    const persistence = persistEventStreamFailure(
+      this.ctx.storage,
+      detail,
+      Date.now(),
+      () => this.#eventLog.append({ type: "stream_failed", error: detail }),
+    );
+    const persistenceError = persistence.fenceError ?? persistence.noticeError;
+    if (persistenceError !== undefined) {
       this.#observe("managed.event_stream_persist_failed", {
         outcome: "failure",
-        error_kind: projectionError instanceof Error ? projectionError.name : typeof projectionError,
+        error_kind: persistenceError instanceof Error
+          ? persistenceError.name
+          : typeof persistenceError,
       }, "error");
       return;
     }
-    this.#publish(event!);
+    this.#publish(persistence.event!);
   }
 
   #publish(event: DurableEvent<StreamMessage>): void {
@@ -6085,26 +6076,32 @@ export class DurableAgentSession extends DurableComputerSession {
       return force ? active.then(() => this.#sealEventArchive(true)) : active;
     }
     const started = performance.now();
-    const observed = this.#eventArchive.seal(force).then((result) => {
-      if (result.sealed) {
-        this.#logCapacity("archive_seal", {
-          archived_bytes: result.archived_bytes,
-          archived_events: result.archived_events,
-          index_node_created: result.index_node_created ? 1 : 0,
-          seal_ms: Math.round((performance.now() - started) * 100) / 100,
-        });
-      }
-      return result;
-    }).catch((error) => {
-      console.warn({ type: "managed.event_archive_seal_failed", error_kind: errorKind(error) });
-      throw error;
-    });
+    const observed = this.#scheduleNextAlarm()
+      .then(() => this.#eventArchive.seal(force))
+      .then(async (result) => {
+        this.#logEventArchiveSeal(result, started);
+        await this.#scheduleNextAlarm();
+        return result;
+      }).catch((error) => {
+        console.warn({ type: "managed.event_archive_seal_failed", error_kind: errorKind(error) });
+        throw error;
+      });
     this.#eventArchiveTask = observed;
     void observed.finally(() => {
       if (this.#eventArchiveTask === observed) this.#eventArchiveTask = undefined;
     }).catch(() => {});
     this.ctx.waitUntil(observed.catch(() => {}));
     return observed;
+  }
+
+  #logEventArchiveSeal(result: ManagedEventSealResult, started: number): void {
+    if (!result.sealed) return;
+    this.#logCapacity("archive_seal", {
+      archived_bytes: result.archived_bytes,
+      archived_events: result.archived_events,
+      index_node_created: result.index_node_created ? 1 : 0,
+      seal_ms: Math.round((performance.now() - started) * 100) / 100,
+    });
   }
 
   #sealTurnArchive(
@@ -6730,12 +6727,6 @@ export class DurableAgentSession extends DurableComputerSession {
         id,
       );
     });
-  }
-
-  #unfinishedTurnCount(): number {
-    return this.ctx.storage.sql.exec<{ count: number }>(
-      "SELECT COUNT(*) AS count FROM managed_turns WHERE state IN ('accepted', 'cancelling')",
-    ).toArray()[0]?.count ?? 0;
   }
 
   #recoverableTurnCount(): number {
@@ -7481,9 +7472,6 @@ async function fetchCreateStage(
 function managedHttpError(error: unknown, fallbackCode = "managed_request_failed") {
   if (error instanceof ManagedRequestError) {
     return { status: error.status, code: error.code, message: error.message };
-  }
-  if (error instanceof EventLogCapacityError) {
-    return { status: 507, code: error.code, message: error.message };
   }
   const code = (error as { code?: unknown } | null)?.code;
   if (code === "invalid_request") return { status: 400, code, message: errorMessage(error) };

--- a/js/managed/src/index.ts
+++ b/js/managed/src/index.ts
@@ -26,6 +26,11 @@ import {
   proxyCloudflareSandboxPreview,
 } from "./sandbox-tools";
 import {
+  createNamespaceExecutionTools,
+  machineMountRoot,
+  type MachineToolResolver,
+} from "./namespace-tools";
+import {
   ContainerProxy,
   Sandbox,
 } from "./sandbox-runtime";
@@ -42,7 +47,7 @@ import {
   hostedToolCatalogEntryAllowed,
   isAppToolCatalogDigest,
 } from "./app-tool-catalog";
-import type { HostedToolCatalogEntry } from "./hosted-tools-protocol";
+import type { HostedMachine, HostedToolCatalogEntry } from "./hosted-tools-protocol";
 import {
   managedCapacitySnapshot,
   type ManagedCapacitySnapshot,
@@ -586,13 +591,16 @@ const AGENT_CAPABILITIES = Object.freeze({
   live_cancel: true,
   workspace: "cloudflare-computer",
   execution_environments: true,
+  execution_namespace: "cwd-root-v1",
+  native_cross_mounts: false,
 }) satisfies AgentCapabilities;
 
 const AGENT_SANDBOX_MACHINE = Object.freeze({
   id: "sandbox",
   name: "Agent sandbox",
   kind: "sandbox",
-  workspace: "/workspace",
+  mount: "/sandbox",
+  workspace: "/sandbox",
   capabilities: Object.freeze([
     "filesystem",
     "native-linux",
@@ -1536,7 +1544,7 @@ export async function routeSandboxPreviewRequest(
   );
 }
 
-export function createManagedSandboxTools(
+export function createManagedNamespaceTools(
   env: Pick<
     Env,
     "NANOCODEX_ADMIN_TOKEN" | "NANOCODEX_SANDBOXES" | "NANOCODEX_SANDBOX_LOCAL"
@@ -1544,13 +1552,20 @@ export function createManagedSandboxTools(
   session: { session_id: string; public_origin: string },
   isAccountOwnedTurn: () => boolean,
   createTools: typeof cloudflareSandboxTools = cloudflareSandboxTools,
+  machines: () => readonly HostedMachine[] = () => [],
+  resolveMachineTool: MachineToolResolver = () => undefined,
 ): NamedTool[] {
-  return Object.entries(createTools(
+  const sandboxTools = createTools(
     env.NANOCODEX_SANDBOXES,
     session.session_id,
     env.NANOCODEX_SANDBOX_LOCAL === "true",
     session.public_origin,
     env.NANOCODEX_ADMIN_TOKEN,
+  );
+  return Object.entries(createNamespaceExecutionTools(
+    sandboxTools,
+    machines,
+    resolveMachineTool,
   )).map(([name, tool]) => ({
     name,
     ...tool,
@@ -1558,8 +1573,8 @@ export function createManagedSandboxTools(
       if (!isAccountOwnedTurn()) {
         throw new ManagedRequestError(
           403,
-          "sandbox_forbidden",
-          "sandbox tools are available only to account-owned turns",
+          "namespace_forbidden",
+          "execution namespace tools are available only to account-owned turns",
         );
       }
       return tool.handler(input, context);
@@ -5224,15 +5239,18 @@ export class DurableAgentSession extends DurableComputerSession {
             (connectionId) => this.#activeTurnMcpAllowed(connectionId),
           ),
     };
-    const sandboxTools = multiplayer ? [] : createManagedSandboxTools(
+    const namespaceTools = multiplayer ? [] : createManagedNamespaceTools(
       this.env,
       session,
       () => this.#isAccountOwnedTurn(),
+      cloudflareSandboxTools,
+      () => this.#hostedTools.machines(),
+      (machineId, name) => this.#hostedTools.machineTool(machineId, name),
     );
     const cloudTools: NamedTool[] = [
       ...(browserRuntime?.tools ?? []),
       ...(multiplayer ? [computer.tool] : []),
-      ...sandboxTools,
+      ...namespaceTools,
       ...(multiplayer ? [] : [{
         name: "accountInfo",
         description: "Report live machine hands, account authentication, safe Vault references, stablecoin balances, and app authorization boundaries. Vault references may show usernames, addresses, phone numbers, and card last four, but never passwords or complete card data.",
@@ -5278,7 +5296,15 @@ export class DurableAgentSession extends DurableComputerSession {
           runtime: "cloudflare-durable-object",
           shell: multiplayer ? computer.descriptor.shell : "unavailable",
           shell_network: multiplayer ? computer.descriptor.network.mode : "unavailable",
-          sandbox: multiplayer ? "disabled" : "cloudflare-sandbox-tools",
+          namespace: multiplayer ? { status: "disabled" } : {
+            status: "cwd-placement",
+            default_cwd: "/sandbox",
+            native_cross_mounts: false,
+            mounts: this.#accountMachines(this.#activeTurnAuthorization()).map(({ id, mount }) => ({
+              id,
+              mount,
+            })),
+          },
           workspace: computer.descriptor.cwd,
           commands: multiplayer ? computer.descriptor.commands : [],
           custom_commands: multiplayer ? computer.descriptor.customCommands : [],
@@ -5346,9 +5372,9 @@ export class DurableAgentSession extends DurableComputerSession {
           ].join("\n\n")
           : [
             "You are the durable Nanocodex brain running on Cloudflare Workers. The brain does not execute shell commands. Its own /workspace is scratch storage for brain-owned artifacts only.",
-            "Hands are separate execution environments listed in accountInfo().machines. The account-owned sandbox is one lazy, retained Linux hand reached only through explicit sandbox_* tools. Zero or more user machines may be connected through deferred private tools; use tool_search when their capabilities require discovery.",
-            "Machine topology changes live as user machines connect or disconnect; the agent itself is not restarted. Call accountInfo immediately before work whose placement depends on an available hand, and do not use a machine that is no longer listed.",
-            "The brain, sandbox, and user-machine workspaces are independent. Never imply that files are synchronized or silently move work between them. Use only the tools and capabilities advertised for the selected hand.",
+            "Hands appear as logical top-level paths listed in accountInfo().machines. exec_command has its standard shape: set workdir to /sandbox/... or an exact connected-hand mount such as /laptop/...; the root of that cwd selects where the process runs. write_stdin remains pinned to the hand that created its session. There is no environment or host argument.",
+            "A Code Mode cell captures its mount mapping. Commands in Promise.all may run concurrently on different cwd roots, and subagents use the same cwd rule independently. A disconnect or reconnect never retargets an admitted command or session.",
+            "The current cwd router is a placement milestone, not a native shared filesystem: native_cross_mounts is false, so a process cannot yet reach peer mounts through ordinary filesystem syscalls. Do not imply files are synchronized or use shell cd to select another hand; select placement with exec_command.workdir until a conforming native namespace adapter is advertised.",
             "The browser_execute tool is the managed remote browser. Reuse its retained session when continuity matters. Never inspect, return, or persist cookies, authorization material, CDP connection URLs, provider URLs, or Live View URLs. If a login, MFA, CAPTCHA, or other human-only gate appears, stop and ask the user to complete it outside the model-visible browser tool; do not bypass or evade the gate.",
             "For ordinary account operations, accountInfo is not a prerequisite to an explicit gh, git, curl, or other shell command. Those commands use transparent authenticated egress when the current grant permits it. accountInfo is a tool, not a shell command.",
             "When accountInfo lists multiple connectorAccounts for a service, choose the appropriate connection by label and pass its exact id as X-Nanocodex-Connector-Connection on that provider request. Never invent a connection id. The egress proxy validates it against the active grant.",
@@ -5550,13 +5576,17 @@ export class DurableAgentSession extends DurableComputerSession {
     if (!this.#isAccountOwnedTurn(authorization)) return [];
     return Object.freeze([
       AGENT_SANDBOX_MACHINE,
-      ...this.#hostedTools.machines().map((machine) => Object.freeze({
-        id: `user:${machine.id}`,
-        name: machine.name,
-        kind: "user" as const,
-        workspace: machine.workspace,
-        capabilities: machine.capabilities,
-      })),
+      ...this.#hostedTools.machines().map((machine) => {
+        const mount = machineMountRoot(machine.id);
+        return Object.freeze({
+          id: `user:${machine.id}`,
+          name: machine.name,
+          kind: "user" as const,
+          mount,
+          workspace: mount,
+          capabilities: machine.capabilities,
+        });
+      }),
     ]);
   }
 

--- a/js/managed/src/managed-event-archive.ts
+++ b/js/managed/src/managed-event-archive.ts
@@ -1,11 +1,11 @@
 import {
   hydrateManagedEventRows,
-  MAX_EVENT_BYTES,
   type DurableEvent,
   type DurableEventHistory,
   type DurableEventLog,
   type ManagedEventRow,
 } from "./durable-events";
+import { sha256Hex } from "./archive-hash";
 
 const VERSION = 1;
 const DEFAULT_SEAL_THRESHOLD_BYTES = 16 * 1024 * 1024;
@@ -13,11 +13,6 @@ const DEFAULT_SEGMENT_TARGET_BYTES = 8 * 1024 * 1024;
 const DEFAULT_RECENT_EVENT_COUNT = 512;
 const MAX_RECENT_DESCRIPTORS = 16;
 const MAX_SEAL_ROWS = 4_096;
-const MAX_ARCHIVE_OBJECT_BYTES = 16 * 1024 * 1024;
-// Reserve a bounded envelope allowance for 4,096 cursors, timestamps, turn
-// identities, JSON structure, and R2 metadata. The final encoded size remains
-// authoritative below.
-const MAX_SEGMENT_PAYLOAD_BYTES = MAX_EVENT_BYTES;
 const encoder = new TextEncoder();
 
 type EventRow = ManagedEventRow;
@@ -125,17 +120,13 @@ export class ManagedEventArchive<Message extends { type: string }> {
       1,
       4_096,
     );
-    this.#sealThresholdBytes = boundedInteger(
+    this.#sealThresholdBytes = positiveInteger(
       policy.sealThresholdBytes,
       DEFAULT_SEAL_THRESHOLD_BYTES,
-      1,
-      48 * 1024 * 1024,
     );
-    this.#segmentTargetBytes = boundedInteger(
+    this.#segmentTargetBytes = positiveInteger(
       policy.segmentTargetBytes,
       DEFAULT_SEGMENT_TARGET_BYTES,
-      1,
-      MAX_SEGMENT_PAYLOAD_BYTES,
     );
     storage.sql.exec(`
       CREATE TABLE IF NOT EXISTS managed_event_archive_state (
@@ -271,9 +262,6 @@ export class ManagedEventArchive<Message extends { type: string }> {
       events,
     } satisfies SegmentEnvelope<Message>);
     const segmentBytes = encoder.encode(segmentBody);
-    if (segmentBytes.byteLength > MAX_ARCHIVE_OBJECT_BYTES) {
-      throw new Error("managed event archive segment exceeds the object boundary");
-    }
     const segmentHash = await sha256Hex(segmentBytes);
     const descriptor: SegmentDescriptor = {
       bytes: segmentBytes.byteLength,
@@ -582,7 +570,7 @@ export class ManagedEventArchive<Message extends { type: string }> {
     if (cache.segment?.key === descriptor.key) return cache.segment.events;
     const object = await this.#bucket.get(this.#portableObjectKey(descriptor.key));
     if (!object || !object.body) throw new Error("managed event archive segment is unavailable");
-    if (object.size !== descriptor.bytes || object.size > MAX_ARCHIVE_OBJECT_BYTES) {
+    if (object.size !== descriptor.bytes) {
       await object.body.cancel();
       throw new Error("managed event archive segment size does not match its descriptor");
     }
@@ -619,10 +607,6 @@ export class ManagedEventArchive<Message extends { type: string }> {
     const key = this.#indexKey(ordinal);
     const object = await this.#bucket.get(key);
     if (!object || !object.body) throw new Error("managed event archive index is unavailable");
-    if (object.size > MAX_ARCHIVE_OBJECT_BYTES) {
-      await object.body.cancel();
-      throw new Error("managed event archive index exceeds the object boundary");
-    }
     const encoded = new Uint8Array(await object.arrayBuffer());
     const expectedHash = object.customMetadata?.sha256;
     if (!expectedHash || object.customMetadata?.kind !== "managed_event_index"
@@ -785,6 +769,10 @@ function boundedInteger(
   return Number.isSafeInteger(value) ? Math.min(maximum, Math.max(minimum, value!)) : fallback;
 }
 
+function positiveInteger(value: number | undefined, fallback: number): number {
+  return Number.isSafeInteger(value) && value! > 0 ? value! : fallback;
+}
+
 function emptySeal(cursor: string): ManagedEventSealResult {
   return {
     archived_bytes: 0,
@@ -813,9 +801,4 @@ function sameFence(left: ArchiveReadFence, right: ArchiveReadFence): boolean {
 
 function padCursor(cursor: string): string {
   return cursor.padStart(19, "0");
-}
-
-async function sha256Hex(value: Uint8Array): Promise<string> {
-  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", value));
-  return [...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }

--- a/js/managed/src/managed-portability-archive.ts
+++ b/js/managed/src/managed-portability-archive.ts
@@ -1,3 +1,5 @@
+import { sha256Hex } from "./archive-hash";
+
 const VERSION = 1;
 const BATCH_OBJECTS = 64;
 const BATCH_BYTES = 8 * 1024 * 1024;
@@ -243,7 +245,7 @@ export class ManagedPortabilityArchive {
       const suffix = object.key.slice(archivePrefix.length);
       const objectKind = object.customMetadata?.kind ?? "";
       if (!validObject(kind, suffix, objectKind)
-        || object.size <= 0 || object.size > 16 * 1024 * 1024
+        || object.size <= 0
         || object.customMetadata?.version !== String(VERSION)
         || !/^[0-9a-f]{64}$/.test(object.customMetadata?.sha256 ?? "")) {
         throw new Error(`managed ${kind} archive contains an invalid object identity`);
@@ -310,11 +312,6 @@ function validateIdentity(value: ManagedPortableArchiveIdentity): void {
     || !/^[0-9a-f]{64}$/.test(value.digest)) {
     throw new Error("managed portable archive identity is invalid");
   }
-}
-
-async function sha256Hex(value: Uint8Array): Promise<string> {
-  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", value));
-  return [...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
 async function mapWithConcurrency<T>(

--- a/js/managed/src/managed-realtime-archive.ts
+++ b/js/managed/src/managed-realtime-archive.ts
@@ -1,7 +1,8 @@
+import { sha256Hex } from "./archive-hash";
+
 const VERSION = 1;
 const DEFAULT_RECENT_OPERATIONS = 512;
 const MAX_SEAL_RECEIPTS = 32;
-const MAX_RECEIPT_BYTES = 4 * 1024 * 1024;
 const encoder = new TextEncoder();
 
 export type ManagedRealtimeReceipt = Readonly<{
@@ -117,9 +118,8 @@ export class ManagedRealtimeArchive {
     const key = `${this.#prefix}by-id/${await sha256Hex(encoder.encode(identity))}.json`;
     const object = await this.#bucket.get(key);
     if (!object) return undefined;
-    if (!object.body || object.size > MAX_RECEIPT_BYTES) {
-      await object.body?.cancel();
-      throw new Error("managed realtime archive receipt exceeds the object boundary");
+    if (!object.body) {
+      throw new Error("managed realtime archive receipt body is unavailable");
     }
     const body = new Uint8Array(await object.arrayBuffer());
     const expectedHash = object.customMetadata?.sha256;
@@ -161,9 +161,6 @@ export class ManagedRealtimeArchive {
         kind: "managed_realtime_receipt",
         receipt,
       } satisfies ReceiptEnvelope));
-      if (body.byteLength > MAX_RECEIPT_BYTES) {
-        throw new Error("managed realtime archive receipt exceeds the object boundary");
-      }
       const bodyHash = await sha256Hex(body);
       const identity = `${receipt.voice_session_id}\n${receipt.operation_id}`;
       const key = `${this.#prefix}by-id/${await sha256Hex(encoder.encode(identity))}.json`;
@@ -283,9 +280,4 @@ function validateReceipt(value: ManagedRealtimeReceipt): void {
 
 function emptySeal(): ManagedRealtimeSealResult {
   return { archived_bytes: 0, archived_receipts: 0, objects: 0, sealed: false };
-}
-
-async function sha256Hex(value: Uint8Array): Promise<string> {
-  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", value));
-  return [...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }

--- a/js/managed/src/managed-turn-archive.ts
+++ b/js/managed/src/managed-turn-archive.ts
@@ -1,7 +1,8 @@
+import { sha256Hex } from "./archive-hash";
+
 const VERSION = 1;
 const DEFAULT_RECENT_TERMINAL_TURNS = 512;
 const MAX_SEAL_RECEIPTS = 32;
-const MAX_RECEIPT_BYTES = 4 * 1024 * 1024;
 const TRANSFER_BATCH_OBJECTS = 64;
 const TRANSFER_BATCH_BYTES = 8 * 1024 * 1024;
 const TRANSFER_COPY_CONCURRENCY = 4;
@@ -201,9 +202,6 @@ export class ManagedTurnArchive {
         kind: "managed_turn_receipt",
         receipt,
       } satisfies ReceiptEnvelope));
-      if (body.byteLength > MAX_RECEIPT_BYTES) {
-        throw new Error("managed turn archive receipt exceeds the object boundary");
-      }
       const bodyHash = await sha256Hex(body);
       const keys = [
         `${this.#prefix}by-id/${await sha256Hex(encoder.encode(receipt.id))}.json`,
@@ -461,7 +459,7 @@ export class ManagedTurnArchive {
       for (const object of page.objects) {
         const suffix = object.key.slice(prefix.length);
         if (!/^(?:by-id|by-request)\/[0-9a-f]{64}\.json$/.test(suffix)
-          || object.size <= 0 || object.size > MAX_RECEIPT_BYTES
+          || object.size <= 0
           || object.customMetadata?.kind !== "managed_turn_receipt"
           || object.customMetadata?.version !== String(VERSION)
           || !/^[0-9a-f]{64}$/.test(object.customMetadata?.sha256 ?? "")) {
@@ -498,9 +496,8 @@ export class ManagedTurnArchive {
   async #read(key: string): Promise<ManagedTurnReceipt | undefined> {
     const object = await this.#bucket.get(key);
     if (!object) return undefined;
-    if (!object.body || object.size > MAX_RECEIPT_BYTES) {
-      await object.body?.cancel();
-      throw new Error("managed turn archive receipt exceeds the object boundary");
+    if (!object.body) {
+      throw new Error("managed turn archive receipt body is unavailable");
     }
     const body = new Uint8Array(await object.arrayBuffer());
     const expectedHash = object.customMetadata?.sha256;
@@ -639,11 +636,6 @@ function identityFromProgress(progress: TransferProgress): ManagedTurnArchiveIde
     objects: progress.object_count,
     version: VERSION,
   };
-}
-
-async function sha256Hex(value: Uint8Array): Promise<string> {
-  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", value));
-  return [...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
 async function mapWithConcurrency<T>(

--- a/js/managed/src/multiplayer-room.ts
+++ b/js/managed/src/multiplayer-room.ts
@@ -2,7 +2,6 @@ import { DurableObject } from "cloudflare:workers";
 
 import {
   DurableEventLog,
-  EventLogCapacityError,
   parseCursor,
   type DurableEvent,
 } from "./durable-events";
@@ -796,9 +795,6 @@ export class MultiplayerRoom extends DurableObject<MultiplayerRoomEnv> {
         this.#scheduleExpiryCleanup();
         return roomJson({ error: error.code }, { status: error.status });
       }
-      if (error instanceof EventLogCapacityError) {
-        return roomJson({ error: error.code }, { status: 507 });
-      }
       throw error;
     }
     if (result.event) this.#publish(result.event);
@@ -1222,14 +1218,7 @@ export class MultiplayerRoom extends DurableObject<MultiplayerRoomEnv> {
           await this.#rescheduleAlarm();
           return;
         }
-        try {
-          if (!this.#projectAgentMessage(job, message)) return;
-        } catch (error) {
-          if (!(error instanceof EventLogCapacityError)) throw error;
-          this.#blockJob(job.source_cursor);
-          await this.#rescheduleAlarm();
-          return;
-        }
+        if (!this.#projectAgentMessage(job, message)) return;
         continue;
       }
       if (turn.state === "cancelled") {
@@ -1238,14 +1227,7 @@ export class MultiplayerRoom extends DurableObject<MultiplayerRoomEnv> {
           await this.#rescheduleAlarm();
           return;
         }
-        try {
-          if (!this.#projectAgentFailure(job, "cancelled", false)) return;
-        } catch (error) {
-          if (!(error instanceof EventLogCapacityError)) throw error;
-          this.#blockJob(job.source_cursor);
-          await this.#rescheduleAlarm();
-          return;
-        }
+        if (!this.#projectAgentFailure(job, "cancelled", false)) return;
         continue;
       }
       if (turn.state === "failed") {
@@ -1254,14 +1236,7 @@ export class MultiplayerRoom extends DurableObject<MultiplayerRoomEnv> {
           await this.#rescheduleAlarm();
           return;
         }
-        try {
-          if (!this.#projectAgentFailure(job, "failed", false)) return;
-        } catch (error) {
-          if (!(error instanceof EventLogCapacityError)) throw error;
-          this.#blockJob(job.source_cursor);
-          await this.#rescheduleAlarm();
-          return;
-        }
+        if (!this.#projectAgentFailure(job, "failed", false)) return;
         continue;
       }
       this.#blockJob(job.source_cursor);
@@ -1337,7 +1312,7 @@ export class MultiplayerRoom extends DurableObject<MultiplayerRoomEnv> {
           id: `agent-${job.source_cursor}`,
           text: projectedText,
           reply_to: job.source_cursor,
-        }, job.turn_id, true);
+        }, job.turn_id);
         this.ctx.storage.sql.exec(
           `UPDATE room_agent_jobs SET state = 'completed', updated_at = ?
            WHERE source_cursor = CAST(? AS INTEGER) AND state = 'submitted'`,
@@ -1369,7 +1344,7 @@ export class MultiplayerRoom extends DurableObject<MultiplayerRoomEnv> {
           id: `agent-${job.source_cursor}`,
           code,
           reply_to: job.source_cursor,
-        }, job.turn_id, true);
+        }, job.turn_id);
         this.ctx.storage.sql.exec(
           `UPDATE room_agent_jobs SET state = ?, updated_at = ?
            WHERE source_cursor = CAST(? AS INTEGER) AND state = 'submitted'`,
@@ -1398,7 +1373,7 @@ export class MultiplayerRoom extends DurableObject<MultiplayerRoomEnv> {
           id: `agent-${job.source_cursor}`,
           code: "rate_limited",
           reply_to: job.source_cursor,
-        }, job.turn_id, true);
+        }, job.turn_id);
         this.ctx.storage.sql.exec(
           `UPDATE room_agent_jobs SET state = 'completed', updated_at = ?
            WHERE source_cursor = CAST(? AS INTEGER) AND state = 'quota_pending'`,
@@ -1470,7 +1445,7 @@ export class MultiplayerRoom extends DurableObject<MultiplayerRoomEnv> {
           id: `agent-${job.source_cursor}`,
           code: "blocked",
           reply_to: job.source_cursor,
-        }, job.turn_id, true);
+        }, job.turn_id);
         this.ctx.storage.sql.exec(
           `UPDATE room_agent_jobs SET state = 'blocked', updated_at = ?
            WHERE source_cursor = CAST(? AS INTEGER)
@@ -2196,15 +2171,6 @@ export class MultiplayerRoom extends DurableObject<MultiplayerRoomEnv> {
   #sendSayError(socket: WebSocket, clientId: string, error: unknown): boolean {
     if (error instanceof RoomMutationError) {
       if (error.code === "room_unavailable") this.#scheduleExpiryCleanup();
-      this.#send(socket, {
-        type: "error",
-        id: clientId,
-        code: error.code,
-        message: error.message,
-      });
-      return true;
-    }
-    if (error instanceof EventLogCapacityError) {
       this.#send(socket, {
         type: "error",
         id: clientId,

--- a/js/managed/src/namespace-tools.ts
+++ b/js/managed/src/namespace-tools.ts
@@ -1,0 +1,330 @@
+import type { ToolMap } from "nanocodex";
+import {
+  createNamespaceManifest,
+  createNamespaceScope,
+  EXEC_COMMAND_PARAMETERS,
+  EXECUTION_OUTPUT_SCHEMA,
+  namespaceMountRoot,
+  PREVIEW_OUTPUT_SCHEMA,
+  routeNamespaceCwd,
+  WRITE_STDIN_PARAMETERS,
+  type HostedMachineToolName,
+  type NamespaceRight,
+  type NamespaceScope,
+  type ToolContext,
+} from "nanocodex-tools";
+
+const TOOL_RESULT = Symbol.for("nanocodex.toolResult");
+const DEFAULT_CWD = "/sandbox";
+
+type RoutedTool = Readonly<{
+  handler(input: unknown, context: ToolContext): unknown | Promise<unknown>;
+}>;
+
+export type NamespaceMachine = Readonly<{
+  id: string;
+  workspace: string;
+}>;
+
+export type MachineToolResolver = (
+  machineId: string,
+  name: HostedMachineToolName,
+) => RoutedTool | undefined;
+
+type MountedHand = Readonly<{
+  mountId: string;
+  machineId?: string;
+  root: string;
+  workspace: string;
+  exec?: RoutedTool;
+  writeStdin?: RoutedTool;
+  preview?: RoutedTool;
+}>;
+
+type CellBinding = Readonly<{
+  scope: NamespaceScope;
+  hands: ReadonlyMap<string, MountedHand>;
+}>;
+
+type ProcessBinding = Readonly<{
+  ownerSessionId: string;
+  providerSessionId: number;
+  writeStdin: RoutedTool;
+}>;
+
+/**
+ * Routes the canonical process tools by the root of their logical cwd. The
+ * binding captured for a Code Mode call owns its exact attached tool handles,
+ * so a disconnect or reconnect cannot retarget an admitted command.
+ */
+export function createNamespaceExecutionTools(
+  sandboxTools: ToolMap,
+  machines: () => readonly NamespaceMachine[],
+  resolveMachineTool: MachineToolResolver = () => undefined,
+): ToolMap {
+  const sandbox = Object.freeze({
+    mountId: "mount:sandbox",
+    root: "/sandbox",
+    workspace: "/workspace",
+    exec: requiredTool(sandboxTools, "exec_command"),
+    writeStdin: requiredTool(sandboxTools, "write_stdin"),
+    preview: requiredTool(sandboxTools, "preview"),
+  }) satisfies MountedHand;
+  const cells = new Map<string, CellBinding>();
+  const sessions = new Map<number, ProcessBinding>();
+
+  const cell = (context: ToolContext): CellBinding => {
+    const key = `${context.sessionId}\u0000${context.parentCallId}`;
+    const retained = cells.get(key);
+    if (retained !== undefined) return retained;
+    const created = createCellBinding(sandbox, machines(), resolveMachineTool, key);
+    cells.set(key, created);
+    return created;
+  };
+
+  const releaseSession = (ownerSessionId: string): void => {
+    const cellPrefix = `${ownerSessionId}\u0000`;
+    for (const key of cells.keys()) {
+      if (key.startsWith(cellPrefix)) cells.delete(key);
+    }
+    for (const [sessionId, binding] of sessions) {
+      if (binding.ownerSessionId === ownerSessionId) sessions.delete(sessionId);
+    }
+  };
+  const dispose = (): void => {
+    cells.clear();
+    sessions.clear();
+  };
+
+  return {
+    exec_command: {
+      description: "Run a command on the hand that owns the root of workdir. workdir is a logical namespace path such as /sandbox/repo or /laptop/repo; it defaults to /sandbox.",
+      parameters: EXEC_COMMAND_PARAMETERS,
+      outputSchema: EXECUTION_OUTPUT_SCHEMA,
+      handler: async (input, context) => {
+        const value = record(input);
+        const binding = cell(context);
+        const route = routeNamespaceCwd(binding.scope, optionalString(value.workdir, "workdir"));
+        const hand = binding.hands.get(route.mount.mountId);
+        if (hand?.exec === undefined) {
+          throw new Error(`namespace mount ${route.mount.root} is not executable`);
+        }
+        const result = await hand.exec.handler({
+          ...without(value, "workdir"),
+          workdir: nativeWorkdir(hand.workspace, route.relativePath),
+        }, context);
+        const structured = executionResult(result);
+        if (structured?.session_id === undefined) return result;
+        if (hand.writeStdin === undefined) {
+          throw new Error(`namespace mount ${route.mount.root} cannot retain process sessions`);
+        }
+        const providerSessionId = positiveSessionId(structured.session_id);
+        const publicSessionId = reserveSessionId(sessions);
+        sessions.set(publicSessionId, Object.freeze({
+          ownerSessionId: context.sessionId,
+          providerSessionId,
+          writeStdin: hand.writeStdin,
+        }));
+        return replaceExecutionResult(result, { ...structured, session_id: publicSessionId });
+      },
+      releaseSession,
+      dispose,
+    },
+    write_stdin: {
+      description: "Write characters to or poll a session returned by exec_command. The session remains pinned to its original hand and namespace binding.",
+      parameters: WRITE_STDIN_PARAMETERS,
+      outputSchema: EXECUTION_OUTPUT_SCHEMA,
+      handler: async (input, context) => {
+        const value = record(input);
+        const publicSessionId = positiveSessionId(value.session_id);
+        const binding = sessions.get(publicSessionId);
+        if (binding === undefined || binding.ownerSessionId !== context.sessionId) {
+          throw new Error("unknown or stale namespace process session");
+        }
+        const result = await binding.writeStdin.handler({
+          ...without(value, "session_id"),
+          session_id: binding.providerSessionId,
+        }, context);
+        const structured = executionResult(result);
+        if (structured?.session_id === undefined) {
+          sessions.delete(publicSessionId);
+          return result;
+        }
+        if (positiveSessionId(structured.session_id) !== binding.providerSessionId) {
+          sessions.delete(publicSessionId);
+          throw new Error("execution hand changed its bound process session");
+        }
+        return replaceExecutionResult(result, { ...structured, session_id: publicSessionId });
+      },
+      releaseSession,
+      dispose,
+    },
+    preview: {
+      description: "Expose an HTTP server from the hand that owns the logical workdir when that hand supports previews.",
+      parameters: {
+        type: "object",
+        properties: {
+          workdir: { type: "string", description: "Logical namespace path selecting the server's hand; defaults to /sandbox." },
+          port: { type: "integer", minimum: 1024, maximum: 65_535 },
+        },
+        required: ["port"],
+        additionalProperties: false,
+      },
+      outputSchema: PREVIEW_OUTPUT_SCHEMA,
+      handler: async (input, context) => {
+        const value = record(input);
+        const binding = cell(context);
+        const route = routeNamespaceCwd(
+          binding.scope,
+          optionalString(value.workdir, "workdir"),
+          "network.preview",
+        );
+        const hand = binding.hands.get(route.mount.mountId);
+        if (hand?.preview === undefined) {
+          throw new Error(`namespace mount ${route.mount.root} does not provide preview`);
+        }
+        return hand.preview.handler(without(value, "workdir"), context);
+      },
+      releaseSession,
+      dispose,
+    },
+  };
+}
+
+export const machineMountRoot = namespaceMountRoot;
+
+function createCellBinding(
+  sandbox: MountedHand,
+  sourceMachines: readonly NamespaceMachine[],
+  resolveMachineTool: MachineToolResolver,
+  key: string,
+): CellBinding {
+  const hands: MountedHand[] = [sandbox];
+  const roots = new Set([sandbox.root]);
+  const keyHash = stableHash(key);
+  for (const machine of sourceMachines) {
+    const root = machineMountRoot(machine.id);
+    if (roots.has(root)) throw new Error(`duplicate namespace mount root ${root}`);
+    roots.add(root);
+    hands.push(Object.freeze({
+      mountId: `mount:user:${machine.id}`,
+      machineId: machine.id,
+      root,
+      workspace: machine.workspace,
+      exec: resolveMachineTool(machine.id, "exec_command"),
+      writeStdin: resolveMachineTool(machine.id, "write_stdin"),
+      preview: resolveMachineTool(machine.id, "preview"),
+    }));
+  }
+  const manifest = createNamespaceManifest({
+    manifestId: `manifest:${keyHash}:${stableHash(hands.map(({ mountId }) => mountId).join("\u0000"))}`,
+    mounts: hands.map((hand) => ({
+      root: hand.root,
+      mountId: hand.mountId,
+      handId: hand.machineId === undefined ? "hand:sandbox" : `hand:user:${hand.machineId}`,
+      exportId: hand.machineId === undefined ? "export:sandbox-workspace" : `export:user:${hand.machineId}`,
+      generation: `cell:${keyHash}:${stableHash(hand.mountId)}`,
+      rights: handRights(hand),
+    })),
+  });
+  const scope = createNamespaceScope(manifest, DEFAULT_CWD);
+  return Object.freeze({
+    scope,
+    hands: new Map(hands.map((hand) => [hand.mountId, hand])),
+  });
+}
+
+function handRights(hand: MountedHand): readonly NamespaceRight[] {
+  const rights: NamespaceRight[] = ["namespace.discover"];
+  if (hand.exec !== undefined) rights.push("process.exec");
+  if (hand.writeStdin !== undefined) rights.push("process.stdin");
+  if (hand.preview !== undefined) rights.push("network.preview");
+  return rights;
+}
+
+function nativeWorkdir(workspace: string, relativePath: string): string {
+  if (typeof workspace !== "string" || workspace.length === 0 || workspace.includes("\0")) {
+    throw new Error("execution hand published an invalid workspace root");
+  }
+  if (relativePath === "/") return workspace;
+  return `${workspace.replace(/\/$/, "")}/${relativePath.slice(1)}`;
+}
+
+function requiredTool(tools: ToolMap, name: string): NonNullable<ToolMap[string]> {
+  const tool = tools[name];
+  if (tool === undefined) throw new Error(`sandbox tool source is missing ${name}`);
+  return tool;
+}
+
+function executionResult(value: unknown): Record<string, unknown> | undefined {
+  const result = isToolResult(value) ? value.structuredResult : value;
+  return result !== null && typeof result === "object" && !Array.isArray(result)
+    ? result as Record<string, unknown>
+    : undefined;
+}
+
+function replaceExecutionResult(original: unknown, structured: Record<string, unknown>): unknown {
+  if (!isToolResult(original)) return structured;
+  return Object.freeze({
+    [TOOL_RESULT]: true,
+    metadata: original.metadata,
+    output: original.output,
+    structuredResult: structured,
+    success: original.success,
+    value: structured,
+  });
+}
+
+function isToolResult(value: unknown): value is Readonly<{
+  metadata: unknown;
+  output: unknown;
+  structuredResult: unknown;
+  success: boolean;
+}> {
+  return Boolean((value as Record<PropertyKey, unknown> | null)?.[TOOL_RESULT]);
+}
+
+function reserveSessionId(sessions: ReadonlyMap<number, unknown>): number {
+  for (let attempt = 0; attempt < 64; attempt += 1) {
+    const bytes = crypto.getRandomValues(new Uint32Array(1));
+    const candidate = (bytes[0]! & 0x7fff_ffff) || 1;
+    if (!sessions.has(candidate)) return candidate;
+  }
+  throw new Error("could not allocate a namespace process session");
+}
+
+function positiveSessionId(value: unknown): number {
+  if (!Number.isSafeInteger(value) || Number(value) <= 0) {
+    throw new TypeError("session_id must be a positive safe integer");
+  }
+  return Number(value);
+}
+
+function optionalString(value: unknown, name: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || value.length === 0) {
+    throw new TypeError(`${name} must be a non-empty string`);
+  }
+  return value;
+}
+
+function without(value: Record<string, unknown>, key: string): Record<string, unknown> {
+  const { [key]: _, ...rest } = value;
+  return rest;
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("tool input must be an object");
+  }
+  return value as Record<string, unknown>;
+}
+
+function stableHash(value: string): string {
+  let hash = 0xcbf29ce484222325n;
+  for (const byte of new TextEncoder().encode(value)) {
+    hash ^= BigInt(byte);
+    hash = BigInt.asUintN(64, hash * 0x100000001b3n);
+  }
+  return hash.toString(16).padStart(16, "0");
+}

--- a/js/managed/src/protocol.ts
+++ b/js/managed/src/protocol.ts
@@ -30,6 +30,8 @@ export type AgentCapabilities = Readonly<{
   live_cancel: true;
   workspace: "cloudflare-computer";
   execution_environments: true;
+  execution_namespace: "cwd-root-v1";
+  native_cross_mounts: false;
 }>;
 
 export type ServerMessage = (

--- a/js/managed/src/protocol.ts
+++ b/js/managed/src/protocol.ts
@@ -29,8 +29,7 @@ export type AgentCapabilities = Readonly<{
   live_steer: true;
   live_cancel: true;
   workspace: "cloudflare-computer";
-  sandbox_tools: true;
-  sandbox_escalation: boolean;
+  execution_environments: true;
 }>;
 
 export type ServerMessage = (

--- a/js/managed/src/sandbox-smoke.ts
+++ b/js/managed/src/sandbox-smoke.ts
@@ -10,6 +10,7 @@ export async function cloudflareSandboxSmokeSetup(
   publicOrigin: string,
   previewSecret: string,
 ): Promise<Record<string, unknown>> {
+  requireProbeId(probeId);
   const started = Date.now();
   const marker = `CLOUDFLARE_SANDBOX_OK_${probeId}`;
   let tools = cloudflareSandboxTools(
@@ -23,103 +24,55 @@ export async function cloudflareSandboxSmokeSetup(
     // Wrangler's emulated R2 watcher takes its initial filesystem snapshot
     // asynchronously after mountBucket() returns. Let that baseline settle so
     // this write is observed as a change; production uses the direct R2 mount.
-    if (localBucket) await invoke(tools, "sandbox_exec", { command: "sleep 2" });
-    const write = record(await invoke(tools, "sandbox_write_file", {
-      path: "probe.txt",
-      content: marker,
-    }));
-    assert(write.bytes_written === marker.length, "write byte count mismatch");
+    if (localBucket) await exec(tools, "sleep 2");
+    const write = record(await exec(
+      tools,
+      `printf %s ${marker} > probe.txt && test "$(cat probe.txt)" = ${marker} && printf EXEC_OK`,
+    ));
+    assert(write.exit_code === 0 && write.output === "EXEC_OK", "shell write/read failed");
 
-    const exec = record(await invoke(tools, "sandbox_exec", {
-      command: `test "$(cat probe.txt)" = "${marker}" && printf EXEC_OK`,
-      timeout_ms: 10_000,
-    }));
-    assert(exec.success === true && exec.stdout === "EXEC_OK", "write was not visible to exec");
+    const list = record(await exec(tools, "find . -maxdepth 1 -name probe.txt -print"));
+    assert(list.output === "./probe.txt\n", "shell listing omitted probe.txt");
 
-    const read = record(await invoke(tools, "sandbox_read_file", { path: "probe.txt" }));
-    assert(read.content === marker, "read did not return written content");
-
-    const list = record(await invoke(tools, "sandbox_list_files", {}));
-    const entries = Array.isArray(list.entries) ? list.entries.map(record) : [];
-    assert(entries.some((entry) => entry.name === "probe.txt"), "list omitted probe.txt");
-
-    const nonzero = record(await invoke(tools, "sandbox_exec", {
-      command: "sh -c 'printf partial; printf failed >&2; exit 7'",
-    }));
+    const nonzero = record(await exec(tools, "sh -c 'printf partial; printf failed >&2; exit 7'"));
     assert(
-      nonzero.success === false
-        && nonzero.exit_code === 7
-        && nonzero.stdout === "partial"
-        && nonzero.stderr === "failed",
+      nonzero.exit_code === 7 && nonzero.output === "partialfailed",
       "non-zero command result was not preserved",
     );
 
-    const flood = record(await invoke(tools, "sandbox_exec", {
-      command: "node -e 'process.stdout.write(\"x\".repeat(140000)); process.stderr.write(\"y\".repeat(140000))'",
+    const yielded = record(await invoke(tools, "exec_command", {
+      cmd: "printf first; sleep 1; printf second",
+      yield_time_ms: 250,
     }));
     assert(
-      flood.stdout_truncated === true,
-      `stdout flood was not truncated: ${JSON.stringify({
-        success: flood.success,
-        exit_code: flood.exit_code,
-        stdout_bytes: new TextEncoder().encode(String(flood.stdout)).byteLength,
-        stderr_bytes: new TextEncoder().encode(String(flood.stderr)).byteLength,
-        stderr_truncated: flood.stderr_truncated,
-      })}`,
+      typeof yielded.session_id === "number" && yielded.output === "first",
+      "command did not yield a resumable session",
     );
-    assert(flood.stderr_truncated === true, "stderr flood was not truncated");
+    const resumed = record(await invoke(tools, "write_stdin", {
+      session_id: yielded.session_id,
+    }));
     assert(
-      new TextEncoder().encode(String(flood.stdout)).byteLength === 128 * 1024,
-      "stdout was not capped at 128 KiB",
+      resumed.exit_code === 0 && resumed.output === "second",
+      "session resume replayed or lost command output",
     );
 
-    const timeoutStarted = Date.now();
-    const timeoutError = await rejectedMessage(invoke(tools, "sandbox_exec", {
-      command: "sleep 5",
-      timeout_ms: 100,
-    }));
-    assert(/time|interrupt|abort/i.test(timeoutError), `unexpected timeout error: ${timeoutError}`);
-    assert(Date.now() - timeoutStarted < 4_000, "command timeout was not enforced promptly");
+    const flood = record(await exec(
+      tools,
+      "node -e 'process.stdout.write(\"x\".repeat(140000)); process.stderr.write(\"y\".repeat(140000))'",
+    ));
+    assert(
+      new TextEncoder().encode(String(flood.output)).byteLength === 40_000
+        && flood.original_token_count === 70_000,
+      "combined command output was not capped",
+    );
 
-    const traversalError = await rejectedMessage(invoke(tools, "sandbox_read_file", {
-      path: "../etc/passwd",
-    }));
-    assert(/must not contain/.test(traversalError), "path traversal was not rejected");
-
-    const oversizedError = await rejectedMessage(invoke(tools, "sandbox_write_file", {
-      path: "oversized.txt",
-      content: "😀".repeat(1024 * 1024 / 4 + 1),
-    }));
-    assert(/exceeds 1 MiB/.test(oversizedError), "oversized UTF-8 write was not rejected");
-
-    const background = record(await invoke(tools, "sandbox_start_process", {
-      command: "sh -c 'printf background-output; printf background-error >&2; exit 7'",
-    }));
-    const processId = String(background.process_id);
-    let backgroundResult: Record<string, unknown> | undefined;
-    for (let attempt = 0; attempt < 50; attempt += 1) {
-      backgroundResult = record(await invoke(tools, "sandbox_get_process", {
-        process_id: processId,
-      }));
-      if (backgroundResult.terminal === true) break;
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    }
-    assert(backgroundResult?.status === "failed", "background process did not reach failed state");
-    assert(backgroundResult.exit_code === 7, "background process exit code was not retained");
-    assert(backgroundResult.stdout === "background-output", "background stdout was not retained");
-    assert(backgroundResult.stderr === "background-error", "background stderr was not retained");
-
-    const process = record(await invoke(tools, "sandbox_start_process", {
-      command: "node -e 'require(\"http\").createServer((q,s)=>require(\"fs\").createReadStream(\"/workspace/probe.txt\").pipe(s)).listen(8000)'",
-      ready_port: 8000,
-      ready_timeout_ms: 10_000,
-    }));
-    assert(process.ready_port === 8000, "managed process did not report port readiness");
-    const server = record(await invoke(tools, "sandbox_get_process", {
-      process_id: process.process_id,
-    }));
-    assert(server.found === true && server.terminal === false, "preview process was not observable");
-    const preview = record(await invoke(tools, "sandbox_preview", { port: 8000 }));
+    const server = record(await exec(tools, [
+      "nohup node -e 'require(\"http\").createServer((q,s)=>require(\"fs\").createReadStream(\"/workspace/probe.txt\").pipe(s)).listen(8000)'",
+      ">/tmp/nanocodex-sandbox-smoke.log 2>&1 &",
+      "for i in $(seq 1 100); do curl -fsS http://127.0.0.1:8000/probe.txt >/dev/null && exit 0; sleep .1; done; exit 1",
+    ].join(" ")));
+    assert(server.exit_code === 0, "background preview server did not become ready");
+    const preview = record(await invoke(tools, "preview", { port: 8000 }));
     const previewUrl = new URL("probe.txt", String(preview.url));
     assert(previewUrl.protocol === "https:", `preview returned an invalid URL: ${previewUrl.href}`);
 
@@ -132,12 +85,9 @@ export async function cloudflareSandboxSmokeSetup(
         "write_exec_read",
         "directory_list",
         "nonzero_exit",
+        "session_resume",
         "bounded_output",
-        "command_timeout",
-        "path_confinement",
-        "write_size_limit",
-        "background_process_result",
-        "managed_process_preview",
+        "shell_managed_preview",
       ],
       duration_ms: Date.now() - started,
     };
@@ -152,14 +102,15 @@ export async function cloudflareSandboxSmokeFinish(
   probeId: string,
   localBucket: boolean,
 ): Promise<Record<string, unknown>> {
+  requireProbeId(probeId);
   const started = Date.now();
   const marker = `CLOUDFLARE_SANDBOX_OK_${probeId}`;
   try {
     await destroyCloudflareSandbox(namespace, probeId);
     const tools = cloudflareSandboxTools(namespace, probeId, localBucket);
-    const persisted = record(await invoke(tools, "sandbox_read_file", { path: "probe.txt" }));
-    assert(persisted.content === marker, "R2 workspace did not survive container destruction");
-    await invoke(tools, "sandbox_exec", { command: "rm -f probe.txt" });
+    const persisted = record(await exec(tools, "cat probe.txt"));
+    assert(persisted.output === marker, "R2 workspace did not survive container destruction");
+    await exec(tools, "rm -f probe.txt");
     return {
       status: "ok",
       probe_id: probeId,
@@ -169,6 +120,10 @@ export async function cloudflareSandboxSmokeFinish(
   } finally {
     await destroyCloudflareSandbox(namespace, probeId).catch(() => {});
   }
+}
+
+function exec(tools: ToolMap, cmd: string): Promise<unknown> {
+  return invoke(tools, "exec_command", { cmd });
 }
 
 async function invoke(tools: ToolMap, name: string, input: unknown): Promise<unknown> {
@@ -183,20 +138,17 @@ async function invoke(tools: ToolMap, name: string, input: unknown): Promise<unk
   });
 }
 
-async function rejectedMessage(operation: Promise<unknown>): Promise<string> {
-  try {
-    await operation;
-  } catch (error) {
-    return error instanceof Error ? error.message : String(error);
-  }
-  throw new Error("operation unexpectedly succeeded");
-}
-
 function record(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error("tool returned a non-object result");
   }
   return value as Record<string, unknown>;
+}
+
+function requireProbeId(value: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/.test(value)) {
+    throw new Error("sandbox smoke probe ID must be a safe identifier");
+  }
 }
 
 function assert(condition: boolean, message: string): asserts condition {

--- a/js/managed/src/sandbox-tools.ts
+++ b/js/managed/src/sandbox-tools.ts
@@ -1,15 +1,21 @@
 import { getSandbox } from "@cloudflare/sandbox";
 import type { ToolMap } from "nanocodex";
+import {
+  EXEC_COMMAND_PARAMETERS,
+  EXECUTION_OUTPUT_SCHEMA,
+  MACHINE_PREVIEW_PARAMETERS,
+  PREVIEW_OUTPUT_SCHEMA,
+  WRITE_STDIN_PARAMETERS,
+} from "nanocodex-tools/execution-contract";
 
 import { isPrivateEgressHeader } from "./managed-egress";
 import type { Sandbox } from "./sandbox-runtime";
 
 const WORKSPACE = "/workspace";
 const WORKSPACE_FLUSH_COMMAND = "sync -f /workspace";
-const MAX_COMMAND_CHARS = 32 * 1024;
-const MAX_FILE_BYTES = 1024 * 1024;
-const MAX_OUTPUT_BYTES = 128 * 1024;
-const MAX_LIST_ENTRIES = 512;
+const DEFAULT_MAX_OUTPUT_TOKENS = 10_000;
+const APPROXIMATE_BYTES_PER_TOKEN = 4;
+const OUTPUT_CURSOR_PREFIX = "sandbox-output-cursor:";
 const WORKSPACE_MOUNT_PROBE_TIMEOUT_MS = 10_000;
 const WORKSPACE_MOUNT_HEALTH_ATTEMPTS = 3;
 const PREVIEW_CAPABILITY_TTL_MS = 60 * 60 * 1_000;
@@ -58,24 +64,15 @@ type SandboxPreparation = {
   promise: Promise<Sandbox>;
 };
 
-type SandboxProcessStatus =
-  | "starting"
-  | "running"
-  | "completed"
-  | "failed"
-  | "killed"
-  | "error";
+type SandboxProcessStatus = "starting" | "running" | "completed" | "failed" | "killed" | "error";
 
 type SandboxProcess = {
   id: string;
-  pid?: number;
-  command: string;
   status: SandboxProcessStatus;
   exitCode?: number;
   kill(): Promise<void>;
   getStatus(): Promise<SandboxProcessStatus>;
   getLogs(): Promise<{ stdout: string; stderr: string }>;
-  waitForPort(port: number, options?: { timeout?: number }): Promise<void>;
   waitForExit(timeout?: number): Promise<{ exitCode: number }>;
 };
 
@@ -97,27 +94,18 @@ type SandboxToolClient = {
   }>;
   startProcess(
     command: string,
-    options: { cwd: string; autoCleanup: false },
+    options: { cwd: string; processId: string; autoCleanup: false },
   ): Promise<SandboxProcess>;
   getProcess(id: string): Promise<SandboxProcess | null>;
-  readFile(
-    path: string,
-    options: { encoding: "none" },
-  ): Promise<{ size: number; content: ReadableStream<Uint8Array> }>;
-  writeFile(
-    path: string,
-    content: string,
-    options: { encoding: "utf-8" },
-  ): Promise<unknown>;
-  listFiles(
-    path: string,
-    options: { includeHidden: true },
-  ): Promise<{
-    files: Array<{ name: string; type: string; size: number }>;
-  }>;
   tunnels: {
     get(port: number): Promise<{ url: string }>;
   };
+};
+
+type SandboxOutputCursorStorage = {
+  delete(key: string): void;
+  get(key: string): unknown;
+  put(key: string, value: unknown): void;
 };
 
 export function cloudflareSandboxTools(
@@ -126,6 +114,7 @@ export function cloudflareSandboxTools(
   localBucket = false,
   publicOrigin?: string,
   previewSecret?: string,
+  outputCursorStorage?: SandboxOutputCursorStorage,
 ): ToolMap {
   return createCloudflareSandboxTools(
     () => prepareSandbox(namespace, sessionId, localBucket),
@@ -141,6 +130,7 @@ export function cloudflareSandboxTools(
           ),
           persistent: false,
         }),
+    outputCursorStorage,
   );
 }
 
@@ -186,267 +176,91 @@ export async function deleteCloudflareSandboxWorkspace(
 export function createCloudflareSandboxTools(
   createSandbox: () => Promise<SandboxToolClient>,
   createPreview?: (port: number) => Promise<{ port: number; url: string; persistent: boolean }>,
+  outputCursorStorage: SandboxOutputCursorStorage = memoryOutputCursorStorage(),
 ): ToolMap {
   return {
-    sandbox_exec: {
-      description: "Run a foreground shell command in this session's isolated Cloudflare Sandbox workspace.",
-      parameters: {
-        type: "object",
-        properties: {
-          command: { type: "string", description: "Shell command to run." },
-          cwd: { type: "string", description: "Workspace-relative working directory." },
-          timeout_ms: {
-            type: "integer",
-            minimum: 1,
-            description: "Optional Sandbox SDK execution timeout in milliseconds.",
-          },
-        },
-        required: ["command"],
-        additionalProperties: false,
-      },
-      handler: async (input) => {
+    exec_command: {
+      description: "Run a shell command in the retained native Linux sandbox, returning a session when it remains live.",
+      parameters: EXEC_COMMAND_PARAMETERS,
+      outputSchema: EXECUTION_OUTPUT_SCHEMA,
+      handler: async (input, context) => {
         const value = objectInput(input);
-        const command = requiredString(value.command, "command", MAX_COMMAND_CHARS);
-        const cwd = workspacePath(optionalString(value.cwd, "cwd") ?? ".");
-        const timeout = optionalPositiveInteger(value.timeout_ms, "timeout_ms");
+        if (value.sandbox_permissions === "require_escalated") {
+          throw new Error("Cloudflare Sandbox exec_command does not support privilege escalation");
+        }
+        if (value.tty === true) throw new Error("Cloudflare Sandbox exec_command does not support TTY sessions");
+        if (value.shell !== undefined || value.login !== undefined) {
+          throw new Error("Cloudflare Sandbox exec_command does not support shell or login overrides");
+        }
+        const command = requiredString(value.cmd, "cmd");
+        const cwd = workspacePath(optionalString(value.workdir, "workdir") ?? ".");
+        const yieldTime = yieldMilliseconds(value.yield_time_ms, 10_000);
+        const outputByteLimit = requestedOutputBytes(value.max_output_tokens);
+        context?.signal.throwIfAborted();
         const sandbox = await createSandbox();
-        return withSandboxRpcResult(
-          sandbox.exec(command, {
+        context?.signal.throwIfAborted();
+        const sessionId = await availableSessionId(sandbox);
+        outputCursorStorage.put(`${OUTPUT_CURSOR_PREFIX}${sessionId}`, 0);
+        let process: SandboxProcess | undefined;
+        try {
+          process = await sandbox.startProcess(mergedShellCommand(command), {
             cwd,
-            ...(timeout === undefined ? {} : { timeout }),
-          }).catch(async (error: unknown) => {
-            try { await flushWorkspace(sandbox); } catch { /* Preserve the execution failure. */ }
-            throw error;
-          }),
-          async (result) => {
-            await flushWorkspace(sandbox);
-            return {
-              success: result.success,
-              exit_code: result.exitCode,
-              ...boundedOutput(result),
-              duration_ms: result.duration,
-            };
-          },
-        );
-      },
-    },
-    sandbox_read_file: {
-      description: "Read a UTF-8 text file from this session's isolated workspace (maximum 1 MiB).",
-      parameters: pathParameters(),
-      handler: async (input) => {
-        const path = workspacePath(requiredString(objectInput(input).path, "path", 1024));
-        return withSandboxRpcResult(
-          (await createSandbox()).readFile(path, { encoding: "none" }),
-          async (result) => {
-            if (result.size > MAX_FILE_BYTES) {
-              await cancelReadableStream(result.content, "file exceeds 1 MiB");
-              throw new Error("file exceeds 1 MiB");
-            }
-            return { path, content: await readBounded(result.content) };
-          },
-        );
-      },
-    },
-    sandbox_start_process: {
-      description: "Start a managed background process in this session's Cloudflare Sandbox, optionally waiting for an HTTP port to become ready.",
-      parameters: {
-        type: "object",
-        properties: {
-          command: { type: "string", description: "Command to start." },
-          cwd: { type: "string", description: "Workspace-relative working directory." },
-          ready_port: { type: "integer", minimum: 1024, maximum: 65_535 },
-          ready_timeout_ms: {
-            type: "integer",
-            minimum: 1,
-            description: "Optional Sandbox SDK port-readiness timeout in milliseconds.",
-          },
-        },
-        required: ["command"],
-        additionalProperties: false,
-      },
-      handler: async (input) => {
-        const value = objectInput(input);
-        const command = requiredString(value.command, "command", MAX_COMMAND_CHARS);
-        const cwd = workspacePath(optionalString(value.cwd, "cwd") ?? ".");
-        const readyPort = optionalPort(value.ready_port, "ready_port");
-        const readyTimeout = optionalPositiveInteger(
-          value.ready_timeout_ms,
-          "ready_timeout_ms",
-        );
-        const sandbox = await createSandbox();
-        return withSandboxRpcResult(
-          sandbox.startProcess(command, {
-            cwd,
+            processId: sandboxProcessId(sessionId),
             autoCleanup: false,
-          }),
-          async (process) => {
-            if (readyPort !== undefined) {
-              try {
-                await process.waitForPort(
-                  readyPort,
-                  readyTimeout === undefined ? undefined : { timeout: readyTimeout },
-                );
-              } catch (error) {
-                let status = await process.getStatus().catch(() => process.status);
-                let killError: string | undefined;
-                if (!isTerminalProcessStatus(status)) {
-                  try {
-                    await process.kill();
-                    status = await process.getStatus().catch(() => status);
-                  } catch (killFailure) {
-                    killError = errorMessage(killFailure);
-                  }
-                }
-                let flushError: string | undefined;
-                try {
-                  await flushWorkspace(sandbox);
-                } catch (flushFailure) {
-                  flushError = errorMessage(flushFailure);
-                }
-                return {
-                  process_id: process.id,
-                  pid: process.pid,
-                  command,
-                  status,
-                  terminal: isTerminalProcessStatus(status),
-                  ready_port: readyPort,
-                  ready: false,
-                  ready_error: errorMessage(error),
-                  ...(killError === undefined ? {} : { kill_error: killError }),
-                  ...(flushError === undefined ? {} : { flush_error: flushError }),
-                };
-              }
-            }
-            const status = await process.getStatus();
-            if (isTerminalProcessStatus(status)) await flushWorkspace(sandbox);
-            return {
-              process_id: process.id,
-              pid: process.pid,
-              command,
-              status,
-              ...(readyPort === undefined ? {} : { ready_port: readyPort, ready: true }),
-            };
-          },
+          });
+          return await observeProcess(
+            sandbox,
+            process,
+            sessionId,
+            yieldTime,
+            outputByteLimit,
+            outputCursorStorage,
+            context?.signal,
+          );
+        } catch (error) {
+          if (process === undefined) {
+            outputCursorStorage.delete(`${OUTPUT_CURSOR_PREFIX}${sessionId}`);
+            try { await flushWorkspace(sandbox); } catch { /* Preserve the execution failure. */ }
+          }
+          throw error;
+        }
+      },
+    },
+    write_stdin: {
+      description: "Poll a session returned by exec_command in the retained native Linux sandbox, or send Ctrl-C to terminate it.",
+      parameters: WRITE_STDIN_PARAMETERS,
+      outputSchema: EXECUTION_OUTPUT_SCHEMA,
+      handler: async (input, context) => {
+        const value = objectInput(input);
+        if (value.chars !== undefined && value.chars !== "" && value.chars !== "\u0003") {
+          throw new Error("Cloudflare Sandbox write_stdin supports only polling or Ctrl-C termination; stdin is unavailable");
+        }
+        const sessionId = requiredSessionId(value.session_id);
+        const yieldTime = yieldMilliseconds(value.yield_time_ms, 5_000);
+        const outputByteLimit = requestedOutputBytes(value.max_output_tokens);
+        context?.signal.throwIfAborted();
+        const sandbox = await createSandbox();
+        const process = await sandbox.getProcess(sandboxProcessId(sessionId));
+        if (process === null) throw new Error(`unknown sandbox session: ${sessionId}`);
+        if (value.chars === "\u0003") await process.kill().catch(() => {});
+        return observeProcess(
+          sandbox,
+          process,
+          sessionId,
+          yieldTime,
+          outputByteLimit,
+          outputCursorStorage,
+          context?.signal,
         );
       },
     },
-    sandbox_get_process: {
-      description: "Get authoritative status for a background process in this session's Cloudflare Sandbox. Terminal results include accumulated output; set include_output only when partial running output is needed.",
-      parameters: processIdParameters(true),
+    preview: {
+      description: "Expose an HTTP server from the retained native Linux sandbox.",
+      parameters: MACHINE_PREVIEW_PARAMETERS,
+      outputSchema: PREVIEW_OUTPUT_SCHEMA,
       handler: async (input) => {
         const value = objectInput(input);
-        const processId = requiredProcessId(value.process_id);
-        const sandbox = await createSandbox();
-        return withSandboxRpcResult(
-          sandbox.getProcess(processId),
-          async (process) => {
-            if (process === null) return { found: false, process_id: processId };
-            const terminal = isTerminalProcessStatus(process.status);
-            let output;
-            if (terminal || value.include_output === true) {
-              const logs = process.getLogs();
-              output = boundedOutput(await (terminal
-                ? Promise.all([logs, flushWorkspace(sandbox)]).then(([result]) => result)
-                : logs));
-            }
-            return {
-              found: true,
-              process_id: process.id,
-              pid: process.pid,
-              command: process.command,
-              status: process.status,
-              terminal,
-              exit_code: process.exitCode ?? null,
-              ...output,
-            };
-          },
-        );
-      },
-    },
-    sandbox_kill_process: {
-      description: "Terminate a running background process in this session's Cloudflare Sandbox.",
-      parameters: processIdParameters(),
-      handler: async (input) => {
-        const processId = requiredProcessId(objectInput(input).process_id);
-        const sandbox = await createSandbox();
-        return withSandboxRpcResult(
-          sandbox.getProcess(processId),
-          async (process) => {
-            if (process === null) return { found: false, process_id: processId };
-            let status = process.status;
-            const killRequested = !isTerminalProcessStatus(status);
-            if (killRequested) {
-              await process.kill();
-              status = await process.getStatus();
-            }
-            await flushWorkspace(sandbox);
-            return {
-              found: true,
-              process_id: process.id,
-              status,
-              terminal: isTerminalProcessStatus(status),
-              kill_requested: killRequested,
-            };
-          },
-        );
-      },
-    },
-    sandbox_write_file: {
-      description: "Write a UTF-8 text file inside this session's isolated workspace (maximum 1 MiB).",
-      parameters: {
-        type: "object",
-        properties: {
-          path: { type: "string", description: "Workspace-relative file path." },
-          content: { type: "string", description: "Complete UTF-8 file content." },
-        },
-        required: ["path", "content"],
-        additionalProperties: false,
-      },
-      handler: async (input) => {
-        const value = objectInput(input);
-        const path = workspacePath(requiredString(value.path, "path", 1024));
-        const content = requiredContent(value.content);
-        const bytes = new TextEncoder().encode(content).byteLength;
-        if (bytes > MAX_FILE_BYTES) throw new Error("content exceeds 1 MiB");
-        const sandbox = await createSandbox();
-        await sandbox.writeFile(path, content, { encoding: "utf-8" });
-        await flushWorkspace(sandbox);
-        return { path, bytes_written: bytes };
-      },
-    },
-    sandbox_list_files: {
-      description: "List files in a directory inside this session's isolated workspace.",
-      parameters: {
-        type: "object",
-        properties: {
-          path: { type: "string", description: "Workspace-relative directory; defaults to the workspace root." },
-        },
-        additionalProperties: false,
-      },
-      handler: async (input) => {
-        const value = objectInput(input);
-        const path = workspacePath(optionalString(value.path, "path") ?? ".");
-        return withSandboxRpcResult(
-          (await createSandbox()).listFiles(path, { includeHidden: true }),
-          (result) => ({
-            path,
-            entries: result.files.slice(0, MAX_LIST_ENTRIES).map((entry) => ({
-              name: entry.name,
-              type: entry.type,
-              size: entry.size,
-            })),
-            truncated: result.files.length > MAX_LIST_ENTRIES,
-          }),
-        );
-      },
-    },
-    sandbox_preview: {
-      // Keep this definition byte-stable so snapshots created before the
-      // Worker-fronted preview implementation can resume safely.
-      description: "Expose a server running in the sandbox through a temporary public Cloudflare Tunnel URL.",
-      parameters: portParameters(),
-      handler: async (input) => {
-        const port = requiredPort(objectInput(input).port);
+        const port = requiredPort(value.port);
         const prepared = await createSandbox();
         if (createPreview) return createPreview(port);
         return withSandboxRpcResult(
@@ -464,6 +278,7 @@ export async function cloudflareSandboxPreviewUrl(
   sessionId: string,
   port: number,
 ): Promise<string> {
+  requiredPort(port);
   const origin = new URL(publicOrigin);
   if (!["http:", "https:"].includes(origin.protocol)
     || origin.username
@@ -497,13 +312,15 @@ export async function openSandboxPreviewCapability(
   const [sessionId, rawPort, rawExpiresAt, ...extra] = new TextDecoder()
     .decode(plaintext)
     .split("\n");
-  const port = Number(rawPort);
+  let port: number;
+  try {
+    port = requiredPort(Number(rawPort));
+  } catch {
+    throw new Error("invalid preview capability");
+  }
   const expiresAt = Number(rawExpiresAt);
   if (!sessionId
     || extra.length > 0
-    || !Number.isInteger(port)
-    || port < 1024
-    || port > 65_535
     || !Number.isSafeInteger(expiresAt)
     || expiresAt <= Date.now()) {
     throw new Error("invalid preview capability");
@@ -518,6 +335,7 @@ export async function proxyCloudflareSandboxPreview(
   request: Request,
   path: string,
 ): Promise<Response> {
+  requiredPort(port);
   const incoming = new URL(request.url);
   const targetPath = path.startsWith("/") ? path : `/${path}`;
   const capabilityPath = sandboxPreviewCapabilityPath(incoming.pathname, targetPath);
@@ -862,7 +680,11 @@ function objectInput(input: unknown): Record<string, unknown> {
   return input as Record<string, unknown>;
 }
 
-function requiredString(value: unknown, name: string, maxChars: number): string {
+function requiredString(
+  value: unknown,
+  name: string,
+  maxChars = Number.MAX_SAFE_INTEGER,
+): string {
   if (typeof value !== "string" || value.length === 0) throw new Error(`${name} must be a non-empty string`);
   if (value.length > maxChars) throw new Error(`${name} is too long`);
   return value;
@@ -871,6 +693,117 @@ function requiredString(value: unknown, name: string, maxChars: number): string 
 function optionalString(value: unknown, name: string): string | undefined {
   if (value === undefined) return undefined;
   return requiredString(value, name, 1024);
+}
+
+function requiredSessionId(value: unknown): number {
+  if (!Number.isSafeInteger(value) || Number(value) < 1) {
+    throw new Error("session_id must be a positive safe integer");
+  }
+  return Number(value);
+}
+
+function yieldMilliseconds(value: unknown, defaultValue: number): number {
+  if (value === undefined) return defaultValue;
+  if (!Number.isSafeInteger(value) || Number(value) < 0) {
+    throw new Error("yield_time_ms must be a non-negative safe integer");
+  }
+  return Number(value);
+}
+
+function sandboxProcessId(sessionId: number): string {
+  return `nanocodex-${sessionId}`;
+}
+
+async function availableSessionId(sandbox: SandboxToolClient): Promise<number> {
+  for (let attempt = 0; attempt < 32; attempt += 1) {
+    const sessionId = crypto.getRandomValues(new Uint32Array(1))[0]! || 1;
+    if (await sandbox.getProcess(sandboxProcessId(sessionId)) === null) return sessionId;
+  }
+  throw new Error("could not allocate a sandbox command session");
+}
+
+async function observeProcess(
+  sandbox: SandboxToolClient,
+  initial: SandboxProcess,
+  sessionId: number,
+  yieldTimeMs: number,
+  outputByteLimit: number,
+  outputCursorStorage: SandboxOutputCursorStorage,
+  signal?: AbortSignal,
+): Promise<Record<string, unknown>> {
+  const startedAt = performance.now();
+  let process = initial;
+  let refreshed: SandboxProcess | undefined;
+  try {
+    let status = await process.getStatus();
+    if (!isTerminalProcessStatus(status) && yieldTimeMs > 0) {
+      await waitForProcessExit(process, yieldTimeMs, signal);
+      status = await process.getStatus();
+    }
+    if (isTerminalProcessStatus(status)) {
+      refreshed = await sandbox.getProcess(initial.id) ?? undefined;
+      process = refreshed ?? process;
+    }
+    const logs = await process.getLogs();
+    const accumulatedOutput = `${logs.stdout}${logs.stderr}`;
+    const cursorKey = `${OUTPUT_CURSOR_PREFIX}${sessionId}`;
+    const retainedCursor = outputCursorStorage.get(cursorKey);
+    const delivered = Math.min(
+      Number.isSafeInteger(retainedCursor) && Number(retainedCursor) >= 0
+        ? Number(retainedCursor)
+        : 0,
+      accumulatedOutput.length,
+    );
+    const terminal = isTerminalProcessStatus(status);
+    const chunk = boundedOutput(accumulatedOutput, delivered, outputByteLimit, terminal);
+    const nextCursor = delivered + chunk.consumedCharacters;
+    const result: Record<string, unknown> = {
+      output: chunk.text,
+      chunk_id: `${sessionId}:${nextCursor}`,
+      wall_time_seconds: Math.max(0, (performance.now() - startedAt) / 1_000),
+    };
+    if (chunk.truncated) result.original_token_count = chunk.originalTokenCount;
+    if (terminal) {
+      await flushWorkspace(sandbox);
+      outputCursorStorage.delete(cursorKey);
+      if (typeof process.exitCode === "number") result.exit_code = process.exitCode;
+    } else {
+      outputCursorStorage.put(cursorKey, nextCursor);
+      result.session_id = sessionId;
+    }
+    return result;
+  } catch (error) {
+    await process.kill().catch(() => {});
+    outputCursorStorage.delete(`${OUTPUT_CURSOR_PREFIX}${sessionId}`);
+    try { await flushWorkspace(sandbox); } catch { /* Preserve the process observation failure. */ }
+    throw error;
+  } finally {
+    if (refreshed !== undefined && refreshed !== initial) disposeSandboxRpcValue(refreshed);
+    disposeSandboxRpcValue(initial);
+  }
+}
+
+async function waitForProcessExit(
+  process: SandboxProcess,
+  milliseconds: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  signal?.throwIfAborted();
+  let removeAbort = () => {};
+  const aborted = new Promise<never>((_resolve, reject) => {
+    const abort = () => {
+      reject(signal?.reason ?? new Error("sandbox command cancelled"));
+    };
+    signal?.addEventListener("abort", abort, { once: true });
+    removeAbort = () => signal?.removeEventListener("abort", abort);
+  });
+  try {
+    await Promise.race([process.waitForExit(milliseconds), aborted]);
+  } catch (error) {
+    if (!(error instanceof Error && error.name === "ProcessReadyTimeoutError")) throw error;
+  } finally {
+    removeAbort();
+  }
 }
 
 function optionalInteger(
@@ -886,100 +819,15 @@ function optionalInteger(
   return value as number;
 }
 
-function optionalPositiveInteger(value: unknown, name: string): number | undefined {
-  if (value === undefined) return undefined;
-  if (!Number.isSafeInteger(value) || Number(value) < 1) {
-    throw new Error(`${name} must be a positive integer`);
-  }
-  return Number(value);
-}
-
 function requiredPort(value: unknown): number {
   const port = optionalPort(value, "port");
   if (port === undefined) throw new Error("port is required");
+  if (port === 3_000) throw new Error("port 3000 is reserved for the sandbox control plane");
   return port;
 }
 
 function optionalPort(value: unknown, name: string): number | undefined {
   return optionalInteger(value, name, 1024, 65_535);
-}
-
-function pathParameters(): Record<string, unknown> {
-  return {
-    type: "object",
-    properties: { path: { type: "string", description: "Workspace-relative file path." } },
-    required: ["path"],
-    additionalProperties: false,
-  };
-}
-
-function portParameters(): Record<string, unknown> {
-  return {
-    type: "object",
-    properties: { port: { type: "integer", minimum: 1024, maximum: 65_535 } },
-    required: ["port"],
-    additionalProperties: false,
-  };
-}
-
-function processIdParameters(includeOutput = false): Record<string, unknown> {
-  return {
-    type: "object",
-    properties: {
-      process_id: {
-        type: "string",
-        description: "Process ID returned by sandbox_start_process.",
-      },
-      ...(includeOutput ? {
-        include_output: {
-          type: "boolean",
-          description: "Include accumulated output before the process reaches a terminal state.",
-        },
-      } : {}),
-    },
-    required: ["process_id"],
-    additionalProperties: false,
-  };
-}
-
-async function readBounded(stream: ReadableStream<Uint8Array>): Promise<string> {
-  const reader = stream.getReader();
-  const chunks: Uint8Array[] = [];
-  let size = 0;
-  let completed = false;
-  let cancelled = false;
-  try {
-    while (true) {
-      const next = await reader.read();
-      if (next.done) {
-        completed = true;
-        break;
-      }
-      size += next.value.byteLength;
-      if (size > MAX_FILE_BYTES) {
-        cancelled = true;
-        await cancelReader(reader, "file exceeds 1 MiB");
-        throw new Error("file exceeds 1 MiB");
-      }
-      chunks.push(next.value);
-    }
-  } catch (error) {
-    if (!completed && !cancelled) await cancelReader(reader, error);
-    throw error;
-  } finally {
-    reader.releaseLock();
-  }
-  const content = new Uint8Array(size);
-  let offset = 0;
-  for (const chunk of chunks) {
-    content.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  try {
-    return new TextDecoder("utf-8", { fatal: true, ignoreBOM: false }).decode(content);
-  } catch {
-    throw new Error("file is not valid UTF-8");
-  }
 }
 
 async function withSandboxRpcResult<T, R>(
@@ -1008,70 +856,109 @@ function disposeSandboxRpcValue(value: unknown): void {
   if (typeof dispose === "function") dispose.call(value);
 }
 
-async function cancelReadableStream(stream: ReadableStream<Uint8Array>, reason: unknown): Promise<void> {
-  try {
-    await stream.cancel(reason);
-  } catch {
-    // Preserve the result or decoding failure when cancellation also fails.
-  }
-}
-
-async function cancelReader(reader: ReadableStreamDefaultReader<Uint8Array>, reason: unknown): Promise<void> {
-  try {
-    await reader.cancel(reason);
-  } catch {
-    // Preserve the result or decoding failure when cancellation also fails.
-  }
-}
-
-function truncate(value: string): { text: string; truncated: boolean } {
+function boundedOutput(
+  accumulated: string,
+  deliveredCharacters: number,
+  outputByteLimit: number,
+  terminal: boolean,
+): {
+  text: string;
+  truncated: boolean;
+  consumedCharacters: number;
+  originalTokenCount: number;
+} {
+  const value = accumulated.slice(deliveredCharacters);
   const encoded = new TextEncoder().encode(value);
-  if (encoded.byteLength <= MAX_OUTPUT_BYTES) return { text: value, truncated: false };
-  let end = MAX_OUTPUT_BYTES;
+  const originalTokenCount = Math.ceil(encoded.byteLength / APPROXIMATE_BYTES_PER_TOKEN);
+  if (encoded.byteLength <= outputByteLimit) {
+    return {
+      text: value,
+      truncated: false,
+      consumedCharacters: value.length,
+      originalTokenCount,
+    };
+  }
+  if (terminal) {
+    const marker = new TextEncoder().encode("\n… output truncated …\n");
+    if (outputByteLimit <= marker.byteLength) {
+      return {
+        text: decodeUtf8Prefix(encoded, outputByteLimit),
+        truncated: true,
+        consumedCharacters: value.length,
+        originalTokenCount,
+      };
+    }
+    const retainedBytes = outputByteLimit - marker.byteLength;
+    const headBytes = Math.ceil(retainedBytes / 2);
+    const head = decodeUtf8Prefix(encoded, headBytes);
+    const tail = decodeUtf8Suffix(encoded, retainedBytes - new TextEncoder().encode(head).byteLength);
+    return {
+      text: `${head}\n… output truncated …\n${tail}`,
+      truncated: true,
+      consumedCharacters: value.length,
+      originalTokenCount,
+    };
+  }
+  const text = decodeUtf8Prefix(encoded, outputByteLimit);
+  return {
+    text,
+    truncated: true,
+    consumedCharacters: text.length,
+    originalTokenCount,
+  };
+}
+
+function decodeUtf8Prefix(encoded: Uint8Array, limit: number): string {
+  let end = Math.min(encoded.byteLength, limit);
   while (end > 0) {
     try {
-      return {
-        text: new TextDecoder("utf-8", { fatal: true, ignoreBOM: false }).decode(encoded.subarray(0, end)),
-        truncated: true,
-      };
+      return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true })
+        .decode(encoded.subarray(0, end));
     } catch {
       end -= 1;
     }
   }
-  return { text: "", truncated: true };
+  return "";
 }
 
-function boundedOutput(output: { stdout: string; stderr: string }): {
-  stdout: string;
-  stderr: string;
-  stdout_truncated: boolean;
-  stderr_truncated: boolean;
-} {
-  const stdout = truncate(output.stdout);
-  const stderr = truncate(output.stderr);
+function decodeUtf8Suffix(encoded: Uint8Array, limit: number): string {
+  let start = Math.max(0, encoded.byteLength - limit);
+  while (start < encoded.byteLength) {
+    try {
+      return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true })
+        .decode(encoded.subarray(start));
+    } catch {
+      start += 1;
+    }
+  }
+  return "";
+}
+
+function requestedOutputBytes(value: unknown): number {
+  if (value !== undefined && (!Number.isSafeInteger(value) || Number(value) < 0)) {
+    throw new Error("max_output_tokens must be a non-negative safe integer");
+  }
+  return Math.min(
+    Number.MAX_SAFE_INTEGER,
+    Number(value ?? DEFAULT_MAX_OUTPUT_TOKENS) * APPROXIMATE_BYTES_PER_TOKEN,
+  );
+}
+
+function memoryOutputCursorStorage(): SandboxOutputCursorStorage {
+  const cursors = new Map<string, unknown>();
   return {
-    stdout: stdout.text,
-    stderr: stderr.text,
-    stdout_truncated: stdout.truncated,
-    stderr_truncated: stderr.truncated,
+    delete: (key) => { cursors.delete(key); },
+    get: (key) => cursors.get(key),
+    put: (key, value) => { cursors.set(key, value); },
   };
+}
+
+function mergedShellCommand(command: string): string {
+  return `exec 2>&1\n${command}`;
 }
 
 function isTerminalProcessStatus(status: SandboxProcessStatus): boolean {
   return status !== "starting" && status !== "running";
-}
-
-function requiredContent(value: unknown): string {
-  if (typeof value !== "string") throw new Error("content must be a string");
-  if (value.length > MAX_FILE_BYTES) throw new Error("content exceeds 1 MiB");
-  return value;
-}
-
-function requiredProcessId(value: unknown): string {
-  if (typeof value !== "string" || !/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(value)) {
-    throw new Error("process_id must be a safe Sandbox process ID");
-  }
-  return value;
 }
 
 function errorMessage(error: unknown): string {

--- a/js/managed/src/sandbox-tools.ts
+++ b/js/managed/src/sandbox-tools.ts
@@ -37,6 +37,16 @@ const PREVIEW_HTTP_RESPONSE_HEADERS_BLOCKED = new Set([
   "trailer",
   "transfer-encoding",
 ]);
+const PREVIEW_HTML_URL_ATTRIBUTES = [
+  "action",
+  "cite",
+  "data",
+  "formaction",
+  "href",
+  "poster",
+  "src",
+] as const;
+const PREVIEW_HTML_URL_SET_ATTRIBUTES = ["imagesrcset", "srcset"] as const;
 
 let cachedPreviewKey:
   | { secret: string; promise: Promise<CryptoKey> }
@@ -510,6 +520,7 @@ export async function proxyCloudflareSandboxPreview(
 ): Promise<Response> {
   const incoming = new URL(request.url);
   const targetPath = path.startsWith("/") ? path : `/${path}`;
+  const capabilityPath = sandboxPreviewCapabilityPath(incoming.pathname, targetPath);
   const target = new URL(`http://sandbox.internal${targetPath}${incoming.search}`);
   const forwarded = new Request(target, request);
   const websocket = request.headers.get("Upgrade")?.toLowerCase() === "websocket";
@@ -521,7 +532,7 @@ export async function proxyCloudflareSandboxPreview(
     const response = await sandbox.wsConnect(forwarded, port);
     if (response.status !== 101 || !response.webSocket) {
       if (response.status === 101) return new Response("Sandbox WebSocket upgrade failed", { status: 502 });
-      return hardenPreviewHttpResponse(response);
+      return hardenPreviewHttpResponse(response, capabilityPath);
     }
     const responseHeaders = new Headers();
     for (const [name, value] of response.headers) {
@@ -535,10 +546,10 @@ export async function proxyCloudflareSandboxPreview(
       webSocket: response.webSocket,
     });
   }
-  return hardenPreviewHttpResponse(await sandbox.containerFetch(forwarded, port));
+  return hardenPreviewHttpResponse(await sandbox.containerFetch(forwarded, port), capabilityPath);
 }
 
-function hardenPreviewHttpResponse(response: Response): Response {
+function hardenPreviewHttpResponse(response: Response, capabilityPath?: string): Response {
   const responseHeaders = new Headers(response.headers);
   for (const name of [...responseHeaders.keys()]) {
     if (PREVIEW_HTTP_RESPONSE_HEADERS_BLOCKED.has(name.toLowerCase())
@@ -550,11 +561,64 @@ function hardenPreviewHttpResponse(response: Response): Response {
   );
   responseHeaders.set("permissions-policy", "camera=(), geolocation=(), microphone=(), payment=(), usb=()");
   responseHeaders.set("referrer-policy", "no-referrer");
-  return new Response(response.body, {
+  const location = responseHeaders.get("location");
+  if (capabilityPath && location && isRootRelativeUrl(location)) {
+    responseHeaders.set("location", scopeRootRelativeUrl(location, capabilityPath));
+  }
+  const hardened = new Response(response.body, {
     status: response.status,
     statusText: response.statusText,
     headers: responseHeaders,
   });
+  if (!capabilityPath || !responseHeaders.get("content-type")?.toLowerCase().startsWith("text/html")) {
+    return hardened;
+  }
+  const browserScope = `<script type="importmap">${JSON.stringify({ imports: { "/": `${capabilityPath}/` } })}</script><script>(()=>{const p=${JSON.stringify(capabilityPath)},W=globalThis.WebSocket;globalThis.WebSocket=new Proxy(W,{construct(t,a,n){try{const u=new URL(a[0],location.href);if((u.protocol==="ws:"||u.protocol==="wss:")&&u.host===location.host&&u.pathname!==p&&!u.pathname.startsWith(p+"/")){u.pathname=p+(u.pathname.startsWith("/")?u.pathname:"/"+u.pathname);a[0]=u.href}}catch{}return Reflect.construct(t,a,n)}})})()</script>`;
+  return new HTMLRewriter()
+    .on("*", {
+      element(element) {
+        for (const attribute of PREVIEW_HTML_URL_ATTRIBUTES) {
+          const value = element.getAttribute(attribute);
+          if (value && isRootRelativeUrl(value)) {
+            element.setAttribute(attribute, scopeRootRelativeUrl(value, capabilityPath));
+          }
+        }
+        for (const attribute of PREVIEW_HTML_URL_SET_ATTRIBUTES) {
+          const value = element.getAttribute(attribute);
+          if (value) {
+            element.setAttribute(attribute, value.replace(
+              /(^|,\s*)(\/(?!\/)[^\s,]*)/g,
+              (_match, separator: string, url: string) => `${separator}${scopeRootRelativeUrl(url, capabilityPath)}`,
+            ));
+          }
+        }
+      },
+    })
+    .on("head", {
+      element(element) {
+        element.prepend(browserScope, { html: true });
+      },
+    })
+    .transform(hardened);
+}
+
+function sandboxPreviewCapabilityPath(incomingPath: string, targetPath: string): string | undefined {
+  if (targetPath === "/" && /^\/sandbox-preview\/[^/]+$/.test(incomingPath)) return incomingPath;
+  if (!incomingPath.endsWith(targetPath)) return undefined;
+  const capabilityPath = incomingPath.slice(0, -targetPath.length);
+  return /^\/sandbox-preview\/[^/]+$/.test(capabilityPath) ? capabilityPath : undefined;
+}
+
+function isRootRelativeUrl(value: string): boolean {
+  return value.startsWith("/") && !value.startsWith("//");
+}
+
+function scopeRootRelativeUrl(value: string, capabilityPath: string): string {
+  if (value === capabilityPath
+    || value.startsWith(`${capabilityPath}/`)
+    || value.startsWith(`${capabilityPath}?`)
+    || value.startsWith(`${capabilityPath}#`)) return value;
+  return `${capabilityPath}${value}`;
 }
 
 async function sealSandboxPreview(

--- a/js/managed/src/turn-completion.ts
+++ b/js/managed/src/turn-completion.ts
@@ -19,6 +19,15 @@ export function managedControlTransitionForResolution(
   cancelling: boolean,
   resolution: TurnResolution,
 ): ManagedTurnTransition {
+  const error = resolution.kind === "retry"
+    ? resolution.error
+    : resolution.terminal.type === "turn_failed"
+    ? resolution.terminal.error
+    : undefined;
+  if (cancelling
+    && error === "the targeted turn has already completed or been cancelled") {
+    return { type: "turn_cancelled", id };
+  }
   if (resolution.kind === "retry") {
     return cancelling ? {
       type: "turn_cancelling",

--- a/js/managed/test/account-info.test.ts
+++ b/js/managed/test/account-info.test.ts
@@ -38,7 +38,8 @@ describe("managed account info", () => {
       id: "sandbox",
       name: "Agent sandbox",
       kind: "sandbox" as const,
-      workspace: "/workspace",
+      mount: "/sandbox",
+      workspace: "/sandbox",
       capabilities: ["filesystem", "native-linux"],
     }];
     const info = await accountInfo(
@@ -67,6 +68,7 @@ describe("managed account info", () => {
       authorizations: [],
       vault: [],
     });
+    expect(info.machines[0]).toMatchObject({ mount: "/sandbox", workspace: "/sandbox" });
     expect(JSON.stringify(info)).not.toMatch(/access_token|secret/);
     expect(fetch).toHaveBeenCalledWith(
       "https://broker.internal/users/user%2Fwith%20spaces/connectors",
@@ -133,7 +135,8 @@ describe("managed account info", () => {
       id: "sandbox",
       name: "Agent sandbox",
       kind: "sandbox" as const,
-      workspace: "/workspace",
+      mount: "/sandbox",
+      workspace: "/sandbox",
       capabilities: ["native-linux"],
     }];
     const info = await accountInfo(

--- a/js/managed/test/account-info.test.ts
+++ b/js/managed/test/account-info.test.ts
@@ -10,6 +10,28 @@ const ADDRESS_ID = "a".repeat(22);
 const PHONE_ID = "p".repeat(22);
 
 describe("managed account info", () => {
+  it("forwards cancellation to every broker request and preserves its reason", async () => {
+    const controller = new AbortController();
+    const reason = new Error("turn cancelled");
+    const fetch = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      expect(init?.signal).toBe(controller.signal);
+      if (String(input).endsWith("/connectors")) return Promise.resolve(Response.json(statuses()));
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+      });
+    });
+
+    const pending = accountInfo(
+      { fetch },
+      "user",
+      { enabled: true, signal: controller.signal },
+    );
+    controller.abort(reason);
+
+    await expect(pending).rejects.toBe(reason);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
   it("projects provider-neutral Google and Slack connection identities", async () => {
     const fetch = vi.fn(async () => Response.json(statuses()));
     const machines = [{
@@ -22,10 +44,7 @@ describe("managed account info", () => {
     const info = await accountInfo(
       { fetch },
       "user/with spaces",
-      true,
-      undefined,
-      undefined,
-      machines,
+      { enabled: true, machines },
     );
 
     expect(info).toEqual({
@@ -56,9 +75,10 @@ describe("managed account info", () => {
 
   it("filters exact grant connection IDs and withholds selectors from legacy grants", async () => {
     const binding = { fetch: async () => Response.json(statuses()) };
-    const exact = await accountInfo(binding, "user", true, ["gmail", "slack"], {
-      gmail: [B],
-      slack: [],
+    const exact = await accountInfo(binding, "user", {
+      allowedConnectors: ["gmail", "slack"],
+      allowedConnections: { gmail: [B], slack: [] },
+      enabled: true,
     });
     expect(exact.authenticated).toEqual(["gmail"]);
     expect(exact.accounts).toEqual({ gmail: "home@example.com" });
@@ -66,7 +86,10 @@ describe("managed account info", () => {
       gmail: [{ id: B, label: "home@example.com", accountId: "google-home", capabilities: ["gmail"] }],
     });
 
-    const legacyGrant = await accountInfo(binding, "user", true, ["gmail"]);
+    const legacyGrant = await accountInfo(binding, "user", {
+      allowedConnectors: ["gmail"],
+      enabled: true,
+    });
     expect(legacyGrant.authenticated).toEqual(["gmail"]);
     expect(legacyGrant.connectorAccounts).toEqual({});
   });
@@ -76,7 +99,7 @@ describe("managed account info", () => {
       fetch: async () => Response.json({ connectors: {
         github: { connected: true, label: "octocat", account_id: "legacy-id" },
       } }),
-    }, "user", true);
+    }, "user", { enabled: true });
     expect(legacy.authenticated).toEqual(["github"]);
     expect(legacy.accounts).toEqual({ github: "octocat" });
     expect(legacy.connectorAccounts).toEqual({});
@@ -95,7 +118,7 @@ describe("managed account info", () => {
       fetch: async () => Response.json({ connectors: {
         github: { connected: true, connections: [{ id: "not-opaque", label: "bad" }] },
       } }),
-    }, "user", true);
+    }, "user", { enabled: true });
     expect(unavailable).toMatchObject({ status: "unavailable", connectorAccounts: {} });
 
     const prompt = withInitialAccountInfo("Use my calendar", unavailable);
@@ -116,10 +139,7 @@ describe("managed account info", () => {
     const info = await accountInfo(
       { fetch: async () => new Response(null, { status: 503 }) },
       "user",
-      true,
-      undefined,
-      undefined,
-      machines,
+      { enabled: true, machines },
     );
     expect(info).toMatchObject({ status: "unavailable", machines });
   });
@@ -177,7 +197,10 @@ describe("managed accountInfo vault projection", () => {
       ] },
     ));
 
-    const result = await accountInfo({ fetch }, "user/id", true, ["github"]);
+    const result = await accountInfo({ fetch }, "user/id", {
+      allowedConnectors: ["github"],
+      enabled: true,
+    });
 
     expect(result).toEqual({
       status: "ready",
@@ -228,7 +251,7 @@ describe("managed accountInfo vault projection", () => {
       fetch: async (input) => Response.json(
         String(input).endsWith("/connectors") ? { connectors: {} } : { vault },
       ),
-    }, "user", true);
+    }, "user", { enabled: true });
 
     expect(result.status).toBe("ready");
     expect(result.vault).toEqual([]);
@@ -265,17 +288,21 @@ describe("managed accountInfo vault projection", () => {
         fetch: async (input) => Response.json(
           String(input).endsWith("/connectors") ? { connectors: {} } : { vault },
         ),
-      }, "user", true);
+      }, "user", { enabled: true });
 
       expect(result.vault).toEqual([]);
     }
   });
 
   it("includes an empty required Vault field in disabled and unavailable results", async () => {
-    await expect(accountInfo({ fetch: vi.fn() }, "user", false)).resolves.toMatchObject({ vault: [] });
+    await expect(accountInfo(
+      { fetch: vi.fn() },
+      "user",
+      { enabled: false },
+    )).resolves.toMatchObject({ vault: [] });
     await expect(accountInfo({
       fetch: async () => new Response(null, { status: 503 }),
-    }, "user", true)).resolves.toMatchObject({ status: "unavailable", vault: [] });
+    }, "user", { enabled: true })).resolves.toMatchObject({ status: "unavailable", vault: [] });
   });
 
   it("keeps connector information ready when only credential metadata is unavailable", async () => {
@@ -283,7 +310,7 @@ describe("managed accountInfo vault projection", () => {
       fetch: async (input) => String(input).endsWith("/connectors")
         ? Response.json({ connectors: { github: { connected: true, label: "octocat" } } })
         : new Response(null, { status: 503 }),
-    }, "user", true);
+    }, "user", { enabled: true });
 
     expect(result).toMatchObject({
       status: "ready",

--- a/js/managed/test/agent-event-watcher.test.ts
+++ b/js/managed/test/agent-event-watcher.test.ts
@@ -8,7 +8,7 @@ import type {
 import { watchManagedAgentFamilyEvents } from "../src/agent-event-watcher";
 
 describe("managed agent event watcher", () => {
-  it("projects both root and Rust-spawned child sessions", () => {
+  it("projects replayable root and Rust-spawned child events without raw provider frames", () => {
     let subscribed: ((
       event: AgentEvent,
       encodedLength?: number,
@@ -25,21 +25,70 @@ describe("managed agent event watcher", () => {
       async *[Symbol.asyncIterator]() {},
     } satisfies EventWatcher;
     const watch = vi.fn((_options?: WatchEventsOptions) => watcher);
-    const observed: Array<{ event: AgentEvent; agentId: number | undefined }> = [];
+    const replayed: Array<{ event: AgentEvent; agentId: number | undefined }> = [];
+    const observed: AgentEvent[] = [];
 
-    expect(watchManagedAgentFamilyEvents({ events: { watch } }, (event, agentId) => {
-      observed.push({ event, agentId });
-    })).toBe(watcher);
+    expect(watchManagedAgentFamilyEvents(
+      { events: { watch } },
+      {
+        replay(event, agentId) {
+          replayed.push({ event, agentId });
+        },
+        observe(event) {
+          observed.push(event);
+        },
+      },
+    )).toBe(watcher);
     expect(watch).toHaveBeenCalledWith({ includeAllSessions: true });
 
     const root = agentEvent("root-session", 1, "run.started");
     const child = agentEvent("child-session", 1, "tool.call");
+    subscribed!(agentEvent("root-session", 2, "assistant.delta"));
+    for (const type of [
+      "api.event",
+      "model.warmup.started",
+      "model.warmup.completed",
+      "model.warmup.failed",
+      "model.attempt.started",
+      "model.attempt.failed",
+      "model.attempt.retrying",
+      "model.connection.started",
+      "model.connection.completed",
+      "model.connection.failed",
+    ]) {
+      const rootTransport = agentEvent("root-session", 2, type);
+      const childTransport = agentEvent("child-session", 2, type);
+      subscribed!(rootTransport, undefined, undefined, undefined);
+      subscribed!(childTransport, undefined, undefined, 1);
+    }
     subscribed!(root, undefined, undefined, undefined);
     subscribed!(child, undefined, undefined, 1);
+    subscribed!(agentEvent("root-session", 3, "future.transport"));
 
-    expect(observed).toEqual([
+    expect(replayed).toEqual([
       { event: root, agentId: undefined },
       { event: child, agentId: 1 },
+    ]);
+    expect(observed.map((event) => event.type)).toEqual([
+      "model.warmup.started",
+      "model.warmup.started",
+      "model.warmup.completed",
+      "model.warmup.completed",
+      "model.warmup.failed",
+      "model.warmup.failed",
+      "model.attempt.started",
+      "model.attempt.started",
+      "model.attempt.failed",
+      "model.attempt.failed",
+      "model.attempt.retrying",
+      "model.attempt.retrying",
+      "model.connection.started",
+      "model.connection.started",
+      "model.connection.completed",
+      "model.connection.completed",
+      "model.connection.failed",
+      "model.connection.failed",
+      "future.transport",
     ]);
   });
 });

--- a/js/managed/test/event-stream-failure.test.ts
+++ b/js/managed/test/event-stream-failure.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { persistEventStreamFailure } from "../src/event-stream-failure";
+
+describe("managed event stream failure persistence", () => {
+  it("retains the durable failure fence when the replay notice cannot allocate another row", () => {
+    const storage = new FailureStorage();
+    const appendNotice = vi.fn(() => {
+      storage.eventRows += 1;
+      throw new Error("SQLITE_FULL: database or disk is full");
+    });
+
+    const result = persistEventStreamFailure(
+      storage as unknown as DurableObjectStorage,
+      "event projection failed: SQLITE_FULL",
+      42,
+      appendNotice,
+    );
+
+    expect(result).toMatchObject({
+      noticeError: expect.objectContaining({ message: "SQLITE_FULL: database or disk is full" }),
+    });
+    expect(storage.streamError).toBe("event projection failed: SQLITE_FULL");
+    expect(storage.lastActive).toBe(42);
+    expect(storage.eventRows).toBe(0);
+    expect(appendNotice).toHaveBeenCalledOnce();
+  });
+
+  it("does not attempt the replay notice when the authoritative fence itself cannot persist", () => {
+    const storage = new FailureStorage();
+    storage.failFence = true;
+    const appendNotice = vi.fn(() => ({ cursor: "1" }));
+
+    const result = persistEventStreamFailure(
+      storage as unknown as DurableObjectStorage,
+      "event projection failed: unavailable",
+      43,
+      appendNotice,
+    );
+
+    expect(result).toMatchObject({
+      fenceError: expect.objectContaining({ message: "session fence unavailable" }),
+    });
+    expect(storage.streamError).toBeNull();
+    expect(appendNotice).not.toHaveBeenCalled();
+  });
+});
+
+class FailureStorage {
+  eventRows = 0;
+  failFence = false;
+  lastActive = 0;
+  streamError: string | null = null;
+
+  readonly sql = {
+    exec: (_query: string, detail: string, now: number) => {
+      if (this.failFence) throw new Error("session fence unavailable");
+      this.streamError = detail;
+      this.lastActive = now;
+      return emptyCursor();
+    },
+  };
+
+  transactionSync<Result>(callback: () => Result): Result {
+    const rows = this.eventRows;
+    try {
+      return callback();
+    } catch (error) {
+      this.eventRows = rows;
+      throw error;
+    }
+  }
+}
+
+function emptyCursor(): SqlStorageCursor<Record<string, SqlStorageValue>> {
+  return {
+    columnNames: [],
+    one: () => { throw new Error("cursor is empty"); },
+    raw: function* () {},
+    rowsRead: 0,
+    rowsWritten: 0,
+    toArray: () => [],
+    [Symbol.iterator]: function* () {},
+  } as unknown as SqlStorageCursor<Record<string, SqlStorageValue>>;
+}

--- a/js/managed/test/hosted-tools-broker.test.ts
+++ b/js/managed/test/hosted-tools-broker.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { hostedToolCatalogDigest } from "nanocodex/tools/hosted-catalog";
+import {
+  EXEC_COMMAND_PARAMETERS,
+  EXECUTION_OUTPUT_SCHEMA,
+  MACHINE_PREVIEW_PARAMETERS,
+  PREVIEW_OUTPUT_SCHEMA,
+  WRITE_STDIN_PARAMETERS,
+} from "nanocodex-tools/execution-contract";
 
 import {
   HostedToolsBroker,
@@ -111,31 +118,32 @@ describe("HostedToolsBroker socket-owned protocol", () => {
     }]);
   });
 
-  it("qualifies same-name machine tools, dispatches wire names, and disconnects independently", async () => {
+  it("reserves canonical machine tools, resolves exact machines, and disconnects independently", async () => {
     const fixture = createFixture();
     const routeB = fixture.socket();
     await fixture.broker.message(routeB.webSocket, JSON.stringify({
       type: "catalog",
       attachment_id: "machine-b",
-      tools: [entry("exec_command")],
+      tools: [machineEntry("exec_command")],
       machines: [{ id: "machine-b", name: "Machine B", workspace: "/b", capabilities: ["shell"] }],
     }));
     const routeA = fixture.socket();
     await fixture.broker.message(routeA.webSocket, JSON.stringify({
       type: "catalog",
       attachment_id: "machine-a",
-      tools: [entry("exec_command")],
+      tools: [machineEntry("exec_command")],
       machines: [{ id: "machine-a", name: "Machine A", workspace: "/a", capabilities: ["filesystem"] }],
     }));
 
     expect(fixture.broker.provider().definitions().map((definition) => definition.name))
-      .toEqual(["user_machine-a_exec_command", "user_machine-b_exec_command"]);
+      .toEqual([]);
+    expect(fixture.broker.provider().resolve("user_machine-a_exec_command")).toBeUndefined();
     expect(fixture.broker.machines().map((machine) => machine.id)).toEqual(["machine-a", "machine-b"]);
 
-    const pendingA = fixture.broker.provider().resolve("user_machine-a_exec_command")!.handler({}, {
+    const pendingA = fixture.broker.machineTool("machine-a", "exec_command")!.handler({ cmd: "pwd" }, {
       sessionId: "session:1", callId: "source:a",
     });
-    const pendingB = fixture.broker.provider().resolve("user_machine-b_exec_command")!.handler({}, {
+    const pendingB = fixture.broker.machineTool("machine-b", "exec_command")!.handler({ cmd: "pwd" }, {
       sessionId: "session:1", callId: "source:b",
     });
     const callA = routeA.sent.find((frame) => frame.type === "call")!;
@@ -165,13 +173,13 @@ describe("HostedToolsBroker socket-owned protocol", () => {
     await fixture.broker.message(replacementA.webSocket, JSON.stringify({
       type: "catalog",
       attachment_id: "machine-a",
-      tools: [entry("exec_command")],
+      tools: [machineEntry("exec_command")],
       machines: [{ id: "machine-a", name: "Machine A2", workspace: "/a2", capabilities: ["filesystem"] }],
     }));
     expect(routeA.closed).toMatchObject({ code: 1008 });
     expect(routeB.closed).toBeUndefined();
     expect(fixture.broker.provider().definitions().map((definition) => definition.name))
-      .toEqual(["user_machine-a_exec_command", "user_machine-b_exec_command"]);
+      .toEqual([]);
 
     fixture.persistence.routes.get("user:machine-a")!.lease_expires_at = NOW + 1;
     const routeBExpiry = fixture.persistence.routes.get("user:machine-b")!.lease_expires_at;
@@ -181,14 +189,82 @@ describe("HostedToolsBroker socket-owned protocol", () => {
     expect(fixture.persistence.routes.get("user:machine-b")!.lease_expires_at).toBe(routeBExpiry);
 
     await fixture.broker.message(replacementA.webSocket, JSON.stringify({ type: "drain" }));
-    expect(fixture.broker.provider().definitions().map((definition) => definition.name)).toEqual(["user_machine-b_exec_command"]);
+    expect(fixture.broker.machineTool("machine-a", "exec_command")).toBeUndefined();
+    expect(fixture.broker.machineTool("machine-b", "exec_command")).toBeDefined();
     expect(fixture.broker.machines().map((machine) => machine.id)).toEqual(["machine-b"]);
     fixture.broker.webSocketClose(replacementA.webSocket, 1000, "done");
-    expect(fixture.broker.provider().definitions().map((definition) => definition.name)).toEqual(["user_machine-b_exec_command"]);
+    expect(fixture.broker.machineTool("machine-b", "exec_command")).toBeDefined();
 
     fixture.broker.webSocketClose(routeB.webSocket, 1000, "done");
     expect(fixture.broker.provider().definitions()).toEqual([]);
     expect(fixture.broker.machines()).toEqual([]);
+  });
+
+  it("keeps a resolved canonical machine tool pinned to its admitted generation", async () => {
+    const fixture = createFixture();
+    const first = fixture.socket();
+    await fixture.broker.message(first.webSocket, JSON.stringify({
+      type: "catalog",
+      attachment_id: "machine-a",
+      tools: [machineEntry("exec_command")],
+      machines: [{ id: "machine-a", name: "Machine A", workspace: "/a", capabilities: ["shell"] }],
+    }));
+    const selected = fixture.broker.machineTool("machine-a", "exec_command")!;
+
+    const replacement = fixture.socket();
+    await fixture.broker.message(replacement.webSocket, JSON.stringify({
+      type: "catalog",
+      attachment_id: "machine-a",
+      tools: [machineEntry("exec_command")],
+      machines: [{ id: "machine-a", name: "Machine A2", workspace: "/a2", capabilities: ["shell"] }],
+    }));
+
+    const outcome = await selected.handler({ cmd: "pwd" }, {
+      sessionId: "session:1", callId: "source:stale",
+    });
+    expect((outcome as Record<PropertyKey, unknown>)[HOSTED_TOOLS_PRE_ADMISSION_UNAVAILABLE]).toBe(true);
+    expect(replacement.sent.some((frame) => frame.type === "call")).toBe(false);
+    expect(fixture.persistence.callBySource("session:1", "source:stale")).toBeUndefined();
+  });
+
+  it("admits only canonical selector-free machine primitive schemas", async () => {
+    const fixture = createFixture();
+    const host = fixture.socket();
+    const tools = [
+      machineEntry("exec_command"),
+      machineEntry("write_stdin"),
+      machineEntry("preview"),
+    ];
+    await fixture.broker.message(host.webSocket, JSON.stringify({
+      type: "catalog",
+      attachment_id: "machine-a",
+      tools,
+      machines: [{ id: "machine-a", name: "Machine A", workspace: "/a", capabilities: ["shell"] }],
+    }));
+
+    expect(host.closed).toBeUndefined();
+    expect(fixture.broker.provider().definitions()).toEqual([]);
+    for (const tool of tools) {
+      expect(tool.definition.parameters.properties).not.toHaveProperty("environment");
+      expect(tool.definition.parameters.properties).not.toHaveProperty("machine");
+      expect(tool.definition.parameters.properties).not.toHaveProperty("host");
+      expect(fixture.broker.machineTool("machine-a", tool.definition.name)).toBeDefined();
+    }
+
+    const invalid = createFixture();
+    const invalidHost = invalid.socket();
+    const invalidExec = machineEntry("exec_command");
+    (invalidExec.definition.parameters.properties as Record<string, unknown>).environment = { type: "string" };
+    await invalid.broker.message(invalidHost.webSocket, JSON.stringify({
+      type: "catalog",
+      attachment_id: "machine-b",
+      tools: [invalidExec],
+      machines: [{ id: "machine-b", name: "Machine B", workspace: "/b", capabilities: ["shell"] }],
+    }));
+    expect(invalidHost.closed).toMatchObject({
+      code: 1008,
+      reason: expect.stringContaining("machine tool exec_command"),
+    });
   });
 
   it("expires only the named route whose lease elapsed", async () => {
@@ -830,6 +906,37 @@ function entry(name = "fixture__lookup") {
     },
     parallel_safe: true,
     summary: "Fixture lookup",
+    timeout_ms: 30_000,
+  };
+}
+
+function machineEntry(name: "exec_command" | "write_stdin" | "preview") {
+  const definitions = {
+    exec_command: {
+      parameters: EXEC_COMMAND_PARAMETERS,
+      output_schema: EXECUTION_OUTPUT_SCHEMA,
+    },
+    write_stdin: {
+      parameters: WRITE_STDIN_PARAMETERS,
+      output_schema: EXECUTION_OUTPUT_SCHEMA,
+    },
+    preview: {
+      parameters: MACHINE_PREVIEW_PARAMETERS,
+      output_schema: PREVIEW_OUTPUT_SCHEMA,
+    },
+  };
+  return {
+    provider: "machine",
+    remote_name: name,
+    definition: {
+      type: "function" as const,
+      name,
+      description: `Canonical machine ${name}`,
+      strict: false,
+      ...structuredClone(definitions[name]),
+    },
+    parallel_safe: name !== "write_stdin",
+    summary: `Machine ${name}`,
     timeout_ms: 30_000,
   };
 }

--- a/js/managed/test/managed-portability-archive.test.ts
+++ b/js/managed/test/managed-portability-archive.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+
+import { sha256Hex } from "../src/archive-hash";
+import { ManagedPortabilityArchive } from "../src/managed-portability-archive";
+
+const SOURCE_STORAGE_ID = "a".repeat(64);
+const DESTINATION_STORAGE_ID = "b".repeat(64);
+
+describe("managed portability archive", () => {
+  it("exports and adopts a live event segment larger than 16 MiB", async () => {
+    const bucket = new MemoryR2Bucket();
+    // Portability validates the immutable object's content-addressed identity;
+    // the event archive owns its JSON envelope. Avoid constructing several
+    // giant intermediate strings in the Workers test runtime.
+    const body = new Uint8Array(16 * 1024 * 1024 + 1);
+    expect(body.byteLength).toBeGreaterThan(16 * 1024 * 1024);
+    const sha256 = await sha256Hex(body);
+    const suffix = `segments/${"1".padStart(19, "0")}-${"1".padStart(19, "0")}-${sha256}.json`;
+    bucket.seed(`agents/${SOURCE_STORAGE_ID}/managed-events/${suffix}`, body, {
+      kind: "managed_event_segment",
+      sha256,
+      version: "1",
+    });
+
+    const source = new ManagedPortabilityArchive(
+      new PortabilityStorage() as unknown as DurableObjectStorage,
+      bucket as unknown as R2Bucket,
+      SOURCE_STORAGE_ID,
+    );
+    const sourceBatch = await source.identityBatch("events");
+    expect(sourceBatch).toMatchObject({
+      complete: true,
+      identity: { bytes: body.byteLength, objects: 1, version: 1 },
+      objects: 1,
+    });
+
+    const destination = new ManagedPortabilityArchive(
+      new PortabilityStorage() as unknown as DurableObjectStorage,
+      bucket as unknown as R2Bucket,
+      DESTINATION_STORAGE_ID,
+    );
+    const adopted = await destination.adoptBatch(
+      "events",
+      SOURCE_STORAGE_ID,
+      sourceBatch.identity!,
+      () => {},
+    );
+    expect(adopted).toEqual({
+      complete: true,
+      identity: sourceBatch.identity,
+      objects: 1,
+    });
+    await expect(destination.identityBatch("events")).resolves.toEqual({
+      complete: true,
+      identity: sourceBatch.identity,
+      objects: 1,
+    });
+    const copied = bucket.bytes(`agents/${DESTINATION_STORAGE_ID}/managed-events/${suffix}`)!;
+    expect(copied.byteLength).toBe(body.byteLength);
+    await expect(sha256Hex(copied)).resolves.toBe(sha256);
+  });
+});
+
+type Progress = {
+  bytes: number;
+  complete: number;
+  digest: string;
+  last_key: string | null;
+  objects: number;
+};
+
+type AdoptionProgress = Progress & {
+  manifest_digest: string;
+  source_storage_id: string;
+};
+
+class PortabilityStorage {
+  readonly #adoptions = new Map<string, AdoptionProgress>();
+  readonly #manifests = new Map<string, Progress>();
+
+  readonly sql = {
+    exec: <Row extends Record<string, SqlStorageValue>>(
+      query: string,
+      ...bindings: SqlStorageValue[]
+    ): SqlStorageCursor<Row> => {
+      const normalized = query.replace(/\s+/g, " ").trim();
+      if (normalized.startsWith("CREATE TABLE")) return cursor<Row>([]);
+      if (normalized.startsWith("SELECT last_key, digest")) {
+        return cursor<Row>(optionalRow(this.#manifests.get(String(bindings[0]))));
+      }
+      if (normalized.startsWith("INSERT INTO managed_portability_manifest_progress")) {
+        this.#manifests.set(String(bindings[0]), emptyProgress());
+        return cursor<Row>([]);
+      }
+      if (normalized.startsWith("UPDATE managed_portability_manifest_progress")) {
+        this.#manifests.set(String(bindings[5]), {
+          last_key: bindings[0] as string | null,
+          digest: String(bindings[1]),
+          bytes: Number(bindings[2]),
+          objects: Number(bindings[3]),
+          complete: Number(bindings[4]),
+        });
+        return cursor<Row>([]);
+      }
+      if (normalized.startsWith("SELECT source_storage_id, manifest_digest")) {
+        return cursor<Row>(optionalRow(this.#adoptions.get(String(bindings[0]))));
+      }
+      if (normalized.startsWith("INSERT INTO managed_portability_adoption_progress")) {
+        this.#adoptions.set(String(bindings[0]), {
+          ...emptyProgress(),
+          source_storage_id: String(bindings[1]),
+          manifest_digest: String(bindings[2]),
+        });
+        return cursor<Row>([]);
+      }
+      if (normalized.startsWith("UPDATE managed_portability_adoption_progress")) {
+        const kind = String(bindings[5]);
+        const retained = this.#adoptions.get(kind)!;
+        this.#adoptions.set(kind, {
+          ...retained,
+          last_key: bindings[0] as string | null,
+          digest: String(bindings[1]),
+          bytes: Number(bindings[2]),
+          objects: Number(bindings[3]),
+          complete: Number(bindings[4]),
+        });
+        return cursor<Row>([]);
+      }
+      throw new Error(`unexpected SQL: ${normalized}`);
+    },
+  };
+
+  transactionSync<Result>(callback: () => Result): Result {
+    return callback();
+  }
+}
+
+type StoredObject = {
+  body: Uint8Array;
+  customMetadata: Record<string, string>;
+};
+
+class MemoryR2Bucket {
+  readonly #objects = new Map<string, StoredObject>();
+
+  seed(key: string, body: Uint8Array, customMetadata: Record<string, string>): void {
+    this.#objects.set(key, { body: body.slice(), customMetadata: { ...customMetadata } });
+  }
+
+  bytes(key: string): Uint8Array | undefined {
+    return this.#objects.get(key)?.body;
+  }
+
+  async list(options: R2ListOptions): Promise<R2Objects> {
+    const keys = [...this.#objects.keys()]
+      .filter((key) => key.startsWith(options.prefix ?? "")
+        && (options.startAfter === undefined || key > options.startAfter))
+      .sort()
+      .slice(0, options.limit);
+    return {
+      delimitedPrefixes: [],
+      objects: keys.map((key) => this.object(key)),
+      truncated: false,
+    } as R2Objects;
+  }
+
+  async get(key: string): Promise<R2ObjectBody | null> {
+    const stored = this.#objects.get(key);
+    if (!stored) return null;
+    return {
+      ...this.object(key),
+      arrayBuffer: async () => stored.body.slice().buffer,
+      body: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(stored.body.slice());
+          controller.close();
+        },
+      }),
+      blob: async () => new Blob([stored.body]),
+      json: async () => JSON.parse(new TextDecoder().decode(stored.body)),
+      text: async () => new TextDecoder().decode(stored.body),
+      writeHttpMetadata: () => {},
+    } as unknown as R2ObjectBody;
+  }
+
+  async put(
+    key: string,
+    value: ReadableStream | ArrayBuffer | ArrayBufferView | string | Blob,
+    options?: R2PutOptions,
+  ): Promise<R2Object | null> {
+    if (this.#objects.has(key) && options?.onlyIf) return null;
+    const body = value instanceof Uint8Array
+      ? value.slice()
+      : new Uint8Array(await new Response(value as BodyInit).arrayBuffer());
+    this.seed(key, body, options?.customMetadata ?? {});
+    return this.object(key);
+  }
+
+  async head(key: string): Promise<R2Object | null> {
+    return this.#objects.has(key) ? this.object(key) : null;
+  }
+
+  private object(key: string): R2Object {
+    const stored = this.#objects.get(key)!;
+    return {
+      checksums: {},
+      customMetadata: { ...stored.customMetadata },
+      etag: stored.customMetadata.sha256 ?? "etag",
+      httpEtag: `\"${stored.customMetadata.sha256 ?? "etag"}\"`,
+      key,
+      size: stored.body.byteLength,
+      uploaded: new Date(0),
+      version: "test",
+      writeHttpMetadata: () => {},
+    } as unknown as R2Object;
+  }
+}
+
+function emptyProgress(): Progress {
+  return {
+    bytes: 0,
+    complete: 0,
+    digest: "0".repeat(64),
+    last_key: null,
+    objects: 0,
+  };
+}
+
+function optionalRow<Row extends object>(value: Row | undefined): Row[] {
+  return value === undefined ? [] : [{ ...value }];
+}
+
+function cursor<Row extends Record<string, SqlStorageValue>>(rows: object[]): SqlStorageCursor<Row> {
+  return {
+    columnNames: [],
+    one: () => {
+      if (rows.length !== 1) throw new Error(`expected one row, received ${rows.length}`);
+      return rows[0] as Row;
+    },
+    raw: function* () {},
+    rowsRead: rows.length,
+    rowsWritten: 0,
+    toArray: () => rows.map((row) => ({ ...row })) as Row[],
+    [Symbol.iterator]: function* () {
+      yield* rows as Row[];
+    },
+  } as unknown as SqlStorageCursor<Row>;
+}

--- a/js/managed/test/memory-scope-worker.ts
+++ b/js/managed/test/memory-scope-worker.ts
@@ -1,1 +1,2 @@
 export { MemoryScope } from "../src/memory-scope";
+export { DurableAgentSession } from "../src/index";

--- a/js/managed/test/namespace-tools.test.ts
+++ b/js/managed/test/namespace-tools.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ToolMap } from "nanocodex";
+
+import {
+  createNamespaceExecutionTools,
+  machineMountRoot,
+} from "../src/namespace-tools";
+
+const context = (overrides: Partial<{
+  sessionId: string;
+  parentCallId: string;
+  callId: string;
+}> = {}) => ({
+  callId: overrides.callId ?? "call",
+  model: "gpt-5.6-sol",
+  parentCallId: overrides.parentCallId ?? "cell",
+  sessionId: overrides.sessionId ?? "root-session",
+  signal: new AbortController().signal,
+});
+
+describe("cwd-root namespace execution", () => {
+  it("keeps canonical schemas and routes the default logical cwd to the sandbox", async () => {
+    const sandboxExec = vi.fn(async () => ({
+      output: "/workspace\n",
+      wall_time_seconds: 0.01,
+      exit_code: 0,
+    }));
+    const tools = createNamespaceExecutionTools(sandboxTools(sandboxExec), () => []);
+
+    expect(tools.exec_command!.parameters).toMatchObject({
+      required: ["cmd"],
+      additionalProperties: false,
+    });
+    expect(JSON.stringify(tools.exec_command!.parameters)).not.toContain("environment");
+    expect(tools.write_stdin!.parameters).toMatchObject({
+      required: ["session_id"],
+      additionalProperties: false,
+    });
+    expect(JSON.stringify(tools.write_stdin!.parameters)).not.toMatch(/environment|host/);
+
+    await tools.exec_command!.handler({ cmd: "pwd" }, context());
+    expect(sandboxExec).toHaveBeenCalledWith(
+      { cmd: "pwd", workdir: "/workspace" },
+      expect.objectContaining({ sessionId: "root-session" }),
+    );
+  });
+
+  it("routes by a portable machine mount and translates only the workdir", async () => {
+    const exec = vi.fn(async () => ({ output: "ok", wall_time_seconds: 0, exit_code: 0 }));
+    const resolve = vi.fn((_id: string, name: string) => (
+      name === "exec_command" ? { handler: exec } : { handler: vi.fn() }
+    ));
+    const tools = createNamespaceExecutionTools(
+      sandboxTools(),
+      () => [{
+        id: "laptop",
+        workspace: "/Users/me/repo",
+      }],
+      resolve,
+    );
+
+    await tools.exec_command!.handler({
+      cmd: "cargo test",
+      workdir: "/laptop/crates/core",
+      yield_time_ms: 30_000,
+    }, context());
+
+    expect(exec).toHaveBeenCalledWith({
+      cmd: "cargo test",
+      workdir: "/Users/me/repo/crates/core",
+      yield_time_ms: 30_000,
+    }, expect.anything());
+    expect(resolve).toHaveBeenCalledWith("laptop", "exec_command");
+  });
+
+  it("captures one immutable machine binding per Code Mode cell", async () => {
+    let machines = [{ id: "laptop", workspace: "/old" }];
+    const oldExec = vi.fn(async (_input: unknown) => ({ output: "old", wall_time_seconds: 0, exit_code: 0 }));
+    const newExec = vi.fn(async (_input: unknown) => ({ output: "new", wall_time_seconds: 0, exit_code: 0 }));
+    let generation = "old";
+    const tools = createNamespaceExecutionTools(
+      sandboxTools(),
+      () => machines,
+      (_id, name) => ({
+        handler: name === "exec_command"
+          ? generation === "old" ? oldExec : newExec
+          : vi.fn(),
+      }),
+    );
+
+    await tools.exec_command!.handler({ cmd: "one", workdir: "/laptop" }, context());
+    generation = "new";
+    machines = [{ id: "laptop", workspace: "/new" }];
+    await tools.exec_command!.handler({ cmd: "two", workdir: "/laptop" }, context({ callId: "two" }));
+    await tools.exec_command!.handler(
+      { cmd: "three", workdir: "/laptop" },
+      context({ parentCallId: "next-cell", callId: "three" }),
+    );
+
+    expect(oldExec).toHaveBeenCalledTimes(2);
+    expect(oldExec.mock.calls[1]![0]).toMatchObject({ workdir: "/old" });
+    expect(newExec).toHaveBeenCalledTimes(1);
+    expect(newExec.mock.calls[0]![0]).toMatchObject({ workdir: "/new" });
+  });
+
+  it("rebinds provider-local sessions and rejects cross-agent use", async () => {
+    const machineWrite = vi.fn(async ({ session_id }: { session_id: number }) => ({
+      output: "more",
+      wall_time_seconds: 0,
+      session_id,
+    }));
+    const tools = createNamespaceExecutionTools(
+      sandboxTools(),
+      () => [{ id: "buildbox", workspace: "/srv/repo" }],
+      (_id, name) => ({
+        handler: name === "exec_command"
+          ? vi.fn(async () => ({ output: "start", wall_time_seconds: 0, session_id: 7 }))
+          : name === "write_stdin" ? machineWrite : vi.fn(),
+      }),
+    );
+    const started = await tools.exec_command!.handler(
+      { cmd: "long", workdir: "/buildbox" },
+      context(),
+    ) as { session_id: number };
+    expect(started.session_id).not.toBe(7);
+
+    const polled = await tools.write_stdin!.handler(
+      { session_id: started.session_id },
+      context({ callId: "poll" }),
+    ) as { session_id: number };
+    expect(polled.session_id).toBe(started.session_id);
+    expect(machineWrite).toHaveBeenCalledWith(
+      { session_id: 7 },
+      expect.anything(),
+    );
+    await expect(tools.write_stdin!.handler(
+      { session_id: started.session_id },
+      context({ sessionId: "sibling-session", callId: "steal" }),
+    )).rejects.toThrow("unknown or stale");
+  });
+
+  it("accepts many simultaneously retained process bindings", async () => {
+    let providerSessionId = 0;
+    const exec = vi.fn(async () => ({
+      output: "started",
+      wall_time_seconds: 0,
+      session_id: ++providerSessionId,
+    }));
+    const writeStdin = vi.fn(async ({ session_id }: { session_id: number }) => ({
+      output: "running",
+      wall_time_seconds: 0,
+      session_id,
+    }));
+    const tools = createNamespaceExecutionTools(
+      sandboxTools(),
+      () => [{ id: "buildbox", workspace: "/srv/repo" }],
+      (_id, name) => ({
+        handler: name === "exec_command"
+          ? exec
+          : name === "write_stdin" ? writeStdin : vi.fn(),
+      }),
+    );
+    const retainedSessionCount = 256;
+    const retained: number[] = [];
+
+    for (let index = 0; index < retainedSessionCount; index += 1) {
+      const result = await tools.exec_command!.handler(
+        { cmd: `long-${index}`, workdir: "/buildbox" },
+        context({ callId: `start-${index}` }),
+      ) as { session_id: number };
+      retained.push(result.session_id);
+    }
+
+    expect(new Set(retained).size).toBe(retainedSessionCount);
+    await expect(tools.write_stdin!.handler(
+      { session_id: retained.at(-1)! },
+      context({ callId: "poll-last" }),
+    )).resolves.toMatchObject({ session_id: retained.at(-1) });
+    expect(writeStdin).toHaveBeenLastCalledWith(
+      { session_id: retainedSessionCount },
+      expect.anything(),
+    );
+  });
+
+  it("retains every live Code Mode cell binding until lifecycle cleanup", async () => {
+    let generation: "old" | "new" = "old";
+    const oldExec = vi.fn(async () => ({ output: "old", wall_time_seconds: 0, exit_code: 0 }));
+    const newExec = vi.fn(async () => ({ output: "new", wall_time_seconds: 0, exit_code: 0 }));
+    const tools = createNamespaceExecutionTools(
+      sandboxTools(),
+      () => [{ id: "laptop", workspace: generation === "old" ? "/old" : "/new" }],
+      (_id, name) => ({
+        handler: name === "exec_command"
+          ? generation === "old" ? oldExec : newExec
+          : vi.fn(),
+      }),
+    );
+
+    for (let index = 0; index < 256; index += 1) {
+      await tools.exec_command!.handler(
+        { cmd: `cell-${index}`, workdir: "/laptop" },
+        context({ parentCallId: `cell-${index}`, callId: `call-${index}` }),
+      );
+    }
+    generation = "new";
+    await tools.exec_command!.handler(
+      { cmd: "revisit", workdir: "/laptop" },
+      context({ parentCallId: "cell-0", callId: "revisit" }),
+    );
+
+    expect(oldExec).toHaveBeenCalledTimes(257);
+    expect(oldExec).toHaveBeenLastCalledWith(
+      { cmd: "revisit", workdir: "/old" },
+      expect.anything(),
+    );
+    expect(newExec).not.toHaveBeenCalled();
+  });
+
+  it("releases retained cells and process bindings with the owner session", async () => {
+    let current = "old";
+    const oldExec = vi.fn(async () => ({
+      output: "started",
+      wall_time_seconds: 0,
+      session_id: 7,
+    }));
+    const newExec = vi.fn(async () => ({
+      output: "rebound",
+      wall_time_seconds: 0,
+      exit_code: 0,
+    }));
+    const tools = createNamespaceExecutionTools(
+      sandboxTools(),
+      () => [{ id: "laptop", workspace: current === "old" ? "/old" : "/new" }],
+      (_id, name) => ({
+        handler: name === "exec_command"
+          ? current === "old" ? oldExec : newExec
+          : vi.fn(async () => ({ output: "more", wall_time_seconds: 0, session_id: 7 })),
+      }),
+    );
+    const started = await tools.exec_command!.handler(
+      { cmd: "long", workdir: "/laptop" },
+      context(),
+    ) as { session_id: number };
+
+    tools.exec_command!.releaseSession?.("root-session");
+    current = "new";
+
+    await expect(tools.write_stdin!.handler(
+      { session_id: started.session_id },
+      context({ callId: "stale" }),
+    )).rejects.toThrow("unknown or stale");
+    await tools.exec_command!.handler(
+      { cmd: "fresh", workdir: "/laptop" },
+      context({ callId: "fresh" }),
+    );
+    expect(oldExec).toHaveBeenCalledTimes(1);
+    expect(newExec).toHaveBeenCalledWith(
+      { cmd: "fresh", workdir: "/new" },
+      expect.anything(),
+    );
+  });
+
+  it("lets sibling subagent sessions place work on separate hands concurrently", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const started: string[] = [];
+    const handler = (hand: string) => vi.fn(async () => {
+      started.push(hand);
+      await gate;
+      return { output: hand, wall_time_seconds: 0.01, exit_code: 0 };
+    });
+    const laptop = handler("laptop");
+    const buildbox = handler("buildbox");
+    const tools = createNamespaceExecutionTools(
+      sandboxTools(),
+      () => [
+        { id: "laptop", workspace: "/one" },
+        { id: "buildbox", workspace: "/two" },
+      ],
+      (id, name) => ({
+        handler: name === "exec_command"
+          ? id === "laptop" ? laptop : buildbox
+          : vi.fn(),
+      }),
+    );
+    const child = (sessionId: string, agentId: string) => ({
+      ...context({ sessionId, parentCallId: `cell-${agentId}`, callId: `call-${agentId}` }),
+      subagent: {
+        agentId,
+        parentAgentId: null,
+        sessionId,
+        role: "builder",
+        task: "test",
+      },
+    });
+
+    const pending = Promise.all([
+      tools.exec_command!.handler({ cmd: "test", workdir: "/laptop" }, child("child-a", "1")),
+      tools.exec_command!.handler({ cmd: "test", workdir: "/buildbox" }, child("child-b", "2")),
+    ]);
+    await vi.waitFor(() => expect(started).toHaveLength(2));
+    release();
+    await expect(pending).resolves.toHaveLength(2);
+    expect(laptop).toHaveBeenCalledTimes(1);
+    expect(buildbox).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed for unknown roots and derives safe deterministic mount names", async () => {
+    const tools = createNamespaceExecutionTools(sandboxTools(), () => []);
+    await expect(tools.exec_command!.handler(
+      { cmd: "pwd", workdir: "/missing/repo" },
+      context(),
+    )).rejects.toThrow("no mount owns");
+    expect(machineMountRoot("laptop")).toBe("/laptop");
+    expect(machineMountRoot("Build Box")).toMatch(/^\/hand-build-box-[0-9a-f]{8}$/);
+    expect(machineMountRoot("sandbox")).toMatch(/^\/hand-sandbox-/);
+  });
+});
+
+function sandboxTools(
+  exec = vi.fn(async () => ({ output: "", wall_time_seconds: 0, exit_code: 0 })),
+): ToolMap {
+  return {
+    exec_command: {
+      description: "sandbox exec",
+      handler: exec,
+    },
+    write_stdin: {
+      description: "sandbox stdin",
+      handler: vi.fn(async () => ({ output: "", wall_time_seconds: 0, exit_code: 0 })),
+    },
+    preview: {
+      description: "sandbox preview",
+      handler: vi.fn(async () => ({ port: 3000, url: "https://preview", persistent: false })),
+    },
+  };
+}

--- a/js/managed/test/sandbox-runtime.test.ts
+++ b/js/managed/test/sandbox-runtime.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../src/sandbox-runtime";
 import { cloudflareSandboxPreviewUrl } from "../src/sandbox-tools";
 import {
-  createManagedSandboxTools,
+  createManagedNamespaceTools,
   routeSandboxPreviewRequest,
 } from "../src/index";
 
@@ -61,7 +61,17 @@ describe("managed sandbox preview wiring", () => {
     const namespace = {} as DurableObjectNamespace<Sandbox>;
     const sourceHandler = vi.fn(async () => ({ ok: true }));
     const sourceTools: ToolMap = {
-      sandbox_preview: {
+      exec_command: {
+        description: "exec",
+        parameters: { type: "object", additionalProperties: false },
+        handler: sourceHandler,
+      },
+      write_stdin: {
+        description: "poll",
+        parameters: { type: "object", additionalProperties: false },
+        handler: sourceHandler,
+      },
+      preview: {
         description: "preview",
         parameters: { type: "object", additionalProperties: false },
         handler: sourceHandler,
@@ -69,7 +79,7 @@ describe("managed sandbox preview wiring", () => {
     };
     const factory = vi.fn(() => sourceTools) as unknown as typeof import("../src/sandbox-tools").cloudflareSandboxTools;
     let accountOwned = true;
-    const tools = createManagedSandboxTools({
+    const tools = createManagedNamespaceTools({
       NANOCODEX_ADMIN_TOKEN: "server-only-preview-secret",
       NANOCODEX_SANDBOXES: namespace,
       NANOCODEX_SANDBOX_LOCAL: "true",
@@ -85,13 +95,14 @@ describe("managed sandbox preview wiring", () => {
       "https://nanocodex.example",
       "server-only-preview-secret",
     );
-    await expect(tools[0]!.handler({}, toolContext())).resolves.toEqual({ ok: true });
+    expect(tools.map(({ name }) => name)).toEqual(["exec_command", "write_stdin", "preview"]);
+    await expect(tools[0]!.handler({ cmd: "pwd" }, toolContext())).resolves.toEqual({ ok: true });
     expect(sourceHandler).toHaveBeenCalledTimes(1);
 
     accountOwned = false;
     await expect(tools[0]!.handler({}, toolContext())).rejects.toMatchObject({
       status: 403,
-      code: "sandbox_forbidden",
+      code: "namespace_forbidden",
     });
     expect(sourceHandler).toHaveBeenCalledTimes(1);
   });

--- a/js/managed/test/sandbox-tools.test.ts
+++ b/js/managed/test/sandbox-tools.test.ts
@@ -615,7 +615,92 @@ describe("Cloudflare sandbox tools", () => {
     expect(response.headers.get("referrer-policy")).toBe("no-referrer");
   });
 
-  it("preserves a WebSocket while allowing only handshake response headers", async () => {
+  it("keeps root-relative redirects inside the preview capability", async () => {
+    const containerFetch = vi.fn(async (request: Request) => new Response(null, {
+      status: 302,
+      headers: {
+        location: request.url.endsWith("/scoped")
+          ? "/sandbox-preview/capability/login"
+          : "/login?next=%2Fapp#form",
+      },
+    }));
+    sandboxSdk.getSandbox.mockReturnValue({
+      containerFetch,
+      wsConnect: vi.fn(),
+    });
+
+    const response = await proxyCloudflareSandboxPreview(
+      fakeNamespace(),
+      "preview-session",
+      8_080,
+      new Request("https://nanocodex.example/sandbox-preview/capability/private"),
+      "/private",
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(
+      "/sandbox-preview/capability/login?next=%2Fapp#form",
+    );
+    const scopedResponse = await proxyCloudflareSandboxPreview(
+      fakeNamespace(),
+      "preview-session",
+      8_080,
+      new Request("https://nanocodex.example/sandbox-preview/capability/scoped"),
+      "/scoped",
+    );
+    expect(scopedResponse.headers.get("location")).toBe("/sandbox-preview/capability/login");
+  });
+
+  it("keeps root-relative HTML asset requests inside the preview capability", async () => {
+    const containerFetch = vi.fn(async (request: Request) => request.url.endsWith("/app.css")
+      ? new Response("css")
+      : new Response([
+        "<!doctype html><html><head>",
+        '<link rel="stylesheet" href="/app.css">',
+        '<script type="module" src="/@vite/client"></script>',
+        '<img srcset="/small.png 1x, /large.png 2x">',
+        '<img src="/sandbox-preview/capability/already-scoped.png">',
+        '<script src="//cdn.example/library.js"></script>',
+        "</head></html>",
+      ].join(""), { headers: { "content-type": "text/html; charset=utf-8" } }));
+    sandboxSdk.getSandbox.mockReturnValue({
+      containerFetch,
+      wsConnect: vi.fn(),
+    });
+    const namespace = fakeNamespace();
+    const previewUrl = "https://nanocodex.example/sandbox-preview/capability/";
+
+    const documentResponse = await proxyCloudflareSandboxPreview(
+      namespace,
+      "preview-session",
+      8_080,
+      new Request(previewUrl),
+      "/",
+    );
+    const html = await documentResponse.text();
+    expect(html).toContain('href="/sandbox-preview/capability/app.css"');
+    expect(html).toContain('src="/sandbox-preview/capability/@vite/client"');
+    expect(html).toContain(
+      'srcset="/sandbox-preview/capability/small.png 1x, /sandbox-preview/capability/large.png 2x"',
+    );
+    expect(html).toContain('src="/sandbox-preview/capability/already-scoped.png"');
+    expect(html).toContain('src="//cdn.example/library.js"');
+    expect(html).toContain('{"imports":{"/":"/sandbox-preview/capability/"}}');
+    expect(html).toContain("globalThis.WebSocket=new Proxy");
+    expect(html).toContain('const p="/sandbox-preview/capability"');
+
+    const assetUrl = new URL("/sandbox-preview/capability/app.css", previewUrl);
+    await proxyCloudflareSandboxPreview(
+      namespace,
+      "preview-session",
+      8_080,
+      new Request(assetUrl),
+      "/app.css",
+    );
+    expect(containerFetch.mock.calls[1]![0].url).toBe("http://sandbox.internal/app.css");
+  });
+
+  it("retains the preview capability for Vite HMR WebSockets", async () => {
     const sockets = new WebSocketPair();
     const wsConnect = vi.fn(async (_request: Request, _port: number) => ({
       status: 101,
@@ -634,7 +719,7 @@ describe("Cloudflare sandbox tools", () => {
       containerFetch: vi.fn(),
       wsConnect,
     });
-    const request = new Request("https://nanocodex.example/sandbox-preview/capability/socket", {
+    const request = new Request("https://nanocodex.example/sandbox-preview/capability/?token=hmr", {
       headers: {
         connection: "Upgrade",
         cookie: "nanocodex=session-secret",
@@ -653,10 +738,11 @@ describe("Cloudflare sandbox tools", () => {
       "preview-session",
       8_080,
       request,
-      "/socket",
+      "/",
     );
 
     const forwarded = wsConnect.mock.calls[0]![0];
+    expect(forwarded.url).toBe("http://sandbox.internal/?token=hmr");
     expect(forwarded.headers.get("connection")).toBe("Upgrade");
     expect(forwarded.headers.get("upgrade")).toBe("websocket");
     expect(forwarded.headers.get("sec-websocket-key")).toBe("socket-key");

--- a/js/managed/test/sandbox-tools.test.ts
+++ b/js/managed/test/sandbox-tools.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const sandboxSdk = vi.hoisted(() => ({ getSandbox: vi.fn() }));
-
 vi.mock("@cloudflare/sandbox", () => ({ getSandbox: sandboxSdk.getSandbox }));
 
 import {
@@ -26,526 +25,273 @@ describe("Cloudflare sandbox tools", () => {
   beforeEach(() => sandboxSdk.getSandbox.mockReset());
   afterEach(() => vi.restoreAllMocks());
 
-  it("asks the sandbox provider to prepare before every tool operation", async () => {
-    const sandbox = fakeSandbox();
-    const create = vi.fn(async () => sandbox);
-    const tools = createCloudflareSandboxTools(create);
+  it("exposes only the canonical shell and preview tools without a host selector", () => {
+    const tools = createCloudflareSandboxTools(async () => fakeSandbox());
 
-    await Promise.all([
-      tools.sandbox_exec!.handler({ command: "uname -a" }, context),
-      tools.sandbox_write_file!.handler({ path: "proof.txt", content: "ok" }, context),
-    ]);
-
-    expect(create).toHaveBeenCalledTimes(2);
-    await tools.sandbox_list_files!.handler({}, context);
-    expect(create).toHaveBeenCalledTimes(3);
-    expect(sandbox.exec).toHaveBeenCalledWith("uname -a", {
-      cwd: "/workspace",
+    expect(Object.keys(tools)).toEqual(["exec_command", "write_stdin", "preview"]);
+    expect(tools.exec_command!.parameters).toMatchObject({
+      required: ["cmd"],
     });
-    expect(sandbox.exec.mock.calls.filter(([command]) => isWorkspaceFlush(command))).toHaveLength(2);
+    const parameters = tools.exec_command!.parameters as {
+      properties: Record<string, Record<string, unknown>>;
+    };
+    expect(parameters.properties.yield_time_ms!.maximum).toBeUndefined();
+    expect(parameters.properties.max_output_tokens!.maximum).toBeUndefined();
+    expect(parameters.properties.environment).toBeUndefined();
+    expect(parameters.properties.host).toBeUndefined();
+    expect(tools.exec_command!.outputSchema).toMatchObject({
+      required: ["wall_time_seconds", "output"],
+    });
+    expect(tools.write_stdin!.parameters).toMatchObject({ required: ["session_id"] });
+    expect(tools.preview!.parameters).toMatchObject({ required: ["port"] });
   });
 
-  it("acknowledges workspace writes only after the retained mount flushes", async () => {
+  it("does not impose command, wait, or output ceilings below the platform", async () => {
     const sandbox = fakeSandbox();
-    const order: string[] = [];
-    sandbox.writeFile.mockImplementation(async () => { order.push("write"); });
-    sandbox.exec.mockImplementation(async (command: string) => {
-      expect(command).toBe("sync -f /workspace");
-      order.push("flush");
-      return executionResult("");
-    });
+    const process = fakeProcess({ status: "completed", exitCode: 0 });
+    const output = "x".repeat(160 * 1024);
+    const command = "x".repeat(33 * 1024);
+    process.getLogs.mockResolvedValue({ stdout: output, stderr: "" });
+    sandbox.startProcess.mockResolvedValue(process);
+    sandbox.getProcess.mockImplementation(async (id: string) => id === process.id ? process : null);
     const tools = createCloudflareSandboxTools(async () => sandbox);
 
-    await expect(tools.sandbox_write_file!.handler({
-      path: "proof.txt",
-      content: "retained",
-    }, context)).resolves.toEqual({ path: "/workspace/proof.txt", bytes_written: 8 });
-
-    expect(order).toEqual(["write", "flush"]);
-  });
-
-  it("fails a workspace mutation when its retained flush fails", async () => {
-    const sandbox = fakeSandbox();
-    sandbox.exec.mockResolvedValue({
-      success: false,
-      exitCode: 1,
-      stdout: "",
-      stderr: "transport failed",
-      duration: 1,
+    await expect(tools.exec_command!.handler({
+      cmd: command,
+      yield_time_ms: 120_001,
+      max_output_tokens: 100_001,
+    }, context)).resolves.toMatchObject({
+      output,
+      exit_code: 0,
     });
-    const tools = createCloudflareSandboxTools(async () => sandbox);
-
-    await expect(tools.sandbox_write_file!.handler({
-      path: "proof.txt",
-      content: "not-yet-durable",
-    }, context)).rejects.toThrow("failed to flush the retained workspace: transport failed");
   });
 
-  it("attempts to flush partial writes when foreground execution rejects", async () => {
+  it("runs canonical exec_command in the retained workspace and flushes mutations", async () => {
     const sandbox = fakeSandbox();
-    const executionError = new Error("command transport stopped");
-    sandbox.exec
-      .mockRejectedValueOnce(executionError)
-      .mockResolvedValueOnce(executionResult(""));
-    const tools = createCloudflareSandboxTools(async () => sandbox);
-
-    await expect(tools.sandbox_exec!.handler({ command: "generate files" }, context))
-      .rejects.toBe(executionError);
-    expect(sandbox.exec.mock.calls).toEqual([
-      ["generate files", { cwd: "/workspace" }],
-      ["sync -f /workspace", { cwd: "/" }],
-    ]);
-  });
-
-  it("prepares one shared sandbox once across concurrent parent and child tool sets", async () => {
-    const namespace = fakeNamespace();
-    const sandbox = preparingSandbox("empty");
-    sandboxSdk.getSandbox.mockReturnValue(sandbox);
-    const parent = cloudflareSandboxTools(namespace, "shared-session");
-    const child = cloudflareSandboxTools(namespace, "shared-session");
-
-    await Promise.all([
-      parent.sandbox_exec!.handler({ command: "printf parent" }, context),
-      child.sandbox_exec!.handler({ command: "printf child" }, {
-        ...context,
-        sessionId: "child-session",
-        subagent: {
-          agentId: "1",
-          parentAgentId: null,
-          sessionId: "child-session",
-          role: "worker",
-          task: "exercise the shared sandbox",
-        },
-      }),
-    ]);
-
-    expect(sandboxSdk.getSandbox).toHaveBeenCalledTimes(1);
-    expect(sandbox.mountBucket).toHaveBeenCalledTimes(1);
-    expect(sandbox.mountBucket).toHaveBeenCalledWith(
-      "NANOCODEX_WORKSPACES",
-      "/workspace",
-      { prefix: "/sessions/shared-session/" },
-    );
-  });
-
-  it("reuses a healthy retained workspace after the managed host reconnects", async () => {
-    const sandbox = preparingSandbox("empty");
-    sandboxSdk.getSandbox.mockReturnValue(sandbox);
-
-    await cloudflareSandboxTools(fakeNamespace(), "retained-session")
-      .sandbox_exec!.handler({ command: "printf first" }, context);
-    await cloudflareSandboxTools(fakeNamespace(), "retained-session")
-      .sandbox_exec!.handler({ command: "printf reconnected" }, context);
-
-    expect(sandbox.mountBucket).toHaveBeenCalledTimes(1);
-    expect(sandbox.exec.mock.calls.filter(([command]) => isMountProbe(command))).toHaveLength(3);
-  });
-
-  it("retries a transient retained mount health failure during background work", async () => {
-    const sandbox = preparingSandbox("empty");
-    const probeStates: MountState[] = [
-      "empty",
-      "mounted",
-      "mounted-unhealthy",
-      "mounted",
-    ];
-    sandbox.exec.mockImplementation(async (command: string) => executionResult(
-      isMountProbe(command) ? probeStates.shift()! : "clone-visible",
+    const process = fakeProcess({ status: "failed", exitCode: 7 });
+    process.getLogs.mockResolvedValue({ stdout: "hello", stderr: "warning" });
+    sandbox.startProcess.mockResolvedValue(process);
+    sandbox.getProcess.mockImplementation(async (id: string) => (
+      id === process.id ? process : null
     ));
-    sandboxSdk.getSandbox.mockReturnValue(sandbox);
-    const tools = cloudflareSandboxTools(fakeNamespace(), "clone-session");
+    const tools = createCloudflareSandboxTools(async () => sandbox);
 
-    const clone = "git clone https://example.invalid/repo.git repo";
-    const started = await tools.sandbox_start_process!.handler({ command: clone }, context);
-    const result = await tools.sandbox_exec!.handler({ command: "git -C repo status" }, context);
-
-    expect(started).toMatchObject({ command: clone });
-    expect(result).toMatchObject({ success: true, stdout: "clone-visible" });
-    expect(sandbox.startProcess).toHaveBeenCalledWith(clone, {
-      cwd: "/workspace",
+    await expect(tools.exec_command!.handler({
+      cmd: "task",
+      workdir: "repo",
+    }, context)).resolves.toEqual({
+      output: "hellowarning",
+      chunk_id: expect.stringMatching(/^[1-9][0-9]*:12$/),
+      exit_code: 7,
+      wall_time_seconds: expect.any(Number),
+    });
+    expect(sandbox.startProcess).toHaveBeenCalledWith("exec 2>&1\ntask", {
+      cwd: "/workspace/repo",
+      processId: expect.stringMatching(/^nanocodex-[1-9][0-9]*$/),
       autoCleanup: false,
     });
-    expect(sandbox.exec.mock.calls.filter(([command]) => isMountProbe(command))).toHaveLength(4);
-    expect(sandbox.mountBucket).toHaveBeenCalledTimes(1);
+    expect(sandbox.exec).toHaveBeenCalledWith("sync -f /workspace", { cwd: "/" });
   });
 
-  it("remounts retained storage after a container replacement before the next command", async () => {
-    const sandbox = preparingSandbox("empty");
-    const events: string[] = [];
-    let retainedMarker = "";
-    sandbox.mountBucket.mockImplementation(async () => {
-      events.push("mount");
-      sandbox.setMountState("mounted");
-    });
-    sandbox.exec.mockImplementation(async (command: string) => {
-      if (isMountProbe(command)) {
-        events.push("probe");
-        return executionResult(sandbox.getMountState());
-      }
-      if (command === "printf retained-marker > marker.txt") {
-        events.push("write-marker");
-        retainedMarker = "retained-marker";
-        return executionResult("");
-      }
-      if (command === "cat marker.txt") {
-        events.push("read-marker");
-        return executionResult(
-          sandbox.getMountState() === "mounted" ? retainedMarker : "ephemeral-marker",
-        );
-      }
-      if (isWorkspaceFlush(command)) {
-        events.push("flush");
-        return executionResult("");
-      }
-      throw new Error(`unexpected command: ${command}`);
-    });
-    sandboxSdk.getSandbox.mockReturnValue(sandbox);
-    const tools = cloudflareSandboxTools(fakeNamespace(), "replacement-session");
-
-    await tools.sandbox_exec!.handler({
-      command: "printf retained-marker > marker.txt",
-    }, context);
-    sandbox.setMountState("empty");
-    const second = await tools.sandbox_exec!.handler({ command: "cat marker.txt" }, context);
-
-    expect(second).toMatchObject({ stdout: "retained-marker" });
-    expect(events).toEqual([
-      "probe",
-      "mount",
-      "probe",
-      "write-marker",
-      "flush",
-      "probe",
-      "mount",
-      "probe",
-      "read-marker",
-      "flush",
-    ]);
-    expect(sandbox.mountBucket).toHaveBeenCalledTimes(2);
-  });
-
-  it("accepts a concurrent mount winner only after the retained mount probes healthy", async () => {
-    const namespace = fakeNamespace();
-    const sandbox = preparingSandbox("empty");
-    const mountError = new Error("S3FS mount failed: MOUNTPOINT directory /workspace is not empty");
-    sandbox.mountBucket.mockImplementationOnce(async () => {
-      sandbox.setMountState("mounted");
-      throw mountError;
-    });
-    sandboxSdk.getSandbox.mockReturnValue(sandbox);
-
-    await expect(cloudflareSandboxTools(namespace, "raced-session")
-      .sandbox_exec!.handler({ command: "printf reused" }, context)).resolves.toMatchObject({
-        success: true,
-      });
-
-    expect(sandbox.mountBucket).toHaveBeenCalledTimes(1);
-    expect(sandbox.exec.mock.calls.filter(([command]) => isMountProbe(command))).toHaveLength(2);
-  });
-
-  it("retries preparation after a real mount failure", async () => {
-    const namespace = fakeNamespace();
-    const sandbox = preparingSandbox("empty");
-    const mountError = new Error("R2 mount unavailable");
-    sandbox.mountBucket
-      .mockRejectedValueOnce(mountError)
-      .mockImplementationOnce(async () => sandbox.setMountState("mounted"));
-    sandboxSdk.getSandbox.mockReturnValue(sandbox);
-    const tools = cloudflareSandboxTools(namespace, "retry-session");
-
-    await expect(tools.sandbox_exec!.handler({ command: "printf first" }, context))
-      .rejects.toBe(mountError);
-    await expect(tools.sandbox_exec!.handler({ command: "printf retry" }, context))
-      .resolves.toMatchObject({ success: true });
-
-    expect(sandboxSdk.getSandbox).toHaveBeenCalledTimes(2);
-    expect(sandbox.mountBucket).toHaveBeenCalledTimes(2);
-  });
-
-  it.each([
-    ["occupied", "unmounted /workspace directory is not empty"],
-    ["mounted-unhealthy", "existing /workspace mount is unhealthy"],
-  ] as const)("refuses to remount a %s workspace", async (state, message) => {
-    const sandbox = preparingSandbox(state);
-    sandboxSdk.getSandbox.mockReturnValue(sandbox);
-
-    await expect(cloudflareSandboxTools(fakeNamespace(), `${state}-session`)
-      .sandbox_exec!.handler({ command: "printf unsafe" }, context)).rejects.toThrow(message);
-
-    expect(sandbox.mountBucket).not.toHaveBeenCalled();
-    expect(sandbox.exec.mock.calls.filter(([command]) => isMountProbe(command))).toHaveLength(
-      state === "mounted-unhealthy" ? 3 : 1,
-    );
-  });
-
-  it("preserves the local R2 mount contract", async () => {
-    const sandbox = preparingSandbox("empty");
-    sandboxSdk.getSandbox.mockReturnValue(sandbox);
-
-    await cloudflareSandboxTools(fakeNamespace(), "local-session", true)
-      .sandbox_exec!.handler({ command: "printf local" }, context);
-
-    expect(sandbox.mountBucket).toHaveBeenCalledWith(
-      "NANOCODEX_WORKSPACES",
-      "/workspace",
-      { prefix: "/sessions/local-session/", localBucket: true },
-    );
-  });
-
-  it("does not impose command or readiness timeout limits", async () => {
+  it("persists the output cursor across tool reconstruction and preserves a terminal tail", async () => {
     const sandbox = fakeSandbox();
+    const process = fakeProcess({ status: "running" });
+    let status: "running" | "completed" = "running";
+    let stdout = "first";
+    process.getStatus.mockImplementation(async () => status);
+    process.getLogs.mockImplementation(async () => ({ stdout, stderr: "" }));
+    sandbox.startProcess.mockImplementation(async (_command: string, options: { processId: string }) => {
+      process.id = options.processId;
+      return process;
+    });
+    sandbox.getProcess.mockImplementation(async (id: string) => id === process.id ? process : null);
+    const cursors = new Map<string, unknown>();
+    const cursorStorage = {
+      delete: (key: string) => { cursors.delete(key); },
+      get: (key: string) => cursors.get(key),
+      put: (key: string, value: unknown) => { cursors.set(key, value); },
+    };
+    let tools = createCloudflareSandboxTools(async () => sandbox, undefined, cursorStorage);
+
+    const started = await tools.exec_command!.handler({
+      cmd: "task",
+      yield_time_ms: 0,
+    }, context) as { session_id: number; output: string };
+    expect(started.output).toBe("first");
+    stdout = "firstsecond";
+    tools = createCloudflareSandboxTools(async () => sandbox, undefined, cursorStorage);
+    await expect(tools.write_stdin!.handler({
+      session_id: started.session_id,
+      yield_time_ms: 0,
+    }, context)).resolves.toMatchObject({
+      output: "second",
+      session_id: started.session_id,
+    });
+
+    stdout += `${"x".repeat(100)}TAIL`;
+    status = "completed";
+    tools = createCloudflareSandboxTools(async () => sandbox, undefined, cursorStorage);
+    await expect(tools.write_stdin!.handler({
+      session_id: started.session_id,
+      max_output_tokens: 9,
+    }, context)).resolves.toMatchObject({
+      output: expect.stringMatching(/^x+\n… output truncated …\n.*TAIL$/),
+      original_token_count: 26,
+      exit_code: 0,
+    });
+    expect(cursors.size).toBe(0);
+  });
+
+  it("uses Ctrl-C as the canonical termination path for a yielded session", async () => {
+    const sandbox = fakeSandbox();
+    const process = fakeProcess({ id: "nanocodex-7", status: "killed", exitCode: 137 });
+    sandbox.getProcess.mockResolvedValue(process);
     const tools = createCloudflareSandboxTools(async () => sandbox);
 
-    await tools.sandbox_exec!.handler({
-      command: "cargo test",
-      timeout_ms: Number.MAX_SAFE_INTEGER,
-    }, context);
-    await tools.sandbox_start_process!.handler({
-      command: "cargo watch",
-      ready_port: 3_000,
-    }, context);
-
-    expect(sandbox.exec).toHaveBeenCalledWith("cargo test", {
-      cwd: "/workspace",
-      timeout: Number.MAX_SAFE_INTEGER,
-    });
-    const process = await sandbox.startProcess.mock.results[0]!.value;
-    expect(process.waitForPort).toHaveBeenCalledWith(3_000, undefined);
+    await expect(tools.write_stdin!.handler({
+      session_id: 7,
+      chars: "\u0003",
+    }, context)).resolves.toMatchObject({ exit_code: 137 });
+    expect(process.kill).toHaveBeenCalledTimes(1);
   });
 
-  it("returns the process identity when port readiness fails", async () => {
+  it("uses the sandbox exit stream once for an unrestricted yield", async () => {
     const sandbox = fakeSandbox();
-    const process = fakeProcess();
-    process.waitForPort.mockRejectedValue(new Error("port never became ready"));
-    process.getStatus.mockResolvedValue("running");
+    const process = fakeProcess({ status: "running" });
+    const timeout = Object.assign(new Error("still running"), {
+      name: "ProcessReadyTimeoutError",
+    });
+    process.waitForExit.mockRejectedValue(timeout);
     sandbox.startProcess.mockResolvedValue(process);
     const tools = createCloudflareSandboxTools(async () => sandbox);
 
-    await expect(tools.sandbox_start_process!.handler({
-      command: "start server",
-      ready_port: 3_000,
-    }, context)).resolves.toMatchObject({
-      process_id: "process",
-      status: "running",
-      terminal: false,
-      ready: false,
-      ready_error: "port never became ready",
-    });
-    expect(process.kill).toHaveBeenCalledOnce();
+    await expect(tools.exec_command!.handler({
+      cmd: "long-job",
+      yield_time_ms: 120_001,
+    }, context)).resolves.toMatchObject({ session_id: expect.any(Number) });
+    expect(process.waitForExit).toHaveBeenCalledOnce();
+    expect(process.waitForExit).toHaveBeenCalledWith(120_001);
     expect(process.getStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects escalation, PTYs, stdin, shell overrides, and escaped workdirs", async () => {
+    const tools = createCloudflareSandboxTools(async () => fakeSandbox());
+
+    await expect(tools.exec_command!.handler({
+      cmd: "pwd", sandbox_permissions: "require_escalated",
+    }, context)).rejects.toThrow("does not support privilege escalation");
+    await expect(tools.exec_command!.handler({ cmd: "pwd", tty: true }, context))
+      .rejects.toThrow("does not support TTY");
+    await expect(tools.exec_command!.handler({
+      cmd: "pwd", shell: "/bin/zsh",
+    }, context)).rejects.toThrow("does not support shell or login overrides");
+    await expect(tools.exec_command!.handler({
+      cmd: "pwd", workdir: "../outside",
+    }, context)).rejects.toThrow("must not contain '..'");
+    await expect(tools.write_stdin!.handler({
+      session_id: 7, chars: "input",
+    }, context)).rejects.toThrow("stdin is unavailable");
+  });
+
+  it("attempts a retained-workspace flush when command transport fails", async () => {
+    const sandbox = fakeSandbox();
+    const failure = new Error("transport stopped");
+    sandbox.startProcess.mockRejectedValueOnce(failure);
+    const tools = createCloudflareSandboxTools(async () => sandbox);
+
+    await expect(tools.exec_command!.handler({ cmd: "task" }, context))
+      .rejects.toBe(failure);
     expect(sandbox.exec).toHaveBeenLastCalledWith("sync -f /workspace", { cwd: "/" });
   });
 
-  it("runs the requested background command unchanged and flushes terminal observations", async () => {
-    const sandbox = fakeSandbox();
-    const tools = createCloudflareSandboxTools(async () => sandbox);
-    const command = "cargo test --workspace";
-
-    await expect(tools.sandbox_start_process!.handler({ command }, context))
-      .resolves.toMatchObject({ command });
-    expect(sandbox.startProcess.mock.calls[0]![0]).toBe(command);
-
-    sandbox.getProcess.mockResolvedValue(fakeProcess({
-      command,
-      status: "completed",
-      exitCode: 0,
-    }));
-    await expect(tools.sandbox_get_process!.handler({ process_id: "process" }, context))
-      .resolves.toMatchObject({ command, status: "completed", terminal: true });
-    expect(sandbox.exec).toHaveBeenLastCalledWith("sync -f /workspace", {
-      cwd: "/",
-    });
-  });
-
-  it("flushes a background process that finishes while it is starting", async () => {
+  it("kills and flushes a started process when observation fails", async () => {
     const sandbox = fakeSandbox();
     const process = fakeProcess({ status: "running" });
-    process.getStatus.mockResolvedValue("completed");
+    const failure = new Error("status transport stopped");
+    process.getStatus.mockRejectedValueOnce(failure);
     sandbox.startProcess.mockResolvedValue(process);
     const tools = createCloudflareSandboxTools(async () => sandbox);
 
-    await expect(tools.sandbox_start_process!.handler({ command: "quick task" }, context))
-      .resolves.toMatchObject({ command: "quick task", status: "completed" });
-    expect(sandbox.exec).toHaveBeenLastCalledWith("sync -f /workspace", {
-      cwd: "/",
-    });
+    await expect(tools.exec_command!.handler({ cmd: "task" }, context))
+      .rejects.toBe(failure);
+    expect(process.kill).toHaveBeenCalledTimes(1);
+    expect(sandbox.exec).toHaveBeenLastCalledWith("sync -f /workspace", { cwd: "/" });
   });
 
-  it("retrieves authoritative background process state and bounded logs", async () => {
-    const sandbox = fakeSandbox();
-    const process = fakeProcess({
-      id: "proc_123",
-      pid: 42,
-      command: "cargo test",
-      status: "failed" as const,
-      exitCode: 101,
-    });
-    process.getLogs.mockResolvedValue({
-      stdout: "compiled\n",
-      stderr: "test failed\n",
-    });
-    sandbox.getProcess.mockResolvedValue(process);
-    const tools = createCloudflareSandboxTools(async () => sandbox);
+  it("mounts one retained workspace and reuses it across tool reconstruction", async () => {
+    const sandbox = preparingSandbox("empty");
+    sandboxSdk.getSandbox.mockReturnValue(sandbox);
+    const namespace = fakeNamespace();
 
-    await expect(tools.sandbox_get_process!.handler({ process_id: "proc_123" }, context))
+    await cloudflareSandboxTools(namespace, "retained").exec_command!.handler(
+      { cmd: "printf first" }, context,
+    );
+    await cloudflareSandboxTools(namespace, "retained").exec_command!.handler(
+      { cmd: "printf second" }, context,
+    );
+
+    expect(sandboxSdk.getSandbox).toHaveBeenCalledTimes(2);
+    expect(sandbox.mountBucket).toHaveBeenCalledTimes(1);
+    expect(sandbox.mountBucket).toHaveBeenCalledWith(
+      "NANOCODEX_WORKSPACES", "/workspace", { prefix: "/sessions/retained/" },
+    );
+  });
+
+  it("preserves local R2 mount options and refuses unsafe remote remounts", async () => {
+    const local = preparingSandbox("empty");
+    sandboxSdk.getSandbox.mockReturnValueOnce(local);
+    await cloudflareSandboxTools(fakeNamespace(), "local", true).exec_command!.handler(
+      { cmd: "printf local" }, context,
+    );
+    expect(local.mountBucket).toHaveBeenCalledWith(
+      "NANOCODEX_WORKSPACES",
+      "/workspace",
+      { prefix: "/sessions/local/", localBucket: true },
+    );
+
+    const occupied = preparingSandbox("occupied");
+    sandboxSdk.getSandbox.mockReturnValueOnce(occupied);
+    await expect(cloudflareSandboxTools(fakeNamespace(), "occupied").exec_command!.handler(
+      { cmd: "printf unsafe" }, context,
+    )).rejects.toThrow("unmounted /workspace directory is not empty");
+    expect(occupied.mountBucket).not.toHaveBeenCalled();
+  });
+
+  it("creates a server-fronted preview without exposing its secret", async () => {
+    const tools = createCloudflareSandboxTools(
+      async () => fakeSandbox(),
+      async (port) => ({
+        port,
+        url: "https://nanocodex.example/sandbox-preview/sealed/",
+        persistent: false,
+      }),
+    );
+
+    await expect(tools.preview!.handler({ port: 8080 }, context))
       .resolves.toEqual({
-        found: true,
-        process_id: "proc_123",
-        pid: 42,
-        command: "cargo test",
-        status: "failed",
-        terminal: true,
-        exit_code: 101,
-        stdout: "compiled\n",
-        stderr: "test failed\n",
-        stdout_truncated: false,
-        stderr_truncated: false,
+        port: 8080,
+        url: "https://nanocodex.example/sandbox-preview/sealed/",
+        persistent: false,
       });
-    expect(sandbox.getProcess).toHaveBeenCalledWith("proc_123");
-    expect(process.getLogs).toHaveBeenCalledOnce();
   });
 
-  it("polls running and missing processes without repeatedly transferring logs", async () => {
-    const sandbox = fakeSandbox();
-    const running = fakeProcess({
-      id: "proc_running",
-      command: "cargo test",
-      status: "running" as const,
-    });
-    running.getLogs.mockResolvedValue({ stdout: "compiling", stderr: "" });
-    sandbox.getProcess
-      .mockResolvedValueOnce(running)
-      .mockResolvedValueOnce(null);
-    const tools = createCloudflareSandboxTools(async () => sandbox);
+  it("never exposes the sandbox control-plane port", async () => {
+    const tools = createCloudflareSandboxTools(async () => fakeSandbox());
 
-    await expect(tools.sandbox_get_process!.handler({ process_id: "proc_running" }, context))
-      .resolves.toEqual({
-        found: true,
-        process_id: "proc_running",
-        pid: 1,
-        command: "cargo test",
-        status: "running",
-        terminal: false,
-        exit_code: null,
-      });
-    expect(running.getLogs).not.toHaveBeenCalled();
-    await expect(tools.sandbox_get_process!.handler({ process_id: "proc_missing" }, context))
-      .resolves.toEqual({ found: false, process_id: "proc_missing" });
-    await expect(tools.sandbox_get_process!.handler({ process_id: "../other" }, context))
-      .rejects.toThrow("process_id must be a safe Sandbox process ID");
-  });
-
-  it("returns partial running output only when explicitly requested", async () => {
-    const sandbox = fakeSandbox();
-    const running = fakeProcess({ id: "proc_running", status: "running" });
-    running.getLogs.mockResolvedValue({ stdout: "compiling", stderr: "warning" });
-    sandbox.getProcess.mockResolvedValue(running);
-    const tools = createCloudflareSandboxTools(async () => sandbox);
-
-    await expect(tools.sandbox_get_process!.handler({
-      process_id: "proc_running",
-      include_output: true,
-    }, context)).resolves.toMatchObject({
-      terminal: false,
-      stdout: "compiling",
-      stderr: "warning",
-    });
-    expect(running.getLogs).toHaveBeenCalledOnce();
-  });
-
-  it("terminates a running background process and reports its refreshed status", async () => {
-    const sandbox = fakeSandbox();
-    const process = fakeProcess({ id: "proc_running", status: "running" });
-    process.getStatus.mockResolvedValue("killed");
-    sandbox.getProcess.mockResolvedValue(process);
-    const tools = createCloudflareSandboxTools(async () => sandbox);
-
-    await expect(tools.sandbox_kill_process!.handler(
-      { process_id: "proc_running" },
-      context,
-    )).resolves.toEqual({
-      found: true,
-      process_id: "proc_running",
-      status: "killed",
-      terminal: true,
-      kill_requested: true,
-    });
-    expect(process.kill).toHaveBeenCalledOnce();
-    expect(process.waitForExit).not.toHaveBeenCalled();
-    expect(process.getStatus).toHaveBeenCalledOnce();
-  });
-
-  it("reports an asynchronously stopping process without waiting indefinitely", async () => {
-    const sandbox = fakeSandbox();
-    const process = fakeProcess({ id: "proc_running", status: "running" });
-    process.getStatus.mockResolvedValue("running");
-    sandbox.getProcess.mockResolvedValue(process);
-    const tools = createCloudflareSandboxTools(async () => sandbox);
-
-    await expect(tools.sandbox_kill_process!.handler(
-      { process_id: "proc_running" },
-      context,
-    )).resolves.toMatchObject({
-      status: "running",
-      terminal: false,
-      kill_requested: true,
-    });
-    expect(process.waitForExit).not.toHaveBeenCalled();
-  });
-
-  it("does not kill missing or already-terminal background processes", async () => {
-    const sandbox = fakeSandbox();
-    const completed = fakeProcess({ id: "proc_completed", status: "completed" });
-    sandbox.getProcess
-      .mockResolvedValueOnce(completed)
-      .mockResolvedValueOnce(null);
-    const tools = createCloudflareSandboxTools(async () => sandbox);
-
-    await expect(tools.sandbox_kill_process!.handler(
-      { process_id: "proc_completed" },
-      context,
-    )).resolves.toEqual({
-      found: true,
-      process_id: "proc_completed",
-      status: "completed",
-      terminal: true,
-      kill_requested: false,
-    });
-    await expect(tools.sandbox_kill_process!.handler(
-      { process_id: "proc_missing" },
-      context,
-    )).resolves.toEqual({ found: false, process_id: "proc_missing" });
-    expect(completed.kill).not.toHaveBeenCalled();
-    expect(completed.getStatus).not.toHaveBeenCalled();
-  });
-
-  it("truncates background process stdout and stderr on UTF-8 boundaries", async () => {
-    const sandbox = fakeSandbox();
-    const process = fakeProcess({
-      id: "proc_flood",
-      command: "flood",
-      status: "completed" as const,
-      exitCode: 0,
-    });
-    process.getLogs.mockResolvedValue({
-      stdout: "🦀".repeat(40_000),
-      stderr: "λ".repeat(80_000),
-    });
-    sandbox.getProcess.mockResolvedValue(process);
-    const tools = createCloudflareSandboxTools(async () => sandbox);
-
-    const result = (await tools.sandbox_get_process!.handler(
-      { process_id: "proc_flood" },
-      context,
-    )) as Record<string, unknown>;
-    expect(result.stdout_truncated).toBe(true);
-    expect(result.stderr_truncated).toBe(true);
-    expect(new TextEncoder().encode(String(result.stdout)).byteLength).toBe(128 * 1024);
-    expect(new TextEncoder().encode(String(result.stderr)).byteLength).toBe(128 * 1024);
+    await expect(tools.preview!.handler({ port: 3_000 }, context))
+      .rejects.toThrow("reserved for the sandbox control plane");
+    await expect(cloudflareSandboxPreviewUrl(
+      "https://nanocodex.example", "secret", "preview-session", 3_000,
+    )).rejects.toThrow("reserved for the sandbox control plane");
+    await expect(proxyCloudflareSandboxPreview(
+      fakeNamespace(), "preview-session", 3_000,
+      new Request("https://nanocodex.example/sandbox-preview/capability/"),
+      "/api/execute",
+    )).rejects.toThrow("reserved for the sandbox control plane");
   });
 
   it("keeps account credentials and origin authority out of sandbox previews", async () => {
-    const containerFetch = vi.fn(async (_request: Request, _port: number) => new Response("preview", {
+    const containerFetch = vi.fn(async (_request: Request) => new Response("preview", {
       status: 201,
       headers: {
         "clear-site-data": '"cookies"',
@@ -554,10 +300,7 @@ describe("Cloudflare sandbox tools", () => {
         "set-cookie": "nanocodex=overwritten",
       },
     }));
-    sandboxSdk.getSandbox.mockReturnValue({
-      containerFetch,
-      wsConnect: vi.fn(),
-    });
+    sandboxSdk.getSandbox.mockReturnValue({ containerFetch, wsConnect: vi.fn() });
     const request = new Request("https://nanocodex.example/sandbox-preview/capability/app?q=kept", {
       method: "POST",
       headers: {
@@ -579,11 +322,7 @@ describe("Cloudflare sandbox tools", () => {
     });
 
     const response = await proxyCloudflareSandboxPreview(
-      fakeNamespace(),
-      "preview-session",
-      8_080,
-      request,
-      "/app",
+      fakeNamespace(), "preview-session", 8_080, request, "/app",
     );
 
     const forwarded = containerFetch.mock.calls[0]![0];
@@ -791,19 +530,25 @@ describe("Cloudflare sandbox tools", () => {
   it("rejects expired and malformed authenticated preview payloads", async () => {
     const secret = "preview-expiry-test-secret";
     const sessionId = "018f25e8-7b51-7a32-8c4d-abcdef012345";
-    const expired = await sealPreviewPayload(
-      secret,
-      `${sessionId}\n8080\n${Date.now() - 1}`,
-    );
-    const malformed = await sealPreviewPayload(
-      secret,
-      `${sessionId}\n8080\nnot-an-expiry`,
-    );
+    const expired = await sealPreviewPayload(secret, `${sessionId}\n8080\n${Date.now() - 1}`);
+    const malformed = await sealPreviewPayload(secret, `${sessionId}\n8080\nnot-an-expiry`);
 
     await expect(openSandboxPreviewCapability(secret, expired))
       .rejects.toThrow("invalid preview capability");
     await expect(openSandboxPreviewCapability(secret, malformed))
       .rejects.toThrow("invalid preview capability");
+  });
+
+  it("round-trips valid preview capabilities", async () => {
+    const secret = "preview-round-trip-secret";
+    const sessionId = "018f25e8-7b51-7a32-8c4d-fedcba987654";
+    const url = await cloudflareSandboxPreviewUrl(
+      "https://nanocodex.example", secret, sessionId, 8_080,
+    );
+    const capability = new URL(url).pathname.split("/")[2]!;
+
+    await expect(openSandboxPreviewCapability(secret, capability))
+      .resolves.toEqual({ sessionId, port: 8_080 });
   });
 
   it("caches one derived preview key and replaces it when the secret rotates", async () => {
@@ -845,103 +590,56 @@ describe("Cloudflare sandbox tools", () => {
     await deleteCloudflareSandboxWorkspace(bucket, "session");
 
     expect(bucket.list).toHaveBeenCalledTimes(3);
-    expect(bucket.list).toHaveBeenCalledWith({ prefix: "/sessions/session/", limit: 1_000 });
-    expect(bucket.delete).toHaveBeenCalledWith([
-      "/sessions/session/a",
-      "/sessions/session/b",
-    ]);
+    expect(bucket.delete).toHaveBeenCalledWith(["/sessions/session/a", "/sessions/session/b"]);
     expect(bucket.delete).toHaveBeenCalledWith(["/sessions/session/c"]);
   });
 });
 
-type FakeLookupProcess = {
-  id: string;
-  pid?: number;
-  command: string;
-  status: "starting" | "running" | "completed" | "failed" | "killed" | "error";
-  exitCode?: number;
-  kill(): Promise<void>;
-  getStatus(): Promise<"starting" | "running" | "completed" | "failed" | "killed" | "error">;
-  getLogs(): Promise<{ stdout: string; stderr: string }>;
-  waitForPort(port: number, options?: { timeout?: number }): Promise<void>;
-  waitForExit(timeout?: number): Promise<{ exitCode: number }>;
-};
-
 function fakeSandbox() {
   const process = fakeProcess();
   return {
-    exec: vi.fn(async (_command: string, _options?: { cwd: string; timeout?: number }) => ({
-      success: true,
-      exitCode: 0,
-      stdout: "",
-      stderr: "",
-      duration: 1,
+    exec: vi.fn(async (_command: string, _options?: { cwd: string }) => executionResult("")),
+    startProcess: vi.fn(async (_command: string, options: { processId: string }) => ({
+      ...process,
+      id: options.processId,
     })),
-    startProcess: vi.fn(async (command: string) => ({ ...process, command })),
-    getProcess: vi.fn(async (id: string): Promise<FakeLookupProcess | null> => (
-      id === process.id ? process : null
-    )),
-    readFile: vi.fn(async () => ({
-      size: 0,
-      content: new ReadableStream<Uint8Array>({ start(controller) { controller.close(); } }),
-    })),
-    writeFile: vi.fn(async () => {}),
-    listFiles: vi.fn(async () => ({ files: [] })),
+    getProcess: vi.fn(async (_id: string) => null as ReturnType<typeof fakeProcess> | null),
     tunnels: { get: vi.fn(async () => ({ url: "https://preview.example" })) },
   };
 }
 
-function fakeProcess(overrides: Partial<Pick<
-  FakeLookupProcess,
-  "id" | "pid" | "command" | "status" | "exitCode"
->> = {}) {
+function fakeProcess(overrides: {
+  id?: string;
+  status?: "starting" | "running" | "completed" | "failed" | "killed" | "error";
+  exitCode?: number;
+} = {}) {
+  const status = overrides.status ?? "completed";
   return {
-    id: "process",
-    pid: 1,
-    command: "",
-    status: "running" as const,
+    id: overrides.id ?? "process",
+    status,
+    exitCode: overrides.exitCode ?? 0,
     kill: vi.fn(async () => {}),
-    getStatus: vi.fn(async (): Promise<FakeLookupProcess["status"]> => "running"),
+    getStatus: vi.fn(async () => status),
     getLogs: vi.fn(async () => ({ stdout: "", stderr: "" })),
-    waitForPort: vi.fn(async () => {}),
-    waitForExit: vi.fn(async () => ({ exitCode: 0 })),
-    ...overrides,
+    waitForExit: vi.fn(async () => ({ exitCode: overrides.exitCode ?? 0 })),
   };
 }
 
-function preparingSandbox(initialState: MountState) {
+function preparingSandbox(initialState: "empty" | "mounted" | "occupied") {
   let mountState = initialState;
   const sandbox = {
     ...fakeSandbox(),
     mountBucket: vi.fn(async () => { mountState = "mounted"; }),
     destroy: vi.fn(async () => {}),
-    setMountState(state: MountState) { mountState = state; },
-    getMountState() { return mountState; },
   };
   sandbox.exec.mockImplementation(async (command: string) => executionResult(
-    isMountProbe(command) ? mountState : "",
+    command.startsWith("if mountpoint -q /workspace") ? mountState : "",
   ));
   return sandbox;
 }
 
-type MountState = "absent" | "empty" | "occupied" | "mounted" | "mounted-unhealthy";
-
-function isMountProbe(command: unknown): boolean {
-  return typeof command === "string" && command.startsWith("if mountpoint -q /workspace");
-}
-
-function isWorkspaceFlush(command: unknown): boolean {
-  return command === "sync -f /workspace";
-}
-
-function executionResult(stdout: string) {
-  return {
-    success: true,
-    exitCode: 0,
-    stdout,
-    stderr: "",
-    duration: 1,
-  };
+function executionResult(stdout: string, stderr = "", exitCode = 0, duration = 1) {
+  return { success: exitCode === 0, exitCode, stdout, stderr, duration };
 }
 
 function fakeNamespace(): DurableObjectNamespace<Sandbox> {
@@ -951,13 +649,7 @@ function fakeNamespace(): DurableObjectNamespace<Sandbox> {
 async function sealPreviewPayload(secret: string, payload: string): Promise<string> {
   const iv = crypto.getRandomValues(new Uint8Array(12));
   const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(secret));
-  const key = await crypto.subtle.importKey(
-    "raw",
-    digest,
-    { name: "AES-GCM" },
-    false,
-    ["encrypt"],
-  );
+  const key = await crypto.subtle.importKey("raw", digest, { name: "AES-GCM" }, false, ["encrypt"]);
   const ciphertext = new Uint8Array(await crypto.subtle.encrypt(
     {
       name: "AES-GCM",

--- a/js/managed/test/turn-admission.test.ts
+++ b/js/managed/test/turn-admission.test.ts
@@ -1,0 +1,70 @@
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+import type { DurableAgentSession } from "../src/index";
+
+const FIXTURE_UNFINISHED_TURNS = 20;
+
+describe("managed durable turn admission", () => {
+  it("accepts another turn when more than 16 durable turns are unfinished", async () => {
+    const sessions = (env as unknown as {
+      NANOCODEX_SESSIONS: DurableObjectNamespace<DurableAgentSession>;
+    }).NANOCODEX_SESSIONS;
+    const stub = sessions.getByName(crypto.randomUUID());
+
+    await runInDurableObject(stub, async (session, state) => {
+      const now = Date.now();
+      const retryAt = now + 60_000;
+      state.storage.sql.exec(
+        `INSERT INTO session_state (
+           singleton, session_id, owner_id, organization_id, team_id,
+           authorization_epoch, public_origin, runtime_profile, accepted_turns,
+           completed_turns, first_prompt, last_active
+         ) VALUES (1, ?, ?, ?, ?, 1, ?, 'managed', ?, 0, ?, ?)`,
+        "01992222-2222-7222-8222-222222222222",
+        "fixture-owner",
+        "fixture-organization",
+        "fixture-team",
+        "https://nanocodex.example/",
+        FIXTURE_UNFINISHED_TURNS,
+        "fixture prompt",
+        now,
+      );
+      for (let index = 0; index < FIXTURE_UNFINISHED_TURNS; index += 1) {
+        state.storage.sql.exec(
+          `INSERT INTO managed_turns (
+             id, request_key, request_hash, input_json, authorization_json,
+             state, accepted_cursor, may_have_inner_operation, attempt_count,
+             retry_at, created_at, accepted_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, 'accepted', 0, 0, 1, ?, ?, ?, ?)`,
+          `fixture-${index}`,
+          `fixture-${index}`,
+          `hash-${index}`,
+          JSON.stringify(`fixture prompt ${index}`),
+          JSON.stringify({ capabilities: [] }),
+          retryAt,
+          now - FIXTURE_UNFINISHED_TURNS + index,
+          now - FIXTURE_UNFINISHED_TURNS + index,
+          now,
+        );
+      }
+
+      const response = await session.fetch(new Request("https://session.internal/turns", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: "accepted-beyond-sixteen", input: "queued prompt" }),
+      }));
+      const body = await response.json<{ error?: string; state?: string; turn_id?: string }>();
+
+      expect(response.status).toBe(202);
+      expect(body).toMatchObject({
+        state: "accepted",
+        turn_id: "accepted-beyond-sixteen",
+      });
+      expect(body.error).not.toBe("turn_queue_full");
+      expect(state.storage.sql.exec<{ count: number }>(
+        "SELECT COUNT(*) AS count FROM managed_turns WHERE state IN ('accepted', 'cancelling')",
+      ).one().count).toBe(FIXTURE_UNFINISHED_TURNS + 1);
+    });
+  });
+});

--- a/js/managed/test/turn-completion.test.ts
+++ b/js/managed/test/turn-completion.test.ts
@@ -193,6 +193,48 @@ describe("managed cancellation projection", () => {
     });
   });
 
+  it("reconciles Rust's exact already-terminal ambiguity after cancellation was accepted", () => {
+    const resolution = classifyTurnFailure(
+      "turn-already-terminal",
+      new Error("the targeted turn has already completed or been cancelled"),
+    );
+
+    expect(resolution).toEqual({
+      kind: "terminal",
+      terminal: {
+        type: "turn_failed",
+        id: "turn-already-terminal",
+        error: "the targeted turn has already completed or been cancelled",
+      },
+      reopenAgent: false,
+    });
+    expect(managedControlTransitionForResolution(
+      "turn-already-terminal",
+      true,
+      resolution,
+    )).toEqual({
+      type: "turn_cancelled",
+      id: "turn-already-terminal",
+    });
+  });
+
+  it("does not terminally reconcile the same ambiguity without an accepted cancellation", () => {
+    const resolution = classifyTurnFailure(
+      "turn-not-cancelling",
+      new Error("the targeted turn has already completed or been cancelled"),
+    );
+
+    expect(managedControlTransitionForResolution(
+      "turn-not-cancelling",
+      false,
+      resolution,
+    )).toEqual({
+      type: "turn_failed",
+      id: "turn-not-cancelling",
+      error: "the targeted turn has already completed or been cancelled",
+    });
+  });
+
   it("does not mistake a control-path terminal classification for the turn result", () => {
     expect(managedControlTransitionForResolution("turn-control", true, {
       kind: "terminal",

--- a/js/managed/wrangler.jsonc
+++ b/js/managed/wrangler.jsonc
@@ -15,11 +15,12 @@
     "logs": {
       "enabled": true,
       "head_sampling_rate": 1,
-      "invocation_logs": false,
+      "invocation_logs": true,
       "persist": true
     },
     "traces": {
-      "enabled": false
+      "enabled": true,
+      "head_sampling_rate": 1
     }
   },
   "services": [

--- a/js/managed/wrangler.test.jsonc
+++ b/js/managed/wrangler.test.jsonc
@@ -7,11 +7,21 @@
   "alias": {
     "node-rsa": "../nanocodex/tools/browser/unsupportedNodeRsa.mjs"
   },
+  "r2_buckets": [
+    {
+      "binding": "NANOCODEX_HISTORY",
+      "bucket_name": "nanocodex-managed-history-test"
+    }
+  ],
   "durable_objects": {
     "bindings": [
       {
         "name": "NANOCODEX_MEMORY",
         "class_name": "MemoryScope"
+      },
+      {
+        "name": "NANOCODEX_SESSIONS",
+        "class_name": "DurableAgentSession"
       }
     ]
   },
@@ -19,6 +29,10 @@
     {
       "tag": "memory-scope-v1",
       "new_sqlite_classes": ["MemoryScope"]
+    },
+    {
+      "tag": "managed-session-v1",
+      "new_sqlite_classes": ["DurableAgentSession"]
     }
   ]
 }

--- a/js/nanocodex-terminal/src/toolPresentation.ts
+++ b/js/nanocodex-terminal/src/toolPresentation.ts
@@ -24,6 +24,8 @@ const TITLE_OVERRIDES: Readonly<Record<string, string>> = {
   sandbox_start_process: "Start process",
 };
 
+const OPAQUE_MACHINE_TOOL = "opaque_machine_tool";
+
 export function presentTool(tool: ToolActivity): ToolPresentation {
   const decodedName = decodeToolName(tool.name, tool.metadata);
   const input = parseDetail(tool.input ?? tool.arguments);
@@ -98,16 +100,13 @@ export function boundedToolDetail(value: string): string {
 
 function decodeToolName(name: string, metadata: unknown): { family: string; sources: string[] } {
   const sources: string[] = [];
-  const metadataName = findMetadataString(metadata, ["tool_name", "toolName"]);
-  const metadataMachine = findMetadataString(metadata, ["machine_name", "machineName"]);
-  let family = metadataName ?? name;
-  if (metadataMachine) sources.push(`Machine ${metadataMachine}`);
-  if (!metadataName && family.startsWith("user_")) {
-    const separator = family.indexOf("_", 5);
-    if (separator > 5 && separator < family.length - 1) {
-      sources.push(`Machine ${family.slice(5, separator)}`);
-      family = family.slice(separator + 1);
-    }
+  const metadataName = metadataString(metadata, ["tool_name", "toolName"]);
+  const metadataMachine = metadataString(metadata, ["machine_name", "machineName"])
+    ?? metadataString(metadata, ["machine_id", "machineId"]);
+  const machineAlias = name.startsWith("user_");
+  let family = metadataName ?? (machineAlias ? OPAQUE_MACHINE_TOOL : name);
+  if (metadataMachine || machineAlias) {
+    sources.push(metadataMachine ? `Machine ${metadataMachine}` : "Machine");
   }
   const mcp = /^mcp__(.+?)__(.+)$/.exec(family);
   if (mcp) {
@@ -124,14 +123,10 @@ function decodeToolName(name: string, metadata: unknown): { family: string; sour
   return { family, sources };
 }
 
-function findMetadataString(value: unknown, keys: readonly string[]): string | undefined {
+function metadataString(value: unknown, keys: readonly string[]): string | undefined {
   if (!isRecord(value)) return undefined;
   for (const key of keys) {
     if (typeof value[key] === "string") return value[key];
-  }
-  for (const nested of Object.values(value)) {
-    const found = findMetadataString(nested, keys);
-    if (found) return found;
   }
   return undefined;
 }
@@ -154,9 +149,15 @@ function toolSource(
 ): string | undefined {
   const resolved = sources.slice();
   if (semanticWrapper && resolved.length === 0) resolved.push("Code mode");
-  const cwd = isRecord(input) ? stringField(input, "cwd") : undefined;
-  if (cwd && (family.startsWith("sandbox_") || family === "exec_command" || resolved[0]?.startsWith("Machine "))) {
-    resolved[0] = `${resolved[0]} · ${compact(cwd)}`;
+  const executionDirectory = isRecord(input)
+    ? family.startsWith("sandbox_")
+      ? stringField(input, "cwd")
+      : family === "exec_command" || resolved[0] === "Machine" || resolved[0]?.startsWith("Machine ")
+        ? stringField(input, "workdir")
+        : undefined
+    : undefined;
+  if (executionDirectory && resolved.length > 0) {
+    resolved[0] = `${resolved[0]} · ${compact(executionDirectory)}`;
   }
   return resolved.length ? resolved.join(" · ") : undefined;
 }
@@ -334,6 +335,7 @@ function parseDetail(value: string | undefined): unknown {
 }
 
 function humanize(value: string): string {
+  if (value === OPAQUE_MACHINE_TOOL) return "Machine tool";
   const words = value
     .replace(/([a-z\d])([A-Z])/g, "$1 $2")
     .replace(/[_-]+/g, " ")

--- a/js/nanocodex-terminal/test/components.test.mjs
+++ b/js/nanocodex-terminal/test/components.test.mjs
@@ -589,7 +589,7 @@ test("subagent and host tools share concise what, where, state, duration, and ou
     {
       id: "local", kind: "tool", tool: {
         callId: "local", name: "exec_command", status: "running",
-        arguments: "pwd", input: JSON.stringify({ cmd: "pwd", cwd: "/repo" }), children: [],
+        arguments: "pwd", input: JSON.stringify({ cmd: "pwd", workdir: "/repo" }), children: [],
       },
     },
     {
@@ -643,6 +643,61 @@ test("subagent and host tools share concise what, where, state, duration, and ou
     .children.some((node) => node.children?.join("") === "2.00 s"));
   assert.equal(renderer.root.findAllByProps({ role: "status" })[0].children.join(""), "Running");
   assert.ok(renderer.root.findAllByType("pre").some((node) => node.children.join("").includes("output_schema")));
+  await act(async () => renderer.unmount());
+});
+
+test("machine aliases use result metadata and stay truthful while provenance is unavailable", async () => {
+  const machineTool = (callId, status, metadata) => ({
+    callId,
+    name: "user_build_agent_exec_command",
+    status,
+    arguments: "pwd",
+    input: JSON.stringify({ cmd: "pwd", workdir: "/repo" }),
+    ...(status === "running" ? {} : { output: JSON.stringify({ exit_code: 1, output: "denied" }) }),
+    ...(metadata === undefined ? {} : { metadata }),
+    children: [],
+  });
+  const entries = [
+    { id: "running", kind: "tool", tool: machineTool("running", "running") },
+    { id: "failed", kind: "tool", tool: machineTool("failed", "failed") },
+    {
+      id: "identified", kind: "tool", tool: machineTool("identified", "failed", {
+        machine_id: "build_agent",
+        tool_name: "exec_command",
+      }),
+    },
+  ];
+  let renderer;
+  await act(async () => {
+    renderer = TestRenderer.create(React.createElement(TerminalTranscriptSurface, {
+      canLoadOlder: false,
+      composer: null,
+      entries,
+      inactiveMessage: "",
+      isLoadingOlder: false,
+      mode: "full",
+      status: "ready",
+      onLoadOlder: async () => false,
+    }), {
+      createNodeMock(element) {
+        return element.type === "div"
+          ? { clientHeight: 300, firstElementChild: null, scrollHeight: 600, scrollTop: 0 }
+          : {};
+      },
+    });
+  });
+
+  assert.deepEqual(renderer.root.findAllByType("strong").map((node) => node.children.join("")), [
+    "Machine tool", "Machine tool", "Run command",
+  ]);
+  assert.deepEqual(renderer.root.findAllByProps({ className: "agent-terminal-tool-source" })
+    .map((node) => node.children.join("")), [
+    "Machine · /repo", "Machine · /repo", "Machine build_agent · /repo",
+  ]);
+  assert.equal(renderer.root.findAllByProps({ className: "agent-terminal-tool-source" })
+    .some((node) => node.children.join("") === "Machine build"), false);
+  assert.equal(renderer.root.findAllByType("code")
+    .filter((node) => node.children.join("") === "user_build_agent_exec_command").length, 3);
   await act(async () => renderer.unmount());
 });
 

--- a/js/nanocodex-tools/package.json
+++ b/js/nanocodex-tools/package.json
@@ -22,6 +22,10 @@
       "types": "./tools/dataset.d.mts",
       "import": "./tools/dataset.mjs"
     },
+    "./execution-contract": {
+      "types": "./tools/execution-contract.d.mts",
+      "import": "./tools/execution-contract.mjs"
+    },
     "./just-bash/browser": {
       "types": "./tools/just-bash-browser.d.mts",
       "import": "./tools/just-bash-browser.mjs"

--- a/js/nanocodex-tools/runtime/utf8.d.mts
+++ b/js/nanocodex-tools/runtime/utf8.d.mts
@@ -1,0 +1,2 @@
+/** Returns the UTF-8 size of a JavaScript string without allocating encoded bytes. */
+export function utf8ByteLength(value: string): number;

--- a/js/nanocodex-tools/src/hosted/broker-core.ts
+++ b/js/nanocodex-tools/src/hosted/broker-core.ts
@@ -12,6 +12,13 @@ import {
   type HostedToolsManagedFrame,
 } from "./protocol.js";
 import { hostedToolCatalogDigest } from "../../tools/hostedCatalog.mjs";
+import {
+  EXEC_COMMAND_PARAMETERS,
+  EXECUTION_OUTPUT_SCHEMA,
+  MACHINE_PREVIEW_PARAMETERS,
+  PREVIEW_OUTPUT_SCHEMA,
+  WRITE_STDIN_PARAMETERS,
+} from "../../tools/execution-contract.mjs";
 
 const SOCKET_TAG = "hosted-tools";
 const INVALID_CONNECT_GRANT_ID = "invalid-connect-grant";
@@ -21,6 +28,12 @@ const MAX_RETAINED_RECEIPTS = 512;
 const MAX_CALLS_PER_GENERATION = 512;
 const TOOL_RESULT = Symbol.for("nanocodex.toolResult");
 const LEGACY_ROUTE_ID = "$legacy";
+export const HOSTED_MACHINE_TOOL_NAMES = Object.freeze([
+  "exec_command",
+  "write_stdin",
+  "preview",
+] as const);
+const MACHINE_TOOL_NAMES: ReadonlySet<string> = new Set(HOSTED_MACHINE_TOOL_NAMES);
 const encoder = new TextEncoder();
 
 /**
@@ -162,6 +175,8 @@ export type HostedToolsCodeTool = Readonly<{
   ): Promise<unknown>;
 }>;
 
+export type HostedMachineToolName = (typeof HOSTED_MACHINE_TOOL_NAMES)[number];
+
 export interface HostedToolsDynamicProvider {
   definitions(): readonly HostedToolsCodeDefinition[];
   resolve(name: string): HostedToolsCodeTool | undefined;
@@ -267,7 +282,7 @@ export class HostedToolsBrokerCore {
       // only the current attached definitions, which stay deferred and can be
       // overlaid onto exact cloud contracts by that router.
       definitions: () => {
-        return this.#catalogBindings()
+        return this.#publicCatalogBindings()
           .filter((binding) => this.#entryAllowed(
             binding.entry,
             binding.connectGrantId,
@@ -285,51 +300,7 @@ export class HostedToolsBrokerCore {
           prepared.connectGrantId,
           prepared.appToolCatalogDigest,
         )) return undefined;
-        return Object.freeze({
-          name,
-          parallelSafe: prepared.entry.parallel_safe,
-          provider: prepared.entry.provider,
-          remoteName: prepared.entry.remote_name,
-          summary: prepared.entry.summary,
-          timeoutMs: prepared.entry.timeout_ms,
-          handler: async (
-            input: unknown,
-            context: { sessionId: string; callId: string; model?: string; signal?: AbortSignal },
-          ) => {
-            if (!this.#entryAllowed(
-              prepared.entry,
-              prepared.connectGrantId,
-              prepared.appToolCatalogDigest,
-            )) {
-              return toolResult("Hosted tool is outside the active grant", {
-                status: "unavailable",
-                message: "Hosted tool is outside the active grant",
-              }, false, null);
-            }
-            const outcome = await prepared.invoke({
-              sessionId: context.sessionId,
-              callId: context.callId,
-              model: context.model ?? "unknown",
-              input: input as Record<string, unknown> | string,
-              outputTokenBudget: 10_000,
-              ...(context.signal === undefined ? {} : { signal: context.signal }),
-            });
-            if (outcome.status === "completed") {
-              return wireToolResult(
-                outcome.output,
-                prepared.canonicalName,
-                prepared.machine,
-              );
-            }
-            const result = toolResult(outcome.message, outcome, false, null);
-            return outcome[HOSTED_TOOLS_PRE_ADMISSION_UNAVAILABLE] === true
-              ? Object.freeze({
-                  ...(result as Record<PropertyKey, unknown>),
-                  [HOSTED_TOOLS_PRE_ADMISSION_UNAVAILABLE]: true,
-                })
-              : result;
-          },
-        });
+        return this.#codeTool(name, prepared);
       },
       setCatalogValidator: (validator: HostedToolsCatalogValidator | undefined) => {
         this.#catalogValidator = validator;
@@ -358,6 +329,22 @@ export class HostedToolsBrokerCore {
   hasPendingCalls(): boolean { return this.#pending.size > 0; }
 
   provider(): HostedToolsDynamicProvider { return this.#provider; }
+
+  /** Resolves one canonical machine primitive against its exact admitted attachment generation. */
+  machineTool(machineId: string, name: HostedMachineToolName): HostedToolsCodeTool | undefined {
+    if (!MACHINE_TOOL_NAMES.has(name)) return undefined;
+    const binding = this.#catalogBindings().find((candidate) => (
+      candidate.machine?.id === machineId && candidate.wireName === name
+    ));
+    if (!binding) return undefined;
+    const prepared = this.#preparedTool(binding);
+    if (!this.#entryAllowed(
+      prepared.entry,
+      prepared.connectGrantId,
+      prepared.appToolCatalogDigest,
+    )) return undefined;
+    return this.#codeTool(name, prepared);
+  }
 
   /** Returns the live, non-secret user-machine snapshot for the account-owned host. */
   machines(): readonly HostedMachine[] {
@@ -548,7 +535,10 @@ export class HostedToolsBrokerCore {
     } satisfies HostedToolsSocketAttachment;
     this.context.writeAttachment(socket, candidate);
     const catalogJson = JSON.stringify(frame.tools);
-    const candidateEntries = frame.tools.map((entry) => exposedEntry(entry, frame.machines?.[0]));
+    const machine = frame.machines?.[0];
+    const candidateEntries = frame.tools
+      .filter((entry) => !reservedMachineEntry(entry, machine))
+      .map((entry) => exposedEntry(entry, machine));
     const candidateDefinitions = candidateEntries.map((entry) => Object.freeze({
       ...entry,
       definition: Object.freeze({
@@ -564,6 +554,7 @@ export class HostedToolsBrokerCore {
         && (frame.machines?.length !== 1 || frame.attachment_id !== frame.machines[0]?.id)) {
         throw new Error("an account machine route requires one machine whose id equals attachment_id");
       }
+      if (machine !== undefined) validateMachineToolContracts(frame.tools);
       if (initial.allowedMcpIds !== undefined) {
         if (!isConnectGrantId(initial.connectGrantId)) {
           throw new Error("Connect tool host is missing its exact grant binding");
@@ -587,7 +578,7 @@ export class HostedToolsBrokerCore {
           throw new Error("the app-local tool catalog does not match the signed Connect grant");
         }
       }
-      const otherBindings = this.#catalogBindings(routeId, true);
+      const otherBindings = this.#publicCatalogBindings(routeId, true);
       const exposedNames = new Set(otherBindings.map((binding) => binding.entry.definition.name));
       const duplicateTool = candidateEntries.find((entry) => exposedNames.has(entry.definition.name));
       if (duplicateTool) {
@@ -753,12 +744,17 @@ export class HostedToolsBrokerCore {
   }
 
   #definitions(): readonly HostedToolsProviderDefinition[] {
-    return this.#catalogBindings().map((binding) => binding.entry);
+    return this.#publicCatalogBindings().map((binding) => binding.entry);
   }
 
   #resolve(name: string): HostedToolsPreparedTool | undefined {
-    const binding = this.#catalogBindings().find((candidate) => candidate.entry.definition.name === name);
+    const binding = this.#publicCatalogBindings()
+      .find((candidate) => candidate.entry.definition.name === name);
     if (!binding) return undefined;
+    return this.#preparedTool(binding);
+  }
+
+  #preparedTool(binding: HostedToolsCatalogBinding): HostedToolsPreparedTool {
     return Object.freeze({
       ...(binding.connectGrantId === undefined ? {} : { connectGrantId: binding.connectGrantId }),
       ...(binding.appToolCatalogDigest === undefined
@@ -768,6 +764,54 @@ export class HostedToolsBrokerCore {
       ...(binding.machine === undefined ? {} : { machine: binding.machine }),
       entry: binding.entry,
       invoke: (request: HostedToolsInvokeRequest) => this.#invoke(binding, request),
+    });
+  }
+
+  #codeTool(name: string, prepared: HostedToolsPreparedTool): HostedToolsCodeTool {
+    return Object.freeze({
+      name,
+      parallelSafe: prepared.entry.parallel_safe,
+      provider: prepared.entry.provider,
+      remoteName: prepared.entry.remote_name,
+      summary: prepared.entry.summary,
+      timeoutMs: prepared.entry.timeout_ms,
+      handler: async (
+        input: unknown,
+        context: { sessionId: string; callId: string; model?: string; signal?: AbortSignal },
+      ) => {
+        if (!this.#entryAllowed(
+          prepared.entry,
+          prepared.connectGrantId,
+          prepared.appToolCatalogDigest,
+        )) {
+          return toolResult("Hosted tool is outside the active grant", {
+            status: "unavailable",
+            message: "Hosted tool is outside the active grant",
+          }, false, null);
+        }
+        const outcome = await prepared.invoke({
+          sessionId: context.sessionId,
+          callId: context.callId,
+          model: context.model ?? "unknown",
+          input: input as Record<string, unknown> | string,
+          outputTokenBudget: 10_000,
+          ...(context.signal === undefined ? {} : { signal: context.signal }),
+        });
+        if (outcome.status === "completed") {
+          return wireToolResult(
+            outcome.output,
+            prepared.canonicalName,
+            prepared.machine,
+          );
+        }
+        const result = toolResult(outcome.message, outcome, false, null);
+        return outcome[HOSTED_TOOLS_PRE_ADMISSION_UNAVAILABLE] === true
+          ? Object.freeze({
+              ...(result as Record<PropertyKey, unknown>),
+              [HOSTED_TOOLS_PRE_ADMISSION_UNAVAILABLE]: true,
+            })
+          : result;
+      },
     });
   }
 
@@ -1149,6 +1193,14 @@ export class HostedToolsBrokerCore {
     return bindings.filter((binding) => counts.get(binding.entry.definition.name) === 1);
   }
 
+  #publicCatalogBindings(
+    excludeRouteId?: string,
+    includeAmbiguous = false,
+  ): HostedToolsCatalogBinding[] {
+    return this.#catalogBindings(excludeRouteId, includeAmbiguous)
+      .filter((binding) => !reservedMachineBinding(binding));
+  }
+
   #machineIds(excludeRouteId?: string): string[] {
     const ids: string[] = [];
     for (const state of this.#sortedStates()) {
@@ -1189,6 +1241,105 @@ function emptyState(routeId: string): HostedToolsStateRow {
 
 function scopedRouteId(connectGrantId: string | undefined, attachmentId: string | undefined): string {
   return `${connectGrantId === undefined ? "user" : "connect"}:${attachmentId ?? LEGACY_ROUTE_ID}`;
+}
+
+function reservedMachineEntry(
+  entry: HostedToolCatalogEntry,
+  machine: HostedMachine | undefined,
+): boolean {
+  return machine !== undefined && MACHINE_TOOL_NAMES.has(entry.definition.name);
+}
+
+function reservedMachineBinding(binding: HostedToolsCatalogBinding): boolean {
+  return binding.machine !== undefined && MACHINE_TOOL_NAMES.has(binding.wireName);
+}
+
+function validateMachineToolContracts(entries: readonly HostedToolCatalogEntry[]): void {
+  for (const entry of entries) {
+    const name = entry.definition.name;
+    if (!MACHINE_TOOL_NAMES.has(name)) continue;
+    if (entry.definition.type !== "function") {
+      throw new Error(`machine tool ${name} must use its canonical function schema`);
+    }
+    switch (name) {
+      case "exec_command":
+        validateCanonicalObjectSchema(name, entry.definition.parameters, EXEC_COMMAND_PARAMETERS);
+        validateCanonicalObjectSchema(
+          `${name} output`,
+          entry.definition.output_schema,
+          EXECUTION_OUTPUT_SCHEMA,
+        );
+        break;
+      case "write_stdin":
+        validateCanonicalObjectSchema(name, entry.definition.parameters, WRITE_STDIN_PARAMETERS);
+        validateCanonicalObjectSchema(
+          `${name} output`,
+          entry.definition.output_schema,
+          EXECUTION_OUTPUT_SCHEMA,
+        );
+        break;
+      case "preview":
+        validateCanonicalObjectSchema(name, entry.definition.parameters, MACHINE_PREVIEW_PARAMETERS);
+        validateCanonicalObjectSchema(
+          `${name} output`,
+          entry.definition.output_schema,
+          PREVIEW_OUTPUT_SCHEMA,
+        );
+        break;
+    }
+  }
+}
+
+function validateCanonicalObjectSchema(
+  label: string,
+  schema: Record<string, unknown> | undefined,
+  canonical: Readonly<Record<string, unknown>>,
+): void {
+  const properties = objectRecord(canonical.properties);
+  const required = canonical.required;
+  if (properties === undefined || !Array.isArray(required)) {
+    throw new Error(`invalid canonical machine tool schema for ${label}`);
+  }
+  const propertyTypes = Object.fromEntries(Object.entries(properties).map(([name, property]) => {
+    const type = objectRecord(property)?.type;
+    if (typeof type !== "string") throw new Error(`invalid canonical type for ${label}.${name}`);
+    return [name, type];
+  }));
+  validateObjectSchema(label, schema, required as string[], propertyTypes);
+}
+
+function validateObjectSchema(
+  label: string,
+  schema: Record<string, unknown> | undefined,
+  required: readonly string[],
+  propertyTypes: Readonly<Record<string, string>>,
+): void {
+  const properties = objectRecord(schema?.properties);
+  const actualRequired = schema?.required;
+  if (schema?.type !== "object"
+    || schema?.additionalProperties !== false
+    || properties === undefined
+    || !Array.isArray(actualRequired)
+    || actualRequired.some((value) => typeof value !== "string")
+    || !sameStrings(actualRequired as string[], required)
+    || !sameStrings(Object.keys(properties), Object.keys(propertyTypes))) {
+    throw new Error(`machine tool ${label} must use its canonical object schema`);
+  }
+  for (const [property, type] of Object.entries(propertyTypes)) {
+    if (objectRecord(properties[property])?.type !== type) {
+      throw new Error(`machine tool ${label}.${property} must use canonical type ${type}`);
+    }
+  }
+}
+
+function objectRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function sameStrings(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value) => right.includes(value));
 }
 
 function exposedEntry(entry: HostedToolCatalogEntry, machine: HostedMachine | undefined): HostedToolCatalogEntry {

--- a/js/nanocodex-tools/src/index.ts
+++ b/js/nanocodex-tools/src/index.ts
@@ -20,9 +20,11 @@ export {
   createWorkspaceFilesystem,
   type WorkspaceStorageClient,
 } from "./workspace.js";
+export * from "./namespace.js";
 export * from "./memory.js";
 export * from "./hosted/index.js";
 export { namedTool } from "../tools/namedTool.mjs";
+export * from "../tools/execution-contract.mjs";
 export * from "../tools/artifact.mjs";
 export { dataset } from "../tools/dataset.mjs";
 export type { DatasetOptions } from "../tools/dataset.mjs";

--- a/js/nanocodex-tools/src/namespace.ts
+++ b/js/nanocodex-tools/src/namespace.ts
@@ -1,0 +1,469 @@
+import { utf8ByteLength } from "../runtime/utf8.mjs";
+
+export const MAX_NAMESPACE_MOUNTS = 64;
+export const MAX_NAMESPACE_GRANTS = 128;
+export const MAX_NAMESPACE_PATH_BYTES = 4_096;
+export const MAX_NAMESPACE_PATH_SEGMENTS = 256;
+export const MAX_NAMESPACE_SEGMENT_BYTES = 255;
+export const MAX_NAMESPACE_ID_BYTES = 256;
+
+export const NAMESPACE_RIGHTS = Object.freeze([
+  "namespace.discover",
+  "filesystem.read",
+  "filesystem.write",
+  "process.exec",
+  "process.stdin",
+  "network.preview",
+] as const);
+
+export type NamespaceRight = (typeof NAMESPACE_RIGHTS)[number];
+
+declare const namespaceIdentityBrand: unique symbol;
+export type NamespaceIdentity = string & {
+  readonly [namespaceIdentityBrand]: "NamespaceIdentity";
+};
+
+export type NamespaceMountInput = Readonly<{
+  root: string;
+  mountId: string;
+  handId: string;
+  exportId: string;
+  generation: string;
+  rights: readonly NamespaceRight[];
+}>;
+
+export type NamespaceManifestInput = Readonly<{
+  manifestId: string;
+  mounts: readonly NamespaceMountInput[];
+}>;
+
+export type NamespaceMount = Readonly<{
+  root: string;
+  mountId: NamespaceIdentity;
+  handId: NamespaceIdentity;
+  exportId: NamespaceIdentity;
+  generation: NamespaceIdentity;
+  rights: readonly NamespaceRight[];
+}>;
+
+export type NamespaceManifest = Readonly<{
+  manifestId: NamespaceIdentity;
+  mounts: readonly NamespaceMount[];
+}>;
+
+export type NamespaceGrant = Readonly<{
+  mountId: NamespaceIdentity;
+  path: string;
+  rights: readonly NamespaceRight[];
+}>;
+
+export type NamespaceScope = Readonly<{
+  manifest: NamespaceManifest;
+  defaultCwd: string;
+  grants: readonly NamespaceGrant[];
+}>;
+
+export type NamespaceAttenuation = Readonly<{
+  mountId: string;
+  path?: string;
+  rights?: readonly NamespaceRight[];
+}>;
+
+export type NamespaceRoute = Readonly<{
+  cwd: string;
+  relativePath: string;
+  mount: NamespaceMount;
+  rights: readonly NamespaceRight[];
+}>;
+
+export class NamespaceError extends Error {
+  constructor(
+    readonly code:
+      | "invalid_manifest"
+      | "invalid_path"
+      | "invalid_scope"
+      | "access_denied"
+      | "no_execution_root",
+    message: string,
+  ) {
+    super(message);
+    this.name = "NamespaceError";
+  }
+}
+
+const PORTABLE_ROOT = /^[a-z0-9](?:[a-z0-9._-]{0,61}[a-z0-9])?$/;
+const WINDOWS_DEVICE_ROOT = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/;
+const CONTROL_CHARACTER = /[\u0000-\u001f\u007f]/;
+const HASH_UTF8 = new TextEncoder();
+const RESERVED_ROOTS = new Set([
+  ".nanocodex",
+  "dev",
+  "proc",
+  "tmp",
+]);
+const RESERVED_HAND_ROOTS = new Set([
+  ...RESERVED_ROOTS,
+  "brain",
+  "sandbox",
+]);
+const RIGHT_SET: ReadonlySet<string> = new Set(NAMESPACE_RIGHTS);
+const admittedManifests = new WeakSet<object>();
+const admittedScopes = new WeakSet<object>();
+
+/**
+ * Admits and snapshots a mount table. Calling this function is an authority
+ * boundary: later APIs only preserve or attenuate mounts admitted here.
+ */
+export function createNamespaceManifest(input: NamespaceManifestInput): NamespaceManifest {
+  if (!isRecord(input) || !Array.isArray(input.mounts)) {
+    throw new NamespaceError("invalid_manifest", "namespace manifest must contain a mounts array");
+  }
+  if (input.mounts.length === 0 || input.mounts.length > MAX_NAMESPACE_MOUNTS) {
+    throw new NamespaceError(
+      "invalid_manifest",
+      `namespace manifest must contain 1 to ${MAX_NAMESPACE_MOUNTS} mounts`,
+    );
+  }
+
+  const manifestId = parseIdentity(input.manifestId, "manifestId");
+  const roots = new Set<string>();
+  const mountIds = new Set<string>();
+  const mounts = input.mounts.map((candidate, index) => {
+    if (!isRecord(candidate)) {
+      throw new NamespaceError("invalid_manifest", `mount ${index} must be an object`);
+    }
+    const root = parseMountRoot(candidate.root, index);
+    if (roots.has(root)) {
+      throw new NamespaceError("invalid_manifest", `duplicate mount root ${root}`);
+    }
+    roots.add(root);
+
+    const mountId = parseIdentity(candidate.mountId, `mount ${root} mountId`);
+    if (mountIds.has(mountId)) {
+      throw new NamespaceError("invalid_manifest", `duplicate mount identity for ${root}`);
+    }
+    mountIds.add(mountId);
+
+    return Object.freeze({
+      root,
+      mountId,
+      handId: parseIdentity(candidate.handId, `mount ${root} handId`),
+      exportId: parseIdentity(candidate.exportId, `mount ${root} exportId`),
+      generation: parseIdentity(candidate.generation, `mount ${root} generation`),
+      rights: parseRights(candidate.rights, `mount ${root}`),
+    });
+  });
+
+  // Canonical ordering makes the same admitted mapping stable regardless of
+  // discovery order. Routing never consults display or host names.
+  mounts.sort((left, right) => left.root.localeCompare(right.root, "en"));
+  const manifest = Object.freeze({ manifestId, mounts: Object.freeze(mounts) });
+  admittedManifests.add(manifest);
+  return manifest;
+}
+
+/** Derives a deterministic portable mount root from an opaque machine identity. */
+export function namespaceMountRoot(machineId: string): string {
+  if (typeof machineId !== "string" || machineId.length === 0) {
+    throw new TypeError("machine identity must be a non-empty string");
+  }
+  const exact = machineId.toLowerCase();
+  if (exact === machineId
+    && PORTABLE_ROOT.test(exact)
+    && !WINDOWS_DEVICE_ROOT.test(exact)
+    && !RESERVED_HAND_ROOTS.has(exact)) {
+    return `/${exact}`;
+  }
+  const slug = exact.replace(/[^a-z0-9._-]+/g, "-").replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, "")
+    .slice(0, 48) || "hand";
+  return `/hand-${slug}-${stableHash(machineId).slice(0, 8)}`;
+}
+
+/** Resolves an absolute logical path without consulting the host filesystem. */
+export function normalizeNamespacePath(path: string): string {
+  return normalizePath(path, undefined);
+}
+
+/** Resolves an optional workdir against a captured, absolute default cwd. */
+export function resolveNamespaceCwd(defaultCwd: string, workdir?: string): string {
+  const base = normalizeNamespacePath(defaultCwd);
+  if (workdir === undefined || workdir === "") return base;
+  return normalizePath(workdir, base);
+}
+
+/** Component-aware containment; lexical siblings such as /host2 never match /host. */
+export function isNamespacePathWithin(path: string, parent: string): boolean {
+  const normalizedPath = normalizeNamespacePath(path);
+  const normalizedParent = normalizeNamespacePath(parent);
+  return pathWithinNormalized(normalizedPath, normalizedParent);
+}
+
+/** Returns the longest component-boundary mount match, if one exists. */
+export function resolveNamespaceMount(
+  manifest: NamespaceManifest,
+  path: string,
+): NamespaceMount | undefined {
+  assertManifest(manifest);
+  const normalized = normalizeNamespacePath(path);
+  let match: NamespaceMount | undefined;
+  for (const mount of manifest.mounts) {
+    if (pathWithinNormalized(normalized, mount.root)
+      && (match === undefined || mount.root.length > match.root.length)) {
+      match = mount;
+    }
+  }
+  return match;
+}
+
+/** Creates the root scope with every right present in the admitted manifest. */
+export function createNamespaceScope(
+  manifest: NamespaceManifest,
+  defaultCwd: string,
+): NamespaceScope {
+  assertManifest(manifest);
+  const cwd = normalizeNamespacePath(defaultCwd);
+  const grants = manifest.mounts.map((mount) => Object.freeze({
+    mountId: mount.mountId,
+    path: mount.root,
+    rights: mount.rights,
+  }));
+  return admitScope(manifest, cwd, grants);
+}
+
+/**
+ * Creates a child snapshot. Omitted attenuation inherits exactly; supplied
+ * entries may only remove mounts, narrow paths, or remove rights.
+ */
+export function deriveChildNamespaceScope(
+  parent: NamespaceScope,
+  attenuation?: readonly NamespaceAttenuation[],
+): NamespaceScope {
+  assertScope(parent);
+  if (attenuation === undefined) {
+    return admitScope(parent.manifest, parent.defaultCwd, parent.grants);
+  }
+  if (!Array.isArray(attenuation) || attenuation.length > MAX_NAMESPACE_GRANTS) {
+    throw new NamespaceError(
+      "invalid_scope",
+      `child namespace may contain at most ${MAX_NAMESPACE_GRANTS} grants`,
+    );
+  }
+
+  const grants: NamespaceGrant[] = [];
+  const keys = new Set<string>();
+  for (const [index, request] of attenuation.entries()) {
+    if (!isRecord(request)) {
+      throw new NamespaceError("invalid_scope", `attenuation ${index} must be an object`);
+    }
+    const mountId = parseIdentity(request.mountId, `attenuation ${index} mountId`);
+    const mount = parent.manifest.mounts.find((candidate) => candidate.mountId === mountId);
+    if (mount === undefined) {
+      throw new NamespaceError("access_denied", "attenuation references an inaccessible mount");
+    }
+    if (request.path !== undefined && typeof request.path !== "string") {
+      throw new NamespaceError("invalid_scope", `attenuation ${index} path must be a string`);
+    }
+    const path = request.path === undefined
+      ? mount.root
+      : resolveNamespaceCwd(mount.root, request.path);
+    if (!pathWithinNormalized(path, mount.root)) {
+      throw new NamespaceError("access_denied", "attenuation path escapes its mount");
+    }
+
+    const available = effectiveRights(parent, mountId, path);
+    const rights = request.rights === undefined
+      ? available
+      : parseRights(request.rights, `attenuation ${index}`);
+    if (rights.some((right) => !available.includes(right))) {
+      throw new NamespaceError("access_denied", "child namespace rights exceed its parent scope");
+    }
+    const key = `${mountId}\u0000${path}`;
+    if (keys.has(key)) {
+      throw new NamespaceError("invalid_scope", "duplicate child namespace grant");
+    }
+    keys.add(key);
+    grants.push(Object.freeze({ mountId, path, rights }));
+  }
+
+  // Scope construction happens only after every requested grant is validated.
+  // Therefore an inaccessible inherited cwd rejects the whole derivation.
+  return admitScope(parent.manifest, parent.defaultCwd, grants);
+}
+
+/** Resolves and authorizes a cwd for process routing on its owning hand. */
+export function routeNamespaceCwd(
+  scope: NamespaceScope,
+  workdir?: string,
+  requiredRight: NamespaceRight = "process.exec",
+): NamespaceRoute {
+  assertScope(scope);
+  assertRight(requiredRight, "required right");
+  const cwd = resolveNamespaceCwd(scope.defaultCwd, workdir);
+  const mount = resolveNamespaceMount(scope.manifest, cwd);
+  if (mount === undefined) {
+    throw new NamespaceError("no_execution_root", `no mount owns namespace cwd ${cwd}`);
+  }
+  const rights = effectiveRights(scope, mount.mountId, cwd);
+  if (!rights.includes(requiredRight)) {
+    throw new NamespaceError("access_denied", `namespace cwd ${cwd} lacks ${requiredRight}`);
+  }
+  const relativePath = cwd === mount.root ? "/" : cwd.slice(mount.root.length);
+  return Object.freeze({ cwd, relativePath, mount, rights });
+}
+
+function admitScope(
+  manifest: NamespaceManifest,
+  defaultCwd: string,
+  sourceGrants: readonly NamespaceGrant[],
+): NamespaceScope {
+  const grants = Object.freeze(sourceGrants.map((grant) => Object.freeze({
+    mountId: grant.mountId,
+    path: grant.path,
+    rights: grant.rights,
+  })));
+  if (grants.length === 0 || !grants.some((grant) => pathWithinNormalized(defaultCwd, grant.path))) {
+    throw new NamespaceError("access_denied", "child namespace cannot access its inherited cwd");
+  }
+  const scope = Object.freeze({ manifest, defaultCwd, grants });
+  admittedScopes.add(scope);
+  return scope;
+}
+
+function effectiveRights(
+  scope: NamespaceScope,
+  mountId: NamespaceIdentity,
+  path: string,
+): readonly NamespaceRight[] {
+  const rights = new Set<NamespaceRight>();
+  for (const grant of scope.grants) {
+    if (grant.mountId === mountId && pathWithinNormalized(path, grant.path)) {
+      for (const right of grant.rights) rights.add(right);
+    }
+  }
+  return Object.freeze(NAMESPACE_RIGHTS.filter((right) => rights.has(right)));
+}
+
+function normalizePath(path: string, base: string | undefined): string {
+  if (typeof path !== "string") {
+    throw new NamespaceError("invalid_path", "namespace path must be a string");
+  }
+  assertByteLimit(path, MAX_NAMESPACE_PATH_BYTES, "namespace path", "invalid_path");
+  if (CONTROL_CHARACTER.test(path) || path.includes("\\")) {
+    throw new NamespaceError("invalid_path", "namespace path contains a non-portable character");
+  }
+  const absolute = path.startsWith("/");
+  if (!absolute && base === undefined) {
+    throw new NamespaceError("invalid_path", "namespace path must be absolute");
+  }
+  const parts = absolute ? [] : splitNormalizedBase(base!);
+  for (const part of path.split("/")) {
+    if (part === "" || part === ".") continue;
+    if (part === "..") {
+      if (parts.length === 0) {
+        throw new NamespaceError("invalid_path", "namespace path escapes logical root");
+      }
+      parts.pop();
+      continue;
+    }
+    assertByteLimit(part, MAX_NAMESPACE_SEGMENT_BYTES, "namespace path segment", "invalid_path");
+    parts.push(part);
+    if (parts.length > MAX_NAMESPACE_PATH_SEGMENTS) {
+      throw new NamespaceError(
+        "invalid_path",
+        `namespace path exceeds ${MAX_NAMESPACE_PATH_SEGMENTS} segments`,
+      );
+    }
+  }
+  const normalized = parts.length === 0 ? "/" : `/${parts.join("/")}`;
+  assertByteLimit(normalized, MAX_NAMESPACE_PATH_BYTES, "normalized namespace path", "invalid_path");
+  return normalized;
+}
+
+function splitNormalizedBase(base: string): string[] {
+  return base === "/" ? [] : base.slice(1).split("/");
+}
+
+function pathWithinNormalized(path: string, parent: string): boolean {
+  return parent === "/" || path === parent || path.startsWith(`${parent}/`);
+}
+
+function parseMountRoot(value: unknown, index: number): string {
+  if (typeof value !== "string" || !value.startsWith("/")) {
+    throw new NamespaceError("invalid_manifest", `mount ${index} root must be absolute`);
+  }
+  const normalized = normalizeNamespacePath(value);
+  const name = normalized.slice(1);
+  if (RESERVED_ROOTS.has(name)) {
+    throw new NamespaceError("invalid_manifest", `mount root ${value} is reserved`);
+  }
+  if (!PORTABLE_ROOT.test(name) || normalized !== value || WINDOWS_DEVICE_ROOT.test(name)) {
+    throw new NamespaceError("invalid_manifest", `mount root ${value} is not a portable top-level root`);
+  }
+  return normalized;
+}
+
+function parseIdentity(value: unknown, label: string): NamespaceIdentity {
+  if (typeof value !== "string" || value.length === 0 || value.trim() !== value
+    || CONTROL_CHARACTER.test(value)) {
+    throw new NamespaceError("invalid_manifest", `${label} must be a non-empty opaque identity`);
+  }
+  assertByteLimit(value, MAX_NAMESPACE_ID_BYTES, label, "invalid_manifest");
+  return value as NamespaceIdentity;
+}
+
+function parseRights(value: unknown, label: string): readonly NamespaceRight[] {
+  if (!Array.isArray(value) || value.length === 0 || value.length > NAMESPACE_RIGHTS.length) {
+    throw new NamespaceError("invalid_manifest", `${label} must contain a bounded non-empty rights set`);
+  }
+  const rights = new Set<NamespaceRight>();
+  for (const right of value) {
+    assertRight(right, label);
+    if (rights.has(right)) {
+      throw new NamespaceError("invalid_manifest", `${label} contains a duplicate right`);
+    }
+    rights.add(right);
+  }
+  return Object.freeze(NAMESPACE_RIGHTS.filter((right) => rights.has(right)));
+}
+
+function assertRight(value: unknown, label: string): asserts value is NamespaceRight {
+  if (typeof value !== "string" || !RIGHT_SET.has(value)) {
+    throw new NamespaceError("invalid_manifest", `${label} contains an unsupported namespace right`);
+  }
+}
+
+function assertManifest(value: NamespaceManifest): void {
+  if (!isRecord(value) || !admittedManifests.has(value)) {
+    throw new NamespaceError("invalid_manifest", "namespace manifest was not admitted by this runtime");
+  }
+}
+
+function assertScope(value: NamespaceScope): void {
+  if (!isRecord(value) || !admittedScopes.has(value)) {
+    throw new NamespaceError("invalid_scope", "namespace scope was not admitted by this runtime");
+  }
+}
+
+function assertByteLimit(
+  value: string,
+  maximum: number,
+  label: string,
+  code: "invalid_manifest" | "invalid_path",
+): void {
+  if (utf8ByteLength(value) > maximum) {
+    throw new NamespaceError(code, `${label} exceeds ${maximum} UTF-8 bytes`);
+  }
+}
+
+function stableHash(value: string): string {
+  let hash = 0xcbf29ce484222325n;
+  for (const byte of HASH_UTF8.encode(value)) {
+    hash ^= BigInt(byte);
+    hash = BigInt.asUintN(64, hash * 0x100000001b3n);
+  }
+  return hash.toString(16).padStart(16, "0");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/js/nanocodex-tools/test/namespace.test.mjs
+++ b/js/nanocodex-tools/test/namespace.test.mjs
@@ -1,0 +1,228 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createNamespaceManifest,
+  createNamespaceScope,
+  deriveChildNamespaceScope,
+  isNamespacePathWithin,
+  MAX_NAMESPACE_MOUNTS,
+  namespaceMountRoot,
+  normalizeNamespacePath,
+  resolveNamespaceCwd,
+  resolveNamespaceMount,
+  routeNamespaceCwd,
+} from "nanocodex-tools";
+
+const allRights = [
+  "namespace.discover",
+  "filesystem.read",
+  "filesystem.write",
+  "process.exec",
+  "process.stdin",
+  "network.preview",
+];
+
+function manifest() {
+  return createNamespaceManifest({
+    manifestId: "manifest:stable-snapshot",
+    mounts: [
+      {
+        root: "/laptop",
+        mountId: "mount:opaque-laptop",
+        handId: "hand:opaque-a",
+        exportId: "export:opaque-a",
+        generation: "generation:a:7",
+        rights: allRights,
+      },
+      {
+        root: "/buildbox",
+        mountId: "mount:opaque-buildbox",
+        handId: "hand:opaque-b",
+        exportId: "export:opaque-b",
+        generation: "generation:b:2",
+        rights: ["namespace.discover", "filesystem.read", "process.exec"],
+      },
+    ],
+  });
+}
+
+test("manifests are canonical immutable snapshots with opaque stable mappings", () => {
+  const input = {
+    manifestId: "manifest:one",
+    mounts: [{
+      root: "/zeta",
+      mountId: "mount:z",
+      handId: "hand:z",
+      exportId: "export:z",
+      generation: "generation:1",
+      rights: ["process.exec"],
+    }, {
+      root: "/alpha",
+      mountId: "mount:a",
+      handId: "hand:a",
+      exportId: "export:a",
+      generation: "generation:9",
+      rights: ["filesystem.read", "process.exec"],
+    }],
+  };
+  const snapshot = createNamespaceManifest(input);
+
+  assert.deepEqual(snapshot.mounts.map(({ root }) => root), ["/alpha", "/zeta"]);
+  assert.ok(Object.isFrozen(snapshot));
+  assert.ok(Object.isFrozen(snapshot.mounts));
+  assert.ok(snapshot.mounts.every(Object.isFrozen));
+  assert.ok(snapshot.mounts.every(({ rights }) => Object.isFrozen(rights)));
+  input.mounts[1].handId = "hand:replaced";
+  input.mounts[1].rights.push("filesystem.write");
+  assert.equal(snapshot.mounts[0].handId, "hand:a");
+  assert.deepEqual(snapshot.mounts[0].rights, ["filesystem.read", "process.exec"]);
+  assert.throws(() => { snapshot.mounts[0].root = "/renamed"; }, TypeError);
+});
+
+test("manifest admission rejects root ambiguity, aliases, reserved roots, and bounds", () => {
+  const mount = (root, mountId = `mount:${root}`) => ({
+    root,
+    mountId,
+    handId: `hand:${root}`,
+    exportId: `export:${root}`,
+    generation: "generation:1",
+    rights: ["process.exec"],
+  });
+  const make = (mounts) => createNamespaceManifest({ manifestId: "manifest:test", mounts });
+
+  for (const root of ["/.nanocodex", "/dev", "/proc", "/tmp"])
+    assert.throws(() => make([mount(root)]), /reserved/);
+  assert.doesNotThrow(() => make([mount("/brain"), mount("/sandbox")]));
+  for (const root of ["laptop", "/a/b", "/UPPER", "/two words", "/con", "/a/../b", "/a\\b"])
+    assert.throws(() => make([mount(root)]), /root|path/);
+  assert.throws(() => make([mount("/one"), mount("/one", "mount:two")]), /duplicate mount root/);
+  assert.throws(() => make([mount("/one", "same"), mount("/two", "same")]), /duplicate mount identity/);
+  assert.throws(
+    () => make(Array.from({ length: MAX_NAMESPACE_MOUNTS + 1 }, (_, index) => mount(`/m${index}`))),
+    /1 to 64 mounts/,
+  );
+});
+
+test("machine identities receive deterministic portable non-system roots", () => {
+  assert.equal(namespaceMountRoot("laptop"), "/laptop");
+  assert.match(namespaceMountRoot("Build Box"), /^\/hand-build-box-[0-9a-f]{8}$/);
+  assert.match(namespaceMountRoot("sandbox"), /^\/hand-sandbox-/);
+  assert.match(namespaceMountRoot("con"), /^\/hand-con-/);
+  assert.equal(namespaceMountRoot("Build Box"), namespaceMountRoot("Build Box"));
+  assert.throws(() => namespaceMountRoot(""), /non-empty/);
+});
+
+test("normalization resolves cwd and rejects traversal and host-dependent separators", () => {
+  assert.equal(normalizeNamespacePath("//laptop/./repo///src/../test"), "/laptop/repo/test");
+  assert.equal(resolveNamespaceCwd("/laptop/repo/src", "../test"), "/laptop/repo/test");
+  assert.equal(resolveNamespaceCwd("/laptop/repo", "/buildbox/work"), "/buildbox/work");
+  assert.equal(resolveNamespaceCwd("/laptop/repo", ""), "/laptop/repo");
+  assert.throws(() => normalizeNamespacePath("relative/path"), /must be absolute/);
+  assert.throws(() => normalizeNamespacePath("/../../escape"), /escapes logical root/);
+  assert.throws(() => normalizeNamespacePath("/laptop/evil\0path"), /non-portable/);
+  assert.throws(() => normalizeNamespacePath("/laptop\\..\\buildbox"), /non-portable/);
+  assert.equal(normalizeNamespacePath("/laptop/%2e%2e/buildbox"), "/laptop/%2e%2e/buildbox");
+});
+
+test("mount resolution uses segment boundaries and retains the admitted identity", () => {
+  const snapshot = manifest();
+  const laptop = resolveNamespaceMount(snapshot, "/laptop/repo");
+  assert.equal(laptop.mountId, "mount:opaque-laptop");
+  assert.equal(laptop.generation, "generation:a:7");
+  assert.equal(resolveNamespaceMount(snapshot, "/laptop2/repo"), undefined);
+  assert.equal(resolveNamespaceMount(snapshot, "/"), undefined);
+  assert.equal(isNamespacePathWithin("/laptop/repo", "/laptop"), true);
+  assert.equal(isNamespacePathWithin("/laptop2/repo", "/laptop"), false);
+});
+
+test("cwd routing is stable, relative, right-checked, and never inferred from names", () => {
+  const snapshot = manifest();
+  const scope = createNamespaceScope(snapshot, "/laptop/repo");
+  const route = routeNamespaceCwd(scope, "src/../test");
+  assert.deepEqual({
+    cwd: route.cwd,
+    relativePath: route.relativePath,
+    mountId: route.mount.mountId,
+    generation: route.mount.generation,
+  }, {
+    cwd: "/laptop/repo/test",
+    relativePath: "/repo/test",
+    mountId: "mount:opaque-laptop",
+    generation: "generation:a:7",
+  });
+  assert.ok(Object.isFrozen(route));
+
+  const readOnly = deriveChildNamespaceScope(scope, [{
+    mountId: "mount:opaque-buildbox",
+    path: "/buildbox/repo",
+    rights: ["filesystem.read"],
+  }, {
+    mountId: "mount:opaque-laptop",
+    path: "/laptop/repo",
+    rights: ["filesystem.read"],
+  }]);
+  assert.throws(() => routeNamespaceCwd(readOnly), /lacks process.exec/);
+  assert.equal(routeNamespaceCwd(readOnly, undefined, "filesystem.read").mount.handId, "hand:opaque-a");
+  assert.throws(
+    () => routeNamespaceCwd({
+      manifest: snapshot,
+      defaultCwd: "/laptop/repo",
+      grants: [{ mountId: "mount:opaque-laptop", path: "/laptop", rights: allRights }],
+    }),
+    /scope was not admitted/,
+  );
+});
+
+test("children and grandchildren can only attenuate identity, subtree, and rights", () => {
+  const parent = createNamespaceScope(manifest(), "/laptop/repo");
+  const child = deriveChildNamespaceScope(parent, [{
+    mountId: "mount:opaque-laptop",
+    path: "repo",
+    rights: ["filesystem.read", "process.exec"],
+  }]);
+  assert.ok(Object.isFrozen(child));
+  assert.ok(Object.isFrozen(child.grants));
+  assert.deepEqual(child.grants[0].rights, ["filesystem.read", "process.exec"]);
+  assert.equal(routeNamespaceCwd(child, "src").cwd, "/laptop/repo/src");
+  assert.throws(() => routeNamespaceCwd(child, "/laptop/other"), /lacks process.exec/);
+  assert.throws(() => deriveChildNamespaceScope(child, [{
+    mountId: "mount:opaque-laptop",
+    path: "/laptop",
+    rights: ["filesystem.read"],
+  }]), /exceed|inherited cwd/);
+  assert.throws(() => deriveChildNamespaceScope(child, [{
+    mountId: "mount:opaque-laptop",
+    path: "/laptop/repo",
+    rights: ["filesystem.write"],
+  }]), /exceed/);
+  assert.throws(() => deriveChildNamespaceScope(child, [{
+    mountId: "mount:opaque-buildbox",
+    path: "/buildbox",
+    rights: ["filesystem.read"],
+  }]), /exceed|inherited cwd/);
+
+  assert.throws(() => deriveChildNamespaceScope(child, [{
+    mountId: "mount:opaque-laptop",
+    path: "/laptop/repo/src",
+    rights: ["filesystem.read"],
+  }]), /inherited cwd/);
+});
+
+test("attenuation rejects an inaccessible inherited cwd atomically", () => {
+  const parent = createNamespaceScope(manifest(), "/laptop/repo");
+  assert.throws(() => deriveChildNamespaceScope(parent, []), /inherited cwd/);
+  assert.throws(() => deriveChildNamespaceScope(parent, [{
+    mountId: "mount:opaque-buildbox",
+    path: "/buildbox/project",
+    rights: ["filesystem.read"],
+  }]), /inherited cwd/);
+  assert.throws(() => deriveChildNamespaceScope(parent, [{
+    mountId: "/laptop",
+    rights: ["process.exec"],
+  }]), /inaccessible mount/);
+
+  const inherited = deriveChildNamespaceScope(parent);
+  assert.notEqual(inherited, parent);
+  assert.equal(routeNamespaceCwd(inherited).mount.mountId, "mount:opaque-laptop");
+});

--- a/js/nanocodex-tools/tools/bash.mjs
+++ b/js/nanocodex-tools/tools/bash.mjs
@@ -1,4 +1,8 @@
 import { namedTool } from "./namedTool.mjs";
+import {
+  EXEC_COMMAND_PARAMETERS,
+  EXECUTION_OUTPUT_SCHEMA,
+} from "./execution-contract.mjs";
 
 const DEFAULT_EXECUTION_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_ENTRIES = 2_000;
@@ -9,38 +13,6 @@ const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
 const DEVICES = new Set(["/dev/full", "/dev/null", "/dev/stderr", "/dev/stdout"]);
-
-const EXEC_PARAMETERS = Object.freeze({
-  type: "object",
-  properties: {
-    cmd: { type: "string", description: "Shell command to execute." },
-    justification: { type: "string", description: "User-facing approval question for `require_escalated`; omit otherwise." },
-    workdir: { type: "string", description: "Working directory for the command. Defaults to the turn cwd." },
-    shell: { type: "string", description: "Shell binary to launch. Defaults to the user's default shell." },
-    login: { type: "boolean", description: "True runs the shell with -l/-i semantics; false disables them. Defaults to true." },
-    tty: { type: "boolean", description: "True allocates a PTY for the command; false or omitted uses plain pipes." },
-    yield_time_ms: { type: "number", description: "Wait before yielding output. Defaults to 10000 ms; effective range is 250-30000 ms." },
-    max_output_tokens: { type: "number", description: "Output token budget. Defaults to 10000 tokens; larger requests may be capped by policy." },
-    prefix_rule: { type: "array", items: { type: "string" }, description: "Reusable approval prefix for `cmd`, only with `sandbox_permissions: \"require_escalated\"`; for example [\"git\", \"pull\"]." },
-    sandbox_permissions: { type: "string", enum: ["use_default", "require_escalated"], description: "Per-command sandbox override. Defaults to `use_default`; use `require_escalated` for unsandboxed execution." },
-  },
-  required: ["cmd"],
-  additionalProperties: false,
-});
-
-const EXEC_OUTPUT = Object.freeze({
-  type: "object",
-  properties: {
-    chunk_id: { type: "string", description: "Chunk identifier included when the response reports one." },
-    wall_time_seconds: { type: "number", description: "Elapsed wall time spent waiting for output in seconds." },
-    exit_code: { type: "number", description: "Process exit code when the command finished during this call." },
-    session_id: { type: "number", description: "Session identifier to pass to write_stdin when the process is still running." },
-    original_token_count: { type: "number", description: "Approximate token count before output truncation." },
-    output: { type: "string", description: "Command output text, possibly truncated." },
-  },
-  required: ["wall_time_seconds", "output"],
-  additionalProperties: false,
-});
 
 export async function justBash(options) {
   if (!options || typeof options !== "object" || Array.isArray(options)) {
@@ -161,8 +133,8 @@ export async function createJustBashRuntime(options) {
       ? {}
       : { supportsParallelToolCalls: options.supportsParallelToolCalls }),
     description: "Runs a shell command, returning output or a session ID for ongoing interaction.",
-    parameters: EXEC_PARAMETERS,
-    outputSchema: EXEC_OUTPUT,
+    parameters: EXEC_COMMAND_PARAMETERS,
+    outputSchema: EXECUTION_OUTPUT_SCHEMA,
     handler(input, context) {
       const execute = () => executeCommand({
         bash,

--- a/js/nanocodex-tools/tools/execution-contract.d.mts
+++ b/js/nanocodex-tools/tools/execution-contract.d.mts
@@ -1,0 +1,5 @@
+export const EXEC_COMMAND_PARAMETERS: Readonly<Record<string, unknown>>;
+export const WRITE_STDIN_PARAMETERS: Readonly<Record<string, unknown>>;
+export const EXECUTION_OUTPUT_SCHEMA: Readonly<Record<string, unknown>>;
+export const MACHINE_PREVIEW_PARAMETERS: Readonly<Record<string, unknown>>;
+export const PREVIEW_OUTPUT_SCHEMA: Readonly<Record<string, unknown>>;

--- a/js/nanocodex-tools/tools/execution-contract.mjs
+++ b/js/nanocodex-tools/tools/execution-contract.mjs
@@ -1,0 +1,63 @@
+export const EXEC_COMMAND_PARAMETERS = Object.freeze({
+  type: "object",
+  properties: {
+    cmd: { type: "string", description: "Shell command to execute." },
+    justification: { type: "string", description: "User-facing approval question for `require_escalated`; omit otherwise." },
+    workdir: { type: "string", description: "Working directory for the command." },
+    shell: { type: "string", description: "Shell binary to launch. Defaults to the selected hand's shell." },
+    login: { type: "boolean", description: "True runs with login-shell semantics when supported." },
+    tty: { type: "boolean", description: "True allocates a PTY when supported." },
+    yield_time_ms: { type: "number", description: "Wait before yielding output. Defaults to 10000 ms." },
+    max_output_tokens: { type: "number", description: "Output token budget. Defaults to 10000 tokens." },
+    prefix_rule: { type: "array", items: { type: "string" }, description: "Reusable approval prefix for `require_escalated`." },
+    sandbox_permissions: { type: "string", enum: ["use_default", "require_escalated"], description: "Per-command sandbox policy request." },
+  },
+  required: ["cmd"],
+  additionalProperties: false,
+});
+
+export const WRITE_STDIN_PARAMETERS = Object.freeze({
+  type: "object",
+  properties: {
+    session_id: { type: "number", description: "Session identifier returned by exec_command." },
+    chars: { type: "string", description: "Characters to write; omit or pass an empty string to poll." },
+    yield_time_ms: { type: "number", description: "Wait before yielding more output." },
+    max_output_tokens: { type: "number", description: "Output token budget." },
+  },
+  required: ["session_id"],
+  additionalProperties: false,
+});
+
+export const EXECUTION_OUTPUT_SCHEMA = Object.freeze({
+  type: "object",
+  properties: {
+    chunk_id: { type: "string", description: "Chunk identifier included when the response reports one." },
+    wall_time_seconds: { type: "number", description: "Elapsed wall time spent waiting for output in seconds." },
+    exit_code: { type: "number", description: "Process exit code when the command finished during this call." },
+    session_id: { type: "number", description: "Session identifier to pass to write_stdin when the process is still running." },
+    original_token_count: { type: "number", description: "Approximate token count before output truncation." },
+    output: { type: "string", description: "Command output text, possibly truncated." },
+  },
+  required: ["wall_time_seconds", "output"],
+  additionalProperties: false,
+});
+
+export const MACHINE_PREVIEW_PARAMETERS = Object.freeze({
+  type: "object",
+  properties: {
+    port: { type: "integer", minimum: 1024, maximum: 65_535, not: { const: 3_000 } },
+  },
+  required: ["port"],
+  additionalProperties: false,
+});
+
+export const PREVIEW_OUTPUT_SCHEMA = Object.freeze({
+  type: "object",
+  properties: {
+    port: { type: "integer" },
+    url: { type: "string" },
+    persistent: { type: "boolean" },
+  },
+  required: ["port", "url", "persistent"],
+  additionalProperties: false,
+});

--- a/js/nanocodex/managed/Agent.d.mts
+++ b/js/nanocodex/managed/Agent.d.mts
@@ -130,10 +130,8 @@ export type Capabilities = Readonly<{
   live_steer: true;
   live_cancel: true;
   workspace: "cloudflare-computer";
-  /** Explicit sandbox_* tools expose one separate, agent-owned Linux hand. */
-  sandbox_tools: true;
-  /** Legacy compatibility field; the brain's shell does not fall through automatically. */
-  sandbox_escalation: boolean;
+  /** Tools can target explicit sandbox and connected-user environments. */
+  execution_environments: true;
 }>;
 
 export type State = Readonly<{

--- a/js/nanocodex/managed/Agent.d.mts
+++ b/js/nanocodex/managed/Agent.d.mts
@@ -132,6 +132,10 @@ export type Capabilities = Readonly<{
   workspace: "cloudflare-computer";
   /** Tools can target explicit sandbox and connected-user environments. */
   execution_environments: true;
+  /** Canonical commands select an execution hand from the root of their logical cwd. */
+  execution_namespace: "cwd-root-v1";
+  /** Native processes cannot yet access peer mounts through filesystem syscalls. */
+  native_cross_mounts: false;
 }>;
 
 export type State = Readonly<{

--- a/js/nanocodex/test/managed-agent.test.mjs
+++ b/js/nanocodex/test/managed-agent.test.mjs
@@ -305,8 +305,7 @@ test("managed Agent covers account-scoped create, list, get, and delete", async 
   assert.equal((await Agent.get(agentId, options)).id, agentId);
   const state = await created.state();
   assert.equal(state.latest_event_cursor, "4");
-  assert.equal(state.capabilities.sandbox_tools, true);
-  assert.equal(state.capabilities.sandbox_escalation, false);
+  assert.equal(state.capabilities.execution_environments, true);
   await created.delete();
   await Agent.delete(agentId, options);
 
@@ -1789,8 +1788,7 @@ function agentState() {
       live_steer: true,
       live_cancel: true,
       workspace: "cloudflare-computer",
-      sandbox_tools: true,
-      sandbox_escalation: false,
+      execution_environments: true,
     },
     latest_event_cursor: "4",
     stream_error: null,

--- a/js/nanocodex/test/managed-agent.test.mjs
+++ b/js/nanocodex/test/managed-agent.test.mjs
@@ -306,6 +306,8 @@ test("managed Agent covers account-scoped create, list, get, and delete", async 
   const state = await created.state();
   assert.equal(state.latest_event_cursor, "4");
   assert.equal(state.capabilities.execution_environments, true);
+  assert.equal(state.capabilities.execution_namespace, "cwd-root-v1");
+  assert.equal(state.capabilities.native_cross_mounts, false);
   await created.delete();
   await Agent.delete(agentId, options);
 
@@ -1789,6 +1791,8 @@ function agentState() {
       live_cancel: true,
       workspace: "cloudflare-computer",
       execution_environments: true,
+      execution_namespace: "cwd-root-v1",
+      native_cross_mounts: false,
     },
     latest_event_cursor: "4",
     stream_error: null,

--- a/js/nanocodex/test/managed-types.test-d.mts
+++ b/js/nanocodex/test/managed-types.test-d.mts
@@ -17,8 +17,7 @@ const capabilities: Capabilities = {
   live_steer: true,
   live_cancel: true,
   workspace: "cloudflare-computer",
-  sandbox_tools: true,
-  sandbox_escalation: false,
+  execution_environments: true,
 };
 void capabilities;
 

--- a/js/nanocodex/test/managed-types.test-d.mts
+++ b/js/nanocodex/test/managed-types.test-d.mts
@@ -18,6 +18,8 @@ const capabilities: Capabilities = {
   live_cancel: true,
   workspace: "cloudflare-computer",
   execution_environments: true,
+  execution_namespace: "cwd-root-v1",
+  native_cross_mounts: false,
 };
 void capabilities;
 


### PR DESCRIPTION
## Summary

- treat the durable managed Agent as the brain and expose its live hands through `accountInfo().machines`
- give each account-owned brain one lazy retained Cloudflare sandbox with explicit `sandbox_*` tools; Just Bash remains its existing brain-owned scratch shell
- let Hosted Tools publish a bounded, immutable snapshot of zero or more user machines, including each machine's name, workspace, and capabilities
- update user-machine topology on attach, replacement, disconnect, drain, and lease expiry without rebuilding the managed Agent
- tell the model to refresh `accountInfo` immediately before placement decisions, and omit live topology from retained prompt context
- remove the old named-workspace fabric and shell fallback approach entirely

## Boundaries

- machine metadata is non-secret, strictly validated, and retained only in the active WebSocket attachment
- Connect-grant hosts cannot publish account machines; sandbox tools and topology are available only to account-owned turns
- sandbox creation is lazy, keyed to the durable session, and agent deletion destroys both the sandbox and its retained R2 workspace
- one Hosted Tools attachment publishes the complete snapshot for the user machines behind that host; topology changes replace that snapshot atomically

## Verification

- `pnpm --filter nanocodex-tools test` — 2 passed
- `pnpm --filter nanocodex test` — 480 runtime/contract tests, 4 performance checks, type/package checks passed
- `pnpm --filter nanocodex-managed-service check` — 131 tests, typecheck, Wrangler dry-run, and sandbox container build passed
- `pnpm --filter nanocodex-web build` — typecheck, production Vite build, and docs check passed
- canonical local browser journey passed: attach and route a browser hand, drain/refuse, reconnect, fence a stale host, and observe no page errors
- live `accountInfo` changed from `sandbox,user:browser` to `sandbox` when the browser hand disconnected, without restarting the brain
- a real managed turn lazily started the Cloudflare sandbox and returned `sandbox-hand-ok` from `sandbox_exec`
