### PR TITLE
fix(ci): build account protocol before tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,8 @@ jobs:
           path: js/nanocodex/pkg-web
       - name: Install JavaScript workspace
         run: pnpm install --frozen-lockfile
+      - name: Build account Worker dependencies
+        run: pnpm exec turbo run build --filter nanocodex-connect-protocol
       - name: Test the account Worker
         run: pnpm --filter nanocodex-web run test:web
       - name: Build JavaScript apps


### PR DESCRIPTION
## Root cause

The JavaScript apps job runs the account Worker tests immediately after pnpm install. The linked nanocodex-connect-protocol package exports dist/index.mjs, but a clean install does not build that output, so two Worker test files fail with ERR_MODULE_NOT_FOUND before the later apps build step.

## Fix

Run the protocol package's Turbo-owned build, including its dependency graph, before the account Worker tests.

## Verification

- Reproduced the clean-checkout failure under Node 24.20.0
- Protocol Turbo build (forced cache miss)
- Account Worker test suite: 49/49 passed
- Exact JavaScript apps Turbo build: 6/6 passed
- actionlint v1.7.7
- typos v1.48.0
- git diff --check