### PR TITLE
fix(account): recover abandoned MCP OAuth after reload

### DIFF
--- a/js/account/package.json
+++ b/js/account/package.json
@@ -13,7 +13,7 @@
     "sync": "node scripts/sync-nanocodex.mjs",
     "publish:repository": "node scripts/publish-repository.mjs",
     "test": "npm run test:web",
-    "test:web": "node --experimental-strip-types --test worker/*.test.ts",
+    "test:web": "node --experimental-strip-types --test src/*.test.ts worker/*.test.ts",
     "typecheck": "tsc --noEmit",
     "check:docs": "node scripts/check-docs.mjs",
     "gen:types": "wrangler types",

--- a/js/account/src/ProfileConnectors.tsx
+++ b/js/account/src/ProfileConnectors.tsx
@@ -30,6 +30,7 @@ import {
   isCallbackCompletionState,
   type CallbackCompletion,
 } from "nanocodex-connect-protocol";
+import { mcpOauthAttemptMode } from "./mcpOauthAttempt";
 
 type AccountConnectorCapability = Exclude<ConnectorCapability, "chatgpt">;
 type AccountConnectorProvider = Exclude<ConnectorProvider, "chatgpt">;
@@ -149,7 +150,7 @@ export function ProfileConnectors({
     if (attempt.popupClosed !== undefined) window.clearTimeout(attempt.popupClosed);
     if (closePopup && attempt.popup && !attempt.popup.closed) attempt.popup.close();
     if (attempt.state) clearPendingMcpAttempt(accountId, attempt.state);
-    setOperation(null);
+    if (mcpOauthAttemptMode(attempt) === "blocking") setOperation(null);
     return true;
   }, [accountId]);
 
@@ -316,7 +317,9 @@ export function ProfileConnectors({
       state: pending.state,
     };
     activeMcp.current = attempt;
-    setOperation(connection.id);
+    // Keep consuming this exact callback state after reload without claiming
+    // the page-wide fence: no popup handle survived to prove work is active.
+    if (mcpOauthAttemptMode(attempt) === "blocking") setOperation(connection.id);
     attempt.disposeCompletion = observePopupCallback({
       connector: mcpCompletionIdentifier(connection.id),
       origin: window.location.origin,
@@ -513,7 +516,9 @@ export function ProfileConnectors({
   };
 
   const connectMcp = async (connection: McpConnection) => {
-    if (operation || activeMcp.current || !mcpConnectionCanAuthorize(connection.status)) return;
+    if (operation
+      || mcpOauthAttemptMode(activeMcp.current) === "blocking"
+      || !mcpConnectionCanAuthorize(connection.status)) return;
     const popup = window.open(
       "about:blank",
       "nanocodex-account-mcp",
@@ -524,6 +529,11 @@ export function ProfileConnectors({
         id: connection.id,
         message: "The MCP authorization popup was blocked. Allow popups and try again.",
       });
+      return;
+    }
+    const recoverable = activeMcp.current;
+    if (recoverable && !finishMcpAttempt(recoverable, false)) {
+      popup.close();
       return;
     }
     const attempt: McpAttempt = {

--- a/js/account/src/mcpOauthAttempt.test.ts
+++ b/js/account/src/mcpOauthAttempt.test.ts
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { mcpOauthAttemptMode } from "./mcpOauthAttempt.ts";
+
+test("only a live MCP OAuth popup owns the account action fence", () => {
+  assert.equal(mcpOauthAttemptMode(undefined), "idle");
+  assert.equal(mcpOauthAttemptMode({ popup: {} }), "blocking");
+  assert.equal(mcpOauthAttemptMode({}), "recoverable");
+});

--- a/js/account/src/mcpOauthAttempt.ts
+++ b/js/account/src/mcpOauthAttempt.ts
@@ -1,0 +1,12 @@
+export type McpOauthAttemptMode = "idle" | "blocking" | "recoverable";
+
+/**
+ * Describes whether an MCP OAuth attempt owns the account-page action fence.
+ * A live attempt has a popup handle; a restored continuation does not.
+ */
+export function mcpOauthAttemptMode(
+  attempt: Readonly<{ popup?: unknown }> | undefined,
+): McpOauthAttemptMode {
+  if (!attempt) return "idle";
+  return attempt.popup === undefined ? "recoverable" : "blocking";
+}

--- a/js/nanocodex-connect-ui/test/popupCallback.test.mjs
+++ b/js/nanocodex-connect-ui/test/popupCallback.test.mjs
@@ -65,6 +65,38 @@ test("consumes a persisted same-origin completion after listener reload", () => 
   assert.equal(runtime.localStorage.getItem(key), null);
 });
 
+test("a replacement observer cannot be settled by the abandoned attempt state", () => {
+  const runtime = new FakeRuntime();
+  const connector = `mcp:${"m".repeat(43)}`;
+  const abandoned = {
+    connector,
+    origin: runtime.location.origin,
+    state: "a".repeat(43),
+  };
+  const replacement = {
+    ...abandoned,
+    state: "r".repeat(43),
+  };
+  const received = [];
+  const disposeAbandoned = observePopupCallback(
+    abandoned,
+    (value) => received.push(value),
+    runtime,
+  );
+  const abandonedChannel = FakeBroadcastChannel.channels.get(
+    `nanocodex-oauth-completion-${abandoned.state}`,
+  );
+  disposeAbandoned();
+  observePopupCallback(replacement, (value) => received.push(value), runtime);
+  abandonedChannel.emit(callbackCompletion({ ...abandoned, result: "success" }));
+  FakeBroadcastChannel.channels.get(
+    `nanocodex-oauth-completion-${replacement.state}`,
+  ).emit(callbackCompletion({ ...replacement, result: "success" }));
+  assert.deepEqual(received, [
+    callbackCompletion({ ...replacement, result: "success" }),
+  ]);
+});
+
 test("rejects a subscriber origin outside the current same-origin transport", () => {
   assert.throws(() => observePopupCallback({
     connector: "github",


### PR DESCRIPTION
A restored MCP OAuth continuation has no popup handle, so it cannot legitimately own the account page action fence. Previously it disabled every connector control until stale state cleanup.

This keeps the exact-state completion observer across reload, makes the restored attempt recoverable, and allows a retry to atomically replace it without accepting the abandoned state. Live popup attempts remain fenced.

Verified under Node 24: account 49/49; Connect UI 15/15 plus build/typecheck; real Linear start/close/reload/retry with callback-state rotation and exact-state completion.