### PR TITLE
fix(deploy): build managed workspace dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,13 @@
   `https://<branch>.nanocodex.localhost`. The paired playground is
   `https://playground.nanocodex.localhost` or
   `https://<branch>.playground.nanocodex.localhost`. With a high
-  `PORTLESS_PORT`, append that port to each URL. Deploy from
-  the root with `pnpm deploy:<component>`; deploy dependencies first and
-  `pnpm deploy:account` last.
+  `PORTLESS_PORT`, append that port to each URL. Deploy from the root, in order,
+  with `pnpm deploy:egress`, `pnpm deploy:managed`,
+  `pnpm deploy:connect-dialog`, `pnpm deploy:connect-api`,
+  `pnpm deploy:chief-of-staff`, `pnpm deploy:connect-playground`, and
+  `pnpm deploy:account`. Each component script must build its complete workspace
+  dependency graph from a clean checkout; do not manually prebuild omitted
+  packages.
 - pnpm owns the JavaScript workspace, Turbo owns task concurrency and build
   caching, Portless owns local names and ports, and Vite/Wrangler own runtime.
 - Do not add custom stack, deploy, test, rollout, probe, or verification wrappers.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
     "deploy:egress": "pnpm --filter nanocodex-egress-service run deploy:broker",
-    "deploy:managed": "pnpm --filter nanocodex-tools run build && pnpm --filter nanocodex-vite run build:wasm && pnpm --filter nanocodex-managed-service run deploy",
+    "deploy:managed": "turbo run build --filter=nanocodex-managed-service && pnpm --filter nanocodex-managed-service run deploy",
     "deploy:connect-dialog": "turbo run build --filter=@nanocodex/connect-dialog && pnpm --filter @nanocodex/connect-dialog run deploy",
     "deploy:connect-api": "turbo run build --filter=@nanocodex/connect-api && pnpm --filter @nanocodex/connect-api run deploy",
     "deploy:chief-of-staff": "pnpm --filter @nanocodex/chief-of-staff run deploy",


### PR DESCRIPTION
## Summary

- build the managed Worker's complete Turbo dependency graph before local Wrangler deployment
- document the canonical dependency-first local deployment order

## Why

A clean-checkout `pnpm deploy:managed` failed before upload because the hand-maintained prebuild list omitted `nanocodex-connect-protocol/dist/index.mjs`.

## Verification

- fresh worktree `pnpm install --frozen-lockfile`
- Node 24 `pnpm exec turbo run build --filter=nanocodex-managed-service` (4/4 tasks passed, including Wrangler dry-run)
- exact root `pnpm deploy:managed` completed and produced managed version `f41fbbe5-6823-4356-b512-fcb762d8d717`
- `git diff --check`
- locally deployed exact master in dependency order and verified account/Connect/Chief of Staff public health and UI routes
