### PR TITLE
Replace passkey login with managed SMS OTP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,14 @@ OPENAI_API_KEY=
 # TWILIO_AUTH_TOKEN=
 # TWILIO_VERIFY_SERVICE_SID=VA...
 
+# Production nanocodex-egress deployments require a base64url-encoded 32-byte
+# vault key. It encrypts provider credentials and persistent account root
+# wallets at rest; configure it as a Worker secret or Secrets Store binding,
+# never as browser or Vite configuration. Local development uses a fixed,
+# development-only key when this is unset.
+# CREDENTIAL_ENCRYPTION_KEY=
+# CREDENTIAL_ENCRYPTION_KEY_PREVIOUS=
+
 # Optional CLI defaults; the eval YAML pins these explicitly.
 # OPENAI_REASONING_EFFORT=low
 

--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,14 @@
 # Required by `just run` and model-backed Harbor evals.
 OPENAI_API_KEY=
 
-# Managed account SMS OTP. Set the HMAC key and either bind NANOCODEX_SMS_SEND
-# to an SMS delivery Worker or configure Twilio Messaging with these secrets.
+# Managed account SMS OTP through Twilio Verify. Verify generates, delivers,
+# and checks six-digit codes, with automatic RCS upgrade where supported.
 # NANOCODEX_OTP_HMAC_KEY=
-# TWILIO_ACCOUNT_SID=
+# TWILIO_ACCOUNT_SID=AC...
+# TWILIO_API_KEY_SID=SK...
+# TWILIO_API_KEY_SECRET=
 # TWILIO_AUTH_TOKEN=
-# TWILIO_FROM_NUMBER=+15551234567
+# TWILIO_VERIFY_SERVICE_SID=VA...
 
 # Optional CLI defaults; the eval YAML pins these explicitly.
 # OPENAI_REASONING_EFFORT=low

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,13 @@
 # Required by `just run` and model-backed Harbor evals.
 OPENAI_API_KEY=
 
+# Managed account SMS OTP. Set the HMAC key and either bind NANOCODEX_SMS_SEND
+# to an SMS delivery Worker or configure Twilio Messaging with these secrets.
+# NANOCODEX_OTP_HMAC_KEY=
+# TWILIO_ACCOUNT_SID=
+# TWILIO_AUTH_TOKEN=
+# TWILIO_FROM_NUMBER=+15551234567
+
 # Optional CLI defaults; the eval YAML pins these explicitly.
 # OPENAI_REASONING_EFFORT=low
 

--- a/docs/MANAGED_LOGIN.md
+++ b/docs/MANAGED_LOGIN.md
@@ -36,7 +36,9 @@ operation for CI, curl, or another machine.
 
 The device envelope still uses Tempo Accounts/Wata `wallet_connect`; this is an
 RPC transport name, not the login mechanism. Nanocodex account login is a
-first-party SMS OTP flow owned by the managed Cloudflare Worker.
+first-party SMS OTP flow owned by the managed Cloudflare Worker. For a
+persistent SMS account, the root signer is the account's custodial Worker-owned
+wallet, not a browser wallet.
 
 ## End-to-end flow
 
@@ -53,8 +55,9 @@ first-party SMS OTP flow owned by the managed Cloudflare Worker.
 3. **Prepare the requested authorization.** A non-MPP request includes
    `urn:nanocodex:authorization:hosted`, allowing Connect to approve hosted
    authority without returning or persisting a key. An explicit MPP request is
-   a separate stronger-auth ceremony: it omits this marker, prepares a local
-   Tempo access key, and requires the signed access-key result.
+   a separate access-key ceremony: it omits this marker, prepares a delegated
+   Tempo access key, and requires the Worker-root-signed access-key result. The
+   delegated key may be returned to the installation; the root key never is.
 
 4. **Register a device authorization.** The CLI starts a Wata device-code
    exchange containing one `wallet_connect` RPC request. The request declares
@@ -76,10 +79,12 @@ first-party SMS OTP flow owned by the managed Cloudflare Worker.
 6. **Establish the Nanocodex account.** The user enters an E.164 phone number
    and a six-digit code delivered by Twilio Verify over SMS or eligible RCS.
    Verify generates and checks the code. The managed Worker binds only an HMAC
-   digest of the phone to the account and issues the same HttpOnly account
-   session used by managed agents. A new phone promotes only the current
-   anonymous browser account; a known phone restores its existing agents,
-   memory, and connections.
+   digest of the phone to the account and provisions the persistent account's
+   root wallet through private egress before issuing the same HttpOnly account
+   session used by managed agents. Wallet provisioning is idempotent and a
+   failure leaves the local challenge retryable. A new phone promotes only the
+   current anonymous browser account; a known phone restores its existing
+   agents, memory, connections, and wallet address.
 
 7. **Run the focused action.** The browser derives its work from the signed
    `wallet_connect` request:
@@ -109,8 +114,11 @@ first-party SMS OTP flow owned by the managed Cloudflare Worker.
    final browser view is the completed installation CTA. The embedded
    `/connect-dialog` approval remains explicit.
 
-9. **Return the explicit Accounts result.** Nanocodex Connect submits the approved
-   `wallet_connect` result to the Wata device-code host. The CLI polls with PKCE
+9. **Return the explicit Accounts result.** For access-key mode, Nanocodex
+   Connect asks the account-authenticated managed Worker to sign the exact
+   `wallet_connect` request; egress uses the account root and returns only a
+   sanitized result. Nanocodex Connect submits the approved result to the Wata
+   device-code host. The CLI polls with PKCE
    and receives exactly one account. The result is either the existing signed
    access-key authorization or a hosted authorization containing a 43-character
    one-time approval identifier and `mode: "hosted"`. The CLI accepts hosted
@@ -153,10 +161,10 @@ first-party SMS OTP flow owned by the managed Cloudflare Worker.
 - The managed Cloudflare Worker owns HMAC phone identity, local abuse limits,
   browser-bound challenges, account sessions, and the one-time hosted
   authorization. Twilio Verify owns OTP generation, delivery, attempt limits,
-  expiry, and checking.
-  Tempo Accounts/Wata owns the device-code transport, PKCE exchange,
-  `wallet_connect` envelope, and the explicit signed access-key step-up used
-  for MPP.
+  expiry, and checking. Tempo Accounts/Wata owns the device-code transport and
+  PKCE exchange. The private egress broker owns persistent SMS-account root
+  wallets and signs only bounded `wallet_connect` access-key authorizations and
+  `wallet_revokeAccessKey` operations.
 - The Worker retains each browser challenge for five minutes, enforces a
   60-second resend delay, and caps starts per phone and Cloudflare client IP.
   The Verify Service must use six-digit codes with a validity window compatible
@@ -166,8 +174,13 @@ first-party SMS OTP flow owned by the managed Cloudflare Worker.
   resources, account linking, connector onboarding, consent UI, and scoped
   grant.
 - The private egress broker exclusively owns hosted ChatGPT, OpenAI, and other
-  provider credentials. Agent actors and CLI clients retain only opaque
-  subjects or scoped grants.
+  provider credentials and persistent account root private keys. Agent actors
+  and CLI clients retain only opaque subjects, scoped grants, and delegated
+  access keys. Root keys and their encrypted envelopes never leave egress.
+- Root wallets use the existing `CREDENTIAL_ENCRYPTION_KEY` envelope in the
+  account's per-user Durable Object. This is custodial server-side encryption,
+  not user-held end-to-end encryption. Configurable-account migration is future
+  work; see [the custody contract](WALLET_CUSTODY.md).
 - A local ChatGPT credential is never uploaded implicitly. In local
   development, `nanocodex connect chatgpt` is the explicit user-approved action
   that claims an available local Codex/ChatGPT credential into the broker when

--- a/docs/MANAGED_LOGIN.md
+++ b/docs/MANAGED_LOGIN.md
@@ -74,11 +74,12 @@ first-party SMS OTP flow owned by the managed Cloudflare Worker.
    browser when possible. `--no-open` suppresses only that automatic launch.
 
 6. **Establish the Nanocodex account.** The user enters an E.164 phone number
-   and a six-digit code delivered by SMS. The managed Worker generates and
-   verifies the code, binds only an HMAC digest of the phone to the account,
-   and issues the same HttpOnly account session used by managed agents. A new
-   phone promotes the current browser account; a known phone restores its
-   existing agents, memory, and connections.
+   and a six-digit code delivered by Twilio Verify over SMS or eligible RCS.
+   Verify generates and checks the code. The managed Worker binds only an HMAC
+   digest of the phone to the account and issues the same HttpOnly account
+   session used by managed agents. A new phone promotes only the current
+   anonymous browser account; a known phone restores its existing agents,
+   memory, and connections.
 
 7. **Run the focused action.** The browser derives its work from the signed
    `wallet_connect` request:
@@ -149,15 +150,18 @@ first-party SMS OTP flow owned by the managed Cloudflare Worker.
 
 ## Capability and storage boundaries
 
-- The managed Cloudflare Worker owns SMS OTP generation, HMAC phone identity,
-  abuse limits, account sessions, and the one-time hosted authorization.
+- The managed Cloudflare Worker owns HMAC phone identity, local abuse limits,
+  browser-bound challenges, account sessions, and the one-time hosted
+  authorization. Twilio Verify owns OTP generation, delivery, attempt limits,
+  expiry, and checking.
   Tempo Accounts/Wata owns the device-code transport, PKCE exchange,
   `wallet_connect` envelope, and the explicit signed access-key step-up used
   for MPP.
-- OTPs expire after five minutes, allow five guesses, enforce a 60-second
-  resend delay, and are capped per phone and per Cloudflare client IP. Twilio
-  Messaging or the `NANOCODEX_SMS_SEND` service binding only delivers the
-  message; it never decides identity or verifies a code.
+- The Worker retains each browser challenge for five minutes, enforces a
+  60-second resend delay, and caps starts per phone and Cloudflare client IP.
+  The Verify Service must use six-digit codes with a validity window compatible
+  with that local lifetime. The Worker stores only keyed HMAC phone digests and
+  opaque Verify identifiers; it never stores an OTP.
 - Nanocodex Connect owns the application identity, requested Nanocodex
   resources, account linking, connector onboarding, consent UI, and scoped
   grant.

--- a/docs/MANAGED_LOGIN.md
+++ b/docs/MANAGED_LOGIN.md
@@ -34,8 +34,9 @@ The interactive CLI receives a scoped Nanocodex Connect grant. It must not
 silently mint a general-purpose Nanocodex API key. API keys remain an explicit
 operation for CI, curl, or another machine.
 
-The flow uses Tempo Accounts/Wata `wallet_connect`. This name refers to the
-Tempo Accounts RPC method, not the WalletConnect protocol.
+The device envelope still uses Tempo Accounts/Wata `wallet_connect`; this is an
+RPC transport name, not the login mechanism. Nanocodex account login is a
+first-party SMS OTP flow owned by the managed Cloudflare Worker.
 
 ## End-to-end flow
 
@@ -49,13 +50,11 @@ Tempo Accounts RPC method, not the WalletConnect protocol.
    capabilities instead of starting a redundant ceremony. Connect deliberately
    starts a new ceremony because it changes the installation grant.
 
-3. **Prepare the requested authorization.** The CLI prepares a Tempo access key
-   so the existing signed result remains interoperable and MPP can use its
-   required spending policy. Private signing material remains on the machine.
-   A non-MPP request explicitly includes
+3. **Prepare the requested authorization.** A non-MPP request includes
    `urn:nanocodex:authorization:hosted`, allowing Connect to approve hosted
-   authority without returning or persisting that key. MPP requests omit this
-   marker and require the signed access-key result.
+   authority without returning or persisting a key. An explicit MPP request is
+   a separate stronger-auth ceremony: it omits this marker, prepares a local
+   Tempo access key, and requires the signed access-key result.
 
 4. **Register a device authorization.** The CLI starts a Wata device-code
    exchange containing one `wallet_connect` RPC request. The request declares
@@ -74,9 +73,12 @@ Tempo Accounts RPC method, not the WalletConnect protocol.
    verification URL. The CLI prints both and opens the verification URL in the
    browser when possible. `--no-open` suppresses only that automatic launch.
 
-6. **Establish the Nanocodex account.** Nanocodex Connect signs an existing user
-   in with their passkey or creates a new passkey-backed Nanocodex account. The
-   verified Tempo address is linked to that account.
+6. **Establish the Nanocodex account.** The user enters an E.164 phone number
+   and a six-digit code delivered by SMS. The managed Worker generates and
+   verifies the code, binds only an HMAC digest of the phone to the account,
+   and issues the same HttpOnly account session used by managed agents. A new
+   phone promotes the current browser account; a known phone restores its
+   existing agents, memory, and connections.
 
 7. **Run the focused action.** The browser derives its work from the signed
    `wallet_connect` request:
@@ -98,12 +100,11 @@ Tempo Accounts RPC method, not the WalletConnect protocol.
    `/connect-dialog` surface may use its own dialog behavior; it is not the CLI
    device flow.
 
-8. **Approve the installation automatically.** Once the passkey-backed account
-   is established, the device wizard signs and submits the exact pending
-   installation request without a separate account-card or approval click. If
-   exactly one saved account is available, the wizard starts that passkey
-   ceremony immediately. Account choice, passkey creation, provider OAuth, and
-   MPP policy remain interactive when they genuinely require user input. The
+8. **Approve the installation automatically.** Once the SMS-backed account is
+   established, the device wizard submits the exact pending hosted
+   installation request without a separate account-card or approval click.
+   SMS verification, provider OAuth, and MPP policy remain interactive when
+   they genuinely require user input. The
    final browser view is the completed installation CTA. The embedded
    `/connect-dialog` approval remains explicit.
 
@@ -148,10 +149,15 @@ Tempo Accounts RPC method, not the WalletConnect protocol.
 
 ## Capability and storage boundaries
 
-- Tempo Accounts/Wata owns the device-code transport, PKCE exchange,
-  `wallet_connect` envelope, and signed access-key authorization. Nanocodex
-  Connect owns the one-time hosted authorization when that explicit mode is
-  requested.
+- The managed Cloudflare Worker owns SMS OTP generation, HMAC phone identity,
+  abuse limits, account sessions, and the one-time hosted authorization.
+  Tempo Accounts/Wata owns the device-code transport, PKCE exchange,
+  `wallet_connect` envelope, and the explicit signed access-key step-up used
+  for MPP.
+- OTPs expire after five minutes, allow five guesses, enforce a 60-second
+  resend delay, and are capped per phone and per Cloudflare client IP. Twilio
+  Messaging or the `NANOCODEX_SMS_SEND` service binding only delivers the
+  message; it never decides identity or verifies a code.
 - Nanocodex Connect owns the application identity, requested Nanocodex
   resources, account linking, connector onboarding, consent UI, and scoped
   grant.

--- a/docs/MILLION_USER_ARCHITECTURE.md
+++ b/docs/MILLION_USER_ARCHITECTURE.md
@@ -280,9 +280,9 @@ to the per-agent SQLite size and requires its own retention policy.
  +--------------------------+                                    +--------------------------+
  | Identity actors          |                                    | User index shards        |
  | SessionDO(token hash)    |                                    | AgentIndexDO(user,bucket)|
- | PasskeyDO(credential ID) |                                    +--------------------------+
+ | SmsIdentityDO(phone HMAC)|                                    +--------------------------+
  | ApiKeyDO(key hash)       |
- | LoginDO(challenge hash)  |
+ | SmsOtpDO(challenge hash) |
  +--------------------------+
       |
       | authorized agent ID

--- a/docs/WALLET_CUSTODY.md
+++ b/docs/WALLET_CUSTODY.md
@@ -1,0 +1,72 @@
+# Persistent account wallet custody
+
+Every persistent SMS account has one platform-owned secp256k1 root wallet. The
+managed Worker asks the private egress broker to create it after Twilio Verify
+approves the account's first OTP login and before the persistent session is
+issued. Provisioning is idempotent: a retry or later login returns the same
+wallet address and must never replace the existing key. If provisioning fails,
+login fails closed with `wallet_unavailable` and the browser-bound OTP challenge
+remains retryable.
+
+The egress broker stores the root private key in that user's existing
+`UserCredentialBroker` Durable Object. The existing `CredentialVault` seals it
+with the `CREDENTIAL_ENCRYPTION_KEY` AES-256-GCM envelope, including its
+per-user scope as authenticated data. `CREDENTIAL_ENCRYPTION_KEY_PREVIOUS`
+continues to support lazy envelope-key rotation. This needs no new binding,
+Durable Object class, or migration.
+
+## Custody and threat model
+
+This is custodial, server-side encryption, not user-held end-to-end encryption.
+The private key is decrypted inside the trusted egress Worker when it must sign.
+An operator or attacker able to control that Worker or its encryption secret is
+inside the trust boundary. The envelope protects stored Durable Object data; it
+does not make the platform unable to use the key.
+
+The root private key is never returned to the browser, account application,
+managed Worker, Connect API, agent, tool, logs, or status response. Public
+surfaces may receive the account address and the bounded signed protocol result
+needed to complete an approved operation. Browser storage must contain neither
+the root key nor an export of the encrypted envelope.
+
+Configurable accounts are not silently assigned a wallet by a read path.
+Migrating those accounts is future work and must define identity matching,
+recovery, and rollout behavior before deployment.
+
+## Allowed operations
+
+The root wallet has only two signing uses:
+
+- `wallet_connect`, to authorize the exact requested delegated access key and
+  its resources, expiry, call scopes, and spending limits;
+- `wallet_revokeAccessKey`, to revoke the exact account access key named by the
+  request.
+
+There is no generic sign-message, transaction-signing, export, import, or raw
+RPC escape hatch. The managed Worker exposes the account-authenticated,
+same-origin routes `POST /v1/wallet/connect` and
+`POST /v1/wallet/revoke-access-key`; `GET /v1/wallet` returns only public wallet
+metadata. It derives the persistent user from the HttpOnly session and forwards
+the bounded request over the existing private `NANOCODEX` Service Binding.
+Egress derives the per-user Durable Object from that trusted user identifier
+and never accepts a browser-selected storage owner or private key.
+
+Across the private binding, egress exposes `GET /users/:userId/wallet` for
+public metadata, idempotent empty-body `PUT /users/:userId/wallet` for
+provisioning, and the corresponding `/connect` and `/revoke-access-key` POST
+operations. These are trusted service operations, not public browser routes.
+
+Connect may return a sanitized `wallet_connect` result containing the address,
+signed authorization, and delegated access-key metadata. That delegated key is
+the installation authority; it is not the root key. Revocation accepts the
+original bounded `wallet_revokeAccessKey` request and returns only the public
+operation result.
+
+## Operational evidence
+
+For a change to this boundary, verify a new OTP account, a returning login, an
+access-key Connect approval, reload/reconnect, and access-key revocation against
+the real Workers. Also test two accounts to prove cross-account isolation.
+Inspect browser network, console, storage, Worker logs, and Durable Object state
+to confirm that only public addresses and sanitized protocol results leave
+egress and that stored key material is an authenticated ciphertext envelope.

--- a/js/account/README.md
+++ b/js/account/README.md
@@ -29,6 +29,14 @@ repository and thread Git data, evaluation reads, and credential-backed model
 operations. Provider credentials stay behind Worker bindings and are not part
 of browser configuration.
 
+Persistent SMS accounts use a Worker-owned secp256k1 root wallet. This app may
+display its public address and send exact `wallet_connect` or
+`wallet_revokeAccessKey` requests to the authenticated managed-Worker routes,
+but it never receives the root private key or its encrypted envelope. The key
+is custodial and server-side encrypted in the per-user egress Durable Object;
+it is not user-held end-to-end encryption. Configurable-account migration is
+future work. See [the wallet custody contract](../../docs/WALLET_CUSTODY.md).
+
 Vite uses the Cloudflare and React plugins plus `nanocodex-vite`. Local
 development also serves the Connect dialog and starts the egress, managed, and
 Connect API auxiliary Workers. Build output includes a Cloudflare Wrangler

--- a/js/account/README.md
+++ b/js/account/README.md
@@ -11,8 +11,8 @@ or a second agent backend.
 - **Home and Durable Agent** show the browser agent and its retained thread.
 - **Attached Tools**, **Multiplayer**, and **World** demonstrate browser-hosted
   tools, a shared managed-agent room, and an agent-populated world.
-- **Account** and **Connect** handle passkey account, connection, device, and
-  request-scoped Connect journeys. The Connect dialog is served at
+- **Account** and **Connect** handle SMS OTP account login, connection, device,
+  and request-scoped Connect journeys. The Connect dialog is served at
   `/connect-dialog`; the separate Connect API routes remain behind the Worker.
 - **Docs**, **Evals**, **Source**, **Commits**, and **Changelog** present the
   product reference, evaluation evidence, and published repository data.

--- a/js/account/src/AccountMenu.tsx
+++ b/js/account/src/AccountMenu.tsx
@@ -392,50 +392,20 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
     return (
       <div className="account-inline">
         <AccountConnectionSurface
-          description={<>Your account wallet signs Connect approvals while its private key remains encrypted in your vault.</>}
+          description={<>Manage the hosted connections your Nanocodex agents can use.</>}
+          footer={<div className="account-wallet-session">
+            <span>Account {shortIdentity(session.account.id)}</span>
+            <button
+              className="wizard-sign-out"
+              disabled={session.operation !== null}
+              onClick={() => void session.signOut()}
+              type="button"
+            >
+              Sign out
+            </button>
+          </div>}
           title="Connect"
         >
-          <AccountConnectionSection
-            eyebrow="Account"
-            meta={session.account.address ? "Ready to sign" : "Unavailable"}
-            title="Tempo wallet"
-            titleId="account-identity-heading"
-          >
-            {session.account.address ? (
-              <div className="account-wallet">
-                <div className="account-wallet-address">
-                  <span>Wallet address</span>
-                  <code>{session.account.address}</code>
-                </div>
-                <button
-                  aria-label="Copy wallet address"
-                  className="account-wallet-copy"
-                  onClick={() => void copyWalletAddress()}
-                  type="button"
-                >
-                  {walletCopied ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}
-                  {walletCopied ? "Copied" : "Copy"}
-                </button>
-              </div>
-            ) : (
-              <div className="account-failure" role="alert">
-                <p>Your wallet address could not be loaded.</p>
-                <button type="button" onClick={() => void session.refresh()}>Retry</button>
-              </div>
-            )}
-            <div className="account-wallet-session">
-              <span>Account {shortIdentity(session.account.id)}</span>
-              <button
-                className="wizard-sign-out"
-                disabled={session.operation !== null}
-                onClick={() => void session.signOut()}
-                type="button"
-              >
-                Sign out
-              </button>
-            </div>
-          </AccountConnectionSection>
-
           <AccountConnectionSection
             eyebrow="Service"
             meta="Available to your agents"
@@ -486,6 +456,15 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
               presentation="wizard"
               refreshSession={refreshSession}
             >
+              <AccountConnectionCard
+                action={walletCopied ? "Copied" : "Copy"}
+                connected={Boolean(session.account.address)}
+                detail={session.account.address ?? "Wallet unavailable"}
+                disabled={!session.account.address}
+                logo={<ConnectionLogo id="tempo" />}
+                onClick={() => void copyWalletAddress()}
+                title="Tempo Wallet"
+              />
               {credentials ? (
                 <>
                   <AccountConnectionCard

--- a/js/account/src/AccountMenu.tsx
+++ b/js/account/src/AccountMenu.tsx
@@ -365,13 +365,11 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
     return (
       <AccountChooser
         description={session.reauthenticationRequired
-          ? "Your session expired. Continue with the saved passkey to restore this account’s memory and connections."
-          : "Continue with a saved passkey, or create a new Nanocodex account."}
+          ? "Your session expired. Enter your phone number to restore this account’s memory and connections."
+          : "Enter your phone number to create or restore your Nanocodex account."}
         disabled={session.operation !== null}
         failure={session.error}
-        newAccountDetail="Create one passkey to keep your agents, memory, and connections."
         onChooseAccount={(selection) => void session.chooseAccount(selection)}
-        storedPasskeys={session.savedPasskeys}
       />
     );
   }
@@ -386,7 +384,7 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
           <AccountConnectionSection
             eyebrow="Account"
             meta={shortIdentity(session.account.id)}
-            title="Passkey identity"
+            title="SMS identity"
             titleId="account-identity-heading"
           >
             <button
@@ -600,13 +598,13 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
               <section className={inline ? "wizard-section account-identity" : "account-summary"}>
                 {inline ? (
                   <header className="wizard-section-title">
-                    <div><span>Account</span><h2>Passkey identity</h2></div>
+                    <div><span>Account</span><h2>SMS identity</h2></div>
                     <small>{shortIdentity(session.account.id)}</small>
                   </header>
                 ) : (
                   <>
-                    <span>{session.account.persistent ? "Passkey identity" : "Browser session"}</span>
-                    <span>{session.account.persistent ? "Available across devices" : "Add a passkey to keep it"}</span>
+                    <span>{session.account.persistent ? "SMS identity" : "Browser session"}</span>
+                    <span>{session.account.persistent ? "Available across devices" : "Verify your phone to keep it"}</span>
                   </>
                 )}
                 {session.account.persistent ? (
@@ -622,26 +620,12 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
               </section>
 
               {!accountPersistent ? (
-                <div className="account-auth-actions">
-                  <p>Add a passkey or use an existing one to connect services and create API keys.</p>
-                  <div className="account-auth-buttons">
-                    <button
-                      className="account-primary-action"
-                      type="button"
-                      disabled={session.operation !== null}
-                      onClick={() => void session.register()}
-                    >
-                      Add a passkey
-                    </button>
-                    <button
-                      type="button"
-                      disabled={session.operation !== null}
-                      onClick={() => void session.signIn()}
-                    >
-                      Use existing passkey
-                    </button>
-                  </div>
-                </div>
+                <AccountChooser
+                  description="Verify your phone to keep this account and unlock connections and API keys."
+                  disabled={session.operation !== null}
+                  failure={session.error}
+                  onChooseAccount={(selection) => void session.chooseAccount(selection)}
+                />
               ) : null}
 
               <div className={inline ? "account-profile-content wizard-sections" : "api-key-panel account-profile-content"}>
@@ -652,7 +636,7 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
                     <h2 id="connections-heading">Connections</h2>
                     {!inline ? <p>{accountPersistent
                       ? "Choose a service to connect it through your private broker. Connected services can be removed from the same tile."
-                      : "Add or use a passkey above to enable connections and API keys."}</p> : null}
+                      : "Verify your phone above to enable connections and API keys."}</p> : null}
                   </div>
                   {inline ? <small>Available to your agents</small> : null}
                 </div>
@@ -841,28 +825,14 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
               </div>
             </>
           ) : (
-            <div className="account-auth-actions">
-              <p>{session.reauthenticationRequired
-                ? "Your passkey session expired. Sign in to restore this account’s memory and connections."
-                : "Sign in with your passkey, or explicitly start a separate account."}</p>
-              <div className="account-auth-buttons">
-                <button
-                  className="account-primary-action"
-                  type="button"
-                  disabled={session.operation !== null}
-                  onClick={() => void session.signIn()}
-                >
-                  Sign in with passkey
-                </button>
-                <button
-                  type="button"
-                  disabled={session.operation !== null}
-                  onClick={() => void session.register()}
-                >
-                  Create new account
-                </button>
-              </div>
-            </div>
+            <AccountChooser
+              description={session.reauthenticationRequired
+                ? "Your session expired. Enter your phone number to restore this account’s memory and connections."
+                : "Enter your phone number to create or restore your Nanocodex account."}
+              disabled={session.operation !== null}
+              failure={session.error}
+              onChooseAccount={(selection) => void session.chooseAccount(selection)}
+            />
           )}
         </section>
       ) : null}

--- a/js/account/src/AccountMenu.tsx
+++ b/js/account/src/AccountMenu.tsx
@@ -18,6 +18,18 @@ import { ConnectionLogo } from "nanocodex-connect-ui/ConnectionLogo";
 import { deploymentHealth } from "./deploymentHealth";
 import { localDevelopmentCredential } from "./localDevelopmentCredential";
 import { ProfileConnectors } from "./ProfileConnectors";
+import {
+  classifyFundingOrder,
+  decodeFundingAttempt,
+  decodeMachineUsdConfig,
+  decodeWalletBalance,
+  defaultFundingAmountCents,
+  formatDollars,
+  formatWalletBalance,
+  type FundingAttempt,
+  type MachineUsdConfig,
+  type WalletBalance,
+} from "./walletFunding";
 
 type ApiKeyMetadata = Readonly<{
   id: string;
@@ -52,6 +64,18 @@ type AccountDataRequest = Readonly<{
   promise: Promise<void>;
 }>;
 
+type WalletBalanceRequest = Readonly<{
+  accountId: string;
+  controller: AbortController;
+  promise: Promise<boolean>;
+}>;
+
+type WalletFundingRun = Readonly<{
+  accountId: string;
+  checkout: Window;
+  controller: AbortController;
+}>;
+
 const API_KEY_ID = /^[A-Za-z0-9_-]{12}$/;
 
 export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) {
@@ -67,6 +91,12 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
   const [label, setLabel] = useState("");
   const [copied, setCopied] = useState(false);
   const [walletCopied, setWalletCopied] = useState(false);
+  const [walletBalance, setWalletBalance] = useState<WalletBalance | null>(null);
+  const [walletBalanceError, setWalletBalanceError] = useState<string | null>(null);
+  const [walletFundingConfig, setWalletFundingConfig] = useState<MachineUsdConfig | null>(null);
+  const [walletFundingError, setWalletFundingError] = useState<string | null>(null);
+  const [walletFundingSuccess, setWalletFundingSuccess] = useState<string | null>(null);
+  const [walletFundingOperation, setWalletFundingOperation] = useState<"prepare" | "payment" | null>(null);
   const [credentials, setCredentials] = useState<CredentialStatus | null>(null);
   const [credentialError, setCredentialError] = useState<string | null>(null);
   const [providerOperation, setProviderOperation] = useState<string | null>(null);
@@ -76,12 +106,24 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
   const cachedAccountId = useRef<string | undefined>(undefined);
   const keyRequest = useRef<AccountDataRequest | undefined>(undefined);
   const credentialRequest = useRef<AccountDataRequest | undefined>(undefined);
+  const walletBalanceRequest = useRef<WalletBalanceRequest | undefined>(undefined);
+  const walletFundingConfigRequest = useRef<AccountDataRequest | undefined>(undefined);
+  const walletFundingRun = useRef<WalletFundingRun | undefined>(undefined);
+
+  const cancelWalletFunding = useCallback(() => {
+    const run = walletFundingRun.current;
+    walletFundingRun.current = undefined;
+    run?.controller.abort();
+    run?.checkout.close();
+  }, []);
 
   const close = useCallback(() => {
+    cancelWalletFunding();
     setOpen(false);
     setNewKey(null);
     setCopied(false);
-  }, []);
+    setWalletFundingOperation(null);
+  }, [cancelWalletFunding]);
 
   const loadKeys = useCallback((): Promise<void> => {
     if (!accountId) return Promise.resolve();
@@ -162,33 +204,130 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
     }
   }, [loadCredentials]);
 
+  const loadWalletBalance = useCallback((force = false): Promise<boolean> => {
+    const address = session.account?.address;
+    if (!accountId || !address) return Promise.resolve(false);
+    if (!force && walletBalanceRequest.current?.accountId === accountId) {
+      return walletBalanceRequest.current.promise;
+    }
+    if (force) walletBalanceRequest.current?.controller.abort();
+    const controller = new AbortController();
+    setWalletBalanceError(null);
+    let current!: Promise<boolean>;
+    current = (async () => {
+      try {
+        const response = await apiRequest("/v1/wallet/balance", { signal: controller.signal });
+        if (response.status === 401) {
+          await response.body?.cancel();
+          await refreshSession();
+          return false;
+        }
+        if (!response.ok) throw await responseFailure(response, "Couldn’t load the MACH balance.");
+        const balance = decodeWalletBalance(await response.json(), address);
+        if (cachedAccountId.current === accountId) setWalletBalance(balance);
+        return true;
+      } catch (cause) {
+        if (!controller.signal.aborted && cachedAccountId.current === accountId) {
+          setWalletBalanceError(failureMessage(cause, "Couldn’t load the MACH balance."));
+        }
+        return false;
+      }
+    })().finally(() => {
+      if (walletBalanceRequest.current?.promise === current) {
+        walletBalanceRequest.current = undefined;
+      }
+    });
+    walletBalanceRequest.current = { accountId, controller, promise: current };
+    return current;
+  }, [accountId, refreshSession, session.account?.address]);
+
+  const loadWalletFundingConfig = useCallback((): Promise<void> => {
+    if (!accountId || walletFundingConfig) return Promise.resolve();
+    if (walletFundingConfigRequest.current?.accountId === accountId) {
+      return walletFundingConfigRequest.current.promise;
+    }
+    setWalletFundingError(null);
+    let current!: Promise<void>;
+    current = (async () => {
+      try {
+        const response = await apiRequest("/v1/machine-usd/config");
+        if (!response.ok) throw await responseFailure(response, "Couldn’t load the MACH onramp.");
+        const config = decodeMachineUsdConfig(await response.json());
+        if (cachedAccountId.current === accountId) setWalletFundingConfig(config);
+      } catch (cause) {
+        if (cachedAccountId.current === accountId) {
+          setWalletFundingError(failureMessage(cause, "Couldn’t load the MACH onramp."));
+        }
+      }
+    })().finally(() => {
+      if (walletFundingConfigRequest.current?.promise === current) {
+        walletFundingConfigRequest.current = undefined;
+      }
+    });
+    walletFundingConfigRequest.current = { accountId, promise: current };
+    return current;
+  }, [accountId, walletFundingConfig]);
+
   useEffect(() => {
     if (!accountId) {
+      cancelWalletFunding();
+      walletBalanceRequest.current?.controller.abort();
+      walletBalanceRequest.current = undefined;
+      walletFundingConfigRequest.current = undefined;
       cachedAccountId.current = undefined;
       setKeys(null);
       setKeyError(null);
       setNewKey(null);
       setWalletCopied(false);
+      setWalletBalance(null);
+      setWalletBalanceError(null);
+      setWalletFundingConfig(null);
+      setWalletFundingError(null);
+      setWalletFundingSuccess(null);
+      setWalletFundingOperation(null);
       setCredentials(null);
       setCredentialError(null);
       return;
     }
     const accountChanged = cachedAccountId.current !== accountId;
     if (accountChanged) {
+      cancelWalletFunding();
+      walletBalanceRequest.current?.controller.abort();
+      walletBalanceRequest.current = undefined;
+      walletFundingConfigRequest.current = undefined;
       cachedAccountId.current = accountId;
       setKeys(null);
       setKeyError(null);
       setNewKey(null);
       setWalletCopied(false);
+      setWalletBalance(null);
+      setWalletBalanceError(null);
+      setWalletFundingConfig(null);
+      setWalletFundingError(null);
+      setWalletFundingSuccess(null);
+      setWalletFundingOperation(null);
       setCredentials(null);
       setCredentialError(null);
     }
     if (!inline && !open) return;
-    const missing: Promise<void>[] = [];
+    const missing: Promise<unknown>[] = [];
     if (accountChanged || keys === null) missing.push(loadKeys());
     if (accountChanged || credentials === null) missing.push(loadCredentials());
+    if (accountChanged || walletBalance === null) missing.push(loadWalletBalance());
+    if (accountChanged || walletFundingConfig === null) missing.push(loadWalletFundingConfig());
     void Promise.all(missing);
-  }, [accountId, credentials, inline, keys, loadCredentials, loadKeys, open]);
+  }, [accountId, cancelWalletFunding, credentials, inline, keys, loadCredentials, loadKeys, loadWalletBalance, loadWalletFundingConfig, open, walletBalance, walletFundingConfig]);
+
+  useEffect(() => () => {
+    cancelWalletFunding();
+    walletBalanceRequest.current?.controller.abort();
+  }, [cancelWalletFunding]);
+
+  useEffect(() => {
+    if (!accountId || !session.account?.address || (!inline && !open)) return;
+    const timer = window.setInterval(() => void loadWalletBalance(), 5 * 60_000);
+    return () => window.clearInterval(timer);
+  }, [accountId, inline, loadWalletBalance, open, session.account?.address]);
 
   useEffect(() => {
     const login = credentials?.chatgpt.login;
@@ -292,6 +431,71 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
     } catch {
       setCredentialError("Couldn’t copy the wallet address. Select and copy it manually.");
     }
+  };
+
+  const fundWallet = () => {
+    const address = session.account?.address;
+    const config = walletFundingConfig;
+    if (!accountId || !address || !config || !config.onrampEnabled || walletFundingOperation) return;
+    const checkout = window.open("about:blank", "nanocodex-mach-checkout");
+    if (!checkout) {
+      setWalletFundingError("Allow pop-ups for Nanocodex, then try again.");
+      return;
+    }
+    checkout.opener = null;
+    const controller = new AbortController();
+    const run: WalletFundingRun = { accountId, checkout, controller };
+    cancelWalletFunding();
+    walletFundingRun.current = run;
+    setWalletFundingOperation("prepare");
+    setWalletFundingError(null);
+    setWalletFundingSuccess(null);
+    void (async () => {
+      let navigated = false;
+      try {
+        const amount = defaultFundingAmountCents(config);
+        const orderToken = randomOrderToken();
+        const response = await apiRequest("/v1/machine-usd/orders", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "idempotency-key": crypto.randomUUID(),
+          },
+          body: JSON.stringify({
+            order_token: orderToken,
+            payment_mode: "hosted_checkout",
+            usd_amount_cents: amount,
+            wallet_address: address,
+          }),
+          signal: controller.signal,
+        });
+        if (!response.ok) throw await responseFailure(response, "Couldn’t create the MACH order.");
+        const attempt = decodeFundingAttempt(await response.json(), orderToken);
+        if (walletFundingRun.current !== run) return;
+        checkout.location.href = attempt.checkoutUrl;
+        navigated = true;
+        setWalletFundingOperation("payment");
+        await waitForFundingOrder(attempt, controller.signal, checkout);
+        if (walletFundingRun.current !== run) return;
+        setWalletFundingSuccess("MACH issued. Refreshing balance…");
+        const refreshed = await loadWalletBalance(true);
+        if (walletFundingRun.current === run) {
+          setWalletFundingSuccess(refreshed
+            ? "MACH added. Balance refreshed."
+            : "MACH issued. Refresh the balance to confirm it.");
+        }
+      } catch (cause) {
+        if (!navigated) checkout.close();
+        if (!controller.signal.aborted && walletFundingRun.current === run) {
+          setWalletFundingError(failureMessage(cause, "The MACH purchase did not complete."));
+        }
+      } finally {
+        if (walletFundingRun.current === run) {
+          walletFundingRun.current = undefined;
+          setWalletFundingOperation(null);
+        }
+      }
+    })();
   };
 
   const connectOpenAi = async (event: FormEvent) => {
@@ -456,14 +660,19 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
               presentation="wizard"
               refreshSession={refreshSession}
             >
-              <AccountConnectionCard
-                action={walletCopied ? "Copied" : "Copy"}
-                connected={Boolean(session.account.address)}
-                detail={session.account.address ?? "Wallet unavailable"}
-                disabled={!session.account.address}
-                logo={<ConnectionLogo id="tempo" />}
-                onClick={() => void copyWalletAddress()}
-                title="Tempo Wallet"
+              <TempoWalletConnectionCard
+                address={session.account.address}
+                balance={walletBalanceError
+                  ? walletBalance ? `${formatWalletBalance(walletBalance)} · refresh failed` : "Balance unavailable"
+                  : walletBalance ? formatWalletBalance(walletBalance) : "Loading balance…"}
+                copied={walletCopied}
+                fundingAmountCents={walletFundingConfig ? defaultFundingAmountCents(walletFundingConfig) : 500}
+                fundingAvailable={walletFundingConfig?.onrampEnabled === true}
+                fundingError={walletFundingError}
+                fundingOperation={walletFundingOperation}
+                fundingSuccess={walletFundingSuccess}
+                onCopy={() => void copyWalletAddress()}
+                onFund={fundWallet}
               />
               {credentials ? (
                 <>
@@ -856,6 +1065,124 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
       ) : null}
     </div>
   );
+}
+
+function TempoWalletConnectionCard({
+  address,
+  balance,
+  copied,
+  fundingAmountCents,
+  fundingAvailable,
+  fundingError,
+  fundingOperation,
+  fundingSuccess,
+  onCopy,
+  onFund,
+}: Readonly<{
+  address?: string | undefined;
+  balance: string;
+  copied: boolean;
+  fundingAmountCents: number;
+  fundingAvailable: boolean;
+  fundingError: string | null;
+  fundingOperation: "prepare" | "payment" | null;
+  fundingSuccess: string | null;
+  onCopy(): void;
+  onFund(): void;
+}>) {
+  const busy = fundingOperation !== null;
+  return (
+    <div className="wizard-connector-card tempo-wallet-connection" role="listitem">
+      <div className={`connection-card tempo-wallet-card${address ? " is-connected" : " is-unavailable"}`}>
+        <ConnectionLogo id="tempo" />
+        <span className="connection-card-copy">
+          <strong>{busy ? "Add MACH" : "Tempo Wallet"}</strong>
+          <span className="tempo-wallet-balance" role={busy ? "status" : undefined}>{fundingOperation === "prepare"
+            ? "Preparing secure checkout…"
+            : fundingOperation === "payment"
+              ? "Complete payment in Stripe"
+              : balance}</span>
+          <code title={address}>{address ?? "Wallet unavailable"}</code>
+          {fundingError ? <span className="tempo-wallet-message is-error" role="alert">{fundingError}</span> : null}
+          {fundingSuccess ? <span className="tempo-wallet-message is-success" role="status">{fundingSuccess}</span> : null}
+        </span>
+        {busy ? <span className="tempo-wallet-payment-status" role="status">Waiting</span> : (
+          <span className="tempo-wallet-card-actions">
+            <button disabled={!address} onClick={onCopy} type="button">{copied ? "Copied" : "Copy"}</button>
+            <button disabled={!address || !fundingAvailable} onClick={onFund} type="button">
+              {fundingAvailable ? `Add ${formatDollars(fundingAmountCents)}` : "Onramp unavailable"}
+            </button>
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+async function waitForFundingOrder(
+  attempt: FundingAttempt,
+  signal: AbortSignal,
+  checkout: Window,
+): Promise<void> {
+  const deadline = Date.now() + 15 * 60_000;
+  let checkoutClosedAt: number | undefined;
+  let retryDelayMs = 1_500;
+  while (Date.now() < deadline) {
+    signal.throwIfAborted();
+    if (checkout.closed) checkoutClosedAt ??= Date.now();
+    if (checkoutClosedAt && Date.now() - checkoutClosedAt >= 2 * 60_000) {
+      throw new Error("Payment status wasn’t confirmed after checkout closed. Check the balance before trying again.");
+    }
+    let response: Response;
+    try {
+      response = await apiRequest(`/v1/machine-usd/orders/${encodeURIComponent(attempt.id)}`, {
+        headers: { authorization: `Bearer ${attempt.orderToken}` },
+        signal,
+      });
+    } catch (cause) {
+      if (signal.aborted) throw cause;
+      retryDelayMs = Math.min(retryDelayMs * 2, 10_000);
+      await abortableDelay(retryDelayMs, signal);
+      continue;
+    }
+    if (!response.ok) {
+      if (response.status < 500) {
+        throw await responseFailure(response, "Couldn’t check the MACH order.");
+      }
+      await response.body?.cancel();
+      retryDelayMs = Math.min(retryDelayMs * 2, 10_000);
+    } else {
+      const body: unknown = await response.json();
+      if (!isRecord(body)) throw new Error("The MACH order response is invalid.");
+      const status = classifyFundingOrder(body.order);
+      if (status === "complete") return;
+      if (status === "failed") throw new Error("The MACH purchase did not complete.");
+      retryDelayMs = 1_500;
+    }
+    await abortableDelay(retryDelayMs, signal);
+  }
+  throw new Error("Payment status wasn’t confirmed. Check the balance before trying again.");
+}
+
+function abortableDelay(durationMs: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      window.clearTimeout(timer);
+      reject(signal.reason);
+    };
+    const timer = window.setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, durationMs);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function randomOrderToken(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
 }
 
 async function apiRequest(path: string, init: RequestInit = {}): Promise<Response> {

--- a/js/account/src/AccountMenu.tsx
+++ b/js/account/src/AccountMenu.tsx
@@ -66,6 +66,7 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
   const [newKey, setNewKey] = useState<NewApiKey | null>(null);
   const [label, setLabel] = useState("");
   const [copied, setCopied] = useState(false);
+  const [walletCopied, setWalletCopied] = useState(false);
   const [credentials, setCredentials] = useState<CredentialStatus | null>(null);
   const [credentialError, setCredentialError] = useState<string | null>(null);
   const [providerOperation, setProviderOperation] = useState<string | null>(null);
@@ -167,6 +168,7 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
       setKeys(null);
       setKeyError(null);
       setNewKey(null);
+      setWalletCopied(false);
       setCredentials(null);
       setCredentialError(null);
       return;
@@ -177,6 +179,7 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
       setKeys(null);
       setKeyError(null);
       setNewKey(null);
+      setWalletCopied(false);
       setCredentials(null);
       setCredentialError(null);
     }
@@ -280,6 +283,17 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
     }
   };
 
+  const copyWalletAddress = async () => {
+    const address = session.account?.address;
+    if (!address) return;
+    try {
+      await navigator.clipboard.writeText(address);
+      setWalletCopied(true);
+    } catch {
+      setCredentialError("Couldn’t copy the wallet address. Select and copy it manually.");
+    }
+  };
+
   const connectOpenAi = async (event: FormEvent) => {
     event.preventDefault();
     if (!openAiKey.trim() || providerOperation) return;
@@ -378,23 +392,48 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
     return (
       <div className="account-inline">
         <AccountConnectionSurface
-          description={<>Signed in as {shortIdentity(session.account.id)}. Manage the same hosted connections your Nanocodex agents can use.</>}
+          description={<>Your account wallet signs Connect approvals while its private key remains encrypted in your vault.</>}
           title="Connect"
         >
           <AccountConnectionSection
             eyebrow="Account"
-            meta={shortIdentity(session.account.id)}
-            title="SMS identity"
+            meta={session.account.address ? "Ready to sign" : "Unavailable"}
+            title="Tempo wallet"
             titleId="account-identity-heading"
           >
-            <button
-              className="wizard-sign-out"
-              disabled={session.operation !== null}
-              onClick={() => void session.signOut()}
-              type="button"
-            >
-              Sign out
-            </button>
+            {session.account.address ? (
+              <div className="account-wallet">
+                <div className="account-wallet-address">
+                  <span>Wallet address</span>
+                  <code>{session.account.address}</code>
+                </div>
+                <button
+                  aria-label="Copy wallet address"
+                  className="account-wallet-copy"
+                  onClick={() => void copyWalletAddress()}
+                  type="button"
+                >
+                  {walletCopied ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}
+                  {walletCopied ? "Copied" : "Copy"}
+                </button>
+              </div>
+            ) : (
+              <div className="account-failure" role="alert">
+                <p>Your wallet address could not be loaded.</p>
+                <button type="button" onClick={() => void session.refresh()}>Retry</button>
+              </div>
+            )}
+            <div className="account-wallet-session">
+              <span>Account {shortIdentity(session.account.id)}</span>
+              <button
+                className="wizard-sign-out"
+                disabled={session.operation !== null}
+                onClick={() => void session.signOut()}
+                type="button"
+              >
+                Sign out
+              </button>
+            </div>
           </AccountConnectionSection>
 
           <AccountConnectionSection

--- a/js/account/src/AccountSession.tsx
+++ b/js/account/src/AccountSession.tsx
@@ -6,14 +6,9 @@ import {
   useMemo,
   useRef,
   useState,
-  useSyncExternalStore,
   type ReactNode,
 } from "react";
-import { Provider, Storage, webAuthn } from "accounts";
-import type {
-  AccountSelection,
-  StoredPasskey,
-} from "nanocodex-connect-ui/AccountChooser";
+import type { AccountSelection } from "nanocodex-connect-ui/AccountChooser";
 import {
   getCurrentUser,
   isRecord,
@@ -22,70 +17,28 @@ import {
   type AuthenticatedAccount,
 } from "./accountSessionRequest";
 import { logoutBrowserAccountSession } from "nanocodex-connect-ui/browserAccountSession";
-import { retainSavedPasskeyLabels } from "nanocodex-connect-ui/savedPasskeyAccounts";
 import { clientFailureMessage } from "./clientFailure";
 
 export { isRecord, responseFailure } from "./accountSessionRequest";
 export type { AuthenticatedAccount } from "./accountSessionRequest";
 
 type SessionStatus = "checking" | "ready" | "error";
-type AccountOperation = "register" | "sign-in" | "sign-out";
+type AccountOperation = "sign-in" | "sign-out";
 
 type AccountSession = Readonly<{
   status: SessionStatus;
   account: AuthenticatedAccount | null;
   error: string | null;
   operation: AccountOperation | null;
-  savedPasskeys: readonly StoredPasskey[];
   chooseAccount: (selection: AccountSelection) => Promise<void>;
   refresh: () => Promise<void>;
-  register: () => Promise<void>;
-  signIn: () => Promise<void>;
   signOut: () => Promise<void>;
   reauthenticationRequired: boolean;
 }>;
 
 const AccountSessionContext = createContext<AccountSession | null>(null);
 
-function createAccountProvider() {
-  return Provider.create({
-    adapter: webAuthn({
-      auth: "/webauthn",
-      name: "Nanocodex",
-      rdns: "xyz.paradigm.nanocodex",
-    }),
-    mpp: false,
-    storage: Storage.idb({ key: "nanocodex" }),
-  });
-}
-
 export function AccountSessionProvider({ children }: { children: ReactNode }) {
-  const providerRef = useRef<ReturnType<typeof createAccountProvider> | null>(null);
-  const accountProvider = useCallback(() => {
-    providerRef.current ??= createAccountProvider();
-    return providerRef.current;
-  }, []);
-  const provider = accountProvider();
-  const providerStore = (provider as unknown as {
-    store: {
-      getState(): { activeAccount: number; accounts: readonly Readonly<{
-        address: `0x${string}`;
-        credential?: Readonly<{ id: string }> | undefined;
-        label?: string | undefined;
-      }>[] };
-      setState(state: { accounts: readonly Readonly<{
-        address: `0x${string}`;
-        credential?: Readonly<{ id: string }> | undefined;
-        label?: string | undefined;
-      }>[] }): unknown;
-      subscribe(listener: () => void): () => void;
-    };
-  }).store;
-  const providerState = useSyncExternalStore(
-    providerStore.subscribe,
-    providerStore.getState,
-    providerStore.getState,
-  );
   const [status, setStatus] = useState<SessionStatus>("checking");
   const [user, setUser] = useState<AuthenticatedAccount | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -93,15 +46,6 @@ export function AccountSessionProvider({ children }: { children: ReactNode }) {
   const [reauthenticationRequired, setReauthenticationRequired] = useState(false);
   const requestId = useRef(0);
   const refreshRequest = useRef<Promise<void> | undefined>(undefined);
-  const savedPasskeys = useMemo(() => providerState.accounts.flatMap((account, index) => account.credential?.id
-    ? [{
-        address: account.address,
-        credentialId: account.credential.id,
-        current: user?.persistent === true && index === providerState.activeAccount,
-        label: account.label,
-      } satisfies StoredPasskey]
-    : []), [providerState, user?.persistent]);
-
   const refresh = useCallback((): Promise<void> => {
     if (refreshRequest.current) return refreshRequest.current;
     const currentRequest = ++requestId.current;
@@ -138,60 +82,22 @@ export function AccountSessionProvider({ children }: { children: ReactNode }) {
   }, [refresh]);
 
   const chooseAccount = useCallback(async (selection: AccountSelection) => {
-    const nextOperation = selection.mode === "register" ? "register" : "sign-in";
-    setOperation(nextOperation);
+    setOperation("sign-in");
     setError(null);
     try {
-      let registrationUser = user;
-      if (selection.mode === "register" && (!registrationUser || registrationUser.persistent)) {
-        await logoutBrowserAccountSession();
-        registrationUser = await getCurrentUser();
-      }
-      if (selection.mode === "register" && !registrationUser) {
-        throw new Error("The browser identity is not ready.");
-      }
-      await retainSavedPasskeyLabels(providerStore, () => provider.request({
-        method: "wallet_connect",
-        params: [{ capabilities: selection.mode === "register"
-          ? {
-              method: "register",
-              name: selection.label,
-              userId: registrationUser!.id,
-            }
-          : {
-              method: "login",
-              ...(selection.credentialId
-                ? { credentialId: selection.credentialId }
-                : { selectAccount: true }),
-            } }],
-      }));
+      if (selection.authentication !== "sms_otp") throw new Error("SMS verification is required.");
       const nextUser = await getCurrentUser();
-      if (!nextUser) throw new Error("The account session was not created.");
+      if (!nextUser?.persistent) throw new Error("The SMS account session was not created.");
       requestId.current++;
       setUser(nextUser);
       setStatus("ready");
       setReauthenticationRequired(false);
     } catch (cause) {
-      setError(accountFailure(
-        cause,
-        selection.mode === "register"
-          ? "Couldn’t register this passkey. Try again."
-          : "Couldn’t sign in with a passkey. Try again.",
-      ));
+      setError(accountFailure(cause, "Couldn’t sign in by SMS. Try again."));
     } finally {
       setOperation(null);
     }
-  }, [provider, user]);
-
-  const register = useCallback(() => chooseAccount({
-    mode: "register",
-    label: user ? `Nanocodex ${user.id}` : "Nanocodex account",
-  }), [chooseAccount, user]);
-  const signIn = useCallback(() => chooseAccount({
-    mode: "login",
-    label: "Another passkey",
-    discoverCredential: true,
-  }), [chooseAccount]);
+  }, []);
   const signOut = useCallback(async () => {
     setOperation("sign-out");
     setError(null);
@@ -214,14 +120,11 @@ export function AccountSessionProvider({ children }: { children: ReactNode }) {
     status,
     error,
     operation,
-    savedPasskeys,
     chooseAccount,
     refresh,
-    register,
-    signIn,
     signOut,
     reauthenticationRequired,
-  }), [chooseAccount, error, operation, reauthenticationRequired, refresh, register, savedPasskeys, signIn, signOut, status, user]);
+  }), [chooseAccount, error, operation, reauthenticationRequired, refresh, signOut, status, user]);
 
   return (
     <AccountSessionContext.Provider value={value}>
@@ -237,8 +140,5 @@ export function useAccountSession(): AccountSession {
 }
 
 function accountFailure(cause: unknown, fallback: string): string {
-  if (cause instanceof DOMException && cause.name === "NotAllowedError") {
-    return "No matching passkey was available, or the request was cancelled. Try another passkey or create a new account.";
-  }
   return clientFailureMessage(cause, fallback);
 }

--- a/js/account/src/DeviceConnect.css
+++ b/js/account/src/DeviceConnect.css
@@ -918,6 +918,89 @@
   opacity: 0.58;
 }
 
+.connect-wizard .wizard-connectors .tempo-wallet-card {
+  cursor: default;
+  grid-template-columns: 40px minmax(0, 1fr) auto;
+}
+
+.connect-wizard .tempo-wallet-card .connection-card-copy {
+  gap: 3px;
+}
+
+.connect-wizard .tempo-wallet-card .tempo-wallet-balance {
+  color: var(--positive);
+  font-size: 10px;
+}
+
+.connect-wizard .tempo-wallet-card code {
+  overflow: hidden;
+  color: var(--faint);
+  font-size: 8px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.connect-wizard .tempo-wallet-message {
+  color: var(--faint);
+  font-size: 9px;
+  line-height: 1.4;
+  white-space: normal;
+}
+
+.connect-wizard .tempo-wallet-message.is-error {
+  color: var(--negative);
+}
+
+.connect-wizard .tempo-wallet-message.is-success {
+  color: var(--positive);
+}
+
+.connect-wizard .tempo-wallet-card-actions {
+  display: flex;
+  align-self: stretch;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.connect-wizard .tempo-wallet-card-actions button {
+  min-height: 36px;
+  padding: 0 10px;
+  border: 1px solid var(--border-soft);
+  color: var(--text);
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  font-size: 9px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.connect-wizard .tempo-wallet-card-actions button:last-child {
+  color: var(--surface);
+  background: var(--text);
+}
+
+.connect-wizard .tempo-wallet-card-actions button:hover:not(:disabled),
+.connect-wizard .tempo-wallet-card-actions button:focus-visible {
+  border-color: var(--text);
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.connect-wizard .tempo-wallet-card-actions button:disabled {
+  cursor: default;
+  opacity: 0.48;
+}
+
+.connect-wizard .tempo-wallet-payment-status {
+  align-self: end;
+  color: var(--positive);
+  font-size: 8px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
 .connect-wizard .mcp-connections {
   display: grid;
   margin-top: 12px;
@@ -1232,6 +1315,20 @@
     white-space: normal;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
+  }
+
+  .connect-wizard .wizard-connectors .tempo-wallet-card {
+    grid-template-columns: 40px minmax(0, 1fr);
+  }
+
+  .connect-wizard .tempo-wallet-card-actions {
+    grid-column: 1 / -1;
+    flex-direction: row;
+  }
+
+  .connect-wizard .tempo-wallet-card-actions button {
+    min-height: 44px;
+    flex: 1;
   }
 
   .connect-wizard .wizard-visibility > div {

--- a/js/account/src/DeviceConnect.css
+++ b/js/account/src/DeviceConnect.css
@@ -1052,25 +1052,6 @@
   font-size: 8px;
 }
 
-.connect-wizard .account-wallet {
-  display: grid;
-  min-width: 0;
-  align-items: center;
-  margin-top: 14px;
-  padding: 16px;
-  border: 1px solid var(--border-soft);
-  background: color-mix(in srgb, var(--positive) 3%, transparent);
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 16px;
-}
-
-.connect-wizard .account-wallet-address {
-  display: grid;
-  min-width: 0;
-  gap: 6px;
-}
-
-.connect-wizard .account-wallet-address span,
 .connect-wizard .account-wallet-session > span {
   color: var(--muted);
   font-size: 8px;
@@ -1078,45 +1059,11 @@
   text-transform: uppercase;
 }
 
-.connect-wizard .account-wallet-address code {
-  overflow: hidden;
-  color: var(--text);
-  font-size: 12px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.connect-wizard .account-wallet-copy {
-  display: inline-flex;
-  min-width: 88px;
-  min-height: 38px;
-  align-items: center;
-  justify-content: center;
-  padding: 0 12px;
-  border: 1px solid var(--border-strong);
-  background: transparent;
-  color: var(--text);
-  cursor: pointer;
-  font-size: 9px;
-  gap: 7px;
-}
-
-.connect-wizard .account-wallet-copy:hover,
-.connect-wizard .account-wallet-copy:focus-visible {
-  border-color: var(--text);
-  outline: none;
-}
-
-.connect-wizard .account-wallet-copy svg {
-  width: 12px;
-  height: 12px;
-}
-
 .connect-wizard .account-wallet-session {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-top: 10px;
+  padding: 16px 0 48px;
   gap: 12px;
 }
 
@@ -1240,20 +1187,6 @@
     margin-right: 16px;
     margin-left: 16px;
     padding-top: 28px;
-  }
-
-  .connect-wizard .account-wallet {
-    grid-template-columns: 1fr;
-  }
-
-  .connect-wizard .account-wallet-address code {
-    overflow-wrap: anywhere;
-    white-space: normal;
-  }
-
-  .connect-wizard .account-wallet-copy {
-    width: 100%;
-    min-height: 44px;
   }
 
   .connect-wizard .sms-auth-panel {

--- a/js/account/src/DeviceConnect.css
+++ b/js/account/src/DeviceConnect.css
@@ -33,7 +33,19 @@
 }
 
 .connect-wizard .wizard-account-page {
-  width: min(620px, calc(100% - (2 * var(--page-margin))));
+  width: min(500px, calc(100% - (2 * var(--page-margin))));
+  margin-right: auto;
+  margin-left: auto;
+  padding: clamp(40px, 8vh, 88px) 0 64px;
+}
+
+.connect-wizard .sms-auth-panel {
+  overflow: hidden;
+  padding: 32px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-medium);
+  background: color-mix(in srgb, var(--surface-raised) 88%, var(--surface));
+  box-shadow: 0 22px 70px rgba(0, 0, 0, 0.22);
 }
 
 .connect-wizard .wizard-review-page {
@@ -48,9 +60,18 @@
   gap: 32px;
 }
 
+.connect-wizard .sms-auth-panel .wizard-intro {
+  display: block;
+  padding-bottom: 26px;
+}
+
 .connect-wizard .wizard-app {
   display: grid;
   gap: 8px;
+}
+
+.connect-wizard .sms-auth-panel .wizard-app {
+  gap: 10px;
 }
 
 .connect-wizard .wizard-app > span,
@@ -68,11 +89,139 @@
   letter-spacing: -0.045em;
 }
 
+.connect-wizard .sms-auth-panel .wizard-app h1 {
+  margin-top: 2px;
+  font-size: clamp(27px, 4vw, 34px);
+  line-height: 1.12;
+}
+
 .connect-wizard .wizard-app p {
   max-width: 620px;
   color: var(--muted);
   font-size: 12px;
   line-height: 1.5;
+}
+
+.connect-wizard .sms-auth-panel .wizard-app p {
+  font-size: 12px;
+  line-height: 1.65;
+}
+
+.connect-wizard .sms-auth-panel .sms-otp-form {
+  display: grid;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  gap: 9px;
+}
+
+.connect-wizard .sms-auth-panel .sms-otp-form > label {
+  margin-top: 2px;
+  font-size: 12px;
+}
+
+.connect-wizard .sms-auth-panel .sms-otp-form > p {
+  font-size: 10px;
+  line-height: 1.55;
+}
+
+.connect-wizard .sms-auth-panel .sms-otp-input-row {
+  display: grid;
+  grid-template-columns: 1fr;
+  margin: 5px 0 3px;
+  gap: 10px;
+}
+
+.connect-wizard .sms-auth-panel .sms-otp-input-row input,
+.connect-wizard .sms-auth-panel .sms-otp-input-row button {
+  width: 100%;
+  min-height: 50px;
+  border-radius: var(--radius-small);
+  font-size: 14px;
+}
+
+.connect-wizard .sms-auth-panel .sms-otp-input-row input {
+  padding: 0 14px;
+  border: 1px solid var(--border);
+  outline: none;
+  background: var(--surface);
+  color: var(--text);
+}
+
+.connect-wizard .sms-auth-panel .sms-otp-input-row button {
+  border: 1px solid var(--text);
+  background: var(--text);
+  color: var(--text-inverse);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.connect-wizard .sms-auth-panel .sms-otp-input-row button:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+
+.connect-wizard .sms-auth-panel .sms-otp-input-row button:hover:not(:disabled),
+.connect-wizard .sms-auth-panel .sms-otp-input-row button:focus-visible {
+  opacity: 0.88;
+}
+
+.connect-wizard .sms-auth-panel .sms-otp-input-row button:focus-visible,
+.connect-wizard .sms-auth-panel .sms-otp-input-row input:focus-visible {
+  outline: 2px solid var(--text);
+  outline-offset: 2px;
+}
+
+.connect-wizard .sms-auth-panel .account-failure {
+  margin: 0 0 18px;
+  padding: 12px 14px;
+  border: 1px solid color-mix(in srgb, var(--negative) 34%, var(--border-soft));
+  border-radius: var(--radius-small);
+}
+
+.connect-wizard .sms-auth-panel .account-failure p {
+  font-size: 11px;
+}
+
+.connect-wizard .sms-auth-panel .sms-otp-change {
+  justify-self: start;
+  min-height: 34px;
+  margin-top: 2px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 10px;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.connect-wizard .sms-auth-security {
+  display: flex;
+  align-items: center;
+  margin-top: 24px;
+  padding-top: 18px;
+  border-top: 1px solid var(--border-soft);
+  color: var(--text-muted);
+  gap: 9px;
+}
+
+.connect-wizard .sms-auth-security span {
+  display: grid;
+  width: 20px;
+  height: 20px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--positive) 55%, var(--border-soft));
+  border-radius: 50%;
+  color: var(--positive);
+  font-size: 10px;
+}
+
+.connect-wizard .sms-auth-security p {
+  font-size: 9px;
+  line-height: 1.45;
 }
 
 .connect-wizard .wizard-account-chooser {
@@ -1013,6 +1162,16 @@
   .connect-wizard .wizard-account-page,
   .connect-wizard .wizard-review-page {
     width: calc(100% - 32px);
+  }
+
+  .connect-wizard .wizard-account-page {
+    margin-right: 16px;
+    margin-left: 16px;
+    padding-top: 28px;
+  }
+
+  .connect-wizard .sms-auth-panel {
+    padding: 24px 20px;
   }
 
   .connect-wizard .wizard-intro {

--- a/js/account/src/DeviceConnect.css
+++ b/js/account/src/DeviceConnect.css
@@ -1052,6 +1052,78 @@
   font-size: 8px;
 }
 
+.connect-wizard .account-wallet {
+  display: grid;
+  min-width: 0;
+  align-items: center;
+  margin-top: 14px;
+  padding: 16px;
+  border: 1px solid var(--border-soft);
+  background: color-mix(in srgb, var(--positive) 3%, transparent);
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 16px;
+}
+
+.connect-wizard .account-wallet-address {
+  display: grid;
+  min-width: 0;
+  gap: 6px;
+}
+
+.connect-wizard .account-wallet-address span,
+.connect-wizard .account-wallet-session > span {
+  color: var(--muted);
+  font-size: 8px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.connect-wizard .account-wallet-address code {
+  overflow: hidden;
+  color: var(--text);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.connect-wizard .account-wallet-copy {
+  display: inline-flex;
+  min-width: 88px;
+  min-height: 38px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 12px;
+  border: 1px solid var(--border-strong);
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  font-size: 9px;
+  gap: 7px;
+}
+
+.connect-wizard .account-wallet-copy:hover,
+.connect-wizard .account-wallet-copy:focus-visible {
+  border-color: var(--text);
+  outline: none;
+}
+
+.connect-wizard .account-wallet-copy svg {
+  width: 12px;
+  height: 12px;
+}
+
+.connect-wizard .account-wallet-session {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 10px;
+  gap: 12px;
+}
+
+.connect-wizard .account-wallet-session .wizard-sign-out {
+  margin-top: 0;
+}
+
 .connect-wizard .wizard-visibility {
   display: grid;
   padding: 6px 0;
@@ -1168,6 +1240,20 @@
     margin-right: 16px;
     margin-left: 16px;
     padding-top: 28px;
+  }
+
+  .connect-wizard .account-wallet {
+    grid-template-columns: 1fr;
+  }
+
+  .connect-wizard .account-wallet-address code {
+    overflow-wrap: anywhere;
+    white-space: normal;
+  }
+
+  .connect-wizard .account-wallet-copy {
+    width: 100%;
+    min-height: 44px;
   }
 
   .connect-wizard .sms-auth-panel {

--- a/js/account/src/HostedToolsDemo.tsx
+++ b/js/account/src/HostedToolsDemo.tsx
@@ -79,7 +79,7 @@ export function HostedToolsDemo() {
   const ensureRuntime = useCallback(async (): Promise<DemoRuntime> => {
     if (runtimeRef.current) return runtimeRef.current;
     const accountId = accountIdRef.current;
-    if (!accountId) throw new Error("sign in with a passkey before attaching browser tools");
+    if (!accountId) throw new Error("sign in by SMS before attaching browser tools");
     const storageKey = `nanocodex.hosted-tools-demo.agent.v1.${accountId}`;
     const retainedId = safeGet(storageKey);
     const listed = await Agent.list();
@@ -244,14 +244,14 @@ export function HostedToolsDemo() {
       </header>
 
       <dl className="hosted-tools-facts" aria-label="Hosted tool connection">
-        <div><dt>Account</dt><dd>{account.account ? "Passkey session" : "Required"}</dd></div>
+        <div><dt>Account</dt><dd>{account.account ? "SMS session" : "Required"}</dd></div>
         <div><dt>Agent</dt><dd>{agentId ? shortId(agentId) : "Chosen on attach"}</dd></div>
         <div><dt>Execution</dt><dd>{executions.length ? `${executions.length} browser call${executions.length === 1 ? "" : "s"}` : "No browser calls"}</dd></div>
       </dl>
 
       {!account.account ? (
         <div className="hosted-tools-gate" role="status">
-          Sign in with a passkey from the account menu to use the managed broker.
+          Sign in by SMS from the account menu to use the managed broker.
         </div>
       ) : !modelReady ? (
         <div className="hosted-tools-gate" role={modelStatus.state === "error" ? "alert" : "status"}>

--- a/js/account/src/Vault.tsx
+++ b/js/account/src/Vault.tsx
@@ -139,18 +139,16 @@ export function Vault() {
         <header className="wizard-intro">
           <div className="wizard-app">
             <h1>Vault</h1>
-            <p>Add a passkey account before storing encrypted credentials and personal details.</p>
+            <p>Verify your phone before storing encrypted credentials and personal details.</p>
           </div>
         </header>
         <AccountChooser
           description={session.reauthenticationRequired
-            ? "Your session expired. Continue with the saved passkey to restore your vault."
-            : "Continue with a saved passkey, or create a Nanocodex account."}
+            ? "Your session expired. Enter your phone number to restore your vault."
+            : "Enter your phone number to create or restore your Nanocodex account."}
           disabled={session.operation !== null}
           failure={session.error}
-          newAccountDetail="Create one passkey to keep your vault available across devices."
           onChooseAccount={(selection) => void session.chooseAccount(selection)}
-          storedPasskeys={session.savedPasskeys}
         />
       </div>
     );

--- a/js/account/src/accountSessionRequest.ts
+++ b/js/account/src/accountSessionRequest.ts
@@ -1,4 +1,5 @@
 export type AuthenticatedAccount = Readonly<{
+  address?: `0x${string}` | undefined;
   id: string;
   persistent: boolean;
 }>;
@@ -7,7 +8,7 @@ const USER_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f
 
 export class ReauthenticationRequiredError extends Error {
   constructor() {
-    super("Your passkey session expired. Sign in to restore your account.");
+    super("Your session expired. Sign in by SMS to restore your account.");
     this.name = "ReauthenticationRequiredError";
   }
 }
@@ -39,13 +40,14 @@ async function readCurrentUser(
   if (!response.ok) throw await responseFailure(response, "Account service unavailable.");
   const body: unknown = await response.json();
   if (!isRecord(body) || !isRecord(body.user)) throw new Error("Invalid account response.");
-  const { id, persistent } = body.user;
+  const { address, id, persistent } = body.user;
   if (
     typeof id !== "string"
     || !USER_ID.test(id)
+    || (address !== undefined && (typeof address !== "string" || !/^0x[0-9a-f]{40}$/.test(address)))
     || typeof persistent !== "boolean"
   ) throw new Error("Invalid account response.");
-  return { id, persistent };
+  return { ...(address ? { address: address as `0x${string}` } : {}), id, persistent };
 }
 
 export async function responseFailure(response: Response, fallback: string): Promise<Error> {

--- a/js/account/src/modelSession.tsx
+++ b/js/account/src/modelSession.tsx
@@ -34,7 +34,7 @@ export function inactiveTerminalMessage({
   if (agentStatus === "error" && source) return agentStartFailure(agentError);
   if (source === undefined || authStatus === undefined) return "";
   const agent = runtime === "managed" ? "managed agent" : "browser agent";
-  if (authStatus.state === "signed_out") return `Sign in with a passkey to start the ${agent}.`;
+  if (authStatus.state === "signed_out") return `Sign in by SMS to start the ${agent}.`;
   if (authStatus.state === "error") return "Could not check your model connection. Use Retry above.";
   if (!authStatus.ready) {
     return `Connect ChatGPT or an OpenAI API key from the account menu to start the ${agent}.`;
@@ -109,7 +109,7 @@ export function AgentSessionBar({
         </p>
       ) : null}
       {status?.state === "signed_out" ? (
-        <p className="agent-session-note" role="status">Sign in with a passkey from the account menu.</p>
+        <p className="agent-session-note" role="status">Sign in by SMS from the account menu.</p>
       ) : null}
       {agentError ? (
         <p className="agent-byok-error" role="alert">

--- a/js/account/src/walletFunding.test.ts
+++ b/js/account/src/walletFunding.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  classifyFundingOrder,
+  decodeFundingAttempt,
+  decodeMachineUsdConfig,
+  decodeWalletBalance,
+  defaultFundingAmountCents,
+  formatDollars,
+  formatWalletBalance,
+} from "./walletFunding.ts";
+
+const account = "0x1111111111111111111111111111111111111111";
+
+test("decodes and formats the canonical MACH balance", () => {
+  const balance = decodeWalletBalance({
+    account,
+    balance: "12345678",
+    decimals: 6,
+    symbol: "MACH",
+    token: "0x20c000000000000000000000f37de3740ADec032",
+  }, account.toUpperCase());
+  assert.equal(balance.atomics, 12_345_678n);
+  assert.equal(formatWalletBalance(balance), "12.345678 MACH");
+  assert.equal(formatWalletBalance({ ...balance, atomics: 0n }), "0.00 MACH");
+  assert.equal(formatWalletBalance({ ...balance, atomics: 1_200_000n }), "1.2 MACH");
+  assert.throws(() => decodeWalletBalance({
+    account,
+    balance: "-1",
+    decimals: 6,
+    symbol: "MACH",
+    token: "0x20c000000000000000000000f37de3740ADec032",
+  }, account));
+  assert.throws(() => decodeWalletBalance({
+    account,
+    balance: "12345678",
+    decimals: 6,
+    symbol: "MACH",
+    token: "0x20c000000000000000000000f37de3740ADec032",
+  }, "0x2222222222222222222222222222222222222222"));
+});
+
+test("validates MACH onramp limits and selects the one-click amount", () => {
+  const config = decodeMachineUsdConfig({
+    chain_id: 4217,
+    min_usd_amount_cents: 500,
+    max_usd_amount_cents: 10_000,
+    onramp_enabled: true,
+    stripe_publishable_key: "pk_test_example",
+    token_address: "0x20c000000000000000000000f37de3740ADec032",
+  });
+  assert.equal(defaultFundingAmountCents(config), 500);
+  assert.equal(defaultFundingAmountCents({ ...config, minUsdAmountCents: 700 }), 700);
+  assert.equal(defaultFundingAmountCents({ ...config, minUsdAmountCents: 100, maxUsdAmountCents: 400 }), 400);
+  assert.equal(formatDollars(500), "$5.00");
+  assert.throws(() => decodeMachineUsdConfig({
+    chain_id: 1,
+    min_usd_amount_cents: 500,
+    max_usd_amount_cents: 10_000,
+    stripe_publishable_key: "pk_test_example",
+    token_address: "0x20c000000000000000000000f37de3740ADec032",
+  }), /configuration/);
+});
+
+test("accepts only Stripe hosted checkout and known order states", () => {
+  assert.deepEqual(decodeFundingAttempt({
+    order: { id: "order-1" },
+    payment: { checkout_url: "https://checkout.stripe.com/c/pay/cs_test" },
+  }, "token"), {
+    checkoutUrl: "https://checkout.stripe.com/c/pay/cs_test",
+    id: "order-1",
+    orderToken: "token",
+  });
+  assert.throws(() => decodeFundingAttempt({
+    order: { id: "order-1" },
+    payment: { checkout_url: "https://example.com/checkout" },
+  }, "token"), /checkout URL/);
+  assert.throws(() => decodeFundingAttempt({
+    order: { id: "order-1" },
+    payment: { checkout_url: "https://user:secret@checkout.stripe.com/c/pay/cs_test" },
+  }, "token"), /checkout URL/);
+  for (const status of ["requires_payment", "processing", "issuing"]) {
+    assert.equal(classifyFundingOrder({ status }), "pending");
+  }
+  assert.equal(classifyFundingOrder({ status: "failed" }), "failed");
+  assert.equal(classifyFundingOrder({
+    status: "complete",
+    issuance_transaction_hash: `0x${"1".repeat(64)}`,
+  }), "complete");
+  assert.throws(() => classifyFundingOrder({
+    status: "complete",
+    issuance_transaction_hash: "0x01",
+  }), /order response/);
+});

--- a/js/account/src/walletFunding.ts
+++ b/js/account/src/walletFunding.ts
@@ -1,0 +1,127 @@
+const ADDRESS = /^0x[0-9a-f]{40}$/i;
+const TRANSACTION_HASH = /^0x[0-9a-f]{64}$/i;
+const INTEGER = /^(?:0|[1-9][0-9]*)$/;
+const MACHINE_USD = "0x20c000000000000000000000f37de3740adec032";
+const TEMPO_CHAIN_ID = 4217;
+
+export type WalletBalance = Readonly<{
+  account: `0x${string}`;
+  atomics: bigint;
+  decimals: 6;
+  symbol: "MACH";
+}>;
+
+export type MachineUsdConfig = Readonly<{
+  minUsdAmountCents: number;
+  maxUsdAmountCents: number;
+  onrampEnabled: boolean;
+}>;
+
+export type FundingAttempt = Readonly<{
+  checkoutUrl: string;
+  id: string;
+  orderToken: string;
+}>;
+
+export function decodeWalletBalance(value: unknown, expectedAccount: string): WalletBalance {
+  const record = object(value, "wallet balance");
+  if (typeof record.account !== "string"
+    || !ADDRESS.test(record.account)
+    || record.account.toLowerCase() !== expectedAccount.toLowerCase()
+    || typeof record.balance !== "string"
+    || !INTEGER.test(record.balance)
+    || record.decimals !== 6
+    || record.symbol !== "MACH"
+    || typeof record.token !== "string"
+    || record.token.toLowerCase() !== MACHINE_USD) {
+    throw new Error("The wallet balance response is invalid.");
+  }
+  return {
+    account: record.account.toLowerCase() as `0x${string}`,
+    atomics: BigInt(record.balance),
+    decimals: 6,
+    symbol: "MACH",
+  };
+}
+
+export function formatWalletBalance(balance: WalletBalance): string {
+  const scale = 1_000_000n;
+  const whole = balance.atomics / scale;
+  const fractional = (balance.atomics % scale).toString().padStart(6, "0").replace(/0+$/, "");
+  return `${whole.toLocaleString("en-US")}.${fractional || "00"} MACH`;
+}
+
+export function decodeMachineUsdConfig(value: unknown): MachineUsdConfig {
+  const record = object(value, "MACH config");
+  const min = record.min_usd_amount_cents;
+  const max = record.max_usd_amount_cents;
+  const enabled = record.onramp_enabled ?? true;
+  if (!Number.isSafeInteger(min) || !Number.isSafeInteger(max)
+    || (min as number) <= 0 || (max as number) < (min as number)
+    || typeof enabled !== "boolean"
+    || record.chain_id !== TEMPO_CHAIN_ID
+    || typeof record.token_address !== "string"
+    || record.token_address.toLowerCase() !== MACHINE_USD
+    || typeof record.stripe_publishable_key !== "string") {
+    throw new Error("The MACH onramp configuration is invalid.");
+  }
+  return {
+    minUsdAmountCents: min as number,
+    maxUsdAmountCents: max as number,
+    onrampEnabled: enabled,
+  };
+}
+
+export function defaultFundingAmountCents(config: MachineUsdConfig): number {
+  return Math.min(config.maxUsdAmountCents, Math.max(config.minUsdAmountCents, 500));
+}
+
+export function decodeFundingAttempt(
+  value: unknown,
+  orderToken: string,
+): FundingAttempt {
+  const record = object(value, "MACH order");
+  const order = object(record.order, "MACH order");
+  const payment = object(record.payment, "MACH payment");
+  if (typeof order.id !== "string" || !order.id || typeof payment.checkout_url !== "string") {
+    throw new Error("The MACH order response is invalid.");
+  }
+  let checkout: URL;
+  try {
+    checkout = new URL(payment.checkout_url);
+  } catch {
+    throw new Error("The MACH checkout URL is invalid.");
+  }
+  if (checkout.origin !== "https://checkout.stripe.com" || checkout.username || checkout.password) {
+    throw new Error("The MACH checkout URL is invalid.");
+  }
+  return { checkoutUrl: checkout.href, id: order.id, orderToken };
+}
+
+export function classifyFundingOrder(value: unknown): "complete" | "failed" | "pending" {
+  const record = object(value, "MACH order");
+  if (record.status === "complete"
+    && typeof record.issuance_transaction_hash === "string"
+    && TRANSACTION_HASH.test(record.issuance_transaction_hash)) {
+    return "complete";
+  }
+  if (record.status === "failed") return "failed";
+  if (record.status === "requires_payment" || record.status === "processing" || record.status === "issuing") {
+    return "pending";
+  }
+  throw new Error("The MACH order response is invalid.");
+}
+
+export function formatDollars(cents: number): string {
+  return `$${(cents / 100).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function object(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`The ${label} response is invalid.`);
+  }
+  return value as Record<string, unknown>;
+}

--- a/js/account/worker/accountFundingProxy.test.ts
+++ b/js/account/worker/accountFundingProxy.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isAccountFundingPath, routeAccountFunding } from "./accountFundingProxy.ts";
+
+const origin = "https://nanocodex.test";
+const address = "0x1111111111111111111111111111111111111111";
+
+test("matches only exact MACH funding routes", () => {
+  for (const path of [
+    "/v1/machine-usd/config",
+    "/v1/machine-usd/orders",
+    "/v1/machine-usd/orders/order_123",
+  ]) assert.equal(isAccountFundingPath(path), true, path);
+  for (const path of [
+    "/v1/machine-usd",
+    "/v1/machine-usd/other",
+    "/v1/machine-usd/orders/order/extra",
+  ]) assert.equal(isAccountFundingPath(path), false, path);
+});
+
+test("creates an order only for the authenticated canonical account wallet", async () => {
+  const upstream: Request[] = [];
+  const request = new Request(`${origin}/v1/machine-usd/orders`, {
+    method: "POST",
+    headers: {
+      cookie: "account_session=secret",
+      "content-type": "application/json",
+      "idempotency-key": "attempt-1",
+    },
+    body: JSON.stringify({
+      order_token: "order-token",
+      payment_mode: "hosted_checkout",
+      usd_amount_cents: 500,
+      wallet_address: "0x2222222222222222222222222222222222222222",
+      ignored: "value",
+    }),
+  });
+  const response = await routeAccountFunding(request, {
+    NANOCODEX_BACKEND: {
+      async fetch(sessionRequest) {
+        assert.equal(new URL(sessionRequest.url).pathname, "/v1/me");
+        assert.equal(sessionRequest.method, "GET");
+        assert.equal(sessionRequest.headers.get("cookie"), "account_session=secret");
+        return Response.json({
+          authentication: "account_session",
+          user: { id: "user-1", persistent: true, address },
+        });
+      },
+    },
+    NANOCODEX_CONNECT_API: {
+      async fetch(upstreamRequest) {
+        upstream.push(upstreamRequest);
+        return Response.json({ ok: true }, { status: 201 });
+      },
+    },
+  }, new URL(request.url));
+  assert.equal(response?.status, 201);
+  assert.equal(upstream.length, 1);
+  assert.equal(upstream[0]?.headers.has("cookie"), false);
+  assert.equal(upstream[0]?.headers.get("idempotency-key"), "attempt-1");
+  assert.deepEqual(await upstream[0]?.json(), {
+    order_token: "order-token",
+    payment_mode: "hosted_checkout",
+    usd_amount_cents: 500,
+    wallet_address: address,
+  });
+});
+
+test("rejects anonymous order creation without reaching the onramp", async () => {
+  let called = false;
+  const request = new Request(`${origin}/v1/machine-usd/orders`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "{}",
+  });
+  const response = await routeAccountFunding(request, {
+    NANOCODEX_BACKEND: { fetch: async () => Response.json({ authenticated: false }, { status: 401 }) },
+    NANOCODEX_CONNECT_API: {
+      fetch: async () => {
+        called = true;
+        return new Response();
+      },
+    },
+  }, new URL(request.url));
+  assert.equal(response?.status, 401);
+  assert.equal(called, false);
+});
+
+test("forwards status bearer credentials without account cookies", async () => {
+  let upstream: Request | undefined;
+  const request = new Request(`${origin}/v1/machine-usd/orders/order_123`, {
+    headers: { authorization: "Bearer order-token", cookie: "account_session=secret" },
+  });
+  const response = await routeAccountFunding(request, {
+    ENVIRONMENT: "development",
+    NANOCODEX_CONNECT_API: {
+      fetch: async (value) => {
+        upstream = value;
+        return Response.json({ order: { status: "processing" } });
+      },
+    },
+  }, new URL(request.url));
+  assert.equal(response?.status, 200);
+  assert.equal(upstream?.headers.get("authorization"), "Bearer order-token");
+  assert.equal(upstream?.headers.has("cookie"), false);
+  assert.equal(upstream?.headers.get("x-nanocodex-local-origin"), origin);
+});

--- a/js/account/worker/accountFundingProxy.ts
+++ b/js/account/worker/accountFundingProxy.ts
@@ -1,0 +1,128 @@
+export type AccountFundingProxyEnv = {
+  ENVIRONMENT?: string;
+  NANOCODEX_BACKEND?: Fetcher;
+  NANOCODEX_CONNECT_API?: Fetcher;
+};
+
+const ADDRESS = /^0x[0-9a-f]{40}$/i;
+const ORDER_PATH = "/v1/machine-usd/orders";
+const ORDER_STATUS_PATH = /^\/v1\/machine-usd\/orders\/[A-Za-z0-9_-]+$/;
+
+/**
+ * Projects the public onramp while binding order creation to the persistent
+ * account's Worker-owned wallet. Account cookies never reach Connect API.
+ */
+export async function routeAccountFunding(
+  request: Request,
+  env: AccountFundingProxyEnv,
+  url: URL,
+): Promise<Response | undefined> {
+  if (!isAccountFundingPath(url.pathname)) return undefined;
+  if (!env.NANOCODEX_CONNECT_API) return unavailable();
+
+  const headers = upstreamHeaders(request, env, url);
+  let upstreamRequest: Request;
+  if (url.pathname === ORDER_PATH && request.method === "POST") {
+    const account = await persistentAccount(request, env, url);
+    if (!account) return json({ error: "authentication_required" }, 401);
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return json({ error: "invalid_request" }, 400);
+    }
+    if (!isRecord(body)) return json({ error: "invalid_request" }, 400);
+    headers.set("content-type", "application/json");
+    upstreamRequest = new Request(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        order_token: body.order_token,
+        payment_mode: body.payment_mode,
+        usd_amount_cents: body.usd_amount_cents,
+        wallet_address: account.address,
+      }),
+    });
+  } else {
+    upstreamRequest = new Request(url, { method: request.method, headers });
+  }
+
+  try {
+    return await env.NANOCODEX_CONNECT_API.fetch(upstreamRequest);
+  } catch {
+    return unavailable();
+  }
+}
+
+export function isAccountFundingPath(pathname: string): boolean {
+  return pathname === "/v1/machine-usd/config"
+    || pathname === ORDER_PATH
+    || ORDER_STATUS_PATH.test(pathname);
+}
+
+async function persistentAccount(
+  request: Request,
+  env: AccountFundingProxyEnv,
+  url: URL,
+): Promise<{ address: string } | undefined> {
+  if (!env.NANOCODEX_BACKEND) return undefined;
+  const headers = new Headers({ accept: "application/json" });
+  const cookie = request.headers.get("cookie");
+  if (cookie) headers.set("cookie", cookie);
+  let response: Response;
+  try {
+    response = await env.NANOCODEX_BACKEND.fetch(new Request(new URL("/v1/me", url), {
+      method: "GET",
+      headers,
+    }));
+  } catch {
+    return undefined;
+  }
+  if (!response.ok) {
+    await response.body?.cancel();
+    return undefined;
+  }
+  const body: unknown = await response.json().catch(() => undefined);
+  if (!isRecord(body)
+    || body.authentication !== "account_session"
+    || !isRecord(body.user)
+    || body.user.persistent !== true
+    || typeof body.user.address !== "string"
+    || !ADDRESS.test(body.user.address)) return undefined;
+  return { address: body.user.address.toLowerCase() };
+}
+
+function upstreamHeaders(request: Request, env: AccountFundingProxyEnv, url: URL): Headers {
+  const headers = new Headers({
+    accept: "application/json",
+    origin: url.origin,
+  });
+  for (const name of ["authorization", "idempotency-key"]) {
+    const value = request.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+  if (env.ENVIRONMENT === "development") {
+    headers.set("x-nanocodex-local-origin", url.origin);
+  }
+  return headers;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function unavailable(): Response {
+  return json({ error: "machine_usd_unavailable" }, 503);
+}
+
+function json(body: unknown, status: number): Response {
+  return Response.json(body, {
+    status,
+    headers: {
+      "cache-control": "no-store",
+      "x-content-type-options": "nosniff",
+    },
+  });
+}
+
+type Fetcher = Readonly<{ fetch(request: Request): Promise<Response> }>;

--- a/js/account/worker/index.ts
+++ b/js/account/worker/index.ts
@@ -30,6 +30,7 @@ import {
 } from "./publicSecurity.ts";
 import { routeLinkPreview } from "./linkPreview.ts";
 import { routeManaged } from "./managedProxy.ts";
+import { routeAccountFunding, type AccountFundingProxyEnv } from "./accountFundingProxy.ts";
 import {
   routeChiefOfStaff,
   type ChiefOfStaffProxyEnv,
@@ -97,6 +98,7 @@ const SECURE_CHATGPT_COOKIE = "__Secure-nanocodex_chatgpt_v2";
 const GIT_SHA_PATTERN = /^[0-9a-f]{40}$/;
 
 type WorkerEnv = GitStorageEnv & ThreadGitStorageEnv & EvalStorageEnv & ChatGptEgressEnv
+  & AccountFundingProxyEnv
   & ConnectDialogProxyEnv
   & LocalConnectApiEnv
   & ConnectApiProxyEnv
@@ -140,6 +142,8 @@ export default {
     if (insecure) return insecure;
     const connectorCallbackReturn = await routeLocalConnectorCallbackReturn(request, env, url);
     if (connectorCallbackReturn != null) return connectorCallbackReturn;
+    const accountFunding = await routeAccountFunding(request, env, url);
+    if (accountFunding != null) return accountFunding;
     const localConnectApi = await routeLocalConnectApi(request, env, url);
     if (localConnectApi != null) return localConnectApi;
     const connectApi = await routeConnectApi(request, env, url);

--- a/js/account/worker/localConnectApi.ts
+++ b/js/account/worker/localConnectApi.ts
@@ -27,14 +27,11 @@ function isLocalConnectApiPath(pathname: string): boolean {
     || pathname === "/v1/connections"
     || pathname === "/v1/connections/disconnect"
     || pathname === "/v1/egress"
-    || pathname === "/v1/machine-usd/config"
-    || pathname === "/v1/machine-usd/orders"
     || pathname === "/v1/mercator/jobs"
     || pathname === "/v1/connect/auth"
     || pathname.startsWith("/v1/connect/auth/")
     || pathname.startsWith("/v1/access-keys/")
     || pathname.startsWith("/v1/grants/")
-    || pathname.startsWith("/v1/machine-usd/orders/")
     || pathname === "/v1/agent/account-info";
 }
 

--- a/js/account/worker/managedProxy.test.ts
+++ b/js/account/worker/managedProxy.test.ts
@@ -6,6 +6,7 @@ import { isManagedRoutePath } from "./managedProxy.ts";
 test("the account Worker exposes only the exact managed wallet routes", () => {
   for (const path of [
     "/v1/wallet",
+    "/v1/wallet/balance",
     "/v1/wallet/connect",
     "/v1/wallet/revoke-access-key",
   ]) {

--- a/js/account/worker/managedProxy.test.ts
+++ b/js/account/worker/managedProxy.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isManagedRoutePath } from "./managedProxy.ts";
+
+test("the account Worker exposes only the exact managed wallet routes", () => {
+  for (const path of [
+    "/v1/wallet",
+    "/v1/wallet/connect",
+    "/v1/wallet/revoke-access-key",
+  ]) {
+    assert.equal(isManagedRoutePath(path), true, path);
+  }
+
+  for (const path of [
+    "/v1/wallet/",
+    "/v1/wallet/export",
+    "/v1/wallet/connect/extra",
+    "/v1/wallet/revoke-access-key/extra",
+  ]) {
+    assert.equal(isManagedRoutePath(path), false, path);
+  }
+});

--- a/js/account/worker/managedProxy.ts
+++ b/js/account/worker/managedProxy.ts
@@ -2,7 +2,7 @@ export type ManagedProxyEnv = {
   NANOCODEX_BACKEND?: Fetcher;
 };
 
-const MANAGED_ROUTE = /^(?:\/auth(?:\/.*)?|\/webauthn\/.*|\/v1\/(?:auth(?:\/.*)?|me|wallet(?:\/(?:connect|revoke-access-key))?|egress|api-keys(?:\/.*)?|credentials(?:\/.*)?|connect(?:\/.*)?|connectors(?:\/.*)?|agents(?:\/.*)?|rooms(?:\/.*)?|history(?:\/.*)?|memory(?:\/.*)?|organization(?:\/.*)?))$/;
+const MANAGED_ROUTE = /^(?:\/auth(?:\/.*)?|\/webauthn\/.*|\/v1\/(?:auth(?:\/.*)?|me|wallet(?:\/(?:balance|connect|revoke-access-key))?|egress|api-keys(?:\/.*)?|credentials(?:\/.*)?|connect(?:\/.*)?|connectors(?:\/.*)?|agents(?:\/.*)?|rooms(?:\/.*)?|history(?:\/.*)?|memory(?:\/.*)?|organization(?:\/.*)?))$/;
 
 export function isManagedRoutePath(pathname: string): boolean {
   return MANAGED_ROUTE.test(pathname);

--- a/js/account/worker/managedProxy.ts
+++ b/js/account/worker/managedProxy.ts
@@ -2,7 +2,7 @@ export type ManagedProxyEnv = {
   NANOCODEX_BACKEND?: Fetcher;
 };
 
-const MANAGED_ROUTE = /^(?:\/auth(?:\/.*)?|\/webauthn\/.*|\/v1\/(?:me|egress|api-keys(?:\/.*)?|credentials(?:\/.*)?|connect(?:\/.*)?|connectors(?:\/.*)?|agents(?:\/.*)?|rooms(?:\/.*)?|history(?:\/.*)?|memory(?:\/.*)?|organization(?:\/.*)?))$/;
+const MANAGED_ROUTE = /^(?:\/auth(?:\/.*)?|\/webauthn\/.*|\/v1\/(?:auth(?:\/.*)?|me|egress|api-keys(?:\/.*)?|credentials(?:\/.*)?|connect(?:\/.*)?|connectors(?:\/.*)?|agents(?:\/.*)?|rooms(?:\/.*)?|history(?:\/.*)?|memory(?:\/.*)?|organization(?:\/.*)?))$/;
 
 export function isManagedRoutePath(pathname: string): boolean {
   return MANAGED_ROUTE.test(pathname);

--- a/js/account/worker/managedProxy.ts
+++ b/js/account/worker/managedProxy.ts
@@ -2,7 +2,7 @@ export type ManagedProxyEnv = {
   NANOCODEX_BACKEND?: Fetcher;
 };
 
-const MANAGED_ROUTE = /^(?:\/auth(?:\/.*)?|\/webauthn\/.*|\/v1\/(?:auth(?:\/.*)?|me|egress|api-keys(?:\/.*)?|credentials(?:\/.*)?|connect(?:\/.*)?|connectors(?:\/.*)?|agents(?:\/.*)?|rooms(?:\/.*)?|history(?:\/.*)?|memory(?:\/.*)?|organization(?:\/.*)?))$/;
+const MANAGED_ROUTE = /^(?:\/auth(?:\/.*)?|\/webauthn\/.*|\/v1\/(?:auth(?:\/.*)?|me|wallet(?:\/(?:connect|revoke-access-key))?|egress|api-keys(?:\/.*)?|credentials(?:\/.*)?|connect(?:\/.*)?|connectors(?:\/.*)?|agents(?:\/.*)?|rooms(?:\/.*)?|history(?:\/.*)?|memory(?:\/.*)?|organization(?:\/.*)?))$/;
 
 export function isManagedRoutePath(pathname: string): boolean {
   return MANAGED_ROUTE.test(pathname);

--- a/js/connect-api/src/deviceRedirect.mts
+++ b/js/connect-api/src/deviceRedirect.mts
@@ -22,6 +22,16 @@ export function connectAuthOrigin(apiOrigin: string): string {
   throw new Error("The Connect API origin is not allowed.");
 }
 
+/**
+ * Server-held wallets have no browser Origin header. This is only an
+ * admission rule for the signed SIWE challenge/verify protocol, not an
+ * authentication signal: account ownership is still proved by the signature.
+ */
+export function allowsHeadlessConnectAuth(requestOrigin: string, origin: string | null): boolean {
+  return origin === null
+    && (requestOrigin === productionApiOrigin || isLocalDevelopmentOrigin(requestOrigin));
+}
+
 export function isLocalDevelopmentOrigin(value: string): boolean {
   try {
     const url = new URL(value);

--- a/js/connect-api/src/index.ts
+++ b/js/connect-api/src/index.ts
@@ -1137,9 +1137,8 @@ async function createHostedAuthorization(
   const appOrigin = requiredString(body.app_origin, "app_origin");
   const resources = encodedResources;
   const app = approvedAppContext(resources);
-  if (app.appId !== CLI_APP_ID || app.origin !== CLI_APP_ORIGIN
-    || appId !== app.appId || appOrigin !== app.origin) {
-    throw new ApiFailure(403, "app_identity_mismatch", "Hosted authorization is reserved for the Nanocodex CLI.");
+  if (appId !== app.appId || appOrigin !== app.origin) {
+    throw new ApiFailure(403, "app_identity_mismatch", "Hosted authorization does not match the approved app.");
   }
   if (!resources.includes(HOSTED_AUTHORIZATION_RESOURCE)
     || resources.includes("urn:nanocodex:mpp:machusd:spend")) {

--- a/js/connect-api/src/index.ts
+++ b/js/connect-api/src/index.ts
@@ -18,6 +18,7 @@ import {
   managedMemoryCapability,
 } from "./devicePolicy.mts";
 import {
+  allowsHeadlessConnectAuth,
   connectAuthOrigin,
   deviceVerificationUrl,
   isLocalDevelopmentOrigin as isLocalDeviceOrigin,
@@ -478,7 +479,7 @@ export default {
       }
 
       if (url.pathname.startsWith("/v1/connect/auth")) {
-        requireDialogOrigin(request);
+        requireConnectAuthOrigin(request);
         const auth = createAuth(
           env,
           store,
@@ -5881,6 +5882,14 @@ async function scopedAppId(app: CallerApp): Promise<string> {
 
 function requireDialogOrigin(request: Request): void {
   requiredDialogOrigin(request);
+}
+
+function requireConnectAuthOrigin(request: Request): void {
+  if (allowsHeadlessConnectAuth(
+    new URL(request.url).origin,
+    request.headers.get("origin"),
+  )) return;
+  requireDialogOrigin(request);
 }
 
 function requiredDialogOrigin(request: Request): string {

--- a/js/connect-api/test/deviceRedirect.test.mjs
+++ b/js/connect-api/test/deviceRedirect.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { connectAuthOrigin, deviceVerificationUrl } from "../src/deviceRedirect.mts";
+import {
+  allowsHeadlessConnectAuth,
+  connectAuthOrigin,
+  deviceVerificationUrl,
+} from "../src/deviceRedirect.mts";
 
 test("production device verification opens the first-class main-site route", () => {
   assert.equal(
@@ -37,4 +41,18 @@ test("Connect authentication binds production and local ceremonies to exact trus
   assert.equal(connectAuthOrigin("http://localhost:5190"), "http://localhost:5190");
   assert.throws(() => connectAuthOrigin("https://connect.attacker.example"), /not allowed/);
   assert.throws(() => connectAuthOrigin("http://127.0.0.1:8787/path"), /not allowed/);
+});
+
+test("headless wallet auth admits only exact Connect API or local request origins without a browser Origin", () => {
+  assert.equal(allowsHeadlessConnectAuth(
+    "https://nanocodex-connect-api.gakonst.workers.dev",
+    null,
+  ), true);
+  assert.equal(allowsHeadlessConnectAuth("http://nanocodex.localhost:18943", null), true);
+  assert.equal(allowsHeadlessConnectAuth("https://nanocodex.gakonst.workers.dev", null), false);
+  assert.equal(allowsHeadlessConnectAuth("https://connect.attacker.example", null), false);
+  assert.equal(allowsHeadlessConnectAuth(
+    "https://nanocodex-connect-api.gakonst.workers.dev",
+    "https://connect.attacker.example",
+  ), false);
 });

--- a/js/egress/README.md
+++ b/js/egress/README.md
@@ -20,8 +20,9 @@ the repository operator interface in `../../AGENTS.md` for actual operation.
 ## Credential boundary
 
 The broker owns per-user provider credentials, connector OAuth state, MCP
-connection material, and brokered SSH private keys. Durable Objects encrypt
-that state with AES-256-GCM before storage. Production requires
+connection material, brokered SSH private keys, and each persistent account's
+secp256k1 root wallet. Durable Objects encrypt that state with AES-256-GCM
+before storage. Production requires
 `CREDENTIAL_ENCRYPTION_KEY`; a static Secrets Store binding can supply it, and
 `CREDENTIAL_ENCRYPTION_KEY_PREVIOUS` supports key rotation.
 
@@ -31,6 +32,20 @@ account authenticates its own control request and supplies the resolved user
 path; browser callers do not select users, subjects, upstreams, or credentials.
 The development-only ChatGPT bootstrap claim is enabled only by the explicit
 development/test environment and `ALLOW_LOCAL_CREDENTIAL_CLAIM=true`.
+
+The wallet is generated idempotently in the existing per-user
+`UserCredentialBroker` after the managed Worker confirms a successful OTP login.
+Its private key is sealed in the same user-scoped credential envelope and never
+leaves egress. The only wallet signing operations are exact `wallet_connect`
+access-key authorization and `wallet_revokeAccessKey`; there is no generic
+signing, transaction, import, or export surface. Public callers receive only
+the address and sanitized signed operation results.
+
+This is custodial server-side encryption, not user-held end-to-end encryption:
+egress can decrypt the key in Worker memory and the deployment encryption key
+is part of the trust boundary. See
+[persistent account wallet custody](../../docs/WALLET_CUSTODY.md) for the
+lifecycle, allowed operations, and migration boundary.
 
 ## Direct, fail-closed egress
 

--- a/js/egress/package.json
+++ b/js/egress/package.json
@@ -15,6 +15,7 @@
     "deploy:broker": "wrangler deploy --env=\"\" --config wrangler.broker.jsonc"
   },
   "dependencies": {
+    "accounts": "0.17.0",
     "nanocodex": "workspace:*"
   },
   "devDependencies": {

--- a/js/egress/package.json
+++ b/js/egress/package.json
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "accounts": "0.17.0",
-    "nanocodex": "workspace:*"
+    "nanocodex": "workspace:*",
+    "viem": "^2.54.0"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.22.0",

--- a/js/egress/src/broker.ts
+++ b/js/egress/src/broker.ts
@@ -1,5 +1,8 @@
 import { DurableObject } from "cloudflare:workers";
 import { Provider, ProviderRequest, secp256k1, Storage } from "accounts";
+import { http } from "viem";
+import { Actions } from "viem/tempo";
+import { tempo } from "viem/tempo/chains";
 
 import {
   CredentialVault,
@@ -34,6 +37,8 @@ const SUBJECT_TOMBSTONE_PREFIX = "!deleted:";
 const ROOT_WALLET_PRIVATE_KEY = /^0x[0-9a-fA-F]{64}$/;
 const ROOT_WALLET_ADDRESS = /^0x[0-9a-fA-F]{40}$/;
 const TEMPO_CHAIN_ID = "0x1079";
+const TEMPO_RPC = "https://rpc.tempo.xyz";
+const MACHINE_USD = "0x20c000000000000000000000f37de3740adec032";
 const PRODUCTION_CONNECT_API_ORIGIN = "https://nanocodex-connect-api.gakonst.workers.dev";
 const MAX_WALLET_RESOURCES = 64;
 const MAX_WALLET_RESOURCE_BYTES = 512;
@@ -333,6 +338,24 @@ export class UserCredentialBroker extends DurableObject<BrokerEnv> {
           return json(publicRootWallet(await this.#ensureRootWallet()), 200);
         }
         return jsonError(405, "method_not_allowed");
+      }
+      if (url.pathname === "/v1/wallet/balance") {
+        if (request.method !== "GET") return jsonError(405, "method_not_allowed");
+        const wallet = this.#credentials.wallet;
+        if (!wallet) return jsonError(404, "wallet_not_configured");
+        const provider = rootWalletProvider(wallet);
+        const balance = await Actions.token.getBalance(provider.getClient({ chainId: tempo.id }), {
+          account: wallet.address,
+          decimals: 6,
+          token: MACHINE_USD,
+        });
+        return json({
+          account: wallet.address,
+          balance: balance.amount.toString(),
+          decimals: 6,
+          symbol: "MACH",
+          token: MACHINE_USD,
+        }, 200);
       }
       if (url.pathname === "/v1/wallet/connect") {
         if (request.method !== "POST") return jsonError(405, "method_not_allowed");
@@ -1037,7 +1060,9 @@ function randomRootPrivateKey(): `0x${string}` {
 function rootWalletProvider(wallet: RootWallet) {
   return Provider.create({
     adapter: secp256k1({ privateKey: wallet.privateKey }),
+    chains: [tempo],
     storage: Storage.memory({ key: "nanocodex-root-wallet" }),
+    transports: { [tempo.id]: http(TEMPO_RPC, { retryCount: 1, timeout: 5_000 }) },
     mpp: false,
   });
 }

--- a/js/egress/src/broker.ts
+++ b/js/egress/src/broker.ts
@@ -1,4 +1,5 @@
 import { DurableObject } from "cloudflare:workers";
+import { Provider, ProviderRequest, secp256k1, Storage } from "accounts";
 
 import {
   CredentialVault,
@@ -30,6 +31,13 @@ const SUBJECT = /^[A-Za-z0-9_-]{43,128}$/;
 const USER_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const SUBJECT_DIRECTORY_PREFIX = "agent-subject-v1:";
 const SUBJECT_TOMBSTONE_PREFIX = "!deleted:";
+const ROOT_WALLET_PRIVATE_KEY = /^0x[0-9a-fA-F]{64}$/;
+const ROOT_WALLET_ADDRESS = /^0x[0-9a-fA-F]{40}$/;
+const TEMPO_CHAIN_ID = "0x1079";
+const PRODUCTION_CONNECT_API_ORIGIN = "https://nanocodex-connect-api.gakonst.workers.dev";
+const MAX_WALLET_RESOURCES = 64;
+const MAX_WALLET_RESOURCE_BYTES = 512;
+const MAX_WALLET_RESOURCE_TOTAL_BYTES = 8 * 1024;
 
 export interface BrokerEnv extends CredentialVaultEnv {
   AGENT_SUBJECTS: DurableObjectNamespace<AgentSubjectDirectory>;
@@ -68,6 +76,11 @@ type PendingLogin = {
   expiresAt: number;
   pollAfterMs: number;
   nextPollAt: number;
+};
+type RootWallet = {
+  privateKey: `0x${string}`;
+  address: `0x${string}`;
+  createdAt: number;
 };
 export type VaultKind = "login" | "card" | "address" | "phone";
 export type VaultEntryPayload =
@@ -116,6 +129,7 @@ type CredentialState = {
   login?: PendingLogin;
   ssh?: Record<string, BrokeredSshIdentity>;
   vault?: Record<string, VaultEntryMetadata>;
+  wallet?: RootWallet;
 };
 type StoredRow = { envelope: EncryptedEnvelope };
 
@@ -307,6 +321,51 @@ export class UserCredentialBroker extends DurableObject<BrokerEnv> {
       }
       if (request.method === "GET" && url.pathname === "/v1/status") {
         return json(this.#publicStatus(), 200);
+      }
+      if (url.pathname === "/v1/wallet") {
+        if (request.method === "GET") {
+          return this.#credentials.wallet
+            ? json(publicRootWallet(this.#credentials.wallet), 200)
+            : jsonError(404, "wallet_not_configured");
+        }
+        if (request.method === "PUT") {
+          if (await hasRequestPayload(request)) return jsonError(400, "invalid_request");
+          return json(publicRootWallet(await this.#ensureRootWallet()), 200);
+        }
+        return jsonError(405, "method_not_allowed");
+      }
+      if (url.pathname === "/v1/wallet/connect") {
+        if (request.method !== "POST") return jsonError(405, "method_not_allowed");
+        if (!isJsonContentType(request.headers.get("content-type"))) {
+          return jsonError(415, "invalid_content_type");
+        }
+        const requestBody = validateWalletConnectRequest(
+          await readJson(request, MAX_VAULT_BODY_BYTES),
+          this.#env,
+        );
+        if (!requestBody) return jsonError(400, "invalid_wallet_connect_request");
+        const wallet = await this.#ensureRootWallet();
+        return json(await rootWalletProvider(wallet).request(requestBody as never), 200);
+      }
+      if (url.pathname === "/v1/wallet/revoke-access-key") {
+        if (request.method !== "POST") return jsonError(405, "method_not_allowed");
+        if (!isJsonContentType(request.headers.get("content-type"))) {
+          return jsonError(415, "invalid_content_type");
+        }
+        const requestBody = validateWalletRevokeRequest(await readJson(request, MAX_VAULT_BODY_BYTES));
+        if (!requestBody) return jsonError(400, "invalid_wallet_revoke_request");
+        const wallet = await this.#ensureRootWallet();
+        const requested = requestBody.params[0]?.address;
+        if (typeof requested !== "string" || requested.toLowerCase() !== wallet.address.toLowerCase()) {
+          return jsonError(403, "wallet_address_mismatch");
+        }
+        const provider = rootWalletProvider(wallet);
+        await provider.request({
+          method: "wallet_connect",
+          params: [{ chainId: TEMPO_CHAIN_ID, capabilities: { method: "login" } }],
+        } as never);
+        await provider.request(requestBody as never);
+        return json({ ok: true }, 200);
       }
       const vaultMatch = url.pathname.match(
         /^\/v1\/vault\/(login|card|address|phone)(?:\/([A-Za-z0-9_-]{22,64}))?$/,
@@ -523,6 +582,15 @@ export class UserCredentialBroker extends DurableObject<BrokerEnv> {
         .map(publicVaultEntry)
         .sort((left, right) => right.created_at - left.created_at || compareText(left.id, right.id)),
     };
+  }
+
+  async #ensureRootWallet(): Promise<RootWallet> {
+    const current = this.#credentials.wallet;
+    if (current) return current;
+    const wallet = await createRootWallet();
+    this.#credentials = { ...this.#credentials, wallet };
+    await this.#persist();
+    return wallet;
   }
 
   async #credential(recover: boolean, revision: number | undefined): Promise<UserCredentialSnapshot> {
@@ -841,6 +909,10 @@ export class UserCredentialBroker extends DurableObject<BrokerEnv> {
   }> {
     let changed = false;
     const legacy: VaultEntry[] = [];
+    if (restored.wallet !== undefined && !validStoredRootWallet(restored.wallet)) {
+      delete restored.wallet;
+      changed = true;
+    }
     const validVault = Object.entries(isRecord(restored.vault) ? restored.vault : {})
       .flatMap(([id, value]) => {
         const metadata = validateStoredVaultMetadata(id, value);
@@ -910,6 +982,155 @@ export class UserCredentialBroker extends DurableObject<BrokerEnv> {
     }
     return times.length ? Math.min(...times) : undefined;
   }
+}
+
+type WalletConnectRequest = Readonly<{
+  method: "wallet_connect";
+  params: readonly [Readonly<Record<string, unknown>>];
+}>;
+type WalletRevokeRequest = Readonly<{
+  method: "wallet_revokeAccessKey";
+  params: readonly [Readonly<Record<string, unknown>>];
+}>;
+
+function publicRootWallet(wallet: RootWallet): Readonly<{ address: string; created_at: number }> {
+  return { address: wallet.address, created_at: wallet.createdAt };
+}
+
+function validStoredRootWallet(value: unknown): value is RootWallet {
+  return isRecord(value)
+    && Object.keys(value).length === 3
+    && ROOT_WALLET_PRIVATE_KEY.test(String(value.privateKey))
+    && ROOT_WALLET_ADDRESS.test(String(value.address))
+    && typeof value.createdAt === "number"
+    && Number.isSafeInteger(value.createdAt)
+    && value.createdAt > 0;
+}
+
+async function createRootWallet(): Promise<RootWallet> {
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const privateKey = randomRootPrivateKey();
+    try {
+      const provider = rootWalletProvider({ privateKey, address: "0x0000000000000000000000000000000000000000", createdAt: Date.now() });
+      const result = await provider.request({
+        method: "wallet_connect",
+        params: [{ chainId: TEMPO_CHAIN_ID, capabilities: { method: "login" } }],
+      } as never) as { accounts?: readonly { address?: unknown }[] };
+      const address = result.accounts?.[0]?.address;
+      if (typeof address === "string" && ROOT_WALLET_ADDRESS.test(address)) {
+        return {
+          privateKey,
+          address: address.toLowerCase() as `0x${string}`,
+          createdAt: Date.now(),
+        };
+      }
+    } catch { /* retry an invalid scalar without exposing it */ }
+  }
+  throw new BrokerFailure(503, "wallet_provisioning_failed");
+}
+
+function randomRootPrivateKey(): `0x${string}` {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  return `0x${Array.from(bytes, (value) => value.toString(16).padStart(2, "0")).join("")}`;
+}
+
+function rootWalletProvider(wallet: RootWallet) {
+  return Provider.create({
+    adapter: secp256k1({ privateKey: wallet.privateKey }),
+    storage: Storage.memory({ key: "nanocodex-root-wallet" }),
+    mpp: false,
+  });
+}
+
+function validateWalletConnectRequest(value: unknown, env: BrokerEnv): WalletConnectRequest | undefined {
+  if (!isRecord(value) || !hasExactKeys(value, ["request"]) || !isRecord(value.request)
+    || !hasExactKeys(value.request, ["method", "params"])
+    || value.request.method !== "wallet_connect" || !Array.isArray(value.request.params)
+    || value.request.params.length !== 1 || !isRecord(value.request.params[0])) return undefined;
+  const params = value.request.params[0];
+  if (!hasOnlyKeys(params, ["chainId", "capabilities"]) || params.chainId !== TEMPO_CHAIN_ID
+    || !isRecord(params.capabilities)) return undefined;
+  const capabilities = params.capabilities;
+  if (!hasOnlyKeys(capabilities, ["auth", "authorizeAccessKey", "method", "showDeposit"])
+    || capabilities.method !== "login" || !validWalletAuth(capabilities.auth, env)) return undefined;
+  const request = { method: "wallet_connect", params: [params] } as const;
+  try {
+    ProviderRequest.parse(request, { method: "wallet_connect" });
+    return request;
+  } catch { return undefined; }
+}
+
+function validateWalletRevokeRequest(value: unknown): WalletRevokeRequest | undefined {
+  if (!isRecord(value) || !hasExactKeys(value, ["request"]) || !isRecord(value.request)
+    || !hasExactKeys(value.request, ["method", "params"])
+    || value.request.method !== "wallet_revokeAccessKey" || !Array.isArray(value.request.params)
+    || value.request.params.length !== 1 || !isRecord(value.request.params[0])) return undefined;
+  const request = { method: "wallet_revokeAccessKey", params: [value.request.params[0]] } as const;
+  try {
+    ProviderRequest.parse(request, { method: "wallet_revokeAccessKey" });
+    return request;
+  } catch { return undefined; }
+}
+
+function validWalletAuth(value: unknown, env: BrokerEnv): boolean {
+  if (!isRecord(value)
+    || !hasOnlyKeys(value, ["url", "challenge", "verify", "logout", "resources", "returnToken"])
+    || !Array.isArray(value.resources)
+    || (value.returnToken !== undefined && value.returnToken !== true)) return false;
+  const base = value.url === undefined
+    ? undefined
+    : typeof value.url === "string"
+      ? validConnectAuthEndpoint(value.url, "/v1/connect/auth", env)
+      : undefined;
+  if (value.url !== undefined && !base) return false;
+  const challenge = typeof value.challenge === "string"
+    ? validConnectAuthEndpoint(value.challenge, "/v1/connect/auth/challenge", env)
+    : base
+      ? validConnectAuthEndpoint(new URL("/v1/connect/auth/challenge", base).href, "/v1/connect/auth/challenge", env)
+      : undefined;
+  const verify = typeof value.verify === "string"
+    ? validConnectAuthEndpoint(value.verify, "/v1/connect/auth", env)
+    : base;
+  const logout = typeof value.logout === "string"
+    ? validConnectAuthEndpoint(value.logout, "/v1/connect/auth/logout", env)
+    : value.logout === undefined && base
+      ? validConnectAuthEndpoint(new URL("/v1/connect/auth/logout", base).href, "/v1/connect/auth/logout", env)
+      : undefined;
+  if (!challenge || !verify || challenge.origin !== verify.origin
+    || (value.logout !== undefined && !logout)
+    || (logout && logout.origin !== verify.origin)
+    || value.resources.length > MAX_WALLET_RESOURCES) return false;
+  let total = 0;
+  const seen = new Set<string>();
+  for (const resource of value.resources) {
+    if (typeof resource !== "string" || !resource || /[\u0000-\u001f\u007f]/.test(resource)) return false;
+    const bytes = new TextEncoder().encode(resource).byteLength;
+    if (bytes > MAX_WALLET_RESOURCE_BYTES || (total += bytes) > MAX_WALLET_RESOURCE_TOTAL_BYTES
+      || seen.has(resource)) return false;
+    seen.add(resource);
+  }
+  return true;
+}
+
+function validConnectAuthEndpoint(
+  value: string,
+  pathname: string,
+  env: BrokerEnv,
+): URL | undefined {
+  let url: URL;
+  try { url = new URL(value); } catch { return undefined; }
+  if (url.username || url.password || url.search || url.hash || url.pathname !== pathname) return undefined;
+  if (url.origin === PRODUCTION_CONNECT_API_ORIGIN && url.protocol === "https:" && !url.port) return url;
+  const environment = env.ENVIRONMENT?.trim().toLowerCase();
+  const local = environment !== "production" && environment !== "preview";
+  return local && (url.protocol === "http:" || url.protocol === "https:")
+    && (url.hostname === "nanocodex.localhost" || url.hostname.endsWith(".nanocodex.localhost"))
+    ? url : undefined;
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: readonly string[]): boolean {
+  const allowedSet = new Set(allowed);
+  return Object.keys(value).every((key) => allowedSet.has(key));
 }
 
 export async function finishRateLimitedRefresh(

--- a/js/egress/src/egress.ts
+++ b/js/egress/src/egress.ts
@@ -886,6 +886,35 @@ async function handleControl(request: Request, url: URL, env: EgressEnv): Promis
     );
   }
 
+  const walletMatch = url.pathname.match(
+    /^\/users\/([A-Za-z0-9][A-Za-z0-9._:-]{0,127})\/wallet(?:\/(connect|revoke-access-key))?$/,
+  );
+  if (walletMatch) {
+    const userId = walletMatch[1]!;
+    const operation = walletMatch[2];
+    const target = operation
+      ? `https://credentials.internal/v1/wallet/${operation}`
+      : "https://credentials.internal/v1/wallet";
+    if (!operation && request.method === "GET") {
+      return userBroker(env, userId).fetch(target, { method: "GET" });
+    }
+    if (!operation && request.method === "PUT") {
+      if (await hasRequestPayload(request)) return jsonError(400, "invalid_request");
+      return userBroker(env, userId).fetch(target, { method: "PUT" });
+    }
+    if (operation && request.method === "POST") {
+      if (!isJsonContentType(request.headers.get("content-type"))) {
+        return jsonError(415, "invalid_content_type");
+      }
+      return userBroker(env, userId).fetch(target, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: request.body,
+      });
+    }
+    return jsonError(405, "method_not_allowed");
+  }
+
   const mcpMatch = url.pathname.match(
     /^\/users\/([A-Za-z0-9][A-Za-z0-9._:-]{0,127})\/mcp-connections(?:\/([A-Za-z0-9_-]{43})(?:\/(start|callback))?)?$/,
   );

--- a/js/egress/src/egress.ts
+++ b/js/egress/src/egress.ts
@@ -887,7 +887,7 @@ async function handleControl(request: Request, url: URL, env: EgressEnv): Promis
   }
 
   const walletMatch = url.pathname.match(
-    /^\/users\/([A-Za-z0-9][A-Za-z0-9._:-]{0,127})\/wallet(?:\/(connect|revoke-access-key))?$/,
+    /^\/users\/([A-Za-z0-9][A-Za-z0-9._:-]{0,127})\/wallet(?:\/(balance|connect|revoke-access-key))?$/,
   );
   if (walletMatch) {
     const userId = walletMatch[1]!;
@@ -901,6 +901,9 @@ async function handleControl(request: Request, url: URL, env: EgressEnv): Promis
     if (!operation && request.method === "PUT") {
       if (await hasRequestPayload(request)) return jsonError(400, "invalid_request");
       return userBroker(env, userId).fetch(target, { method: "PUT" });
+    }
+    if (operation === "balance" && request.method === "GET") {
+      return userBroker(env, userId).fetch(target, { method: "GET" });
     }
     if (operation && request.method === "POST") {
       if (!isJsonContentType(request.headers.get("content-type"))) {

--- a/js/egress/test/root-wallet.test.ts
+++ b/js/egress/test/root-wallet.test.ts
@@ -1,0 +1,143 @@
+import { env } from "cloudflare:workers";
+import { runInDurableObject, SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+import type { UserCredentialBroker } from "../src/broker";
+import { CredentialVault, type EncryptedEnvelope } from "../src/credential-vault";
+import type { EgressEnv } from "../src/egress";
+
+const workerEnv = env as unknown as EgressEnv;
+
+describe("per-user root wallets", () => {
+  it("provisions once, keeps root material encrypted, and separates users", async () => {
+    const first = await provision("wallet-provision-a");
+    const second = await provision("wallet-provision-a");
+    const other = await provision("wallet-provision-b");
+
+    expect(second).toEqual(first);
+    expect(other.address).not.toBe(first.address);
+    expect(JSON.stringify(first)).not.toMatch(/private/i);
+
+    const metadata = await SELF.fetch("https://broker.internal/users/wallet-provision-a/wallet");
+    expect(metadata.status).toBe(200);
+    expect(await metadata.json()).toEqual(first);
+
+    const stub = workerEnv.USER_CREDENTIALS.getByName("wallet-provision-a");
+    await runInDurableObject(stub, async (_instance: UserCredentialBroker, state) => {
+      const row = await state.storage.get<{ envelope: EncryptedEnvelope }>("credential-state");
+      expect(row).toBeDefined();
+      expect(JSON.stringify(row)).not.toContain(first.address);
+      expect(JSON.stringify(row)).not.toMatch(/privateKey|private_key/);
+
+      const vault = new CredentialVault(workerEnv, `user/${state.id.toString()}`);
+      const opened = await vault.open<{ wallet?: { address: string; privateKey: string } }>(row!.envelope);
+      expect(opened.value.wallet?.address).toBe(first.address);
+      expect(opened.value.wallet?.privateKey).toMatch(/^0x[0-9a-f]{64}$/i);
+    });
+  });
+
+  it("returns the exact SDK connect result through mocked Connect auth fetches", async () => {
+    const wallet = await provision("wallet-connect");
+    const response = await walletConnect("wallet-connect", {
+      request: {
+        method: "wallet_connect",
+        params: [{
+          chainId: "0x1079",
+          capabilities: {
+            method: "login",
+            auth: {
+              challenge: "https://nanocodex.localhost/v1/connect/auth/challenge",
+              verify: "https://nanocodex.localhost/v1/connect/auth",
+              logout: "https://nanocodex.localhost/v1/connect/auth/logout",
+              resources: ["urn:nanocodex:agent:run"],
+              returnToken: true,
+            },
+          },
+        }],
+      },
+    });
+    expect(response.status).toBe(200);
+    const result = await response.json<Record<string, unknown>>();
+    const accounts = result.accounts as readonly Record<string, unknown>[];
+    expect(String(accounts[0]?.address).toLowerCase()).toBe(wallet.address);
+    expect(result).toMatchObject({
+      accounts: [{
+        capabilities: { auth: { approval_id: "wallet-test-approval", token: "wallet-test-token" } },
+      }],
+    });
+    expect(JSON.stringify(result)).not.toMatch(/privateKey|private_key/);
+  });
+
+  it("accepts the SDK base-url auth form while pinning its derived endpoints", async () => {
+    const response = await walletConnect("wallet-connect-url", {
+      request: {
+        method: "wallet_connect",
+        params: [{
+          chainId: "0x1079",
+          capabilities: {
+            method: "login",
+            auth: {
+              url: "https://nanocodex.localhost/v1/connect/auth",
+              resources: ["urn:nanocodex:agent:run"],
+              returnToken: true,
+            },
+          },
+        }],
+      },
+    });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      accounts: [{ capabilities: { auth: { token: "wallet-test-token" } } }],
+    });
+  });
+
+  it("rejects malformed and other wallet methods without exposing root material", async () => {
+    const user = "wallet-invalid";
+    const missing = await SELF.fetch(`https://broker.internal/users/${user}/wallet`);
+    expect(missing.status).toBe(404);
+
+    const malformed = await walletConnect(user, {
+      request: { method: "personal_sign", params: [] },
+    });
+    expect(malformed.status).toBe(400);
+
+    const wrongChain = await walletConnect(user, {
+      request: {
+        method: "wallet_connect",
+        params: [{ chainId: "0x1", capabilities: { method: "login", auth: {} } }],
+      },
+    });
+    expect(wrongChain.status).toBe(400);
+
+    const provisioned = await provision(user);
+    const revoke = await SELF.fetch(`https://broker.internal/users/${user}/wallet/revoke-access-key`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        request: {
+          method: "wallet_revokeAccessKey",
+          params: [{
+            address: "0x0000000000000000000000000000000000000001",
+            accessKeyAddress: "0x0000000000000000000000000000000000000002",
+          }],
+        },
+      }),
+    });
+    expect(revoke.status).toBe(403);
+    expect(JSON.stringify(await revoke.json())).not.toContain(provisioned.address);
+  });
+});
+
+async function provision(user: string): Promise<{ address: string; created_at: number }> {
+  const response = await SELF.fetch(`https://broker.internal/users/${user}/wallet`, { method: "PUT" });
+  expect(response.status).toBe(200);
+  return response.json<{ address: string; created_at: number }>();
+}
+
+function walletConnect(user: string, body: unknown): Promise<Response> {
+  return SELF.fetch(`https://broker.internal/users/${user}/wallet/connect`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}

--- a/js/egress/test/root-wallet.test.ts
+++ b/js/egress/test/root-wallet.test.ts
@@ -1,5 +1,6 @@
 import { env } from "cloudflare:workers";
 import { runInDurableObject, SELF } from "cloudflare:test";
+import { Provider, secp256k1, Storage } from "accounts";
 import { describe, expect, it } from "vitest";
 
 import type { UserCredentialBroker } from "../src/broker";
@@ -33,6 +34,16 @@ describe("per-user root wallets", () => {
       const opened = await vault.open<{ wallet?: { address: string; privateKey: string } }>(row!.envelope);
       expect(opened.value.wallet?.address).toBe(first.address);
       expect(opened.value.wallet?.privateKey).toMatch(/^0x[0-9a-f]{64}$/i);
+      const provider = Provider.create({
+        adapter: secp256k1({ privateKey: opened.value.wallet!.privateKey as `0x${string}` }),
+        storage: Storage.memory({ key: "root-wallet-vault-proof" }),
+        mpp: false,
+      });
+      const derived = await provider.request({
+        method: "wallet_connect",
+        params: [{ chainId: "0x1079", capabilities: { method: "login" } }],
+      } as never) as { accounts?: readonly { address?: string }[] };
+      expect(derived.accounts?.[0]?.address.toLowerCase()).toBe(first.address);
     });
   });
 

--- a/js/egress/test/root-wallet.test.ts
+++ b/js/egress/test/root-wallet.test.ts
@@ -43,7 +43,7 @@ describe("per-user root wallets", () => {
         method: "wallet_connect",
         params: [{ chainId: "0x1079", capabilities: { method: "login" } }],
       } as never) as { accounts?: readonly { address?: string }[] };
-      expect(derived.accounts?.[0]?.address.toLowerCase()).toBe(first.address);
+      expect(derived.accounts?.[0]?.address?.toLowerCase()).toBe(first.address);
     });
   });
 
@@ -77,6 +77,19 @@ describe("per-user root wallets", () => {
       }],
     });
     expect(JSON.stringify(result)).not.toMatch(/privateKey|private_key/);
+  });
+
+  it("reads MACH through the signer-backed SDK provider without exposing root material", async () => {
+    const wallet = await provision("wallet-balance");
+    const response = await SELF.fetch("https://broker.internal/users/wallet-balance/wallet/balance");
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      account: wallet.address,
+      balance: "12345678",
+      decimals: 6,
+      symbol: "MACH",
+      token: "0x20c000000000000000000000f37de3740adec032",
+    });
   });
 
   it("accepts the SDK base-url auth form while pinning its derived endpoints", async () => {

--- a/js/egress/vitest.config.ts
+++ b/js/egress/vitest.config.ts
@@ -513,6 +513,29 @@ export default defineConfig({
               ? new Response(null, { status: 200 })
               : Response.json({ error: "invalid_request" }, { status: 400 });
           }
+          if (url.hostname === "nanocodex.localhost" && request.method === "POST"
+            && url.pathname === "/v1/connect/auth/challenge") {
+            const body = await request.json() as { chainId?: unknown; resources?: unknown };
+            if (body.chainId !== 4217 || JSON.stringify(body.resources) !== JSON.stringify(["urn:nanocodex:agent:run"])) {
+              return Response.json({ error: "invalid_request" }, { status: 400 });
+            }
+            return Response.json({
+              message: "nanocodex.localhost wants you to sign in with your Ethereum account:\n0x0000000000000000000000000000000000000001\n\nAuthorize Nanocodex.\n\nURI: https://nanocodex.localhost\nVersion: 1\nChain ID: 4217\nNonce: wallettestnonce\nIssued At: 2026-01-01T00:00:00.000Z\nResources:\n- urn:nanocodex:agent:run",
+            });
+          }
+          if (url.hostname === "nanocodex.localhost" && request.method === "POST"
+            && url.pathname === "/v1/connect/auth") {
+            const body = await request.json() as {
+              address?: unknown;
+              message?: unknown;
+              signature?: unknown;
+              returnToken?: unknown;
+            };
+            return typeof body.address === "string" && typeof body.message === "string"
+              && typeof body.signature === "string" && body.returnToken === true
+              ? Response.json({ approval_id: "wallet-test-approval", token: "wallet-test-token" })
+              : Response.json({ error: "invalid_request" }, { status: 400 });
+          }
           if (request.method === "POST" && url.pathname.endsWith("/deviceauth/usercode")) {
             return Response.json({
               device_auth_id: "device-secret",

--- a/js/egress/vitest.config.ts
+++ b/js/egress/vitest.config.ts
@@ -569,6 +569,30 @@ export default defineConfig({
               refresh_token: "chatgpt-refresh-rotated",
             });
           }
+          if (url.hostname === "rpc.tempo.xyz" && request.method === "POST") {
+            const body = await request.json() as { id?: unknown; method?: unknown; params?: unknown };
+            const call = Array.isArray(body.params) && body.params[0] && typeof body.params[0] === "object"
+              ? body.params[0] as { data?: unknown; to?: unknown }
+              : undefined;
+            const validCall = body.method === "eth_call"
+              && Array.isArray(body.params)
+              && body.params[1] === "latest"
+              && typeof call?.to === "string"
+              && call.to.toLowerCase() === "0x20c000000000000000000000f37de3740adec032"
+              && typeof call.data === "string"
+              && /^0x70a082310{24}[0-9a-f]{40}$/i.test(call.data)
+              && request.headers.get("content-type")?.startsWith("application/json") === true
+              && !request.headers.has("authorization")
+              && !request.headers.has("cookie");
+            if (!validCall) {
+              return Response.json({ jsonrpc: "2.0", id: body.id, error: { message: "unexpected method" } });
+            }
+            return Response.json({
+              jsonrpc: "2.0",
+              id: body.id,
+              result: "0x0000000000000000000000000000000000000000000000000000000000bc614e",
+            });
+          }
           if (url.hostname === "api.openai.com" || url.hostname === "chatgpt.com") {
             const authorization = request.headers.get("authorization");
             return Response.json({

--- a/js/managed/README.md
+++ b/js/managed/README.md
@@ -48,7 +48,7 @@ protocol. `/health` is the service health endpoint.
 
 | Binding | Role |
 | --- | --- |
-| `NANOCODEX` | Private Service Binding to `nanocodex-egress`. |
+| `NANOCODEX` | Private Service Binding to `nanocodex-egress` for credentials and persistent-account wallets. |
 | `NANOCODEX_SESSIONS` | One `DurableAgentSession` per managed agent. |
 | `NANOCODEX_ROOMS`, `NANOCODEX_MULTIPLAYER_QUOTA` | Multiplayer state and global quota. |
 | `NANOCODEX_AUTH`, `NANOCODEX_USERS`, `NANOCODEX_API_KEYS`, `NANOCODEX_ORGANIZATIONS`, `NANOCODEX_MEMORY` | Account, key, organization, and durable-memory ownership. |
@@ -71,9 +71,27 @@ It never logs phone numbers, codes, provider responses, or credentials. Keep the
 HMAC key stable; rotating it requires an identity migration or known phones will
 resolve to new accounts.
 
+### Persistent account wallet
+
+After Twilio Verify approves an OTP, the Worker provisions that persistent
+account's secp256k1 root wallet through the existing `NANOCODEX` Service
+Binding before issuing the account session. Provisioning is idempotent. A
+wallet failure returns `wallet_unavailable`, issues no session, and leaves the
+browser-bound challenge retryable. `GET /v1/wallet` returns public metadata;
+same-origin authenticated `POST /v1/wallet/connect` and
+`POST /v1/wallet/revoke-access-key` authorize and revoke exact access keys.
+
+The private key is encrypted and used only inside the per-user egress Durable
+Object. It never enters this Worker or the browser. This is custodial
+server-side encryption, not user-held end-to-end encryption. See
+[the wallet custody contract](../../docs/WALLET_CUSTODY.md). Existing
+configurable-account migration is future work.
+
 `wrangler.jsonc` is the binding and migration source of truth. Development
 uses the same Worker role with local Durable Objects, local egress binding, R2,
-and shorter idle timing; AI Search is a production binding.
+and shorter idle timing; AI Search is a production binding. The wallet reuses
+the existing `NANOCODEX` binding, so it adds no managed-Worker secret, binding,
+or Durable Object migration.
 
 ### Host-principal project registry
 

--- a/js/managed/README.md
+++ b/js/managed/README.md
@@ -56,13 +56,20 @@ protocol. `/health` is the service health endpoint.
 
 ### SMS OTP delivery
 
-Set `NANOCODEX_OTP_HMAC_KEY` to at least 32 random bytes. Delivery can use a
-private `NANOCODEX_SMS_SEND` Service Binding accepting `{ "to", "body" }`, or
-Twilio Messaging via the `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and
-`TWILIO_FROM_NUMBER` Worker secrets. The Worker stores phone numbers only as
-keyed HMAC digests and never logs the code or provider credentials. Keep the
-HMAC key stable; rotating it requires an identity migration or known phones
-will resolve to new accounts.
+Set `NANOCODEX_OTP_HMAC_KEY` to at least 32 random bytes and create a Twilio
+Verify Service configured for SMS with six-digit codes. Provide its
+`TWILIO_VERIFY_SERVICE_SID` with `TWILIO_API_KEY_SID` and
+`TWILIO_API_KEY_SECRET` Worker secrets. `TWILIO_ACCOUNT_SID` plus
+`TWILIO_AUTH_TOKEN` is accepted as a fallback credential pair when an API key
+is not configured.
+
+Twilio Verify generates, delivers, and checks each code, automatically upgrading
+eligible SMS requests to RCS. Nanocodex retains a five-minute opaque local
+challenge so a successful verification can be bound to the initiating browser,
+and stores the phone only as a keyed HMAC digest for identity and abuse limits.
+It never logs phone numbers, codes, provider responses, or credentials. Keep the
+HMAC key stable; rotating it requires an identity migration or known phones will
+resolve to new accounts.
 
 `wrangler.jsonc` is the binding and migration source of truth. Development
 uses the same Worker role with local Durable Objects, local egress binding, R2,

--- a/js/managed/README.md
+++ b/js/managed/README.md
@@ -24,7 +24,7 @@ storage ownership.
 
 ## Public journeys and protocol boundaries
 
-- Passkey/account and API-key routes establish the account identity that owns
+- SMS OTP/account and API-key routes establish the account identity that owns
   agents, organizations, connectors, memory, and history.
 - `/v1/agents` lists or creates agents. Agent routes create turns, read state,
   cancel or steer work, delete an agent, and support explicit durability import
@@ -53,6 +53,16 @@ protocol. `/health` is the service health endpoint.
 | `NANOCODEX_ROOMS`, `NANOCODEX_MULTIPLAYER_QUOTA` | Multiplayer state and global quota. |
 | `NANOCODEX_AUTH`, `NANOCODEX_USERS`, `NANOCODEX_API_KEYS`, `NANOCODEX_ORGANIZATIONS`, `NANOCODEX_MEMORY` | Account, key, organization, and durable-memory ownership. |
 | `NANOCODEX_HISTORY`, `HISTORY_AI_SEARCH` | R2 history archive and production history retrieval. |
+
+### SMS OTP delivery
+
+Set `NANOCODEX_OTP_HMAC_KEY` to at least 32 random bytes. Delivery can use a
+private `NANOCODEX_SMS_SEND` Service Binding accepting `{ "to", "body" }`, or
+Twilio Messaging via the `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and
+`TWILIO_FROM_NUMBER` Worker secrets. The Worker stores phone numbers only as
+keyed HMAC digests and never logs the code or provider credentials. Keep the
+HMAC key stable; rotating it requires an identity migration or known phones
+will resolve to new accounts.
 
 `wrangler.jsonc` is the binding and migration source of truth. Development
 uses the same Worker role with local Durable Objects, local egress binding, R2,

--- a/js/managed/README.md
+++ b/js/managed/README.md
@@ -63,6 +63,11 @@ Verify Service configured for SMS with six-digit codes. Provide its
 `TWILIO_AUTH_TOKEN` is accepted as a fallback credential pair when an API key
 is not configured.
 
+The checked-in `development` Wrangler environment uses `123456` as a local
+Verify fixture and does not contact Twilio. The fixture is active only when
+`ENVIRONMENT` is exactly `development`; production ignores the fixture value
+and still requires a valid Verify Service and credentials.
+
 Twilio Verify generates, delivers, and checks each code, automatically upgrading
 eligible SMS requests to RCS. Nanocodex retains a five-minute opaque local
 challenge so a successful verification can be bound to the initiating browser,

--- a/js/managed/src/account-auth.ts
+++ b/js/managed/src/account-auth.ts
@@ -391,6 +391,12 @@ export async function routeAccountRequest(
     if (!principal) return unauthorized();
     return proxyAccountWalletRequest(env, principal.userId, "");
   }
+  if (url.pathname === "/v1/wallet/balance") {
+    if (request.method !== "GET") return methodNotAllowed();
+    const principal = await authenticatePersistentAccount(request, env, url);
+    if (!principal) return unauthorized();
+    return proxyAccountWalletRequest(env, principal.userId, "/balance");
+  }
   if (url.pathname === "/v1/wallet/connect" || url.pathname === "/v1/wallet/revoke-access-key") {
     if (request.method !== "POST") return methodNotAllowed();
     const principal = await authenticatePersistentAccount(request, env, url);
@@ -1307,7 +1313,7 @@ async function readAccountWallet(
 async function proxyAccountWalletRequest(
   env: AccountAuthEnv,
   userId: string,
-  suffix: "" | "/connect" | "/revoke-access-key",
+  suffix: "" | "/balance" | "/connect" | "/revoke-access-key",
   body?: Record<string, unknown>,
 ): Promise<Response> {
   if (!env.NANOCODEX) return json({ error: "wallet_unavailable" }, { status: 503 });

--- a/js/managed/src/account-auth.ts
+++ b/js/managed/src/account-auth.ts
@@ -20,9 +20,9 @@ const PERSISTENT_SESSION_TTL_SECONDS = 365 * 24 * 60 * 60;
 const WEBAUTHN_CHALLENGE_TTL_SECONDS = 5 * 60;
 const OTP_CHALLENGE_TTL_SECONDS = 5 * 60;
 const OTP_RESEND_SECONDS = 60;
-const OTP_MAX_ATTEMPTS = 5;
 const OTP_PHONE_REQUESTS_PER_HOUR = 5;
 const OTP_IP_REQUESTS_PER_HOUR = 20;
+const OTP_PROVIDER_TIMEOUT_MS = 10_000;
 const USER_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const API_KEY = /^ncx_live_([A-Za-z0-9_-]{12})_([A-Za-z0-9_-]{43})$/;
@@ -32,6 +32,8 @@ const LEGACY_PASSKEY_SESSION_TOKEN = /^[0-9a-f]{64}$/;
 const OTP_CHALLENGE_ID = /^[A-Za-z0-9_-]{43}$/;
 const OTP_CODE = /^\d{6}$/;
 const E164_PHONE = /^\+[1-9]\d{7,14}$/;
+const TWILIO_VERIFY_SERVICE_SID = /^VA[0-9a-f]{32}$/i;
+const TWILIO_VERIFICATION_SID = /^VE[0-9a-f]{32}$/i;
 const ACCOUNT_ADDRESS = /^0x[0-9a-f]{40}$/;
 const PORTABLE_CREDENTIAL_ID = /^[A-Za-z0-9_-]{1,512}$/;
 const PORTABLE_PUBLIC_KEY = /^0x(?:[0-9a-fA-F]{2}){1,1024}$/;
@@ -64,10 +66,11 @@ export interface AccountAuthEnv {
   NANOCODEX_API_KEYS: DurableObjectNamespace<ApiKeyRecord>;
   NANOCODEX_LOCAL_WEBAUTHN_HMAC_KEY?: string;
   NANOCODEX_OTP_HMAC_KEY?: string;
-  NANOCODEX_SMS_SEND?: Fetcher;
   TWILIO_ACCOUNT_SID?: string;
+  TWILIO_API_KEY_SECRET?: string;
+  TWILIO_API_KEY_SID?: string;
   TWILIO_AUTH_TOKEN?: string;
-  TWILIO_FROM_NUMBER?: string;
+  TWILIO_VERIFY_SERVICE_SID?: string;
   NANOCODEX_ORGANIZATIONS: DurableObjectNamespace<Organization>;
 }
 
@@ -211,17 +214,14 @@ type AccountSessionPayload = Readonly<{
 }>;
 
 type SmsIdentity = Readonly<{
-  accountAddress: `0x${string}`;
   userId: string;
 }>;
 
 type SmsOtpChallenge = Readonly<{
-  attemptsRemaining: number;
-  candidateAccountAddress: `0x${string}`;
   candidateUserId: string;
-  digest: string;
   expiresAt: number;
   phoneDigest: string;
+  verificationSid: string;
 }>;
 
 type PortableCredential = Readonly<{
@@ -486,32 +486,24 @@ async function startSmsOtp(
     });
   }
 
-  const principal = await authenticate(request, env, url);
-  const candidateUserId = principal?.kind === "account_session"
-    ? principal.userId
+  const session = await readBrowserSession(request, env);
+  const sessionToken = cookieValue(request, ACCOUNT_COOKIE);
+  const candidateUserId = session && sessionToken && ANONYMOUS_SESSION_TOKEN.test(sessionToken)
+    ? session.userId
     : crypto.randomUUID();
-  const candidateAccountAddress = await accountAddressForRequest(
-    request,
-    env,
-    url,
-    candidateUserId,
-  );
   const challengeId = randomBase64Url(32);
-  const code = randomOtpCode();
-  const challenge: SmsOtpChallenge = {
-    attemptsRemaining: OTP_MAX_ATTEMPTS,
-    candidateAccountAddress,
-    candidateUserId,
-    digest: await keyedDigest(secret, `otp:${challengeId}:${code}`),
-    expiresAt: now + OTP_CHALLENGE_TTL_SECONDS,
-    phoneDigest,
-  };
-  await Promise.all([
-    store.set(`challenge:${challengeId}`, challenge, { ttl: OTP_CHALLENGE_TTL_SECONDS }),
-    store.set(`active:${phoneDigest}`, challengeId, { ttl: OTP_CHALLENGE_TTL_SECONDS }),
-  ]);
   try {
-    await sendSms(env, phone, `Your Nanocodex code is ${code}. It expires in 5 minutes.`);
+    const verificationSid = await startTwilioSmsVerification(env, phone);
+    const challenge: SmsOtpChallenge = {
+      candidateUserId,
+      expiresAt: now + OTP_CHALLENGE_TTL_SECONDS,
+      phoneDigest,
+      verificationSid,
+    };
+    await Promise.all([
+      store.set(`challenge:${challengeId}`, challenge, { ttl: OTP_CHALLENGE_TTL_SECONDS }),
+      store.set(`active:${phoneDigest}`, challengeId, { ttl: OTP_CHALLENGE_TTL_SECONDS }),
+    ]);
   } catch {
     await Promise.all([
       store.delete(`challenge:${challengeId}`),
@@ -555,24 +547,23 @@ async function verifySmsOtp(
     || challenge.phoneDigest !== phoneDigest || challenge.expiresAt <= now) {
     return json({ error: "invalid_or_expired_otp" }, { status: 400 });
   }
-  const expected = await keyedDigest(secret, `otp:${challengeId}:${code}`);
-  if (!constantTimeEqual(challenge.digest, expected)) {
-    const attemptsRemaining = challenge.attemptsRemaining - 1;
-    if (attemptsRemaining > 0) {
-      await store.set(`challenge:${challengeId}`, {
-        ...challenge,
-        attemptsRemaining,
-      }, { ttl: Math.max(1, challenge.expiresAt - now) });
-    } else {
-      await store.delete(`active:${phoneDigest}`);
-    }
-    return json({ error: "invalid_or_expired_otp", attempts_remaining: attemptsRemaining }, {
-      status: 400,
+  let approved: boolean;
+  try {
+    approved = await checkTwilioSmsVerification(env, challenge.verificationSid, code);
+  } catch {
+    await store.set(`challenge:${challengeId}`, challenge, {
+      ttl: Math.max(1, challenge.expiresAt - now),
     });
+    return json({ error: "sms_verification_failed" }, { status: 503 });
+  }
+  if (!approved) {
+    await store.set(`challenge:${challengeId}`, challenge, {
+      ttl: Math.max(1, challenge.expiresAt - now),
+    });
+    return json({ error: "invalid_or_expired_otp" }, { status: 400 });
   }
 
   const proposedIdentity: SmsIdentity = {
-    accountAddress: challenge.candidateAccountAddress,
     userId: challenge.candidateUserId,
   };
   const identityKey = `identity:${phoneDigest}`;
@@ -587,7 +578,6 @@ async function verifySmsOtp(
     return json({ error: "sms_identity_unavailable" }, { status: 503 });
   }
   await ensureAccount(env, identity.userId, true);
-  await rememberAccountAddress(env, identity.userId, identity.accountAddress);
 
   const previousToken = cookieValue(request, ACCOUNT_COOKIE);
   if (previousToken && (ANONYMOUS_SESSION_TOKEN.test(previousToken) || SMS_SESSION_TOKEN.test(previousToken))) {
@@ -603,7 +593,6 @@ async function verifySmsOtp(
   await store.delete(`active:${phoneDigest}`);
   return json({
     user: {
-      address: identity.accountAddress,
       id: identity.userId,
       persistent: true,
     },
@@ -775,16 +764,10 @@ export async function authenticatePersistentHostedAccount(
         return { accountAddress, principal };
       }
     } catch {
-      // Fall through to the hosted SMS account address.
+      // A persistent SMS identity is valid without an attached wallet.
     }
   }
-  try {
-    const accountAddress = await derivedAccountAddress(env, principal.userId);
-    await rememberAccountAddress(env, principal.userId, accountAddress);
-    return { accountAddress, principal };
-  } catch {
-    return undefined;
-  }
+  return undefined;
 }
 
 /** @deprecated Use authenticatePersistentHostedAccount. */
@@ -1327,6 +1310,7 @@ async function resolveOrCreateBrowserAccount(
   await Promise.all([
     ensureAccount(env, userId, false),
     authStore(env, "account").set(accountSessionKey(token), {
+      authentication: "anonymous",
       userId,
       issuedAt,
       expiresAt: issuedAt + SESSION_TTL_SECONDS,
@@ -2142,15 +2126,6 @@ async function reserveWindowSlot(
   return false;
 }
 
-function randomOtpCode(): string {
-  const ceiling = 4_294_000_000;
-  for (;;) {
-    const bytes = crypto.getRandomValues(new Uint8Array(4));
-    const value = new DataView(bytes.buffer).getUint32(0);
-    if (value < ceiling) return String(value % 1_000_000).padStart(6, "0");
-  }
-}
-
 async function keyedDigest(secret: string, value: string): Promise<string> {
   const key = await crypto.subtle.importKey(
     "raw",
@@ -2166,66 +2141,103 @@ async function keyedDigest(secret: string, value: string): Promise<string> {
   )));
 }
 
-function constantTimeEqual(left: string, right: string): boolean {
-  const length = Math.max(left.length, right.length);
-  let different = left.length ^ right.length;
-  for (let index = 0; index < length; index += 1) {
-    different |= (left.charCodeAt(index) || 0) ^ (right.charCodeAt(index) || 0);
-  }
-  return different === 0;
-}
-
 function isSmsOtpChallenge(value: unknown): value is SmsOtpChallenge {
   if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
   const challenge = value as Partial<SmsOtpChallenge>;
-  return Number.isSafeInteger(challenge.attemptsRemaining)
-    && Number(challenge.attemptsRemaining) > 0
-    && Number(challenge.attemptsRemaining) <= OTP_MAX_ATTEMPTS
-    && typeof challenge.candidateAccountAddress === "string"
-    && ACCOUNT_ADDRESS.test(challenge.candidateAccountAddress)
-    && isUserId(challenge.candidateUserId)
-    && typeof challenge.digest === "string" && BASE64_URL.test(challenge.digest)
+  return isUserId(challenge.candidateUserId)
     && Number.isSafeInteger(challenge.expiresAt)
-    && typeof challenge.phoneDigest === "string" && BASE64_URL.test(challenge.phoneDigest);
+    && typeof challenge.phoneDigest === "string" && BASE64_URL.test(challenge.phoneDigest)
+    && typeof challenge.verificationSid === "string"
+    && TWILIO_VERIFICATION_SID.test(challenge.verificationSid);
 }
 
 function isSmsIdentity(value: unknown): value is SmsIdentity {
   if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
   const identity = value as Partial<SmsIdentity>;
-  return typeof identity.accountAddress === "string"
-    && ACCOUNT_ADDRESS.test(identity.accountAddress)
-    && isUserId(identity.userId);
+  return isUserId(identity.userId);
 }
 
-async function sendSms(env: AccountAuthEnv, to: string, body: string): Promise<void> {
-  let response: Response;
-  if (env.NANOCODEX_SMS_SEND) {
-    response = await env.NANOCODEX_SMS_SEND.fetch("https://sms.internal/send", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ body, to }),
-    });
-  } else {
-    const sid = env.TWILIO_ACCOUNT_SID;
-    const token = env.TWILIO_AUTH_TOKEN;
-    const from = normalizedPhone(env.TWILIO_FROM_NUMBER);
-    if (!sid || !/^AC[0-9a-f]{32}$/i.test(sid) || !token || !from) {
-      throw new Error("SMS delivery is not configured");
-    }
-    response = await fetch(`https://api.twilio.com/2010-04-01/Accounts/${sid}/Messages.json`, {
-      method: "POST",
-      headers: {
-        authorization: `Basic ${btoa(`${sid}:${token}`)}`,
-        "content-type": "application/x-www-form-urlencoded;charset=UTF-8",
-      },
-      body: new URLSearchParams({ Body: body, From: from, To: to }),
-    });
+function twilioVerifyRequest(
+  env: AccountAuthEnv,
+  resource: "Verifications" | "VerificationCheck",
+  body: Record<string, string>,
+): Readonly<{ body: URLSearchParams; headers: Record<string, string>; method: "POST"; url: string }> {
+  const accountSid = env.TWILIO_ACCOUNT_SID;
+  const apiKeySid = env.TWILIO_API_KEY_SID;
+  const apiKeySecret = env.TWILIO_API_KEY_SECRET;
+  const authToken = env.TWILIO_AUTH_TOKEN;
+  const serviceSid = env.TWILIO_VERIFY_SERVICE_SID;
+  const apiKey = apiKeySid && /^SK[0-9a-f]{32}$/i.test(apiKeySid) && apiKeySecret
+    ? { secret: apiKeySecret, sid: apiKeySid }
+    : undefined;
+  const credential = apiKey ?? (authToken && accountSid && /^AC[0-9a-f]{32}$/i.test(accountSid)
+    ? { secret: authToken, sid: accountSid }
+    : undefined);
+  if (!serviceSid || !TWILIO_VERIFY_SERVICE_SID.test(serviceSid) || !credential) {
+    throw new Error("Twilio Verify is not configured");
   }
-  if (!response.ok) {
-    await response.body?.cancel();
-    throw new Error(`SMS delivery failed with HTTP ${response.status}`);
-  }
-  await response.body?.cancel();
+  return {
+    body: new URLSearchParams(body),
+    headers: {
+      authorization: `Basic ${btoa(`${credential.sid}:${credential.secret}`)}`,
+      "content-type": "application/x-www-form-urlencoded;charset=UTF-8",
+    },
+    method: "POST",
+    url: `https://verify.twilio.com/v2/Services/${serviceSid}/${resource}`,
+  };
+}
+
+async function startTwilioSmsVerification(env: AccountAuthEnv, to: string): Promise<string> {
+  const request = twilioVerifyRequest(env, "Verifications", { Channel: "sms", To: to });
+  return fetchResponseWithDeadline(
+    { fetch: (input: RequestInfo | URL, init?: RequestInit) => fetch(input, init) },
+    request.url,
+    { body: request.body, headers: request.headers, method: request.method },
+    OTP_PROVIDER_TIMEOUT_MS,
+    "SMS OTP delivery",
+    async (response) => {
+      if (!response.ok) throw new Error(`SMS delivery failed with HTTP ${response.status}`);
+      const value: unknown = await response.json();
+      if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        throw new Error("Twilio Verify returned an invalid response");
+      }
+      const verification = value as { sid?: unknown; status?: unknown };
+      if (typeof verification.sid !== "string" || !TWILIO_VERIFICATION_SID.test(verification.sid)
+        || verification.status !== "pending") {
+        throw new Error("Twilio Verify did not create a pending verification");
+      }
+      return verification.sid;
+    },
+    { retryable: true },
+  );
+}
+
+async function checkTwilioSmsVerification(
+  env: AccountAuthEnv,
+  verificationSid: string,
+  code: string,
+): Promise<boolean> {
+  const request = twilioVerifyRequest(env, "VerificationCheck", {
+    Code: code,
+    VerificationSid: verificationSid,
+  });
+  return fetchResponseWithDeadline(
+    { fetch: (input: RequestInfo | URL, init?: RequestInit) => fetch(input, init) },
+    request.url,
+    { body: request.body, headers: request.headers, method: request.method },
+    OTP_PROVIDER_TIMEOUT_MS,
+    "SMS OTP verification",
+    async (response) => {
+      if (response.status === 404) return false;
+      if (!response.ok) throw new Error(`SMS verification failed with HTTP ${response.status}`);
+      const value: unknown = await response.json();
+      if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        throw new Error("Twilio Verify returned an invalid response");
+      }
+      return (value as { status?: unknown }).status === "approved";
+    },
+    { retryable: true },
+  );
 }
 
 async function accountAddressForRequest(
@@ -2233,7 +2245,7 @@ async function accountAddressForRequest(
   env: AccountAuthEnv,
   url: URL,
   userId: string,
-): Promise<`0x${string}`> {
+): Promise<`0x${string}` | undefined> {
   const remembered = await readAccountAddress(env, userId);
   if (remembered) return remembered;
   const session = await webAuthnHandler(env, url).getSession(request);
@@ -2248,25 +2260,10 @@ async function accountAddressForRequest(
         return address;
       }
     } catch {
-      // Legacy credentials that cannot be decoded receive the hosted address.
+      // Legacy credentials that cannot be decoded do not imply wallet ownership.
     }
   }
-  const address = await derivedAccountAddress(env, userId);
-  await rememberAccountAddress(env, userId, address);
-  return address;
-}
-
-async function derivedAccountAddress(
-  env: AccountAuthEnv,
-  userId: string,
-): Promise<`0x${string}`> {
-  const secret = otpSecret(env);
-  if (!secret) throw new Error("hosted account identity is unavailable");
-  const digest = decodeBase64Url(await keyedDigest(secret, `account-address:${userId}`));
-  if (!digest || digest.byteLength < 20) throw new Error("hosted account identity is unavailable");
-  return `0x${[...digest.slice(0, 20)]
-    .map((byte) => byte.toString(16).padStart(2, "0"))
-    .join("")}`;
+  return undefined;
 }
 
 async function rememberAccountAddress(

--- a/js/managed/src/account-auth.ts
+++ b/js/managed/src/account-auth.ts
@@ -62,6 +62,8 @@ export function isUserId(value: unknown): value is string {
 export const NonceStorage = Kv.NonceStorage;
 
 export interface AccountAuthEnv {
+  ENVIRONMENT?: string;
+  NANOCODEX_MOCK_TWILIO_VERIFY_CODE?: string;
   NANOCODEX_AUTH: DurableObjectNamespace;
   NANOCODEX_USERS: DurableObjectNamespace<UserAccount>;
   NANOCODEX_API_KEYS: DurableObjectNamespace<ApiKeyRecord>;
@@ -2318,6 +2320,9 @@ function twilioVerifyRequest(
 }
 
 async function startTwilioSmsVerification(env: AccountAuthEnv, to: string): Promise<string> {
+  if (developmentTwilioVerifyCode(env)) {
+    return "VE00000000000000000000000000000000";
+  }
   const request = twilioVerifyRequest(env, "Verifications", { Channel: "sms", To: to });
   return fetchResponseWithDeadline(
     { fetch: (input: RequestInfo | URL, init?: RequestInit) => fetch(input, init) },
@@ -2347,6 +2352,8 @@ async function checkTwilioSmsVerification(
   verificationSid: string,
   code: string,
 ): Promise<boolean> {
+  const mockCode = developmentTwilioVerifyCode(env);
+  if (mockCode) return code === mockCode;
   const request = twilioVerifyRequest(env, "VerificationCheck", {
     Code: code,
     VerificationSid: verificationSid,
@@ -2368,6 +2375,15 @@ async function checkTwilioSmsVerification(
     },
     { retryable: true },
   );
+}
+
+function developmentTwilioVerifyCode(env: AccountAuthEnv): string | undefined {
+  const code = env.NANOCODEX_MOCK_TWILIO_VERIFY_CODE;
+  return env.ENVIRONMENT?.trim().toLowerCase() === "development"
+    && typeof code === "string"
+    && /^[0-9]{6}$/.test(code)
+    ? code
+    : undefined;
 }
 
 async function accountAddressForRequest(

--- a/js/managed/src/account-auth.ts
+++ b/js/managed/src/account-auth.ts
@@ -16,13 +16,23 @@ const LOCAL_PORTABLE_CREDENTIAL_COOKIE = "nanocodex_local_passkey";
 const LOCAL_WEBAUTHN_RP_ID = "nanocodex.localhost";
 const LOCAL_WEBAUTHN_HOST = /^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)?nanocodex\.localhost$/;
 const SESSION_TTL_SECONDS = 30 * 24 * 60 * 60;
+const PERSISTENT_SESSION_TTL_SECONDS = 365 * 24 * 60 * 60;
 const WEBAUTHN_CHALLENGE_TTL_SECONDS = 5 * 60;
-const PASSKEY_REAUTH_WINDOW_SECONDS = 365 * 24 * 60 * 60;
+const OTP_CHALLENGE_TTL_SECONDS = 5 * 60;
+const OTP_RESEND_SECONDS = 60;
+const OTP_MAX_ATTEMPTS = 5;
+const OTP_PHONE_REQUESTS_PER_HOUR = 5;
+const OTP_IP_REQUESTS_PER_HOUR = 20;
 const USER_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const API_KEY = /^ncx_live_([A-Za-z0-9_-]{12})_([A-Za-z0-9_-]{43})$/;
 const ANONYMOUS_SESSION_TOKEN = /^a_[A-Za-z0-9_-]{43}$/;
-const PASSKEY_SESSION_TOKEN = /^[0-9a-f]{64}$/;
+const SMS_SESSION_TOKEN = /^s_[A-Za-z0-9_-]{43}$/;
+const LEGACY_PASSKEY_SESSION_TOKEN = /^[0-9a-f]{64}$/;
+const OTP_CHALLENGE_ID = /^[A-Za-z0-9_-]{43}$/;
+const OTP_CODE = /^\d{6}$/;
+const E164_PHONE = /^\+[1-9]\d{7,14}$/;
+const ACCOUNT_ADDRESS = /^0x[0-9a-f]{40}$/;
 const PORTABLE_CREDENTIAL_ID = /^[A-Za-z0-9_-]{1,512}$/;
 const PORTABLE_PUBLIC_KEY = /^0x(?:[0-9a-fA-F]{2}){1,1024}$/;
 const BASE64_URL = /^[A-Za-z0-9_-]+$/;
@@ -53,6 +63,11 @@ export interface AccountAuthEnv {
   NANOCODEX_USERS: DurableObjectNamespace<UserAccount>;
   NANOCODEX_API_KEYS: DurableObjectNamespace<ApiKeyRecord>;
   NANOCODEX_LOCAL_WEBAUTHN_HMAC_KEY?: string;
+  NANOCODEX_OTP_HMAC_KEY?: string;
+  NANOCODEX_SMS_SEND?: Fetcher;
+  TWILIO_ACCOUNT_SID?: string;
+  TWILIO_AUTH_TOKEN?: string;
+  TWILIO_FROM_NUMBER?: string;
   NANOCODEX_ORGANIZATIONS: DurableObjectNamespace<Organization>;
 }
 
@@ -189,9 +204,24 @@ const teamStorageKey = (teamId: string) => `team:${teamId}`;
 const userMembershipStorageKey = (userId: string) => `membership:user:${userId}`;
 
 type AccountSessionPayload = Readonly<{
+  authentication?: "anonymous" | "sms_otp";
   userId: string;
   issuedAt: number;
   expiresAt: number;
+}>;
+
+type SmsIdentity = Readonly<{
+  accountAddress: `0x${string}`;
+  userId: string;
+}>;
+
+type SmsOtpChallenge = Readonly<{
+  attemptsRemaining: number;
+  candidateAccountAddress: `0x${string}`;
+  candidateUserId: string;
+  digest: string;
+  expiresAt: number;
+  phoneDigest: string;
 }>;
 
 type PortableCredential = Readonly<{
@@ -244,6 +274,24 @@ export async function routeAccountRequest(
 ): Promise<Response | undefined> {
   if (url.pathname === "/auth" || url.pathname.startsWith("/auth/")) {
     return json({ error: "not_found" }, { status: 404 });
+  }
+  if (url.pathname === "/v1/auth/sms/start") {
+    if (request.method !== "POST") return methodNotAllowed();
+    const originFailure = requireBrowserOrigin(request, url);
+    if (originFailure) return originFailure;
+    return startSmsOtp(request, env, url);
+  }
+  if (url.pathname === "/v1/auth/sms/verify") {
+    if (request.method !== "POST") return methodNotAllowed();
+    const originFailure = requireBrowserOrigin(request, url);
+    if (originFailure) return originFailure;
+    return verifySmsOtp(request, env, url);
+  }
+  if (url.pathname === "/v1/auth/logout") {
+    if (request.method !== "POST") return methodNotAllowed();
+    const originFailure = requireBrowserOrigin(request, url);
+    if (originFailure) return originFailure;
+    return logoutAccountSession(request, env, url);
   }
   if (url.pathname === "/webauthn/portable-credential") {
     if (request.method !== "DELETE") return methodNotAllowed();
@@ -300,6 +348,8 @@ export async function routeAccountRequest(
     const resolved = await resolveOrCreateBrowserAccount(request, env, url);
     if (resolved instanceof Response) return resolved;
     const principal = resolved.principal;
+    const accountAddress = await accountAddressForRequest(request, env, url, principal.userId)
+      .catch(() => undefined);
     const portableCookie = resolved.persistent
       ? await portableLocalCredentialCookieForSession(request, env, url, principal)
       : undefined;
@@ -313,6 +363,7 @@ export async function routeAccountRequest(
     for (const cookie of cookies) headers.append("set-cookie", cookie);
     return json({
       user: {
+        ...(accountAddress ? { address: accountAddress } : {}),
         id: principal.userId,
         persistent: resolved.persistent,
       },
@@ -401,6 +452,190 @@ export async function routeAccountRequest(
   return undefined;
 }
 
+async function startSmsOtp(
+  request: Request,
+  env: AccountAuthEnv,
+  url: URL,
+): Promise<Response> {
+  const secret = otpSecret(env);
+  if (!secret) return json({ error: "sms_otp_unavailable" }, { status: 503 });
+  const body = await readJson(request, 1_024);
+  if (body instanceof Response) return body;
+  const phone = normalizedPhone(body.phone);
+  if (!phone) return json({ error: "invalid_phone" }, { status: 400 });
+
+  const store = authStore(env, "sms-otp");
+  if (!store.create) return json({ error: "sms_otp_unavailable" }, { status: 503 });
+  const [phoneDigest, ipDigest] = await Promise.all([
+    keyedDigest(secret, `phone:${phone}`),
+    keyedDigest(secret, `ip:${request.headers.get("cf-connecting-ip") ?? "local"}`),
+  ]);
+  const now = Math.floor(Date.now() / 1_000);
+  const limited = !await store.create(`cooldown:${phoneDigest}`, true, { ttl: OTP_RESEND_SECONDS })
+    || !await reserveWindowSlot(
+      store,
+      `phone:${phoneDigest}`,
+      OTP_PHONE_REQUESTS_PER_HOUR,
+      now,
+    )
+    || !await reserveWindowSlot(store, `ip:${ipDigest}`, OTP_IP_REQUESTS_PER_HOUR, now);
+  if (limited) {
+    return json({ error: "rate_limited", retry_after: OTP_RESEND_SECONDS }, {
+      status: 429,
+      headers: { "retry-after": String(OTP_RESEND_SECONDS) },
+    });
+  }
+
+  const principal = await authenticate(request, env, url);
+  const candidateUserId = principal?.kind === "account_session"
+    ? principal.userId
+    : crypto.randomUUID();
+  const candidateAccountAddress = await accountAddressForRequest(
+    request,
+    env,
+    url,
+    candidateUserId,
+  );
+  const challengeId = randomBase64Url(32);
+  const code = randomOtpCode();
+  const challenge: SmsOtpChallenge = {
+    attemptsRemaining: OTP_MAX_ATTEMPTS,
+    candidateAccountAddress,
+    candidateUserId,
+    digest: await keyedDigest(secret, `otp:${challengeId}:${code}`),
+    expiresAt: now + OTP_CHALLENGE_TTL_SECONDS,
+    phoneDigest,
+  };
+  await Promise.all([
+    store.set(`challenge:${challengeId}`, challenge, { ttl: OTP_CHALLENGE_TTL_SECONDS }),
+    store.set(`active:${phoneDigest}`, challengeId, { ttl: OTP_CHALLENGE_TTL_SECONDS }),
+  ]);
+  try {
+    await sendSms(env, phone, `Your Nanocodex code is ${code}. It expires in 5 minutes.`);
+  } catch {
+    await Promise.all([
+      store.delete(`challenge:${challengeId}`),
+      store.delete(`active:${phoneDigest}`),
+      store.delete(`cooldown:${phoneDigest}`),
+    ]);
+    return json({ error: "sms_delivery_failed" }, { status: 503 });
+  }
+  return json({
+    challenge_id: challengeId,
+    expires_in: OTP_CHALLENGE_TTL_SECONDS,
+    resend_after: OTP_RESEND_SECONDS,
+  }, { status: 202 });
+}
+
+async function verifySmsOtp(
+  request: Request,
+  env: AccountAuthEnv,
+  url: URL,
+): Promise<Response> {
+  const secret = otpSecret(env);
+  if (!secret) return json({ error: "sms_otp_unavailable" }, { status: 503 });
+  const body = await readJson(request, 1_024);
+  if (body instanceof Response) return body;
+  const phone = normalizedPhone(body.phone);
+  const challengeId = typeof body.challenge_id === "string" && OTP_CHALLENGE_ID.test(body.challenge_id)
+    ? body.challenge_id
+    : undefined;
+  const code = typeof body.code === "string" && OTP_CODE.test(body.code) ? body.code : undefined;
+  if (!phone || !challengeId || !code) {
+    return json({ error: "invalid_otp" }, { status: 400 });
+  }
+
+  const store = authStore(env, "sms-otp");
+  if (!store.take) return json({ error: "sms_otp_unavailable" }, { status: 503 });
+  const phoneDigest = await keyedDigest(secret, `phone:${phone}`);
+  const active = await store.get<unknown>(`active:${phoneDigest}`);
+  const challenge = await store.take<unknown>(`challenge:${challengeId}`);
+  const now = Math.floor(Date.now() / 1_000);
+  if (active !== challengeId || !isSmsOtpChallenge(challenge)
+    || challenge.phoneDigest !== phoneDigest || challenge.expiresAt <= now) {
+    return json({ error: "invalid_or_expired_otp" }, { status: 400 });
+  }
+  const expected = await keyedDigest(secret, `otp:${challengeId}:${code}`);
+  if (!constantTimeEqual(challenge.digest, expected)) {
+    const attemptsRemaining = challenge.attemptsRemaining - 1;
+    if (attemptsRemaining > 0) {
+      await store.set(`challenge:${challengeId}`, {
+        ...challenge,
+        attemptsRemaining,
+      }, { ttl: Math.max(1, challenge.expiresAt - now) });
+    } else {
+      await store.delete(`active:${phoneDigest}`);
+    }
+    return json({ error: "invalid_or_expired_otp", attempts_remaining: attemptsRemaining }, {
+      status: 400,
+    });
+  }
+
+  const proposedIdentity: SmsIdentity = {
+    accountAddress: challenge.candidateAccountAddress,
+    userId: challenge.candidateUserId,
+  };
+  const identityKey = `identity:${phoneDigest}`;
+  if (!store.create || !await store.create(identityKey, proposedIdentity)) {
+    const existing = await store.get<unknown>(identityKey);
+    if (!isSmsIdentity(existing)) {
+      return json({ error: "sms_identity_unavailable" }, { status: 503 });
+    }
+  }
+  const identity = await store.get<unknown>(identityKey);
+  if (!isSmsIdentity(identity)) {
+    return json({ error: "sms_identity_unavailable" }, { status: 503 });
+  }
+  await ensureAccount(env, identity.userId, true);
+  await rememberAccountAddress(env, identity.userId, identity.accountAddress);
+
+  const previousToken = cookieValue(request, ACCOUNT_COOKIE);
+  if (previousToken && (ANONYMOUS_SESSION_TOKEN.test(previousToken) || SMS_SESSION_TOKEN.test(previousToken))) {
+    await authStore(env, "account").delete(accountSessionKey(previousToken));
+  }
+  const token = `s_${randomBase64Url(32)}`;
+  await authStore(env, "account").set(accountSessionKey(token), {
+    authentication: "sms_otp",
+    userId: identity.userId,
+    issuedAt: now,
+    expiresAt: now + SESSION_TTL_SECONDS,
+  } satisfies AccountSessionPayload, { ttl: SESSION_TTL_SECONDS });
+  await store.delete(`active:${phoneDigest}`);
+  return json({
+    user: {
+      address: identity.accountAddress,
+      id: identity.userId,
+      persistent: true,
+    },
+  }, {
+    headers: {
+      "set-cookie": accountCookie(token, PERSISTENT_SESSION_TTL_SECONDS, url.protocol),
+    },
+  });
+}
+
+async function logoutAccountSession(
+  request: Request,
+  env: AccountAuthEnv,
+  url: URL,
+): Promise<Response> {
+  const token = cookieValue(request, ACCOUNT_COOKIE);
+  if (token && (ANONYMOUS_SESSION_TOKEN.test(token) || SMS_SESSION_TOKEN.test(token))) {
+    await authStore(env, "account").delete(accountSessionKey(token));
+  }
+  if (token && LEGACY_PASSKEY_SESSION_TOKEN.test(token)) {
+    const response = await webAuthnHandler(env, url).fetch(new Request(
+      new URL("/webauthn/logout", url),
+      { method: "POST", headers: request.headers },
+    ));
+    await response.body?.cancel();
+  }
+  return new Response(null, {
+    status: 204,
+    headers: { "set-cookie": clearAccountCookie(url.protocol) },
+  });
+}
+
 export async function authenticate(
   request: Request,
   env: AccountAuthEnv,
@@ -427,7 +662,7 @@ export async function authenticate(
     };
   }
   const cookie = cookieValue(request, ACCOUNT_COOKIE);
-  if (cookie && ANONYMOUS_SESSION_TOKEN.test(cookie)) {
+  if (cookie && (ANONYMOUS_SESSION_TOKEN.test(cookie) || SMS_SESSION_TOKEN.test(cookie))) {
     const session = await readBrowserSession(request, env);
     if (session) {
       return resolveUserPrincipal(
@@ -436,7 +671,7 @@ export async function authenticate(
         `account_session:${await sha256(cookie)}`,
       );
     }
-  } else if (cookie && PASSKEY_SESSION_TOKEN.test(cookie)) {
+  } else if (cookie && LEGACY_PASSKEY_SESSION_TOKEN.test(cookie)) {
     const passkey = await webAuthnHandler(env, url).getSession(request);
     const passkeyUserId = passkey?.userId ? decodeUserId(passkey.userId) : undefined;
     if (isUserId(passkeyUserId)) {
@@ -513,28 +748,58 @@ export async function authenticatePersistentAccount(
   return account?.persistent === true ? principal : undefined;
 }
 
-export type PersistentPasskeyAccount = Readonly<{
+export type PersistentHostedAccount = Readonly<{
   accountAddress: string;
-  credentialId: string;
   principal: Principal;
-  publicKey: string;
 }>;
 
+export async function authenticatePersistentHostedAccount(
+  request: Request,
+  env: AccountAuthEnv,
+  url = new URL(request.url),
+): Promise<PersistentHostedAccount | undefined> {
+  const principal = await authenticatePersistentAccount(request, env, url);
+  if (!principal) return undefined;
+  const remembered = await readAccountAddress(env, principal.userId);
+  if (remembered) return { accountAddress: remembered, principal };
+  const session = await webAuthnHandler(env, url).getSession(request);
+  const userId = session?.userId ? decodeUserId(session.userId) : undefined;
+  if (session && userId === principal.userId
+    && typeof session.publicKey === "string"
+    && PORTABLE_PUBLIC_KEY.test(session.publicKey)) {
+    try {
+      const publicKey = PublicKey.fromHex(session.publicKey as `0x${string}`);
+      if (publicKey.y !== undefined) {
+        const accountAddress = Address.fromPublicKey(publicKey).toLowerCase();
+        await rememberAccountAddress(env, principal.userId, accountAddress);
+        return { accountAddress, principal };
+      }
+    } catch {
+      // Fall through to the hosted SMS account address.
+    }
+  }
+  try {
+    const accountAddress = await derivedAccountAddress(env, principal.userId);
+    await rememberAccountAddress(env, principal.userId, accountAddress);
+    return { accountAddress, principal };
+  } catch {
+    return undefined;
+  }
+}
+
+/** @deprecated Use authenticatePersistentHostedAccount. */
 export async function authenticatePersistentPasskeyAccount(
   request: Request,
   env: AccountAuthEnv,
   url = new URL(request.url),
-): Promise<PersistentPasskeyAccount | undefined> {
+): Promise<(PersistentHostedAccount & Readonly<{ credentialId: string; publicKey: string }>) | undefined> {
   const principal = await authenticatePersistentAccount(request, env, url);
   if (!principal) return undefined;
   const session = await webAuthnHandler(env, url).getSession(request);
   const userId = session?.userId ? decodeUserId(session.userId) : undefined;
-  if (!session
-    || userId !== principal.userId
-    || typeof session.credentialId !== "string"
-    || !PORTABLE_CREDENTIAL_ID.test(session.credentialId)
-    || typeof session.publicKey !== "string"
-    || !PORTABLE_PUBLIC_KEY.test(session.publicKey)) return undefined;
+  if (!session || userId !== principal.userId
+    || typeof session.credentialId !== "string" || !PORTABLE_CREDENTIAL_ID.test(session.credentialId)
+    || typeof session.publicKey !== "string" || !PORTABLE_PUBLIC_KEY.test(session.publicKey)) return undefined;
   try {
     const publicKey = PublicKey.fromHex(session.publicKey as `0x${string}`);
     if (publicKey.y === undefined) return undefined;
@@ -1040,7 +1305,8 @@ async function resolveOrCreateBrowserAccount(
   if (request.headers.has("authorization")) return unauthorized();
   if (hasCookie(request, ACCOUNT_COOKIE)) {
     const token = cookieValue(request, ACCOUNT_COOKIE);
-    const reauthenticationRequired = Boolean(token && PASSKEY_SESSION_TOKEN.test(token));
+    const reauthenticationRequired = Boolean(token
+      && (SMS_SESSION_TOKEN.test(token) || LEGACY_PASSKEY_SESSION_TOKEN.test(token)));
     return json({
       error: reauthenticationRequired
         ? "reauthentication_required"
@@ -1049,7 +1315,7 @@ async function resolveOrCreateBrowserAccount(
       status: 401,
       headers: {
         "set-cookie": reauthenticationRequired
-          ? accountCookie(token!, PASSKEY_REAUTH_WINDOW_SECONDS, new URL(request.url).protocol)
+          ? accountCookie(token!, PERSISTENT_SESSION_TTL_SECONDS, new URL(request.url).protocol)
           : clearAccountCookie(new URL(request.url).protocol),
       },
     });
@@ -1105,7 +1371,9 @@ function decodeUserId(value: string): string | undefined {
 function cookieValue(request: Request, name: string): string | undefined {
   const cookie = rawCookie(request, name);
   return cookie.present
-    && (ANONYMOUS_SESSION_TOKEN.test(cookie.value) || PASSKEY_SESSION_TOKEN.test(cookie.value))
+    && (ANONYMOUS_SESSION_TOKEN.test(cookie.value)
+      || SMS_SESSION_TOKEN.test(cookie.value)
+      || LEGACY_PASSKEY_SESSION_TOKEN.test(cookie.value))
     ? cookie.value
     : undefined;
 }
@@ -1130,8 +1398,8 @@ function serializeAccountCookie(token: string, protocol: string): string {
 
 function serializePersistentSessionCookie(request: Request, protocol: string): string | undefined {
   const token = cookieValue(request, ACCOUNT_COOKIE);
-  return token && PASSKEY_SESSION_TOKEN.test(token)
-    ? accountCookie(token, PASSKEY_REAUTH_WINDOW_SECONDS, protocol)
+  return token && (SMS_SESSION_TOKEN.test(token) || LEGACY_PASSKEY_SESSION_TOKEN.test(token))
+    ? accountCookie(token, PERSISTENT_SESSION_TTL_SECONDS, protocol)
     : undefined;
 }
 
@@ -1846,6 +2114,186 @@ function organizationName(value: unknown): string | null | undefined {
   return name.length <= 120 ? name : undefined;
 }
 
+function normalizedPhone(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const phone = value.replace(/[\s()-]/g, "");
+  return E164_PHONE.test(phone) ? phone : undefined;
+}
+
+function otpSecret(env: AccountAuthEnv): string | undefined {
+  return typeof env.NANOCODEX_OTP_HMAC_KEY === "string"
+    && env.NANOCODEX_OTP_HMAC_KEY.length >= 32
+    ? env.NANOCODEX_OTP_HMAC_KEY
+    : undefined;
+}
+
+async function reserveWindowSlot(
+  store: Kv.Kv,
+  subject: string,
+  limit: number,
+  now: number,
+): Promise<boolean> {
+  if (!store.create) return false;
+  const window = Math.floor(now / 3_600);
+  const ttl = 7_200;
+  for (let slot = 0; slot < limit; slot += 1) {
+    if (await store.create(`rate:${subject}:${window}:${slot}`, true, { ttl })) return true;
+  }
+  return false;
+}
+
+function randomOtpCode(): string {
+  const ceiling = 4_294_000_000;
+  for (;;) {
+    const bytes = crypto.getRandomValues(new Uint8Array(4));
+    const value = new DataView(bytes.buffer).getUint32(0);
+    if (value < ceiling) return String(value % 1_000_000).padStart(6, "0");
+  }
+}
+
+async function keyedDigest(secret: string, value: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { hash: "SHA-256", name: "HMAC" },
+    false,
+    ["sign"],
+  );
+  return encodeBase64Url(new Uint8Array(await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(value),
+  )));
+}
+
+function constantTimeEqual(left: string, right: string): boolean {
+  const length = Math.max(left.length, right.length);
+  let different = left.length ^ right.length;
+  for (let index = 0; index < length; index += 1) {
+    different |= (left.charCodeAt(index) || 0) ^ (right.charCodeAt(index) || 0);
+  }
+  return different === 0;
+}
+
+function isSmsOtpChallenge(value: unknown): value is SmsOtpChallenge {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const challenge = value as Partial<SmsOtpChallenge>;
+  return Number.isSafeInteger(challenge.attemptsRemaining)
+    && Number(challenge.attemptsRemaining) > 0
+    && Number(challenge.attemptsRemaining) <= OTP_MAX_ATTEMPTS
+    && typeof challenge.candidateAccountAddress === "string"
+    && ACCOUNT_ADDRESS.test(challenge.candidateAccountAddress)
+    && isUserId(challenge.candidateUserId)
+    && typeof challenge.digest === "string" && BASE64_URL.test(challenge.digest)
+    && Number.isSafeInteger(challenge.expiresAt)
+    && typeof challenge.phoneDigest === "string" && BASE64_URL.test(challenge.phoneDigest);
+}
+
+function isSmsIdentity(value: unknown): value is SmsIdentity {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const identity = value as Partial<SmsIdentity>;
+  return typeof identity.accountAddress === "string"
+    && ACCOUNT_ADDRESS.test(identity.accountAddress)
+    && isUserId(identity.userId);
+}
+
+async function sendSms(env: AccountAuthEnv, to: string, body: string): Promise<void> {
+  let response: Response;
+  if (env.NANOCODEX_SMS_SEND) {
+    response = await env.NANOCODEX_SMS_SEND.fetch("https://sms.internal/send", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ body, to }),
+    });
+  } else {
+    const sid = env.TWILIO_ACCOUNT_SID;
+    const token = env.TWILIO_AUTH_TOKEN;
+    const from = normalizedPhone(env.TWILIO_FROM_NUMBER);
+    if (!sid || !/^AC[0-9a-f]{32}$/i.test(sid) || !token || !from) {
+      throw new Error("SMS delivery is not configured");
+    }
+    response = await fetch(`https://api.twilio.com/2010-04-01/Accounts/${sid}/Messages.json`, {
+      method: "POST",
+      headers: {
+        authorization: `Basic ${btoa(`${sid}:${token}`)}`,
+        "content-type": "application/x-www-form-urlencoded;charset=UTF-8",
+      },
+      body: new URLSearchParams({ Body: body, From: from, To: to }),
+    });
+  }
+  if (!response.ok) {
+    await response.body?.cancel();
+    throw new Error(`SMS delivery failed with HTTP ${response.status}`);
+  }
+  await response.body?.cancel();
+}
+
+async function accountAddressForRequest(
+  request: Request,
+  env: AccountAuthEnv,
+  url: URL,
+  userId: string,
+): Promise<`0x${string}`> {
+  const remembered = await readAccountAddress(env, userId);
+  if (remembered) return remembered;
+  const session = await webAuthnHandler(env, url).getSession(request);
+  const sessionUserId = session?.userId ? decodeUserId(session.userId) : undefined;
+  if (session && sessionUserId === userId && typeof session.publicKey === "string"
+    && PORTABLE_PUBLIC_KEY.test(session.publicKey)) {
+    try {
+      const publicKey = PublicKey.fromHex(session.publicKey as `0x${string}`);
+      if (publicKey.y !== undefined) {
+        const address = Address.fromPublicKey(publicKey).toLowerCase() as `0x${string}`;
+        await rememberAccountAddress(env, userId, address);
+        return address;
+      }
+    } catch {
+      // Legacy credentials that cannot be decoded receive the hosted address.
+    }
+  }
+  const address = await derivedAccountAddress(env, userId);
+  await rememberAccountAddress(env, userId, address);
+  return address;
+}
+
+async function derivedAccountAddress(
+  env: AccountAuthEnv,
+  userId: string,
+): Promise<`0x${string}`> {
+  const secret = otpSecret(env);
+  if (!secret) throw new Error("hosted account identity is unavailable");
+  const digest = decodeBase64Url(await keyedDigest(secret, `account-address:${userId}`));
+  if (!digest || digest.byteLength < 20) throw new Error("hosted account identity is unavailable");
+  return `0x${[...digest.slice(0, 20)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")}`;
+}
+
+async function rememberAccountAddress(
+  env: AccountAuthEnv,
+  userId: string,
+  address: string,
+): Promise<void> {
+  if (!ACCOUNT_ADDRESS.test(address)) throw new Error("invalid hosted account address");
+  const store = authStore(env, "account");
+  if (!store.create) throw new Error("hosted account identity is unavailable");
+  const key = `address:${userId}`;
+  if (!await store.create(key, address)) {
+    const existing = await store.get<unknown>(key);
+    if (existing !== address) throw new Error("hosted account identity conflict");
+  }
+}
+
+async function readAccountAddress(
+  env: AccountAuthEnv,
+  userId: string,
+): Promise<`0x${string}` | undefined> {
+  const value = await authStore(env, "account").get<unknown>(`address:${userId}`);
+  return typeof value === "string" && ACCOUNT_ADDRESS.test(value)
+    ? value as `0x${string}`
+    : undefined;
+}
+
 function proxyOrganizationResponse(response: Response): Response {
   return response;
 }
@@ -1864,16 +2312,61 @@ async function sha256(value: string): Promise<string> {
   return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
 }
 
-async function readJson(request: Request): Promise<Record<string, unknown> | Response> {
+async function readJson(
+  request: Request,
+  maxBytes?: number,
+): Promise<Record<string, unknown> | Response> {
   if (!request.headers.get("content-type")?.toLowerCase().startsWith("application/json")) {
     return json({ error: "expected_json" }, { status: 415 });
   }
+  const contentLength = request.headers.get("content-length");
+  if (maxBytes !== undefined && contentLength
+    && (!/^\d+$/.test(contentLength) || Number(contentLength) > maxBytes)) {
+    return json({ error: "payload_too_large" }, { status: 413 });
+  }
   try {
-    const value = await request.json<unknown>();
+    const value = maxBytes === undefined
+      ? await request.json<unknown>()
+      : await readBoundedJsonValue(request, maxBytes);
     if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error();
     return value as Record<string, unknown>;
-  } catch {
+  } catch (cause) {
+    if (cause instanceof PayloadTooLargeError) {
+      return json({ error: "payload_too_large" }, { status: 413 });
+    }
     return json({ error: "invalid_json" }, { status: 400 });
+  }
+}
+
+class PayloadTooLargeError extends Error {}
+
+async function readBoundedJsonValue(request: Request, maxBytes: number): Promise<unknown> {
+  if (!request.body) throw new Error("missing body");
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let length = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      length += value.byteLength;
+      if (length > maxBytes) {
+        await reader.cancel();
+        throw new PayloadTooLargeError();
+      }
+      chunks.push(value);
+    }
+    const encoded = new Uint8Array(length);
+    let offset = 0;
+    for (const chunk of chunks) {
+      encoded.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return JSON.parse(
+      new TextDecoder("utf-8", { fatal: true, ignoreBOM: false }).decode(encoded),
+    ) as unknown;
+  } finally {
+    reader.releaseLock();
   }
 }
 

--- a/js/managed/src/account-auth.ts
+++ b/js/managed/src/account-auth.ts
@@ -23,6 +23,7 @@ const OTP_RESEND_SECONDS = 60;
 const OTP_PHONE_REQUESTS_PER_HOUR = 5;
 const OTP_IP_REQUESTS_PER_HOUR = 20;
 const OTP_PROVIDER_TIMEOUT_MS = 10_000;
+const MAX_WALLET_MUTATION_BODY_BYTES = 16 * 1024;
 const USER_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const API_KEY = /^ncx_live_([A-Za-z0-9_-]{12})_([A-Za-z0-9_-]{43})$/;
@@ -66,6 +67,7 @@ export interface AccountAuthEnv {
   NANOCODEX_API_KEYS: DurableObjectNamespace<ApiKeyRecord>;
   NANOCODEX_LOCAL_WEBAUTHN_HMAC_KEY?: string;
   NANOCODEX_OTP_HMAC_KEY?: string;
+  NANOCODEX?: Fetcher;
   TWILIO_ACCOUNT_SID?: string;
   TWILIO_API_KEY_SECRET?: string;
   TWILIO_API_KEY_SID?: string;
@@ -217,6 +219,11 @@ type SmsIdentity = Readonly<{
   userId: string;
 }>;
 
+export type AccountWalletMetadata = Readonly<{
+  address: `0x${string}`;
+  created_at: number;
+}>;
+
 type SmsOtpChallenge = Readonly<{
   candidateUserId: string;
   expiresAt: number;
@@ -348,8 +355,9 @@ export async function routeAccountRequest(
     const resolved = await resolveOrCreateBrowserAccount(request, env, url);
     if (resolved instanceof Response) return resolved;
     const principal = resolved.principal;
-    const accountAddress = await accountAddressForRequest(request, env, url, principal.userId)
-      .catch(() => undefined);
+    const accountAddress = resolved.persistent
+      ? await readAccountWallet(env, principal.userId).then((wallet) => wallet?.address).catch(() => undefined)
+      : await accountAddressForRequest(request, env, url, principal.userId).catch(() => undefined);
     const portableCookie = resolved.persistent
       ? await portableLocalCredentialCookieForSession(request, env, url, principal)
       : undefined;
@@ -374,6 +382,31 @@ export async function routeAccountRequest(
     }, cookies.length
       ? { headers }
       : undefined);
+  }
+  if (url.pathname === "/v1/wallet") {
+    if (request.method !== "GET") return methodNotAllowed();
+    const principal = await authenticatePersistentAccount(request, env, url);
+    if (!principal) return unauthorized();
+    return proxyAccountWalletRequest(env, principal.userId, "");
+  }
+  if (url.pathname === "/v1/wallet/connect" || url.pathname === "/v1/wallet/revoke-access-key") {
+    if (request.method !== "POST") return methodNotAllowed();
+    const principal = await authenticatePersistentAccount(request, env, url);
+    if (!principal) return unauthorized();
+    const originFailure = requireSameOriginMutation(request, url, principal);
+    if (originFailure) return originFailure;
+    let body = await readJson(request, MAX_WALLET_MUTATION_BODY_BYTES);
+    if (body instanceof Response) return body;
+    if (containsBrowserPrivateKey(body)) {
+      return json({ error: "invalid_wallet_request" }, { status: 400 });
+    }
+    const suffix = url.pathname === "/v1/wallet/connect" ? "/connect" : "/revoke-access-key";
+    if (suffix === "/revoke-access-key") {
+      const wallet = await readAccountWallet(env, principal.userId).catch(() => undefined);
+      if (!wallet) return json({ error: "wallet_unavailable" }, { status: 503 });
+      body = withCanonicalWalletAddress(body, wallet.address);
+    }
+    return proxyAccountWalletRequest(env, principal.userId, suffix, body);
   }
   if (url.pathname === "/v1/organization") {
     const principal = await authenticate(request, env, url);
@@ -578,7 +611,15 @@ async function verifySmsOtp(
     return json({ error: "sms_identity_unavailable" }, { status: 503 });
   }
   await ensureAccount(env, identity.userId, true);
-
+  let wallet: AccountWalletMetadata;
+  try {
+    wallet = await ensureAccountWallet(env, identity.userId);
+  } catch {
+    await store.set(`challenge:${challengeId}`, challenge, {
+      ttl: Math.max(1, challenge.expiresAt - now),
+    });
+    return json({ error: "wallet_unavailable" }, { status: 503 });
+  }
   const previousToken = cookieValue(request, ACCOUNT_COOKIE);
   if (previousToken && (ANONYMOUS_SESSION_TOKEN.test(previousToken) || SMS_SESSION_TOKEN.test(previousToken))) {
     await authStore(env, "account").delete(accountSessionKey(previousToken));
@@ -593,6 +634,7 @@ async function verifySmsOtp(
   await store.delete(`active:${phoneDigest}`);
   return json({
     user: {
+      address: wallet.address,
       id: identity.userId,
       persistent: true,
     },
@@ -749,25 +791,8 @@ export async function authenticatePersistentHostedAccount(
 ): Promise<PersistentHostedAccount | undefined> {
   const principal = await authenticatePersistentAccount(request, env, url);
   if (!principal) return undefined;
-  const remembered = await readAccountAddress(env, principal.userId);
-  if (remembered) return { accountAddress: remembered, principal };
-  const session = await webAuthnHandler(env, url).getSession(request);
-  const userId = session?.userId ? decodeUserId(session.userId) : undefined;
-  if (session && userId === principal.userId
-    && typeof session.publicKey === "string"
-    && PORTABLE_PUBLIC_KEY.test(session.publicKey)) {
-    try {
-      const publicKey = PublicKey.fromHex(session.publicKey as `0x${string}`);
-      if (publicKey.y !== undefined) {
-        const accountAddress = Address.fromPublicKey(publicKey).toLowerCase();
-        await rememberAccountAddress(env, principal.userId, accountAddress);
-        return { accountAddress, principal };
-      }
-    } catch {
-      // A persistent SMS identity is valid without an attached wallet.
-    }
-  }
-  return undefined;
+  const wallet = await readAccountWallet(env, principal.userId);
+  return wallet ? { accountAddress: wallet.address, principal } : undefined;
 }
 
 /** @deprecated Use authenticatePersistentHostedAccount. */
@@ -1230,6 +1255,74 @@ export async function ensureAccount(
     if (current?.id === userId && (current.persistent || !persistent)) return;
   }
   throw new Error("account provisioning failed");
+}
+
+/** Ensures the egress-owned managed wallet exists and returns only public metadata. */
+export async function ensureAccountWallet(
+  env: AccountAuthEnv,
+  userId: string,
+): Promise<AccountWalletMetadata> {
+  if (!isUserId(userId) || !env.NANOCODEX) throw new Error("wallet unavailable");
+  let response: Response;
+  try {
+    response = await env.NANOCODEX.fetch(
+      `https://broker.internal/users/${encodeURIComponent(userId)}/wallet`,
+      { method: "PUT" },
+    );
+  } catch {
+    throw new Error("wallet unavailable");
+  }
+  if (!response.ok) {
+    await response.body?.cancel().catch(() => {});
+    throw new Error("wallet unavailable");
+  }
+  const metadata = await response.json<unknown>().catch(() => undefined);
+  if (!isAccountWalletMetadata(metadata)) throw new Error("wallet unavailable");
+  return metadata;
+}
+
+async function readAccountWallet(
+  env: AccountAuthEnv,
+  userId: string,
+): Promise<AccountWalletMetadata | undefined> {
+  if (!isUserId(userId) || !env.NANOCODEX) throw new Error("wallet unavailable");
+  let response: Response;
+  try {
+    response = await env.NANOCODEX.fetch(
+      `https://broker.internal/users/${encodeURIComponent(userId)}/wallet`,
+    );
+  } catch {
+    throw new Error("wallet unavailable");
+  }
+  if (!response.ok) {
+    await response.body?.cancel().catch(() => {});
+    return undefined;
+  }
+  const metadata = await response.json<unknown>().catch(() => undefined);
+  return isAccountWalletMetadata(metadata) ? metadata : undefined;
+}
+
+async function proxyAccountWalletRequest(
+  env: AccountAuthEnv,
+  userId: string,
+  suffix: "" | "/connect" | "/revoke-access-key",
+  body?: Record<string, unknown>,
+): Promise<Response> {
+  if (!env.NANOCODEX) return json({ error: "wallet_unavailable" }, { status: 503 });
+  try {
+    return await env.NANOCODEX.fetch(
+      `https://broker.internal/users/${encodeURIComponent(userId)}/wallet${suffix}`,
+      body === undefined
+        ? undefined
+        : {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        },
+    );
+  } catch {
+    return json({ error: "wallet_unavailable" }, { status: 503 });
+  }
 }
 
 async function readAccount(env: AccountAuthEnv, userId: string): Promise<UserRecord | undefined> {
@@ -1893,6 +1986,43 @@ function isUserRecord(value: unknown): value is UserRecord {
     && typeof record.persistent === "boolean"
     && Number.isFinite(record.createdAt)
     && Number.isFinite(record.lastAuthenticatedAt);
+}
+
+function isAccountWalletMetadata(value: unknown): value is AccountWalletMetadata {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const metadata = value as Partial<AccountWalletMetadata>;
+  return Object.keys(metadata).length === 2
+    && ACCOUNT_ADDRESS.test(metadata.address ?? "")
+    && Number.isSafeInteger(metadata.created_at)
+    && (metadata.created_at ?? -1) >= 0;
+}
+
+function containsBrowserPrivateKey(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(containsBrowserPrivateKey);
+  if (typeof value !== "object" || value === null) return false;
+  return Object.entries(value).some(([key, nested]) => {
+    const normalized = key.toLowerCase().replaceAll(/[-_]/g, "");
+    return normalized.includes("privatekey")
+      || containsBrowserPrivateKey(nested);
+  });
+}
+
+function withCanonicalWalletAddress(
+  body: Record<string, unknown>,
+  address: `0x${string}`,
+): Record<string, unknown> {
+  const request = body.request;
+  if (typeof request !== "object" || request === null || Array.isArray(request)) return body;
+  const params = (request as Record<string, unknown>).params;
+  if (!Array.isArray(params) || params.length !== 1
+    || typeof params[0] !== "object" || params[0] === null || Array.isArray(params[0])) return body;
+  return {
+    ...body,
+    request: {
+      ...(request as Record<string, unknown>),
+      params: [{ ...(params[0] as Record<string, unknown>), address }],
+    },
+  };
 }
 
 function isOrganizationMetadata(value: unknown): value is OrganizationMetadata {

--- a/js/managed/src/account-links.ts
+++ b/js/managed/src/account-links.ts
@@ -3,7 +3,7 @@ import { Kv } from "accounts/server";
 import {
   authenticate,
   authenticatePersistentAccount,
-  authenticatePersistentPasskeyAccount,
+  authenticatePersistentHostedAccount,
   isUserId,
   requireSameOriginMutation,
   type AccountAuthEnv,
@@ -11,9 +11,10 @@ import {
 
 const CONNECT_DIALOG_ORIGIN = "https://nanocodex.gakonst.workers.dev";
 const CONNECT_APP_ID = "atlas-workspace";
-const HOSTED_CONNECT_APP_ID = "nanocodex-cli";
-const HOSTED_CONNECT_APP_ORIGIN = "https://cli.nanocodex.xyz";
 const HOSTED_MPP_RESOURCE = "urn:nanocodex:mpp:machusd:spend";
+const HOSTED_AUTHORIZATION_RESOURCE = "urn:nanocodex:authorization:hosted";
+const APP_RESOURCE_PREFIX = "urn:nanocodex:app:";
+const APP_ORIGIN_RESOURCE_PREFIX = "urn:nanocodex:origin:";
 const INTERNAL_ORIGIN = "https://nanocodex.internal";
 const NANOCODEX_ORIGIN = "https://nanocodex.gakonst.workers.dev";
 const AUTHORIZATION_TTL_SECONDS = 5 * 60;
@@ -40,8 +41,8 @@ type AuthorizationCode = Readonly<{
 
 type HostedAuthorizationCode = Readonly<{
   accountAddress: string;
-  appId: typeof HOSTED_CONNECT_APP_ID;
-  appOrigin: typeof HOSTED_CONNECT_APP_ORIGIN;
+  appId: string;
+  appOrigin: string;
   resources: readonly string[];
   userId: string;
 }>;
@@ -188,7 +189,7 @@ async function authorizeHostedConnection(
   env: AccountAuthEnv,
   url: URL,
 ): Promise<Response> {
-  const account = await authenticatePersistentPasskeyAccount(request, env, url);
+  const account = await authenticatePersistentHostedAccount(request, env, url);
   if (!account) return json({ error: "unauthorized" }, { status: 401 });
   const originFailure = requireSameOriginMutation(request, url, account.principal);
   if (originFailure) return originFailure;
@@ -197,16 +198,17 @@ async function authorizeHostedConnection(
   if (!hasExactKeys(parsed, ["account_address", "app_id", "app_origin", "resources"])) {
     return json({ error: "invalid_hosted_authorization" }, { status: 400 });
   }
-  const appId = parsed.app_id === HOSTED_CONNECT_APP_ID ? HOSTED_CONNECT_APP_ID : undefined;
-  const appOrigin = parsed.app_origin === HOSTED_CONNECT_APP_ORIGIN
-    ? HOSTED_CONNECT_APP_ORIGIN
-    : undefined;
+  const appId = typeof parsed.app_id === "string" ? parsed.app_id : undefined;
+  const appOrigin = typeof parsed.app_origin === "string" ? parsed.app_origin : undefined;
   const accountAddress = parseAddress(parsed.account_address);
   const resources = parseHostedResources(parsed.resources);
-  if (!appId || !appOrigin || !accountAddress || !resources) {
+  const app = resources ? hostedApp(resources) : undefined;
+  if (!appId || !appOrigin || !accountAddress || !resources
+    || !app || app.id !== appId || app.origin !== appOrigin) {
     return json({ error: "invalid_hosted_authorization" }, { status: 400 });
   }
-  if (resources.includes(HOSTED_MPP_RESOURCE)) {
+  if (!resources.includes(HOSTED_AUTHORIZATION_RESOURCE)
+    || resources.includes(HOSTED_MPP_RESOURCE)) {
     return json({ error: "hosted_mpp_forbidden" }, { status: 400 });
   }
   if (accountAddress !== account.accountAddress) {
@@ -347,13 +349,14 @@ async function exchangeHostedAuthorizationCode(
   const code = typeof parsed.code === "string" && OPAQUE_TOKEN.test(parsed.code)
     ? parsed.code
     : undefined;
-  const appId = parsed.app_id === HOSTED_CONNECT_APP_ID ? HOSTED_CONNECT_APP_ID : undefined;
-  const appOrigin = parsed.app_origin === HOSTED_CONNECT_APP_ORIGIN
-    ? HOSTED_CONNECT_APP_ORIGIN
-    : undefined;
+  const appId = typeof parsed.app_id === "string" ? parsed.app_id : undefined;
+  const appOrigin = typeof parsed.app_origin === "string" ? parsed.app_origin : undefined;
   const accountAddress = parseAddress(parsed.account_address);
   const resources = parseHostedResources(parsed.resources);
+  const app = resources ? hostedApp(resources) : undefined;
   if (!code || !appId || !appOrigin || !accountAddress || !resources
+    || !app || app.id !== appId || app.origin !== appOrigin
+    || !resources.includes(HOSTED_AUTHORIZATION_RESOURCE)
     || resources.includes(HOSTED_MPP_RESOURCE)) {
     return json({ error: "invalid_exchange" }, { status: 400 });
   }
@@ -443,6 +446,8 @@ function validCode(value: unknown): value is AuthorizationCode {
 function validHostedCode(value: unknown): value is HostedAuthorizationCode {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const record = value as Partial<HostedAuthorizationCode>;
+  const resources = parseHostedResources(record.resources);
+  const app = resources ? hostedApp(resources) : undefined;
   return hasExactKeys(record as Record<string, unknown>, [
     "accountAddress",
     "appId",
@@ -451,10 +456,12 @@ function validHostedCode(value: unknown): value is HostedAuthorizationCode {
     "userId",
   ])
     && parseAddress(record.accountAddress) === record.accountAddress
-    && record.appId === HOSTED_CONNECT_APP_ID
-    && record.appOrigin === HOSTED_CONNECT_APP_ORIGIN
-    && parseHostedResources(record.resources) !== undefined
-    && !record.resources!.includes(HOSTED_MPP_RESOURCE)
+    && typeof record.appId === "string"
+    && typeof record.appOrigin === "string"
+    && app?.id === record.appId
+    && app.origin === record.appOrigin
+    && resources!.includes(HOSTED_AUTHORIZATION_RESOURCE)
+    && !resources!.includes(HOSTED_MPP_RESOURCE)
     && isUserId(record.userId);
 }
 
@@ -545,6 +552,29 @@ function parseHostedResources(value: unknown): string[] | undefined {
     resources.push(resource);
   }
   return resources;
+}
+
+function hostedApp(resources: readonly string[]): Readonly<{ id: string; origin: string }> | undefined {
+  const ids = resources.filter((resource) => resource.startsWith(APP_RESOURCE_PREFIX));
+  const origins = resources.filter((resource) => resource.startsWith(APP_ORIGIN_RESOURCE_PREFIX));
+  if (ids.length !== 1 || origins.length !== 1) return undefined;
+  const id = ids[0]!.slice(APP_RESOURCE_PREFIX.length);
+  let origin: string;
+  try {
+    origin = decodeURIComponent(origins[0]!.slice(APP_ORIGIN_RESOURCE_PREFIX.length));
+  } catch {
+    return undefined;
+  }
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(id)) return undefined;
+  try {
+    const url = new URL(origin);
+    if (url.origin !== origin || url.username || url.password
+      || (url.protocol !== "https:" && url.hostname !== "localhost"
+        && url.hostname !== "127.0.0.1" && url.hostname !== "[::1]")) return undefined;
+  } catch {
+    return undefined;
+  }
+  return { id, origin };
 }
 
 function equalResources(left: readonly string[], right: readonly string[]): boolean {

--- a/js/managed/test/account-auth.test.ts
+++ b/js/managed/test/account-auth.test.ts
@@ -552,6 +552,15 @@ describe("managed wallet bridge", () => {
         params: [{ capabilities: { authorizeAccessKey: { scopes: [{ address: publicScopeAddress }] } } }],
       },
     });
+
+    const balanceUrl = new URL("/v1/wallet/balance", origin);
+    const anonymousBalance = await routeAccountRequest(new Request(balanceUrl), local.env, balanceUrl);
+    expect(anonymousBalance?.status).toBe(401);
+    const balance = await routeAccountRequest(new Request(balanceUrl, {
+      headers: { cookie },
+    }), local.env, balanceUrl);
+    expect(balance?.status).toBe(202);
+    expect(requests[1]?.url).toBe(`https://broker.internal/users/${USER_ID}/wallet/balance`);
   });
 
   it("forwards each wallet operation only to its authenticated user and uses the canonical address for /v1/me", async () => {

--- a/js/managed/test/account-auth.test.ts
+++ b/js/managed/test/account-auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   authenticate,
@@ -6,7 +6,6 @@ import {
   routeAccountRequest,
   type AccountAuthEnv,
 } from "../src/account-auth";
-import { routeAccountLinkRequest } from "../src/account-links";
 import { routeConnectorRequest } from "../src/connectors";
 import { routeCredentialRequest } from "../src/credentials";
 
@@ -24,6 +23,14 @@ const CONNECT_GRANT_ID = `0x${"a".repeat(64)}`;
 const CONNECT_MCP_ID = "m".repeat(43);
 const CONNECTOR_CONNECTION_ID = "n".repeat(43);
 const APP_TOOL_CATALOG_DIGEST = `0x${"c".repeat(64)}`;
+const TWILIO_ACCOUNT_SID = `AC${"d".repeat(32)}`;
+const TWILIO_API_KEY_SID = `SK${"e".repeat(32)}`;
+const TWILIO_API_KEY_SECRET = "test-twilio-api-key-secret";
+const TWILIO_VERIFY_SERVICE_SID = `VA${"f".repeat(32)}`;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("Connect grant assertions", () => {
   it("projects the trusted assertion to the exact live capability and tool slice", async () => {
@@ -170,47 +177,55 @@ describe("SMS OTP authentication", () => {
     try {
       const local = portableEnv();
       local.env.NANOCODEX_OTP_HMAC_KEY = "test-sms-otp-hmac-key-with-at-least-thirty-two-bytes";
-      const messages: Array<{ body: string; to: string }> = [];
-      local.env.NANOCODEX_SMS_SEND = {
-        async fetch(input: RequestInfo | URL, init?: RequestInit) {
-          const request = new Request(input, init);
-          messages.push(await request.json<{ body: string; to: string }>());
-          return new Response(null, { status: 202 });
-        },
-      } as Fetcher;
+      const twilio = mockTwilioVerify(local.env);
       const origin = "https://nanocodex.example";
 
       const first = await beginSmsOtp(local.env, origin, "+30 (690) 000-0000");
       expect(first.response.status).toBe(202);
       expect(first.challengeId).toMatch(/^[A-Za-z0-9_-]{43}$/);
-      expect(messages).toHaveLength(1);
+      expect(twilio.calls[0]).toEqual({
+        authorization: `Basic ${btoa(`${TWILIO_API_KEY_SID}:${TWILIO_API_KEY_SECRET}`)}`,
+        form: {
+          Channel: "sms",
+          To: "+306900000000",
+        },
+        url: `https://verify.twilio.com/v2/Services/${TWILIO_VERIFY_SERVICE_SID}/Verifications`,
+      });
       expect(JSON.stringify([...local.values("sms-otp")])).not.toContain("+306900000000");
-      const firstCode = messages[0]!.body.match(/\b(\d{6})\b/)?.[1];
-      expect(firstCode).toBeDefined();
+      expect(JSON.stringify([...local.values("sms-otp")])).not.toContain("123456");
 
+      twilio.checkStatus = "pending";
       const wrong = await completeSmsOtp(
         local.env,
         origin,
         "+306900000000",
         first.challengeId,
-        "999999" === firstCode ? "999998" : "999999",
+        "999999",
       );
       expect(wrong.status).toBe(400);
-      await expect(wrong.json()).resolves.toMatchObject({ attempts_remaining: 4 });
+      await expect(wrong.json()).resolves.toEqual({ error: "invalid_or_expired_otp" });
 
+      twilio.checkStatus = "approved";
       const verified = await completeSmsOtp(
         local.env,
         origin,
         "+306900000000",
         first.challengeId,
-        firstCode!,
+        "123456",
       );
       expect(verified.status).toBe(200);
+      expect(twilio.calls[2]).toEqual({
+        authorization: `Basic ${btoa(`${TWILIO_API_KEY_SID}:${TWILIO_API_KEY_SECRET}`)}`,
+        form: {
+          Code: "123456",
+          VerificationSid: `VE${"0".repeat(31)}1`,
+        },
+        url: `https://verify.twilio.com/v2/Services/${TWILIO_VERIFY_SERVICE_SID}/VerificationCheck`,
+      });
       const firstAccount = await verified.clone().json<{
-        user: { address: string; id: string; persistent: boolean };
+        user: { id: string; persistent: boolean };
       }>();
-      expect(firstAccount.user).toMatchObject({ persistent: true });
-      expect(firstAccount.user.address).toMatch(/^0x[0-9a-f]{40}$/);
+      expect(firstAccount.user).toEqual({ id: expect.any(String), persistent: true });
       const cookie = verified.headers.get("set-cookie")!.split(";", 1)[0]!;
       expect(cookie).toMatch(/^nanocodex_account=s_[A-Za-z0-9_-]{43}$/);
 
@@ -218,45 +233,6 @@ describe("SMS OTP authentication", () => {
         headers: { cookie },
       }), local.env, new URL(`${origin}/v1/me`));
       await expect(current!.json()).resolves.toMatchObject(firstAccount);
-
-      const resources = [
-        "urn:nanocodex:agent:run",
-        "urn:nanocodex:app:test-workspace",
-        `urn:nanocodex:origin:${encodeURIComponent("https://app.example")}`,
-        "urn:nanocodex:authorization:hosted",
-      ];
-      const authorizeUrl = new URL("/v1/connect/hosted-authorization/authorize", origin);
-      const authorized = await routeAccountLinkRequest(new Request(authorizeUrl, {
-        method: "POST",
-        headers: { cookie, "content-type": "application/json", origin },
-        body: JSON.stringify({
-          account_address: firstAccount.user.address,
-          app_id: "test-workspace",
-          app_origin: "https://app.example",
-          resources,
-        }),
-      }), local.env, authorizeUrl);
-      expect(authorized?.status).toBe(200);
-      const { code } = await authorized!.json<{ code: string }>();
-
-      const exchangeUrl = new URL("https://nanocodex.internal/connect/hosted-authorizations/exchange");
-      const exchanged = await routeAccountLinkRequest(new Request(exchangeUrl, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          account_address: firstAccount.user.address,
-          app_id: "test-workspace",
-          app_origin: "https://app.example",
-          code,
-          resources,
-        }),
-      }), local.env, exchangeUrl);
-      expect(exchanged?.status).toBe(200);
-      await expect(exchanged!.json()).resolves.toMatchObject({
-        account_address: firstAccount.user.address,
-        resources,
-        user_id: firstAccount.user.id,
-      });
 
       const loggedOut = await routeAccountRequest(new Request(`${origin}/v1/auth/logout`, {
         method: "POST",
@@ -268,13 +244,12 @@ describe("SMS OTP authentication", () => {
       local.deleteMatching("sms-otp", "cooldown:");
       const second = await beginSmsOtp(local.env, origin, "+306900000000", "198.51.100.2");
       expect(second.response.status).toBe(202);
-      const secondCode = messages[1]!.body.match(/\b(\d{6})\b/)?.[1];
       const restored = await completeSmsOtp(
         local.env,
         origin,
         "+306900000000",
         second.challengeId,
-        secondCode!,
+        "654321",
       );
       await expect(restored.json()).resolves.toEqual(firstAccount);
     } finally {
@@ -282,12 +257,48 @@ describe("SMS OTP authentication", () => {
     }
   });
 
+  it("promotes only the anonymous pre-login user and never aliases a new phone to a persistent account", async () => {
+    const local = portableEnv();
+    local.env.NANOCODEX_OTP_HMAC_KEY = "test-sms-otp-hmac-key-with-at-least-thirty-two-bytes";
+    mockTwilioVerify(local.env);
+    const origin = "https://nanocodex.example";
+    const meUrl = new URL("/v1/me", origin);
+    const anonymous = await routeAccountRequest(new Request(meUrl), local.env, meUrl);
+    const anonymousUser = await anonymous!.clone().json<{ user: { id: string; persistent: boolean } }>();
+    const anonymousCookie = anonymous!.headers.get("set-cookie")!.split(";", 1)[0]!;
+    expect(anonymousUser.user.persistent).toBe(false);
+
+    const first = await beginSmsOtp(local.env, origin, "+14155550125", "198.51.100.10", anonymousCookie);
+    const promoted = await completeSmsOtp(
+      local.env,
+      origin,
+      "+14155550125",
+      first.challengeId,
+      "123456",
+      anonymousCookie,
+    );
+    const promotedUser = await promoted.clone().json<{ user: { id: string; persistent: boolean } }>();
+    const persistentCookie = promoted.headers.get("set-cookie")!.split(";", 1)[0]!;
+    expect(promotedUser.user).toEqual({ id: anonymousUser.user.id, persistent: true });
+
+    const second = await beginSmsOtp(local.env, origin, "+14155550126", "198.51.100.11", persistentCookie);
+    const separate = await completeSmsOtp(
+      local.env,
+      origin,
+      "+14155550126",
+      second.challengeId,
+      "654321",
+      persistentCookie,
+    );
+    const separateUser = await separate.json<{ user: { id: string; persistent: boolean } }>();
+    expect(separateUser.user.persistent).toBe(true);
+    expect(separateUser.user.id).not.toBe(promotedUser.user.id);
+  });
+
   it("enforces browser origin, resend limits, and configured delivery", async () => {
     const local = portableEnv();
     local.env.NANOCODEX_OTP_HMAC_KEY = "test-sms-otp-hmac-key-with-at-least-thirty-two-bytes";
-    local.env.NANOCODEX_SMS_SEND = {
-      fetch() { return Promise.resolve(new Response(null, { status: 202 })); },
-    } as unknown as Fetcher;
+    mockTwilioVerify(local.env);
     const origin = "https://nanocodex.example";
 
     const crossOrigin = await routeAccountRequest(new Request(`${origin}/v1/auth/sms/start`, {
@@ -314,46 +325,80 @@ describe("SMS OTP authentication", () => {
     unavailable.env.NANOCODEX_OTP_HMAC_KEY = local.env.NANOCODEX_OTP_HMAC_KEY;
     const failed = await beginSmsOtp(unavailable.env, origin, "+14155550124");
     expect(failed.response.status).toBe(503);
-    unavailable.env.NANOCODEX_SMS_SEND = local.env.NANOCODEX_SMS_SEND;
+    mockTwilioVerify(unavailable.env);
     const retried = await beginSmsOtp(unavailable.env, origin, "+14155550124");
     expect(retried.response.status).toBe(202);
   });
 
-  it("invalidates a challenge after five incorrect codes", async () => {
+  it("fails closed on provider errors and preserves the challenge for retry", async () => {
     const local = portableEnv();
     local.env.NANOCODEX_OTP_HMAC_KEY = "test-sms-otp-hmac-key-with-at-least-thirty-two-bytes";
-    let deliveredCode = "";
-    local.env.NANOCODEX_SMS_SEND = {
-      async fetch(input: RequestInfo | URL, init?: RequestInit) {
-        const request = new Request(input, init);
-        const message = await request.json<{ body: string }>();
-        deliveredCode = message.body.match(/\b(\d{6})\b/)?.[1] ?? "";
-        return new Response(null, { status: 202 });
-      },
-    } as unknown as Fetcher;
+    const twilio = mockTwilioVerify(local.env);
     const origin = "https://nanocodex.example";
     const started = await beginSmsOtp(local.env, origin, "+14155550124");
-    const incorrect = deliveredCode === "000000" ? "000001" : "000000";
-
-    for (let attemptsRemaining = 4; attemptsRemaining >= 0; attemptsRemaining -= 1) {
-      const response = await completeSmsOtp(
-        local.env,
-        origin,
-        "+14155550124",
-        started.challengeId,
-        incorrect,
-      );
-      expect(response.status).toBe(400);
-      await expect(response.json()).resolves.toMatchObject({ attempts_remaining: attemptsRemaining });
-    }
-    const exhausted = await completeSmsOtp(
+    twilio.checkHttpStatus = 404;
+    const rejected = await completeSmsOtp(
       local.env,
       origin,
       "+14155550124",
       started.challengeId,
-      deliveredCode,
+      "000000",
     );
-    expect(exhausted.status).toBe(400);
+    expect(rejected.status).toBe(400);
+    await expect(rejected.json()).resolves.toEqual({ error: "invalid_or_expired_otp" });
+
+    twilio.checkHttpStatus = 503;
+    const unavailable = await completeSmsOtp(
+      local.env,
+      origin,
+      "+14155550124",
+      started.challengeId,
+      "123456",
+    );
+    expect(unavailable.status).toBe(503);
+    await expect(unavailable.json()).resolves.toEqual({ error: "sms_verification_failed" });
+
+    twilio.checkHttpStatus = 200;
+    twilio.checkStatus = "approved";
+    const retried = await completeSmsOtp(
+      local.env,
+      origin,
+      "+14155550124",
+      started.challengeId,
+      "123456",
+    );
+    expect(retried.status).toBe(200);
+  });
+
+  it("cleans up failed delivery so the same phone can retry immediately", async () => {
+    const local = portableEnv();
+    local.env.NANOCODEX_OTP_HMAC_KEY = "test-sms-otp-hmac-key-with-at-least-thirty-two-bytes";
+    const twilio = mockTwilioVerify(local.env);
+    const origin = "https://nanocodex.example";
+    twilio.startHttpStatus = 503;
+
+    const unavailable = await beginSmsOtp(local.env, origin, "+14155550127");
+    expect(unavailable.response.status).toBe(503);
+    await expect(unavailable.response.json()).resolves.toEqual({ error: "sms_delivery_failed" });
+
+    twilio.startHttpStatus = 201;
+    const retried = await beginSmsOtp(local.env, origin, "+14155550127");
+    expect(retried.response.status).toBe(202);
+  });
+
+  it("supports account SID and auth token credentials", async () => {
+    const local = portableEnv();
+    local.env.NANOCODEX_OTP_HMAC_KEY = "test-sms-otp-hmac-key-with-at-least-thirty-two-bytes";
+    const twilio = mockTwilioVerify(local.env);
+    delete local.env.TWILIO_API_KEY_SID;
+    delete local.env.TWILIO_API_KEY_SECRET;
+    local.env.TWILIO_AUTH_TOKEN = "test-twilio-auth-token";
+
+    const started = await beginSmsOtp(local.env, "https://nanocodex.example", "+14155550128");
+    expect(started.response.status).toBe(202);
+    expect(twilio.calls[0]?.authorization).toBe(
+      `Basic ${btoa(`${TWILIO_ACCOUNT_SID}:test-twilio-auth-token`)}`,
+    );
   });
 });
 
@@ -1015,11 +1060,51 @@ function loginWithPortableCookie(
   }), env, url) as Promise<Response>;
 }
 
+type TwilioVerifyCall = Readonly<{
+  authorization: string | null;
+  form: Record<string, string>;
+  url: string;
+}>;
+
+function mockTwilioVerify(env: AccountAuthEnv) {
+  env.TWILIO_ACCOUNT_SID = TWILIO_ACCOUNT_SID;
+  env.TWILIO_API_KEY_SID = TWILIO_API_KEY_SID;
+  env.TWILIO_API_KEY_SECRET = TWILIO_API_KEY_SECRET;
+  env.TWILIO_VERIFY_SERVICE_SID = TWILIO_VERIFY_SERVICE_SID;
+  const state = {
+    calls: [] as TwilioVerifyCall[],
+    checkHttpStatus: 200,
+    checkStatus: "approved",
+    startHttpStatus: 201,
+    verificationCount: 0,
+  };
+  vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = new Request(input, init);
+    const form = Object.fromEntries([...await request.formData()]
+      .map(([key, value]) => [key, String(value)]));
+    state.calls.push({
+      authorization: request.headers.get("authorization"),
+      form,
+      url: request.url,
+    });
+    if (request.url.endsWith("/Verifications")) {
+      state.verificationCount += 1;
+      return Response.json({
+        sid: `VE${state.verificationCount.toString(16).padStart(32, "0")}`,
+        status: "pending",
+      }, { status: state.startHttpStatus });
+    }
+    return Response.json({ status: state.checkStatus }, { status: state.checkHttpStatus });
+  }));
+  return state;
+}
+
 async function beginSmsOtp(
   env: AccountAuthEnv,
   origin: string,
   phone: string,
   ip = "198.51.100.1",
+  cookie?: string,
 ): Promise<{ challengeId: string; response: Response }> {
   const url = new URL("/v1/auth/sms/start", origin);
   const response = await routeAccountRequest(new Request(url, {
@@ -1028,6 +1113,7 @@ async function beginSmsOtp(
       "cf-connecting-ip": ip,
       "content-type": "application/json",
       origin,
+      ...(cookie ? { cookie } : {}),
     },
     body: JSON.stringify({ phone }),
   }), env, url) as Response;
@@ -1043,11 +1129,12 @@ function completeSmsOtp(
   phone: string,
   challengeId: string,
   code: string,
+  cookie?: string,
 ): Promise<Response> {
   const url = new URL("/v1/auth/sms/verify", origin);
   return routeAccountRequest(new Request(url, {
     method: "POST",
-    headers: { "content-type": "application/json", origin },
+    headers: { "content-type": "application/json", origin, ...(cookie ? { cookie } : {}) },
     body: JSON.stringify({ challenge_id: challengeId, code, phone }),
   }), env, url) as Promise<Response>;
 }

--- a/js/managed/test/account-auth.test.ts
+++ b/js/managed/test/account-auth.test.ts
@@ -171,6 +171,45 @@ describe("account provisioning", () => {
 });
 
 describe("SMS OTP authentication", () => {
+  it("uses a fixed Verify code only in the explicit development environment", async () => {
+    const local = portableEnv();
+    local.env.NANOCODEX_OTP_HMAC_KEY = "test-sms-otp-hmac-key-with-at-least-thirty-two-bytes";
+    local.env.ENVIRONMENT = "development";
+    local.env.NANOCODEX_MOCK_TWILIO_VERIFY_CODE = "123456";
+    const origin = "https://nanocodex.example";
+    const started = await beginSmsOtp(local.env, origin, "+14155550120");
+    expect(started.response.status).toBe(202);
+
+    const rejected = await completeSmsOtp(
+      local.env,
+      origin,
+      "+14155550120",
+      started.challengeId,
+      "000000",
+    );
+    expect(rejected.status).toBe(400);
+    await expect(rejected.json()).resolves.toEqual({
+      error: "invalid_or_expired_otp",
+    });
+
+    const approved = await completeSmsOtp(
+      local.env,
+      origin,
+      "+14155550120",
+      started.challengeId,
+      "123456",
+    );
+    expect(approved.status).toBe(200);
+    expect(approved.headers.get("set-cookie")).toMatch(/^nanocodex_account=s_/);
+
+    const production = portableEnv();
+    production.env.NANOCODEX_OTP_HMAC_KEY = local.env.NANOCODEX_OTP_HMAC_KEY;
+    production.env.ENVIRONMENT = "production";
+    production.env.NANOCODEX_MOCK_TWILIO_VERIFY_CODE = "123456";
+    const unavailable = await beginSmsOtp(production.env, origin, "+14155550121");
+    expect(unavailable.response.status).toBe(503);
+  });
+
   it("creates and restores one persistent account without exposing the phone number", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-09-02T12:00:00Z"));

--- a/js/managed/test/account-auth.test.ts
+++ b/js/managed/test/account-auth.test.ts
@@ -6,6 +6,7 @@ import {
   routeAccountRequest,
   type AccountAuthEnv,
 } from "../src/account-auth";
+import { routeAccountLinkRequest } from "../src/account-links";
 import { routeConnectorRequest } from "../src/connectors";
 import { routeCredentialRequest } from "../src/credentials";
 
@@ -159,6 +160,200 @@ describe("account provisioning", () => {
       : Response.json(account(USER_ID, false)));
 
     await expect(ensureAccount(env, USER_ID, true)).rejects.toThrow("account provisioning failed");
+  });
+});
+
+describe("SMS OTP authentication", () => {
+  it("creates and restores one persistent account without exposing the phone number", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-02T12:00:00Z"));
+    try {
+      const local = portableEnv();
+      local.env.NANOCODEX_OTP_HMAC_KEY = "test-sms-otp-hmac-key-with-at-least-thirty-two-bytes";
+      const messages: Array<{ body: string; to: string }> = [];
+      local.env.NANOCODEX_SMS_SEND = {
+        async fetch(input: RequestInfo | URL, init?: RequestInit) {
+          const request = new Request(input, init);
+          messages.push(await request.json<{ body: string; to: string }>());
+          return new Response(null, { status: 202 });
+        },
+      } as Fetcher;
+      const origin = "https://nanocodex.example";
+
+      const first = await beginSmsOtp(local.env, origin, "+30 (690) 000-0000");
+      expect(first.response.status).toBe(202);
+      expect(first.challengeId).toMatch(/^[A-Za-z0-9_-]{43}$/);
+      expect(messages).toHaveLength(1);
+      expect(JSON.stringify([...local.values("sms-otp")])).not.toContain("+306900000000");
+      const firstCode = messages[0]!.body.match(/\b(\d{6})\b/)?.[1];
+      expect(firstCode).toBeDefined();
+
+      const wrong = await completeSmsOtp(
+        local.env,
+        origin,
+        "+306900000000",
+        first.challengeId,
+        "999999" === firstCode ? "999998" : "999999",
+      );
+      expect(wrong.status).toBe(400);
+      await expect(wrong.json()).resolves.toMatchObject({ attempts_remaining: 4 });
+
+      const verified = await completeSmsOtp(
+        local.env,
+        origin,
+        "+306900000000",
+        first.challengeId,
+        firstCode!,
+      );
+      expect(verified.status).toBe(200);
+      const firstAccount = await verified.clone().json<{
+        user: { address: string; id: string; persistent: boolean };
+      }>();
+      expect(firstAccount.user).toMatchObject({ persistent: true });
+      expect(firstAccount.user.address).toMatch(/^0x[0-9a-f]{40}$/);
+      const cookie = verified.headers.get("set-cookie")!.split(";", 1)[0]!;
+      expect(cookie).toMatch(/^nanocodex_account=s_[A-Za-z0-9_-]{43}$/);
+
+      const current = await routeAccountRequest(new Request(`${origin}/v1/me`, {
+        headers: { cookie },
+      }), local.env, new URL(`${origin}/v1/me`));
+      await expect(current!.json()).resolves.toMatchObject(firstAccount);
+
+      const resources = [
+        "urn:nanocodex:agent:run",
+        "urn:nanocodex:app:test-workspace",
+        `urn:nanocodex:origin:${encodeURIComponent("https://app.example")}`,
+        "urn:nanocodex:authorization:hosted",
+      ];
+      const authorizeUrl = new URL("/v1/connect/hosted-authorization/authorize", origin);
+      const authorized = await routeAccountLinkRequest(new Request(authorizeUrl, {
+        method: "POST",
+        headers: { cookie, "content-type": "application/json", origin },
+        body: JSON.stringify({
+          account_address: firstAccount.user.address,
+          app_id: "test-workspace",
+          app_origin: "https://app.example",
+          resources,
+        }),
+      }), local.env, authorizeUrl);
+      expect(authorized?.status).toBe(200);
+      const { code } = await authorized!.json<{ code: string }>();
+
+      const exchangeUrl = new URL("https://nanocodex.internal/connect/hosted-authorizations/exchange");
+      const exchanged = await routeAccountLinkRequest(new Request(exchangeUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          account_address: firstAccount.user.address,
+          app_id: "test-workspace",
+          app_origin: "https://app.example",
+          code,
+          resources,
+        }),
+      }), local.env, exchangeUrl);
+      expect(exchanged?.status).toBe(200);
+      await expect(exchanged!.json()).resolves.toMatchObject({
+        account_address: firstAccount.user.address,
+        resources,
+        user_id: firstAccount.user.id,
+      });
+
+      const loggedOut = await routeAccountRequest(new Request(`${origin}/v1/auth/logout`, {
+        method: "POST",
+        headers: { cookie, origin },
+      }), local.env, new URL(`${origin}/v1/auth/logout`));
+      expect(loggedOut?.status).toBe(204);
+
+      vi.setSystemTime(new Date("2026-09-02T12:01:01Z"));
+      local.deleteMatching("sms-otp", "cooldown:");
+      const second = await beginSmsOtp(local.env, origin, "+306900000000", "198.51.100.2");
+      expect(second.response.status).toBe(202);
+      const secondCode = messages[1]!.body.match(/\b(\d{6})\b/)?.[1];
+      const restored = await completeSmsOtp(
+        local.env,
+        origin,
+        "+306900000000",
+        second.challengeId,
+        secondCode!,
+      );
+      await expect(restored.json()).resolves.toEqual(firstAccount);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("enforces browser origin, resend limits, and configured delivery", async () => {
+    const local = portableEnv();
+    local.env.NANOCODEX_OTP_HMAC_KEY = "test-sms-otp-hmac-key-with-at-least-thirty-two-bytes";
+    local.env.NANOCODEX_SMS_SEND = {
+      fetch() { return Promise.resolve(new Response(null, { status: 202 })); },
+    } as unknown as Fetcher;
+    const origin = "https://nanocodex.example";
+
+    const crossOrigin = await routeAccountRequest(new Request(`${origin}/v1/auth/sms/start`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: "https://evil.example" },
+      body: JSON.stringify({ phone: "+14155550123" }),
+    }), local.env, new URL(`${origin}/v1/auth/sms/start`));
+    expect(crossOrigin?.status).toBe(403);
+
+    const oversized = await routeAccountRequest(new Request(`${origin}/v1/auth/sms/start`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin },
+      body: JSON.stringify({ phone: `+1${"2".repeat(1_100)}` }),
+    }), local.env, new URL(`${origin}/v1/auth/sms/start`));
+    expect(oversized?.status).toBe(413);
+
+    const first = await beginSmsOtp(local.env, origin, "+14155550123");
+    expect(first.response.status).toBe(202);
+    const limited = await beginSmsOtp(local.env, origin, "+14155550123");
+    expect(limited.response.status).toBe(429);
+    expect(limited.response.headers.get("retry-after")).toBe("60");
+
+    const unavailable = portableEnv();
+    unavailable.env.NANOCODEX_OTP_HMAC_KEY = local.env.NANOCODEX_OTP_HMAC_KEY;
+    const failed = await beginSmsOtp(unavailable.env, origin, "+14155550124");
+    expect(failed.response.status).toBe(503);
+    unavailable.env.NANOCODEX_SMS_SEND = local.env.NANOCODEX_SMS_SEND;
+    const retried = await beginSmsOtp(unavailable.env, origin, "+14155550124");
+    expect(retried.response.status).toBe(202);
+  });
+
+  it("invalidates a challenge after five incorrect codes", async () => {
+    const local = portableEnv();
+    local.env.NANOCODEX_OTP_HMAC_KEY = "test-sms-otp-hmac-key-with-at-least-thirty-two-bytes";
+    let deliveredCode = "";
+    local.env.NANOCODEX_SMS_SEND = {
+      async fetch(input: RequestInfo | URL, init?: RequestInit) {
+        const request = new Request(input, init);
+        const message = await request.json<{ body: string }>();
+        deliveredCode = message.body.match(/\b(\d{6})\b/)?.[1] ?? "";
+        return new Response(null, { status: 202 });
+      },
+    } as unknown as Fetcher;
+    const origin = "https://nanocodex.example";
+    const started = await beginSmsOtp(local.env, origin, "+14155550124");
+    const incorrect = deliveredCode === "000000" ? "000001" : "000000";
+
+    for (let attemptsRemaining = 4; attemptsRemaining >= 0; attemptsRemaining -= 1) {
+      const response = await completeSmsOtp(
+        local.env,
+        origin,
+        "+14155550124",
+        started.challengeId,
+        incorrect,
+      );
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({ attempts_remaining: attemptsRemaining });
+    }
+    const exhausted = await completeSmsOtp(
+      local.env,
+      origin,
+      "+14155550124",
+      started.challengeId,
+      deliveredCode,
+    );
+    expect(exhausted.status).toBe(400);
   });
 });
 
@@ -691,6 +886,8 @@ function portableEnv(secret = LOCAL_HMAC_KEY): {
   env: AccountAuthEnv;
   get(name: string, key: string): unknown;
   set(name: string, key: string, value: unknown): void;
+  values(name: string): IterableIterator<unknown>;
+  deleteMatching(name: string, prefix: string): void;
 } {
   const stores = new Map<string, Map<string, unknown>>();
   const store = (name: string) => {
@@ -790,6 +987,10 @@ function portableEnv(secret = LOCAL_HMAC_KEY): {
     } as unknown as AccountAuthEnv,
     get: (name, key) => store(name).get(key),
     set: (name, key, value) => store(name).set(key, value),
+    values: (name) => store(name).values(),
+    deleteMatching: (name, prefix) => {
+      for (const key of store(name).keys()) if (key.startsWith(prefix)) store(name).delete(key);
+    },
   };
 }
 
@@ -811,6 +1012,43 @@ function loginWithPortableCookie(
       id: credentialId,
       metadata: { clientDataJSON: JSON.stringify({ challenge: "AQ" }) },
     }),
+  }), env, url) as Promise<Response>;
+}
+
+async function beginSmsOtp(
+  env: AccountAuthEnv,
+  origin: string,
+  phone: string,
+  ip = "198.51.100.1",
+): Promise<{ challengeId: string; response: Response }> {
+  const url = new URL("/v1/auth/sms/start", origin);
+  const response = await routeAccountRequest(new Request(url, {
+    method: "POST",
+    headers: {
+      "cf-connecting-ip": ip,
+      "content-type": "application/json",
+      origin,
+    },
+    body: JSON.stringify({ phone }),
+  }), env, url) as Response;
+  const body: { challenge_id?: string } = await response.clone()
+    .json<{ challenge_id?: string }>()
+    .catch(() => ({}));
+  return { challengeId: body.challenge_id ?? "", response };
+}
+
+function completeSmsOtp(
+  env: AccountAuthEnv,
+  origin: string,
+  phone: string,
+  challengeId: string,
+  code: string,
+): Promise<Response> {
+  const url = new URL("/v1/auth/sms/verify", origin);
+  return routeAccountRequest(new Request(url, {
+    method: "POST",
+    headers: { "content-type": "application/json", origin },
+    body: JSON.stringify({ challenge_id: challengeId, code, phone }),
   }), env, url) as Promise<Response>;
 }
 

--- a/js/managed/test/account-auth.test.ts
+++ b/js/managed/test/account-auth.test.ts
@@ -223,9 +223,13 @@ describe("SMS OTP authentication", () => {
         url: `https://verify.twilio.com/v2/Services/${TWILIO_VERIFY_SERVICE_SID}/VerificationCheck`,
       });
       const firstAccount = await verified.clone().json<{
-        user: { id: string; persistent: boolean };
+        user: { address: string; id: string; persistent: boolean };
       }>();
-      expect(firstAccount.user).toEqual({ id: expect.any(String), persistent: true });
+      expect(firstAccount.user).toEqual({
+        address: "0x1111111111111111111111111111111111111111",
+        id: expect.any(String),
+        persistent: true,
+      });
       const cookie = verified.headers.get("set-cookie")!.split(";", 1)[0]!;
       expect(cookie).toMatch(/^nanocodex_account=s_[A-Za-z0-9_-]{43}$/);
 
@@ -277,9 +281,15 @@ describe("SMS OTP authentication", () => {
       "123456",
       anonymousCookie,
     );
-    const promotedUser = await promoted.clone().json<{ user: { id: string; persistent: boolean } }>();
+    const promotedUser = await promoted.clone().json<{
+      user: { address: string; id: string; persistent: boolean };
+    }>();
     const persistentCookie = promoted.headers.get("set-cookie")!.split(";", 1)[0]!;
-    expect(promotedUser.user).toEqual({ id: anonymousUser.user.id, persistent: true });
+    expect(promotedUser.user).toEqual({
+      address: "0x1111111111111111111111111111111111111111",
+      id: anonymousUser.user.id,
+      persistent: true,
+    });
 
     const second = await beginSmsOtp(local.env, origin, "+14155550126", "198.51.100.11", persistentCookie);
     const separate = await completeSmsOtp(
@@ -399,6 +409,166 @@ describe("SMS OTP authentication", () => {
     expect(twilio.calls[0]?.authorization).toBe(
       `Basic ${btoa(`${TWILIO_ACCOUNT_SID}:test-twilio-auth-token`)}`,
     );
+  });
+});
+
+describe("managed wallet bridge", () => {
+  it("includes the broker wallet address in OTP success and leaves a failed wallet provision retryable", async () => {
+    const local = portableEnv();
+    local.env.NANOCODEX_OTP_HMAC_KEY = "test-sms-otp-hmac-key-with-at-least-thirty-two-bytes";
+    mockTwilioVerify(local.env);
+    let available = false;
+    local.env.NANOCODEX = {
+      async fetch(input: RequestInfo | URL, init?: RequestInit) {
+        const request = new Request(input, init);
+        if (request.method !== "PUT") return new Response(null, { status: 404 });
+        return available
+          ? Response.json({ address: "0x2222222222222222222222222222222222222222", created_at: 2 })
+          : new Response(null, { status: 503 });
+      },
+    } as Fetcher;
+    const origin = "https://nanocodex.example";
+    const started = await beginSmsOtp(local.env, origin, "+14155550129");
+
+    const unavailable = await completeSmsOtp(
+      local.env,
+      origin,
+      "+14155550129",
+      started.challengeId,
+      "123456",
+    );
+    expect(unavailable.status).toBe(503);
+    await expect(unavailable.json()).resolves.toEqual({ error: "wallet_unavailable" });
+    expect(unavailable.headers.get("set-cookie")).toBeNull();
+
+    available = true;
+    const retried = await completeSmsOtp(
+      local.env,
+      origin,
+      "+14155550129",
+      started.challengeId,
+      "123456",
+    );
+    expect(retried.status).toBe(200);
+    await expect(retried.json()).resolves.toMatchObject({
+      user: { address: "0x2222222222222222222222222222222222222222", persistent: true },
+    });
+  });
+
+  it("requires a persistent session and same-origin mutations before forwarding wallet requests", async () => {
+    const local = portableEnv();
+    const requests: Request[] = [];
+    local.env.NANOCODEX = {
+      async fetch(input: RequestInfo | URL, init?: RequestInit) {
+        requests.push(new Request(input, init));
+        return Response.json({ accepted: true }, { status: 202, headers: { "x-wallet": "preserved" } });
+      },
+    } as Fetcher;
+    const origin = "https://nanocodex.example";
+    const url = new URL("/v1/wallet/connect", origin);
+    const anonymous = await routeAccountRequest(new Request(url, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin },
+      body: "{}",
+    }), local.env, url);
+    expect(anonymous?.status).toBe(401);
+
+    const cookie = persistentAccountCookie(local, USER_ID, "d");
+    const crossOrigin = await routeAccountRequest(new Request(url, {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json", origin: "https://evil.example" },
+      body: "{}",
+    }), local.env, url);
+    expect(crossOrigin?.status).toBe(403);
+
+    const rejectedMaterial = await routeAccountRequest(new Request(url, {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json", origin },
+      body: JSON.stringify({ private_key: "0xdeadbeef" }),
+    }), local.env, url);
+    expect(rejectedMaterial?.status).toBe(400);
+    expect(requests).toHaveLength(0);
+
+    const publicScopeAddress = "0x3333333333333333333333333333333333333333";
+    const allowedPublicAddress = await routeAccountRequest(new Request(url, {
+      method: "POST",
+      headers: { cookie, "content-type": "application/json", origin },
+      body: JSON.stringify({
+        request: {
+          method: "wallet_connect",
+          params: [{
+            capabilities: {
+              authorizeAccessKey: {
+                scopes: [{ address: publicScopeAddress, type: "contract" }],
+              },
+            },
+          }],
+        },
+      }),
+    }), local.env, url);
+    expect(allowedPublicAddress?.status).toBe(202);
+    expect(requests).toHaveLength(1);
+    await expect(requests[0]!.json()).resolves.toMatchObject({
+      request: {
+        params: [{ capabilities: { authorizeAccessKey: { scopes: [{ address: publicScopeAddress }] } } }],
+      },
+    });
+  });
+
+  it("forwards each wallet operation only to its authenticated user and uses the canonical address for /v1/me", async () => {
+    const local = portableEnv();
+    const requests: Request[] = [];
+    local.env.NANOCODEX = {
+      async fetch(input: RequestInfo | URL, init?: RequestInit) {
+        const request = new Request(input, init);
+        requests.push(request);
+        return Response.json({
+          address: new URL(request.url).pathname.includes(SECOND_USER_ID)
+            ? "0x2222222222222222222222222222222222222222"
+            : "0x1111111111111111111111111111111111111111",
+          created_at: 1,
+        });
+      },
+    } as Fetcher;
+    const origin = "https://nanocodex.example";
+    const firstCookie = persistentAccountCookie(local, USER_ID, "d");
+    const secondCookie = persistentAccountCookie(local, SECOND_USER_ID, "e");
+    local.set("account", `address:${USER_ID}`, "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+    const firstUrl = new URL("/v1/wallet/connect", origin);
+    const first = await routeAccountRequest(new Request(firstUrl, {
+      method: "POST",
+      headers: { cookie: firstCookie, "content-type": "application/json", origin },
+      body: JSON.stringify({ request: { method: "wallet_connect", params: [{}] } }),
+    }), local.env, firstUrl);
+    expect(first?.status).toBe(200);
+
+    const secondUrl = new URL("/v1/wallet/revoke-access-key", origin);
+    await routeAccountRequest(new Request(secondUrl, {
+      method: "POST",
+      headers: { cookie: secondCookie, "content-type": "application/json", origin },
+      body: JSON.stringify({ request: { method: "wallet_revokeAccessKey", params: [{ key_id: "key_123" }] } }),
+    }), local.env, secondUrl);
+    const mutations = requests.filter((request) => request.method === "POST");
+    expect(mutations.map((request) => request.url)).toEqual([
+      `https://broker.internal/users/${USER_ID}/wallet/connect`,
+      `https://broker.internal/users/${SECOND_USER_ID}/wallet/revoke-access-key`,
+    ]);
+    await expect(mutations[0]!.json()).resolves.toEqual({
+      request: { method: "wallet_connect", params: [{}] },
+    });
+    await expect(mutations[1]!.json()).resolves.toEqual({
+      request: {
+        method: "wallet_revokeAccessKey",
+        params: [{ address: "0x2222222222222222222222222222222222222222", key_id: "key_123" }],
+      },
+    });
+
+    const meUrl = new URL("/v1/me", origin);
+    const me = await routeAccountRequest(new Request(meUrl, { headers: { cookie: firstCookie } }), local.env, meUrl);
+    await expect(me?.json()).resolves.toMatchObject({
+      user: { address: "0x1111111111111111111111111111111111111111", id: USER_ID },
+    });
   });
 });
 
@@ -1026,6 +1196,19 @@ function portableEnv(secret = LOCAL_HMAC_KEY): {
   return {
     env: {
       NANOCODEX_AUTH: auth,
+      NANOCODEX: {
+        async fetch(input: RequestInfo | URL, init?: RequestInit) {
+          const request = new Request(input, init);
+          const match = new URL(request.url).pathname.match(
+            /^\/users\/([0-9a-f-]+)\/wallet(?:\/(connect|revoke-access-key))?$/,
+          );
+          if (!match) return new Response(null, { status: 404 });
+          return Response.json({
+            address: "0x1111111111111111111111111111111111111111",
+            created_at: 1,
+          });
+        },
+      } as Fetcher,
       NANOCODEX_LOCAL_WEBAUTHN_HMAC_KEY: secret,
       NANOCODEX_ORGANIZATIONS: organizations,
       NANOCODEX_USERS: users,
@@ -1058,6 +1241,22 @@ function loginWithPortableCookie(
       metadata: { clientDataJSON: JSON.stringify({ challenge: "AQ" }) },
     }),
   }), env, url) as Promise<Response>;
+}
+
+function persistentAccountCookie(
+  local: ReturnType<typeof portableEnv>,
+  userId: string,
+  character: string,
+): string {
+  const token = character.repeat(64);
+  local.set("webauthn", `session:${token}`, {
+    credentialId: CREDENTIAL_ID,
+    publicKey: PUBLIC_KEY,
+    userId: encodeUserId(userId),
+    issuedAt: 1,
+    expiresAt: Math.floor(Date.now() / 1_000) + 60,
+  });
+  return `nanocodex_account=${token}`;
 }
 
 type TwilioVerifyCall = Readonly<{

--- a/js/managed/wrangler.jsonc
+++ b/js/managed/wrangler.jsonc
@@ -131,6 +131,7 @@
       "vars": {
         "AGENT_IDLE_TIMEOUT_MS": "1000",
         "NANOCODEX_ADMIN_TOKEN": "nanocodex-local-room-signing-key",
+        "NANOCODEX_OTP_HMAC_KEY": "nanocodex-local-sms-otp-hmac-key-v1-only",
         "NANOCODEX_LOCAL_WEBAUTHN_HMAC_KEY": "nanocodex-local-passkey-portability-v1",
         "NANOCODEX_LOCAL_OAUTH_RELAY_HMAC_KEY": "nanocodex-local-oauth-relay-hmac-v1-only"
       }

--- a/js/managed/wrangler.jsonc
+++ b/js/managed/wrangler.jsonc
@@ -130,7 +130,9 @@
       },
       "vars": {
         "AGENT_IDLE_TIMEOUT_MS": "1000",
+        "ENVIRONMENT": "development",
         "NANOCODEX_ADMIN_TOKEN": "nanocodex-local-room-signing-key",
+        "NANOCODEX_MOCK_TWILIO_VERIFY_CODE": "123456",
         "NANOCODEX_OTP_HMAC_KEY": "nanocodex-local-sms-otp-hmac-key-v1-only",
         "NANOCODEX_LOCAL_WEBAUTHN_HMAC_KEY": "nanocodex-local-passkey-portability-v1",
         "NANOCODEX_LOCAL_OAUTH_RELAY_HMAC_KEY": "nanocodex-local-oauth-relay-hmac-v1-only"

--- a/js/nanocodex-connect-ui/src/AccountChooser.tsx
+++ b/js/nanocodex-connect-ui/src/AccountChooser.tsx
@@ -8,25 +8,32 @@ export type StoredPasskey = Readonly<{
 }>;
 
 export type AccountSelection = Readonly<{
+  address?: `0x${string}` | undefined;
+  authentication?: "sms_otp" | undefined;
   current?: boolean | undefined;
   mode: "login" | "register";
   label: string;
-  address?: `0x${string}` | undefined;
   credentialId?: string | undefined;
   discoverCredential?: boolean | undefined;
 }>;
 
+type OtpChallenge = Readonly<{
+  challengeId: string;
+  expiresAt: number;
+  phone: string;
+}>;
+
 export function AccountChooser({
   confirmationCode,
-  description = "Continue to Nanocodex CLI with a saved passkey, or create a new account.",
+  description = "Sign in with the code sent to your phone.",
   disabled,
   failure,
   requestContext,
-  newAccountDetail = "Create one passkey to sign in and authorize this hosted CLI connection.",
   onCancel,
   onChooseAccount,
-  storedPasskeys,
+  authOrigin = "",
 }: Readonly<{
+  authOrigin?: string | undefined;
   confirmationCode?: string | undefined;
   description?: string | undefined;
   disabled: boolean;
@@ -35,16 +42,90 @@ export function AccountChooser({
   newAccountDetail?: string | undefined;
   onCancel?: (() => void) | undefined;
   onChooseAccount(account: AccountSelection): void;
-  storedPasskeys: readonly StoredPasskey[];
+  storedPasskeys?: readonly StoredPasskey[] | undefined;
 }>) {
-  const [creatingAccount, setCreatingAccount] = useState(false);
-  const accountNameId = useId();
+  const phoneId = useId();
+  const codeId = useId();
+  const [phone, setPhone] = useState("");
+  const [code, setCode] = useState("");
+  const [challenge, setChallenge] = useState<OtpChallenge>();
+  const [operation, setOperation] = useState<"send" | "verify">();
+  const [localFailure, setLocalFailure] = useState<string>();
 
+  async function sendCode() {
+    if (operation) return;
+    setOperation("send");
+    setLocalFailure(undefined);
+    try {
+      const response = await fetch(`${authOrigin}/v1/auth/sms/start`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ phone }),
+      });
+      const body: unknown = await response.json().catch(() => undefined);
+      if (!response.ok) throw new Error(otpError(body, "Couldn’t send the code."));
+      if (!isRecord(body)
+        || typeof body.challenge_id !== "string"
+        || typeof body.expires_in !== "number") {
+        throw new Error("The account service returned an invalid challenge.");
+      }
+      setChallenge({
+        challengeId: body.challenge_id,
+        expiresAt: Date.now() + body.expires_in * 1_000,
+        phone,
+      });
+      setCode("");
+    } catch (cause) {
+      setLocalFailure(errorMessage(cause));
+    } finally {
+      setOperation(undefined);
+    }
+  }
+
+  async function verifyCode() {
+    if (!challenge || operation) return;
+    setOperation("verify");
+    setLocalFailure(undefined);
+    try {
+      const response = await fetch(`${authOrigin}/v1/auth/sms/verify`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          challenge_id: challenge.challengeId,
+          code,
+          phone: challenge.phone,
+        }),
+      });
+      const body: unknown = await response.json().catch(() => undefined);
+      if (!response.ok) throw new Error(otpError(body, "That code didn’t work."));
+      if (!isRecord(body) || !isRecord(body.user)
+        || typeof body.user.id !== "string"
+        || typeof body.user.address !== "string"
+        || !/^0x[0-9a-f]{40}$/.test(body.user.address)) {
+        throw new Error("The account service returned an invalid session.");
+      }
+      onChooseAccount({
+        address: body.user.address as `0x${string}`,
+        authentication: "sms_otp",
+        current: true,
+        label: maskedPhone(challenge.phone),
+        mode: "login",
+      });
+    } catch (cause) {
+      setLocalFailure(errorMessage(cause));
+    } finally {
+      setOperation(undefined);
+    }
+  }
+
+  const unavailable = disabled || operation !== undefined;
   return (
     <div className="wizard-page wizard-account-page">
       <header className="wizard-intro">
         <div className="wizard-app">
-          <h1>Choose an account</h1>
+          <h1>Sign in with your phone</h1>
           <p>{description}</p>
         </div>
         {confirmationCode ? (
@@ -55,103 +136,75 @@ export function AccountChooser({
         ) : null}
       </header>
 
-      {failure ? <div className="account-failure" role="alert"><p>{failure}</p></div> : null}
+      {failure || localFailure ? (
+        <div className="account-failure" role="alert"><p>{localFailure ?? failure}</p></div>
+      ) : null}
       {requestContext ? <div className="wizard-sections">{requestContext}</div> : null}
 
-      <div className="wizard-account-chooser" role="group" aria-label="Choose a Nanocodex account">
-        {orderedPasskeys(storedPasskeys).map((account) => (
+      {!challenge ? (
+        <form className="sms-otp-form" onSubmit={(event) => {
+          event.preventDefault();
+          void sendCode();
+        }}>
+          <label htmlFor={phoneId}>Mobile number</label>
+          <p>Include the country code, for example +1 or +30.</p>
+          <div className="sms-otp-input-row">
+            <input
+              autoComplete="tel"
+              autoFocus
+              disabled={unavailable}
+              id={phoneId}
+              inputMode="tel"
+              onChange={(event) => setPhone(event.target.value)}
+              placeholder="+30 69…"
+              required
+              type="tel"
+              value={phone}
+            />
+            <button disabled={unavailable || phone.trim().length < 8} type="submit">
+              {operation === "send" ? "Sending…" : "Send code"}
+            </button>
+          </div>
+        </form>
+      ) : (
+        <form className="sms-otp-form" onSubmit={(event) => {
+          event.preventDefault();
+          void verifyCode();
+        }}>
+          <label htmlFor={codeId}>6-digit code</label>
+          <p>Sent to {maskedPhone(challenge.phone)}. It expires at {new Date(challenge.expiresAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}.</p>
+          <div className="sms-otp-input-row">
+            <input
+              autoComplete="one-time-code"
+              autoFocus
+              disabled={unavailable}
+              id={codeId}
+              inputMode="numeric"
+              maxLength={6}
+              onChange={(event) => setCode(event.target.value.replace(/\D/g, "").slice(0, 6))}
+              pattern="[0-9]{6}"
+              placeholder="000000"
+              required
+              value={code}
+            />
+            <button disabled={unavailable || code.length !== 6} type="submit">
+              {operation === "verify" ? "Checking…" : "Continue"}
+            </button>
+          </div>
           <button
-            className={`wizard-account-choice${account.current ? " is-current" : ""}`}
-            disabled={disabled}
-            key={account.credentialId}
-            onClick={() => onChooseAccount({
-              current: account.current,
-              mode: "login",
-              label: account.label || shortAddress(account.address),
-              address: account.address,
-              credentialId: account.credentialId,
-            })}
-            type="button"
-          >
-            <span className="wizard-account-avatar" aria-hidden="true">
-              {(account.label?.trim().slice(0, 1) || "N").toUpperCase()}
-            </span>
-            <span className="wizard-account-copy">
-              <strong>{account.label || shortAddress(account.address)}</strong>
-              <small>{account.current
-                ? `Current account · ${shortAddress(account.address)}`
-                : account.label ? shortAddress(account.address) : "Saved passkey"}</small>
-            </span>
-            <span className="wizard-account-arrow" aria-hidden="true">
-              {account.current ? "Continue" : "→"}
-            </span>
-          </button>
-        ))}
-        <button
-          className="wizard-account-choice"
-          disabled={disabled}
-          onClick={() => onChooseAccount({
-            mode: "login",
-            label: "Another passkey",
-            discoverCredential: true,
-          })}
-          type="button"
-        >
-          <span className="wizard-account-avatar wizard-passkey-avatar" aria-hidden="true">◇</span>
-          <span className="wizard-account-copy">
-            <strong>Use another passkey</strong>
-            <small>Choose a passkey available on this device.</small>
-          </span>
-          <span className="wizard-account-arrow" aria-hidden="true">→</span>
-        </button>
-        {creatingAccount ? (
-          <form
-            className="wizard-account-choice wizard-account-create-form"
-            onSubmit={(event) => {
-              event.preventDefault();
-              const name = String(new FormData(event.currentTarget).get("account-name") ?? "").trim();
-              if (!name) return;
-              onChooseAccount({ mode: "register", label: name.slice(0, 80) });
+            className="sms-otp-change"
+            disabled={unavailable}
+            onClick={() => {
+              setChallenge(undefined);
+              setCode("");
+              setLocalFailure(undefined);
             }}
-          >
-            <span className="wizard-account-avatar" aria-hidden="true">+</span>
-            <label className="wizard-account-copy" htmlFor={accountNameId}>
-              <strong>Name this account</strong>
-              <input
-                autoFocus
-                id={accountNameId}
-                maxLength={80}
-                name="account-name"
-                placeholder="Work, personal, laptop…"
-                required
-              />
-            </label>
-            <button
-              aria-label="Cancel new account"
-              disabled={disabled}
-              onClick={() => setCreatingAccount(false)}
-              type="button"
-            >×</button>
-            <button disabled={disabled} type="submit">Continue</button>
-          </form>
-        ) : (
-          <button
-            className="wizard-account-choice wizard-new-account"
-            disabled={disabled}
-            onClick={() => setCreatingAccount(true)}
             type="button"
-          >
-            <span className="wizard-account-avatar" aria-hidden="true">+</span>
-            <span className="wizard-account-copy">
-              <strong>Create a new account</strong>
-              <small>{newAccountDetail}</small>
-            </span>
-            <span className="wizard-account-arrow" aria-hidden="true">→</span>
-          </button>
-        )}
-      </div>
+          >Use a different number</button>
+        </form>
+      )}
       {onCancel ? (
-        <button className="wizard-cancel" disabled={disabled} onClick={onCancel} type="button">Cancel</button>
+        <button className="wizard-cancel" disabled={unavailable} onClick={onCancel} type="button">Cancel</button>
       ) : null}
     </div>
   );
@@ -163,8 +216,24 @@ export function orderedPasskeys(storedPasskeys: readonly StoredPasskey[]): reado
     : storedPasskeys;
 }
 
-function shortAddress(value: unknown) {
-  return typeof value === "string" && value.length > 15
-    ? `${value.slice(0, 8)}…${value.slice(-6)}`
-    : "Unavailable";
+function maskedPhone(value: string): string {
+  const normalized = value.replace(/\D/g, "");
+  return normalized.length > 4 ? `+••• ••${normalized.slice(-4)}` : "your phone";
+}
+
+function otpError(value: unknown, fallback: string): string {
+  if (!isRecord(value) || typeof value.error !== "string") return fallback;
+  if (value.error === "rate_limited") return "Too many codes requested. Wait a minute and try again.";
+  if (value.error === "invalid_phone") return "Enter a mobile number with its country code.";
+  if (value.error === "invalid_or_expired_otp") return "That code is invalid or expired.";
+  if (value.error === "sms_delivery_failed") return "The code could not be delivered. Try again.";
+  return fallback;
+}
+
+function errorMessage(value: unknown): string {
+  return value instanceof Error ? value.message : "The account service is unavailable.";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }

--- a/js/nanocodex-connect-ui/src/AccountChooser.tsx
+++ b/js/nanocodex-connect-ui/src/AccountChooser.tsx
@@ -46,6 +46,9 @@ export function AccountChooser({
 }>) {
   const phoneId = useId();
   const codeId = useId();
+  const phoneHintId = useId();
+  const codeHintId = useId();
+  const failureId = useId();
   const [phone, setPhone] = useState("");
   const [code, setCode] = useState("");
   const [challenge, setChallenge] = useState<OtpChallenge>();
@@ -54,6 +57,11 @@ export function AccountChooser({
 
   async function sendCode() {
     if (operation) return;
+    const normalized = normalizedPhone(phone);
+    if (!normalized) {
+      setLocalFailure("Enter a valid mobile number with its country code, like +30 697 123 4567.");
+      return;
+    }
     setOperation("send");
     setLocalFailure(undefined);
     try {
@@ -61,7 +69,7 @@ export function AccountChooser({
         method: "POST",
         credentials: "include",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ phone }),
+        body: JSON.stringify({ phone: normalized }),
       });
       const body: unknown = await response.json().catch(() => undefined);
       if (!response.ok) throw new Error(otpError(body, "Couldn’t send the code."));
@@ -73,7 +81,7 @@ export function AccountChooser({
       setChallenge({
         challengeId: body.challenge_id,
         expiresAt: Date.now() + body.expires_in * 1_000,
-        phone,
+        phone: normalized,
       });
       setCode("");
     } catch (cause) {
@@ -85,6 +93,10 @@ export function AccountChooser({
 
   async function verifyCode() {
     if (!challenge || operation) return;
+    if (!/^\d{6}$/.test(code)) {
+      setLocalFailure("Enter the six-digit code from the message.");
+      return;
+    }
     setOperation("verify");
     setLocalFailure(undefined);
     try {
@@ -122,61 +134,68 @@ export function AccountChooser({
   }
 
   const unavailable = disabled || operation !== undefined;
+  const visibleFailure = localFailure ?? failure;
   return (
     <div className="wizard-page wizard-account-page">
-      <header className="wizard-intro">
-        <div className="wizard-app">
-          <h1>Sign in with your phone</h1>
-          <p>{description}</p>
-        </div>
-        {confirmationCode ? (
-          <div className="wizard-terminal-code" role="status">
-            <span>Terminal code</span>
-            <strong>{confirmationCode.slice(0, 4)}-{confirmationCode.slice(4)}</strong>
+      <section className="sms-auth-panel" aria-labelledby={`${phoneId}-heading`}>
+        <header className="wizard-intro">
+          <div className="wizard-app">
+            <span>Nanocodex account</span>
+            <h1 id={`${phoneId}-heading`}>Sign in with your phone</h1>
+            <p>{description}</p>
           </div>
+          {confirmationCode ? (
+            <div className="wizard-terminal-code" role="status">
+              <span>Terminal code</span>
+              <strong>{confirmationCode.slice(0, 4)}-{confirmationCode.slice(4)}</strong>
+            </div>
+          ) : null}
+        </header>
+
+        {visibleFailure ? (
+          <div className="account-failure" id={failureId} role="alert"><p>{visibleFailure}</p></div>
         ) : null}
-      </header>
+        {requestContext ? <div className="wizard-sections">{requestContext}</div> : null}
 
-      {failure || localFailure ? (
-        <div className="account-failure" role="alert"><p>{localFailure ?? failure}</p></div>
-      ) : null}
-      {requestContext ? <div className="wizard-sections">{requestContext}</div> : null}
-
-      {!challenge ? (
-        <form className="sms-otp-form" onSubmit={(event) => {
+        {!challenge ? (
+          <form className="sms-otp-form" noValidate onSubmit={(event) => {
           event.preventDefault();
           void sendCode();
         }}>
           <label htmlFor={phoneId}>Mobile number</label>
-          <p>Include the country code, for example +1 or +30.</p>
+          <p id={phoneHintId}>Include the country code. We’ll text you a one-time code.</p>
           <div className="sms-otp-input-row">
             <input
+              aria-describedby={`${phoneHintId}${visibleFailure ? ` ${failureId}` : ""}`}
+              aria-invalid={localFailure ? true : undefined}
               autoComplete="tel"
               autoFocus
               disabled={unavailable}
               id={phoneId}
               inputMode="tel"
               onChange={(event) => setPhone(event.target.value)}
-              placeholder="+30 69…"
+              placeholder="+30 697 123 4567"
               required
               type="tel"
               value={phone}
             />
-            <button disabled={unavailable || phone.trim().length < 8} type="submit">
+            <button disabled={unavailable} type="submit">
               {operation === "send" ? "Sending…" : "Send code"}
             </button>
           </div>
           <p>By continuing, you agree to receive an automated one-time account code. Message and data rates may apply.</p>
         </form>
       ) : (
-        <form className="sms-otp-form" onSubmit={(event) => {
+        <form className="sms-otp-form" noValidate onSubmit={(event) => {
           event.preventDefault();
           void verifyCode();
         }}>
           <label htmlFor={codeId}>6-digit code</label>
-          <p>Sent to {maskedPhone(challenge.phone)}. It expires at {new Date(challenge.expiresAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}.</p>
+          <p id={codeHintId}>Sent to {maskedPhone(challenge.phone)}. It expires at {new Date(challenge.expiresAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}.</p>
           <div className="sms-otp-input-row">
             <input
+              aria-describedby={`${codeHintId}${visibleFailure ? ` ${failureId}` : ""}`}
+              aria-invalid={localFailure ? true : undefined}
               autoComplete="one-time-code"
               autoFocus
               disabled={unavailable}
@@ -189,7 +208,7 @@ export function AccountChooser({
               required
               value={code}
             />
-            <button disabled={unavailable || code.length !== 6} type="submit">
+            <button disabled={unavailable} type="submit">
               {operation === "verify" ? "Checking…" : "Continue"}
             </button>
           </div>
@@ -205,9 +224,14 @@ export function AccountChooser({
           >Use a different number</button>
         </form>
       )}
-      {onCancel ? (
-        <button className="wizard-cancel" disabled={unavailable} onClick={onCancel} type="button">Cancel</button>
-      ) : null}
+        <div className="sms-auth-security" aria-label="Security note">
+          <span aria-hidden="true">✓</span>
+          <p>Your wallet key stays encrypted in your account vault.</p>
+        </div>
+        {onCancel ? (
+          <button className="wizard-cancel" disabled={unavailable} onClick={onCancel} type="button">Cancel</button>
+        ) : null}
+      </section>
     </div>
   );
 }
@@ -221,6 +245,11 @@ export function orderedPasskeys(storedPasskeys: readonly StoredPasskey[]): reado
 function maskedPhone(value: string): string {
   const normalized = value.replace(/\D/g, "");
   return normalized.length > 4 ? `+••• ••${normalized.slice(-4)}` : "your phone";
+}
+
+function normalizedPhone(value: string): string | undefined {
+  const normalized = value.replace(/[\s()-]/g, "");
+  return /^\+[1-9]\d{7,14}$/.test(normalized) ? normalized : undefined;
 }
 
 function otpError(value: unknown, fallback: string): string {

--- a/js/nanocodex-connect-ui/src/AccountChooser.tsx
+++ b/js/nanocodex-connect-ui/src/AccountChooser.tsx
@@ -102,12 +102,13 @@ export function AccountChooser({
       if (!response.ok) throw new Error(otpError(body, "That code didn’t work."));
       if (!isRecord(body) || !isRecord(body.user)
         || typeof body.user.id !== "string"
-        || typeof body.user.address !== "string"
-        || !/^0x[0-9a-f]{40}$/.test(body.user.address)) {
+        || (body.user.address !== undefined
+          && (typeof body.user.address !== "string"
+            || !/^0x[0-9a-f]{40}$/.test(body.user.address)))) {
         throw new Error("The account service returned an invalid session.");
       }
       onChooseAccount({
-        address: body.user.address as `0x${string}`,
+        ...(body.user.address ? { address: body.user.address as `0x${string}` } : {}),
         authentication: "sms_otp",
         current: true,
         label: maskedPhone(challenge.phone),

--- a/js/nanocodex-connect-ui/src/AccountChooser.tsx
+++ b/js/nanocodex-connect-ui/src/AccountChooser.tsx
@@ -166,6 +166,7 @@ export function AccountChooser({
               {operation === "send" ? "Sending…" : "Send code"}
             </button>
           </div>
+          <p>By continuing, you agree to receive an automated one-time account code. Message and data rates may apply.</p>
         </form>
       ) : (
         <form className="sms-otp-form" onSubmit={(event) => {
@@ -227,7 +228,13 @@ function otpError(value: unknown, fallback: string): string {
   if (value.error === "rate_limited") return "Too many codes requested. Wait a minute and try again.";
   if (value.error === "invalid_phone") return "Enter a mobile number with its country code.";
   if (value.error === "invalid_or_expired_otp") return "That code is invalid or expired.";
+  if (value.error === "invalid_otp") return "Enter the six-digit code from the message.";
   if (value.error === "sms_delivery_failed") return "The code could not be delivered. Try again.";
+  if (value.error === "sms_verification_failed") return "The code could not be checked right now. Try again.";
+  if (value.error === "wallet_unavailable") return "Your account key could not be prepared. Try again.";
+  if (value.error === "sms_otp_unavailable" || value.error === "sms_identity_unavailable") {
+    return "Phone sign-in is temporarily unavailable. Try again.";
+  }
   return fallback;
 }
 

--- a/js/nanocodex-connect-ui/src/AccountChooser.tsx
+++ b/js/nanocodex-connect-ui/src/AccountChooser.tsx
@@ -59,7 +59,9 @@ export function AccountChooser({
     if (operation) return;
     const normalized = normalizedPhone(phone);
     if (!normalized) {
-      setLocalFailure("Enter a valid mobile number with its country code, like +30 697 123 4567.");
+      setLocalFailure(/^\d{6}$/.test(phone.trim())
+        ? "That looks like a verification code. First enter your mobile number; we’ll ask for the code next."
+        : "Enter a valid mobile number with its country code, like +30 697 123 4567.");
       return;
     }
     setOperation("send");
@@ -140,9 +142,11 @@ export function AccountChooser({
       <section className="sms-auth-panel" aria-labelledby={`${phoneId}-heading`}>
         <header className="wizard-intro">
           <div className="wizard-app">
-            <span>Nanocodex account</span>
-            <h1 id={`${phoneId}-heading`}>Sign in with your phone</h1>
-            <p>{description}</p>
+            <span>Nanocodex account · Step {challenge ? "2" : "1"} of 2</span>
+            <h1 id={`${phoneId}-heading`}>{challenge ? "Enter your code" : "Enter your phone number"}</h1>
+            <p>{challenge
+              ? "Use the six-digit code from the text message to finish signing in."
+              : description}</p>
           </div>
           {confirmationCode ? (
             <div className="wizard-terminal-code" role="status">
@@ -173,14 +177,17 @@ export function AccountChooser({
               disabled={unavailable}
               id={phoneId}
               inputMode="tel"
-              onChange={(event) => setPhone(event.target.value)}
+              onChange={(event) => {
+                setPhone(event.target.value);
+                setLocalFailure(undefined);
+              }}
               placeholder="+30 697 123 4567"
               required
               type="tel"
               value={phone}
             />
             <button disabled={unavailable} type="submit">
-              {operation === "send" ? "Sending…" : "Send code"}
+              {operation === "send" ? "Sending…" : "Text me a code"}
             </button>
           </div>
           <p>By continuing, you agree to receive an automated one-time account code. Message and data rates may apply.</p>
@@ -202,7 +209,10 @@ export function AccountChooser({
               id={codeId}
               inputMode="numeric"
               maxLength={6}
-              onChange={(event) => setCode(event.target.value.replace(/\D/g, "").slice(0, 6))}
+              onChange={(event) => {
+                setCode(event.target.value.replace(/\D/g, "").slice(0, 6));
+                setLocalFailure(undefined);
+              }}
               pattern="[0-9]{6}"
               placeholder="000000"
               required

--- a/js/nanocodex-connect-ui/src/App.tsx
+++ b/js/nanocodex-connect-ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { dialog, Provider, Storage, webAuthn } from "accounts";
+import { Provider, Storage, webAuthn } from "accounts";
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { Dialog } from "nanocodex/connect";
 
@@ -38,6 +38,10 @@ import {
   type BrowserAccountSession,
 } from "./browserAccountSession.js";
 import { retainSavedPasskeyLabels } from "./savedPasskeyAccounts.js";
+import {
+  requestManagedWalletConnect,
+  requestManagedWalletRevocation,
+} from "./walletWorker.mjs";
 
 import { classifyMachineUsdOrder } from "./machineUsdOrder.mjs";
 import {
@@ -64,20 +68,32 @@ import {
   usesBrowserLocalWebAuthn,
 } from "./connectPolicy.mjs";
 import type { ConnectRequest, McpConnection, WalletRequest } from "./connectTypes.js";
+type ProviderStoreAccount = Readonly<{
+  address: `0x${string}`;
+  credential?: Readonly<{ id: string }> | undefined;
+  label?: string | undefined;
+}>;
+const emptyProviderState = Object.freeze({ activeAccount: 0, accounts: Object.freeze([]) as readonly ProviderStoreAccount[] });
+const emptyProviderStore = Object.freeze({
+  getState: () => emptyProviderState,
+  setState: (_state: { accounts: readonly ProviderStoreAccount[] }) => undefined,
+  subscribe: (_listener: () => void) => () => undefined,
+});
 const browserLocalWebAuthn = usesBrowserLocalWebAuthn(window.location.origin);
-const provider = createProvider(browserLocalWebAuthn);
-const providerStore = (provider as unknown as {
+const provider = browserLocalWebAuthn ? createLocalProvider() : undefined;
+const providerStore = provider ? (provider as unknown as {
   store: {
     getState(): { activeAccount: number; accounts: readonly ProviderStoreAccount[] };
     setState(state: { accounts: readonly ProviderStoreAccount[] }): unknown;
     subscribe(listener: () => void): () => void;
   };
-}).store;
+}).store : emptyProviderStore;
 let browserSession: Promise<BrowserAccountSession> | undefined;
 
 export async function logoutAccount() {
   try {
-    await provider.request({ method: "wallet_disconnect" });
+    if (provider) await provider.request({ method: "wallet_disconnect" });
+    else await logoutBrowserAccountSession();
   } finally {
     invalidateBrowserSession();
   }
@@ -124,11 +140,6 @@ type ConnectorAttempt = {
   token: string;
 };
 type CeremonyAttempt = Readonly<{ requestId: string }>;
-type ProviderStoreAccount = Readonly<{
-  address: `0x${string}`;
-  credential?: Readonly<{ id: string }> | undefined;
-  label?: string | undefined;
-}>;
 type WizardAccountSelection = AccountSelection;
 
 export type { ConnectRequest } from "./connectTypes.js";
@@ -220,7 +231,10 @@ export function ConnectOnboarding({
   }, [request?.id, finishConnectorAttempt]);
 
   useEffect(() => {
-    if (!request || request.type !== "walletConnect" || request.hostPrincipalExchange) return;
+    if (!request
+      || (request.type === "walletConnect" && request.hostPrincipalExchange)
+      || (request.type !== "walletConnect"
+        && (request.type !== "walletRevokeAccessKey" || browserLocalWebAuthn))) return;
     const requestId = request.id;
     void ensureBrowserSession().then((session) => {
       if (currentRequestId.current === requestId) setBrowserAccountState(session);
@@ -468,6 +482,17 @@ export function ConnectOnboarding({
     activeCeremony.current = attempt;
     setCeremonyRequestId(activeRequest.id);
     try {
+      if (activeRequest.type === "walletRevokeAccessKey" && !browserLocalWebAuthn) {
+        const session = browserAccountState;
+        if (!session || session === "reauthentication" || !session.persistent || !session.address) {
+          throw new Error("Sign in by SMS before revoking this account key.");
+        }
+        await completeRequest(
+          await requestManagedWalletRevocation(activeRequest.rpc, session.address),
+          activeRequest.id,
+        );
+        return;
+      }
       if (activeRequest.type === "walletConnect" && activeRequest.hostPrincipalExchange) {
         const hosted = await authorizeHostPrincipal(activeRequest);
         const result = sanitizeHostPrincipalWalletResult({
@@ -498,8 +523,12 @@ export function ConnectOnboarding({
         return;
       }
       const selectedMode = selectedAccount?.mode ?? accountMode;
+      const managedWallet = activeRequest.type === "walletConnect"
+        && selectedAccount?.authentication === "sms_otp"
+        && !browserLocalWebAuthn;
       const hostedAuthorization = activeRequest.type === "walletConnect"
-        && (selectedMode === "register"
+        && (managedWallet
+          || selectedMode === "register"
           || authenticatedSavedAccount)
         && walletConnectContext(activeRequest).resources.includes(hostedAuthorizationResource)
         && !walletConnectContext(activeRequest).resources.includes("urn:nanocodex:mpp:machusd:spend");
@@ -517,7 +546,9 @@ export function ConnectOnboarding({
       ) {
         registrationUserId = await prepareRegistrationSession();
       }
-      let result: undefined | { accounts: readonly Readonly<{ address: `0x${string}` }>[] };
+      let result: unknown;
+      let managedAddress: `0x${string}` | undefined;
+      let managedAuthToken: string | undefined;
       if (authenticatedSavedAccount) {
         result = { accounts: [{ address: selectedAccount!.address! }] };
       } else {
@@ -527,19 +558,48 @@ export function ConnectOnboarding({
             && selectedAccount?.discoverCredential) {
             await clearPortableCredential(connectApiUrl(activeRequest));
           }
-          result = await retainSavedPasskeyLabels(providerStore, () => provider.request(
-            (activeRequest.type === "walletConnect"
-              ? walletRequest(
+          if (managedWallet) {
+            if (hostedAuthorization) {
+              if (!selectedAccount?.address) {
+                throw new Error("The account service did not return the managed account address.");
+              }
+              managedAddress = selectedAccount.address;
+              result = { accounts: [{ address: selectedAccount.address }] };
+            } else {
+              const connected = await requestManagedWalletConnect(
+                walletRequest(
                   activeRequest,
                   selectedMode,
                   registrationUserId,
                   selectedAccount?.credentialId,
                   selectedAccount?.label,
                   selectedAccount?.discoverCredential,
-                  hostedAuthorization,
-                )
-              : activeRequest.rpc) as never,
-          ) as Promise<typeof result>);
+                  false,
+                  true,
+                ),
+                activeRequest.confirmationCode !== undefined,
+              );
+              result = connected.result;
+              managedAddress = connected.address;
+              managedAuthToken = connected.authToken;
+            }
+          } else if (provider) {
+            result = await retainSavedPasskeyLabels(providerStore, () => provider.request(
+              (activeRequest.type === "walletConnect"
+                ? walletRequest(
+                    activeRequest,
+                    selectedMode,
+                    registrationUserId,
+                    selectedAccount?.credentialId,
+                    selectedAccount?.label,
+                    selectedAccount?.discoverCredential,
+                    hostedAuthorization,
+                  )
+                : activeRequest.rpc) as never,
+            ));
+          } else {
+            throw new Error("Sign in by SMS to connect this account.");
+          }
         } finally {
           if (activeRequest.type === "walletConnect") invalidateBrowserSession();
         }
@@ -547,11 +607,12 @@ export function ConnectOnboarding({
       if (currentRequestId.current !== attempt.requestId) {
         throw new DOMException("The Connect request changed.", "AbortError");
       }
-      if (activeRequest.type === "walletConnect" && !result?.accounts[0]) {
+      if (activeRequest.type === "walletConnect"
+        && (!Array.isArray(record(result).accounts) || !record(result).accounts[0])) {
         throw new Error("Accounts did not return a connected account.");
       }
       if (activeRequest.type === "walletConnect") {
-        const account = result!.accounts[0] as Readonly<{
+        const account = record(result).accounts[0] as Readonly<{
           address: `0x${string}`;
           capabilities?: Readonly<{ auth?: Readonly<{
             connectors?: ConnectorStatuses;
@@ -562,14 +623,18 @@ export function ConnectOnboarding({
         }>;
         const auth = account.capabilities?.auth;
         if (hostedAuthorization) {
-          const hosted = await authorizeHostedRegistration(activeRequest, account.address);
+          const accountAddress = managedAddress ?? account.address;
+          if (!accountAddress || !/^0x[0-9a-fA-F]{40}$/.test(accountAddress)) {
+            throw new Error("Accounts did not return the canonical account address.");
+          }
+          const hosted = await authorizeHostedRegistration(activeRequest, accountAddress);
           const next: PendingApproval = {
-            accountAddress: account.address,
+            accountAddress,
             apiUrl: connectApiUrl(activeRequest),
             deferredChatGptImport: walletView(activeRequest).connectPolicy.chatGptCredentialImport,
             result: sanitizeCliWalletResult({
               accounts: [{
-                address: account.address,
+                address: accountAddress,
                 capabilities: {
                   auth: { approval_id: hosted.approvalId, mode: "hosted" },
                 },
@@ -596,10 +661,10 @@ export function ConnectOnboarding({
           }
           return;
         }
-        const token = auth?.token;
+        const token = managedAuthToken ?? auth?.token;
         if (!token) throw new Error("Accounts did not return an authenticated Connect session.");
         const next: PendingApproval = {
-          accountAddress: account.address,
+          accountAddress: managedAddress ?? account.address,
           apiUrl: connectApiUrl(activeRequest),
           deferredChatGptImport: walletView(activeRequest).connectPolicy.chatGptCredentialImport,
           result: activeRequest.confirmationCode
@@ -1200,7 +1265,7 @@ export function ConnectOnboarding({
         <span className="wordmark">nanocodex/connect</span>
           <span className="secure-label"><span aria-hidden="true" /> {hostPrincipalRequest
             ? "host identity"
-            : "SMS OTP + Tempo Wallet"}</span>
+            : "SMS account"}</span>
       </header> : null}
 
       {request.type === "walletConnect" ? (
@@ -1262,6 +1327,36 @@ export function ConnectOnboarding({
             ) : null}
           </div>}
         </>
+      ) : request.type === "walletRevokeAccessKey" && !browserLocalWebAuthn
+        && !managedRevocationSessionMatches(browserAccountState, request) ? (
+        <div className="dialog-content">
+          {browserAccountState === undefined ? (
+            <p role="status">Checking your account session…</p>
+          ) : (
+            <AccountChooser
+              authOrigin={isLocalDevelopmentOrigin(window.location.origin)
+                ? window.location.origin
+                : productionNanocodexOrigin}
+              description="Sign in by SMS to the account that owns this access key."
+              disabled={ceremonyActive}
+              failure={failure?.id === request.id ? failure.message : undefined}
+              onCancel={reject}
+              onChooseAccount={(account) => {
+                const requestedAddress = record(firstParam(request.rpc.params)).address;
+                if (!account.address || typeof requestedAddress !== "string"
+                  || account.address.toLowerCase() !== requestedAddress.toLowerCase()) {
+                  setFailure({
+                    id: request.id,
+                    message: "That phone is linked to a different account.",
+                  });
+                  return;
+                }
+                setFailure(undefined);
+                setBrowserAccountState({ address: account.address, id: "sms", persistent: true });
+              }}
+            />
+          )}
+        </div>
       ) : request.type === "walletRevokeAccessKey" ? (
         <>
           <div className="dialog-content">
@@ -1273,7 +1368,7 @@ export function ConnectOnboarding({
           <div className="dialog-actions">
             <button type="button" disabled={ceremonyActive} onClick={reject}>Cancel</button>
             <button type="button" disabled={ceremonyActive} onClick={() => void approve()}>
-              Revoke in Tempo Wallet
+              Revoke account key
             </button>
           </div>
         </>
@@ -1292,7 +1387,7 @@ function RevocationApproval({ request }: Readonly<{ request: WalletRequest }>) {
         <h1 id="revocation-heading">Revoke agent access</h1>
       </section>
       <section className="detail-section" aria-labelledby="revocation-details">
-        <SectionHeading id="revocation-details" label="Revocation" value="Tempo Wallet" />
+        <SectionHeading id="revocation-details" label="Revocation" value="Account key" />
         <div className="permission-rows">
           <PermissionRow label="Account" value={shortAddress(params.address)} />
           <PermissionRow label="Access key" value={shortAddress(params.accessKeyAddress)} />
@@ -1301,6 +1396,17 @@ function RevocationApproval({ request }: Readonly<{ request: WalletRequest }>) {
       </section>
     </>
   );
+}
+
+function managedRevocationSessionMatches(
+  session: BrowserAccountSession | "reauthentication" | null | undefined,
+  request: WalletRequest,
+): boolean {
+  if (!session || session === "reauthentication" || !session.persistent || !session.address) return false;
+  const requestedAddress = record(firstParam(request.rpc.params)).address;
+  return typeof requestedAddress === "string"
+    && /^0x[0-9a-fA-F]{40}$/.test(requestedAddress)
+    && session.address.toLowerCase() === requestedAddress.toLowerCase();
 }
 
 type ConnectionView = Omit<Dialog.ConnectionRequest, "auth" | "accessKey"> & Readonly<{
@@ -1442,8 +1548,8 @@ function ConnectionWizard({
         authOrigin={nanocodexOriginFor(request.apiUrl)}
         confirmationCode={confirmationCode}
         description={reauthenticationRequired
-          ? `Your session expired. Sign in by SMS, then connect your Tempo Wallet to approve ${requester}.`
-          : `Sign in by SMS, then connect your Tempo Wallet to approve ${requester}.`}
+          ? `Your session expired. Sign in by SMS, then connect your account to approve ${requester}.`
+          : `Sign in by SMS, then connect your account to approve ${requester}.`}
         disabled={disabled}
         onCancel={onCancel}
         onChooseAccount={onChooseAccount}
@@ -1955,6 +2061,7 @@ function walletRequest(
   selectedLabel?: string,
   discoverCredential?: boolean,
   hostedRegistration = false,
+  managedWallet = false,
 ) {
   const params = record(firstParam(request.rpc.params));
   const capabilities = record(params.capabilities);
@@ -1974,13 +2081,18 @@ function walletRequest(
     const auth = capabilities.auth;
     if (!auth) return auth;
     if (typeof auth === "string") {
-      return { url: auth, verify: `${apiUrl}/v1/connect/auth` };
+      return {
+        url: auth,
+        verify: `${apiUrl}/v1/connect/auth`,
+        ...(managedWallet ? { returnToken: true } : {}),
+      };
     }
     const forwarded = record(auth);
     return {
       ...forwarded,
       verify: `${apiUrl}/v1/connect/auth`,
       resources,
+      ...(managedWallet ? { returnToken: true } : {}),
     };
   })();
   return {
@@ -2024,14 +2136,12 @@ async function clearPortableCredential(apiUrl: string): Promise<void> {
   }
 }
 
-function createProvider(browserLocal: boolean) {
+function createLocalProvider() {
   return Provider.create({
-    adapter: browserLocal
-      ? webAuthn({
-          name: "Nanocodex",
-          rdns: "xyz.paradigm.nanocodex",
-        })
-      : dialog({ name: "Tempo Wallet", rdns: "xyz.tempo" }),
+    adapter: webAuthn({
+      name: "Nanocodex",
+      rdns: "xyz.paradigm.nanocodex",
+    }),
     mpp: false,
     storage: Storage.idb({ key: "nanocodex" }),
   });

--- a/js/nanocodex-connect-ui/src/App.tsx
+++ b/js/nanocodex-connect-ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { Provider, Storage, webAuthn } from "accounts";
+import { dialog, Provider, Storage, webAuthn } from "accounts";
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { Dialog } from "nanocodex/connect";
 
@@ -7,7 +7,6 @@ import {
   type AccountSelection,
   type StoredPasskey,
 } from "./AccountChooser.js";
-import { PasskeyAccountChooser } from "./PasskeyAccountChooser.js";
 import {
   AccountConnectionCard,
   AccountConnectionGrid,
@@ -500,8 +499,7 @@ export function ConnectOnboarding({
       }
       const selectedMode = selectedAccount?.mode ?? accountMode;
       const hostedAuthorization = activeRequest.type === "walletConnect"
-        && (selectedAccount?.authentication === "sms_otp"
-          || selectedMode === "register"
+        && (selectedMode === "register"
           || authenticatedSavedAccount)
         && walletConnectContext(activeRequest).resources.includes(hostedAuthorizationResource)
         && !walletConnectContext(activeRequest).resources.includes("urn:nanocodex:mpp:machusd:spend");
@@ -1202,9 +1200,7 @@ export function ConnectOnboarding({
         <span className="wordmark">nanocodex/connect</span>
           <span className="secure-label"><span aria-hidden="true" /> {hostPrincipalRequest
             ? "host identity"
-            : connectionRequest?.auth.resources.includes(hostedAuthorizationResource)
-              ? "SMS OTP"
-              : "passkey"}</span>
+            : "SMS OTP + Tempo Wallet"}</span>
       </header> : null}
 
       {request.type === "walletConnect" ? (
@@ -1223,8 +1219,8 @@ export function ConnectOnboarding({
                 setWizardAccount(account);
                 void approve(
                   account,
-                  account.authentication === "sms_otp"
-                    || (wizard
+                  account.authentication !== "sms_otp"
+                    && (wizard
                       && account.current === true
                         && browserAccountState !== "reauthentication"
                         && browserAccountState?.persistent === true),
@@ -1277,7 +1273,7 @@ export function ConnectOnboarding({
           <div className="dialog-actions">
             <button type="button" disabled={ceremonyActive} onClick={reject}>Cancel</button>
             <button type="button" disabled={ceremonyActive} onClick={() => void approve()}>
-              Revoke with passkey
+              Revoke in Tempo Wallet
             </button>
           </div>
         </>
@@ -1296,7 +1292,7 @@ function RevocationApproval({ request }: Readonly<{ request: WalletRequest }>) {
         <h1 id="revocation-heading">Revoke agent access</h1>
       </section>
       <section className="detail-section" aria-labelledby="revocation-details">
-        <SectionHeading id="revocation-details" label="Revocation" value="One passkey" />
+        <SectionHeading id="revocation-details" label="Revocation" value="Tempo Wallet" />
         <div className="permission-rows">
           <PermissionRow label="Account" value={shortAddress(params.address)} />
           <PermissionRow label="Access key" value={shortAddress(params.accessKeyAddress)} />
@@ -1441,27 +1437,17 @@ function ConnectionWizard({
       request={request}
       requester={requester}
     />;
-    return hostedAuthorization ? (
+    return (
       <AccountChooser
         authOrigin={nanocodexOriginFor(request.apiUrl)}
         confirmationCode={confirmationCode}
         description={reauthenticationRequired
-          ? `Your session expired. Sign in by SMS before approving ${requester}.`
-          : `Sign in by SMS to choose the Nanocodex account that will approve ${requester}.`}
+          ? `Your session expired. Sign in by SMS, then connect your Tempo Wallet to approve ${requester}.`
+          : `Sign in by SMS, then connect your Tempo Wallet to approve ${requester}.`}
         disabled={disabled}
         onCancel={onCancel}
         onChooseAccount={onChooseAccount}
         requestContext={requestContext}
-      />
-    ) : (
-      <PasskeyAccountChooser
-        confirmationCode={confirmationCode}
-        description={`Confirm with a passkey before approving ${requester}.`}
-        disabled={disabled}
-        onCancel={onCancel}
-        onChooseAccount={onChooseAccount}
-        requestContext={requestContext}
-        storedPasskeys={storedPasskeys}
       />
     );
   }
@@ -2040,16 +2026,12 @@ async function clearPortableCredential(apiUrl: string): Promise<void> {
 
 function createProvider(browserLocal: boolean) {
   return Provider.create({
-    adapter: webAuthn(browserLocal
-      ? {
+    adapter: browserLocal
+      ? webAuthn({
           name: "Nanocodex",
           rdns: "xyz.paradigm.nanocodex",
-        }
-      : {
-          auth: "/webauthn",
-          name: "Nanocodex",
-          rdns: "xyz.paradigm.nanocodex",
-        }),
+        })
+      : dialog({ name: "Tempo Wallet", rdns: "xyz.tempo" }),
     mpp: false,
     storage: Storage.idb({ key: "nanocodex" }),
   });

--- a/js/nanocodex-connect-ui/src/App.tsx
+++ b/js/nanocodex-connect-ui/src/App.tsx
@@ -7,6 +7,7 @@ import {
   type AccountSelection,
   type StoredPasskey,
 } from "./AccountChooser.js";
+import { PasskeyAccountChooser } from "./PasskeyAccountChooser.js";
 import {
   AccountConnectionCard,
   AccountConnectionGrid,
@@ -499,14 +500,15 @@ export function ConnectOnboarding({
       }
       const selectedMode = selectedAccount?.mode ?? accountMode;
       const hostedAuthorization = activeRequest.type === "walletConnect"
-        && (selectedMode === "register" || authenticatedSavedAccount)
-        && activeRequest.confirmationCode !== undefined
+        && (selectedAccount?.authentication === "sms_otp"
+          || selectedMode === "register"
+          || authenticatedSavedAccount)
         && walletConnectContext(activeRequest).resources.includes(hostedAuthorizationResource)
         && !walletConnectContext(activeRequest).resources.includes("urn:nanocodex:mpp:machusd:spend");
       if (authenticatedSavedAccount && (!hostedAuthorization
         || selectedMode !== "login"
         || !selectedAccount?.address)) {
-        throw new Error("This saved account requires passkey authentication.");
+        throw new Error("This account requires a fresh SMS sign-in.");
       }
       setAccountMode(selectedMode);
       let registrationUserId: string | undefined;
@@ -751,7 +753,7 @@ export function ConnectOnboarding({
     mcpConnections: readonly McpConnection[];
     token: string;
   }> {
-    const resources = walletConnectContext(activeRequest).resources;
+    const { app, resources } = walletConnectContext(activeRequest);
     const websiteOrigin = nanocodexOriginFor(connectApiUrl(activeRequest));
     const authorize = await fetch(`${websiteOrigin}/v1/connect/hosted-authorization/authorize`, {
       method: "POST",
@@ -759,8 +761,8 @@ export function ConnectOnboarding({
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         account_address: accountAddress,
-        app_id: "nanocodex-cli",
-        app_origin: "https://cli.nanocodex.xyz",
+        app_id: app.id,
+        app_origin: app.origin,
         resources,
       }),
     });
@@ -777,8 +779,8 @@ export function ConnectOnboarding({
       },
       body: JSON.stringify({
         account_address: accountAddress,
-        app_id: "nanocodex-cli",
-        app_origin: "https://cli.nanocodex.xyz",
+        app_id: app.id,
+        app_origin: app.origin,
         code,
         resources,
       }),
@@ -1198,7 +1200,11 @@ export function ConnectOnboarding({
     >
       {!wizard ? <header className="dialog-header">
         <span className="wordmark">nanocodex/connect</span>
-          <span className="secure-label"><span aria-hidden="true" /> {hostPrincipalRequest ? "host identity" : "passkey"}</span>
+          <span className="secure-label"><span aria-hidden="true" /> {hostPrincipalRequest
+            ? "host identity"
+            : connectionRequest?.auth.resources.includes(hostedAuthorizationResource)
+              ? "SMS OTP"
+              : "passkey"}</span>
       </header> : null}
 
       {request.type === "walletConnect" ? (
@@ -1217,10 +1223,11 @@ export function ConnectOnboarding({
                 setWizardAccount(account);
                 void approve(
                   account,
-                  wizard
-                    && account.current === true
-                    && browserAccountState !== "reauthentication"
-                    && browserAccountState?.persistent === true,
+                  account.authentication === "sms_otp"
+                    || (wizard
+                      && account.current === true
+                        && browserAccountState !== "reauthentication"
+                        && browserAccountState?.persistent === true),
                 );
               }}
               onCancel={reject}
@@ -1301,6 +1308,7 @@ function RevocationApproval({ request }: Readonly<{ request: WalletRequest }>) {
 }
 
 type ConnectionView = Omit<Dialog.ConnectionRequest, "auth" | "accessKey"> & Readonly<{
+  apiUrl: string;
   auth: Readonly<{ message?: string; resources: readonly string[] }>;
   accessKey?: Omit<Dialog.ConnectionRequest["accessKey"], "witness"> & Readonly<{ witness?: `0x${string}` }>;
   connectPolicy: ReturnType<typeof parseConnectPolicy>;
@@ -1428,21 +1436,31 @@ function ConnectionWizard({
   const requester = presentation === "wizard" ? "Nanocodex CLI" : request.app.name;
   const hostedAuthorization = request.auth.resources.includes(hostedAuthorizationResource);
   if (!request.hostPrincipalExchange && !connectorStatuses && !accountAddress) {
-    return (
+    const requestContext = <RequestedConnectionContext
+      appVisibility={appVisibility}
+      request={request}
+      requester={requester}
+    />;
+    return hostedAuthorization ? (
       <AccountChooser
+        authOrigin={nanocodexOriginFor(request.apiUrl)}
         confirmationCode={confirmationCode}
         description={reauthenticationRequired
-          ? `Your session expired. Use a remembered passkey to reauthenticate before approving ${requester}.`
-          : `Choose the Nanocodex account that will approve ${requester}.`}
+          ? `Your session expired. Sign in by SMS before approving ${requester}.`
+          : `Sign in by SMS to choose the Nanocodex account that will approve ${requester}.`}
         disabled={disabled}
-        newAccountDetail={`Create one passkey and approve only the access requested by ${requester}.`}
         onCancel={onCancel}
         onChooseAccount={onChooseAccount}
-        requestContext={<RequestedConnectionContext
-          appVisibility={appVisibility}
-          request={request}
-          requester={requester}
-        />}
+        requestContext={requestContext}
+      />
+    ) : (
+      <PasskeyAccountChooser
+        confirmationCode={confirmationCode}
+        description={`Confirm with a passkey before approving ${requester}.`}
+        disabled={disabled}
+        onCancel={onCancel}
+        onChooseAccount={onChooseAccount}
+        requestContext={requestContext}
         storedPasskeys={storedPasskeys}
       />
     );
@@ -1464,13 +1482,13 @@ function ConnectionWizard({
                   ? `${connectorProviderLabel(focusedControl.provider)} is connected. You can return to ${requester}.`
                   : connectorAction === focusedProvider
                   ? `Continue in ${connectorProviderLabel(requiredConnectorProvider(focused.id))}. You’ll return here when the requested access is connected.`
-                  : request.hostPrincipalExchange ? "Approve with your host identity." : "Continue with your passkey."
+                  : request.hostPrincipalExchange ? "Approve with your host identity." : "Continue with SMS verification."
                 : focusedMcp
                   ? mcpConnections?.find(({ id }) => id === focusedMcp.id)?.status === "connected"
                     ? `${focusedMcp.name} is connected. You can return to ${requester}.`
                     : mcpConnectionAction === focusedMcp.id
                       ? `Continue in ${focusedMcp.name}. You’ll return here when it is connected.`
-                      : request.hostPrincipalExchange ? "Approve with your host identity." : "Continue with your passkey."
+                      : request.hostPrincipalExchange ? "Approve with your host identity." : "Continue with SMS verification."
                 : presentation === "dialog"
                   ? `Connect any missing accounts, then approve ${requester}’s requested access.`
                   : `Review ${requester}’s hosted access.`}</>}
@@ -2110,6 +2128,7 @@ function walletView(request: WalletRequest): ConnectionView {
       }
     : undefined;
   return {
+    apiUrl: connectApiUrl(request),
     id: request.id,
     type: "connect",
     app,

--- a/js/nanocodex-connect-ui/src/ConnectionLogo.tsx
+++ b/js/nanocodex-connect-ui/src/ConnectionLogo.tsx
@@ -13,6 +13,7 @@ export type ConnectionLogoId =
   | "gcontacts"
   | "mcp"
   | "slack"
+  | "tempo"
   | "x";
 
 export function ConnectionLogo({ id }: Readonly<{ id: ConnectionLogoId }>) {
@@ -73,6 +74,9 @@ export function ConnectionLogo({ id }: Readonly<{ id: ConnectionLogoId }>) {
   }
   if (id === "slack") {
     return <span className="connector-logo connector-logo-slack" aria-hidden="true">S</span>;
+  }
+  if (id === "tempo") {
+    return <span className="connector-logo connector-logo-tempo" aria-hidden="true">T</span>;
   }
   return <span className="connector-logo connector-logo-x" aria-hidden="true">X</span>;
 }

--- a/js/nanocodex-connect-ui/src/PasskeyAccountChooser.tsx
+++ b/js/nanocodex-connect-ui/src/PasskeyAccountChooser.tsx
@@ -1,0 +1,153 @@
+import { useId, useState, type ReactNode } from "react";
+
+import {
+  orderedPasskeys,
+  type AccountSelection,
+  type StoredPasskey,
+} from "./AccountChooser.js";
+
+/** Passkeys remain available only for explicit access-key and MPP step-up flows. */
+export function PasskeyAccountChooser({
+  confirmationCode,
+  description,
+  disabled,
+  failure,
+  requestContext,
+  onCancel,
+  onChooseAccount,
+  storedPasskeys,
+}: Readonly<{
+  confirmationCode?: string | undefined;
+  description: string;
+  disabled: boolean;
+  failure?: string | null | undefined;
+  requestContext?: ReactNode;
+  onCancel?: (() => void) | undefined;
+  onChooseAccount(account: AccountSelection): void;
+  storedPasskeys: readonly StoredPasskey[];
+}>) {
+  const [creatingAccount, setCreatingAccount] = useState(false);
+  const accountNameId = useId();
+
+  return (
+    <div className="wizard-page wizard-account-page">
+      <header className="wizard-intro">
+        <div className="wizard-app">
+          <h1>Confirm with a passkey</h1>
+          <p>{description}</p>
+        </div>
+        {confirmationCode ? (
+          <div className="wizard-terminal-code" role="status">
+            <span>Terminal code</span>
+            <strong>{confirmationCode.slice(0, 4)}-{confirmationCode.slice(4)}</strong>
+          </div>
+        ) : null}
+      </header>
+
+      {failure ? <div className="account-failure" role="alert"><p>{failure}</p></div> : null}
+      {requestContext ? <div className="wizard-sections">{requestContext}</div> : null}
+
+      <div className="wizard-account-chooser" role="group" aria-label="Choose a passkey">
+        {orderedPasskeys(storedPasskeys).map((account) => (
+          <button
+            className={`wizard-account-choice${account.current ? " is-current" : ""}`}
+            disabled={disabled}
+            key={account.credentialId}
+            onClick={() => onChooseAccount({
+              current: account.current,
+              mode: "login",
+              label: account.label || shortAddress(account.address),
+              address: account.address,
+              credentialId: account.credentialId,
+            })}
+            type="button"
+          >
+            <span className="wizard-account-avatar" aria-hidden="true">
+              {(account.label?.trim().slice(0, 1) || "N").toUpperCase()}
+            </span>
+            <span className="wizard-account-copy">
+              <strong>{account.label || shortAddress(account.address)}</strong>
+              <small>{account.current
+                ? `Current account · ${shortAddress(account.address)}`
+                : account.label ? shortAddress(account.address) : "Saved passkey"}</small>
+            </span>
+            <span className="wizard-account-arrow" aria-hidden="true">
+              {account.current ? "Continue" : "→"}
+            </span>
+          </button>
+        ))}
+        <button
+          className="wizard-account-choice"
+          disabled={disabled}
+          onClick={() => onChooseAccount({
+            mode: "login",
+            label: "Another passkey",
+            discoverCredential: true,
+          })}
+          type="button"
+        >
+          <span className="wizard-account-avatar wizard-passkey-avatar" aria-hidden="true">◇</span>
+          <span className="wizard-account-copy">
+            <strong>Use another passkey</strong>
+            <small>Choose a passkey available on this device.</small>
+          </span>
+          <span className="wizard-account-arrow" aria-hidden="true">→</span>
+        </button>
+        {creatingAccount ? (
+          <form
+            className="wizard-account-choice wizard-account-create-form"
+            onSubmit={(event) => {
+              event.preventDefault();
+              const name = String(new FormData(event.currentTarget).get("account-name") ?? "").trim();
+              if (!name) return;
+              onChooseAccount({ mode: "register", label: name.slice(0, 80) });
+            }}
+          >
+            <span className="wizard-account-avatar" aria-hidden="true">+</span>
+            <label className="wizard-account-copy" htmlFor={accountNameId}>
+              <strong>Name this account</strong>
+              <input
+                autoFocus
+                id={accountNameId}
+                maxLength={80}
+                name="account-name"
+                placeholder="Work, personal, laptop…"
+                required
+              />
+            </label>
+            <button
+              aria-label="Cancel new account"
+              disabled={disabled}
+              onClick={() => setCreatingAccount(false)}
+              type="button"
+            >×</button>
+            <button disabled={disabled} type="submit">Continue</button>
+          </form>
+        ) : (
+          <button
+            className="wizard-account-choice wizard-new-account"
+            disabled={disabled}
+            onClick={() => setCreatingAccount(true)}
+            type="button"
+          >
+            <span className="wizard-account-avatar" aria-hidden="true">+</span>
+            <span className="wizard-account-copy">
+              <strong>Create a new account</strong>
+              <small>Create a passkey to authorize this higher-risk connection.</small>
+            </span>
+            <span className="wizard-account-arrow" aria-hidden="true">→</span>
+          </button>
+        )}
+      </div>
+      {onCancel ? (
+        <button className="wizard-cancel" disabled={disabled} onClick={onCancel} type="button">Cancel</button>
+      ) : null}
+    </div>
+  );
+}
+
+function shortAddress(value: unknown) {
+  return typeof value === "string" && value.length > 15
+    ? `${value.slice(0, 8)}…${value.slice(-6)}`
+    : "Unavailable";
+}

--- a/js/nanocodex-connect-ui/src/browserAccountSession.ts
+++ b/js/nanocodex-connect-ui/src/browserAccountSession.ts
@@ -1,8 +1,12 @@
-export type BrowserAccountSession = Readonly<{ id: string; persistent: boolean }>;
+export type BrowserAccountSession = Readonly<{
+  address?: `0x${string}` | undefined;
+  id: string;
+  persistent: boolean;
+}>;
 
 export class BrowserAccountReauthenticationRequiredError extends Error {
   constructor() {
-    super("Your passkey session expired. Sign in to restore your account.");
+    super("Your session expired. Sign in by SMS to restore your account.");
     this.name = "BrowserAccountReauthenticationRequiredError";
   }
 }
@@ -16,7 +20,7 @@ export function readBrowserAccountSession(
 export async function logoutBrowserAccountSession(
   fetcher: typeof fetch = fetch,
 ): Promise<void> {
-  const response = await fetcher("/webauthn/logout", {
+  const response = await fetcher("/v1/auth/logout", {
     credentials: "same-origin",
     method: "POST",
   });
@@ -48,10 +52,16 @@ async function readSession(
   if (!response.ok) throw new Error("The Nanocodex account service is unavailable.");
   if (!isRecord(body) || !isRecord(body.user)
     || typeof body.user.id !== "string"
+    || (body.user.address !== undefined
+      && (typeof body.user.address !== "string" || !/^0x[0-9a-f]{40}$/.test(body.user.address)))
     || typeof body.user.persistent !== "boolean") {
     throw new Error("The Nanocodex account service returned an invalid browser session.");
   }
-  return { id: body.user.id, persistent: body.user.persistent };
+  return {
+    ...(body.user.address ? { address: body.user.address as `0x${string}` } : {}),
+    id: body.user.id,
+    persistent: body.user.persistent,
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/js/nanocodex-connect-ui/src/walletWorker.mts
+++ b/js/nanocodex-connect-ui/src/walletWorker.mts
@@ -1,0 +1,133 @@
+import {
+  sanitizeCliWalletResult,
+  sanitizeWalletResult,
+} from "./connectPolicy.mjs";
+
+type JsonResponse = Readonly<{ ok: boolean; json(): Promise<unknown> }>;
+type FetchJson = (input: string, init: Readonly<{
+  body: string;
+  credentials: "include";
+  headers: Readonly<{ "content-type": "application/json" }>;
+  method: "POST";
+}>) => Promise<JsonResponse>;
+
+export type ManagedWalletConnect = Readonly<{
+  address?: `0x${string}`;
+  authToken?: string;
+  result: ReturnType<typeof sanitizeWalletResult> | ReturnType<typeof sanitizeCliWalletResult>;
+}>;
+
+/**
+ * Calls the authenticated, same-origin account Wallet Worker. The Worker is
+ * deliberately the only production path for an SMS account: private key
+ * material is rejected before the signed public wallet result is returned.
+ */
+export async function requestManagedWalletConnect(
+  request: unknown,
+  cli: boolean,
+  fetchJson: FetchJson = fetch,
+): Promise<ManagedWalletConnect> {
+  const response = await fetchJson("/v1/wallet/connect", postBody({ request }));
+  const body = await response.json().catch(() => undefined);
+  if (!response.ok) throw new Error(workerError(body, "Unable to connect this account."));
+  rejectPrivateKeys(body);
+  const result = responseResult(body);
+  const sanitized = cli ? sanitizeCliWalletResult(result) : sanitizeWalletResult(result);
+  return {
+    ...(canonicalAddress(body, result) ? { address: canonicalAddress(body, result) } : {}),
+    ...(authToken(body, result) ? { authToken: authToken(body, result) } : {}),
+    result: sanitized,
+  };
+}
+
+export async function requestManagedWalletRevocation(
+  request: unknown,
+  authenticatedAddress: `0x${string}`,
+  fetchJson: FetchJson = fetch,
+): Promise<void> {
+  const requestedAddress = revocationAddress(request);
+  if (!requestedAddress || requestedAddress.toLowerCase() !== authenticatedAddress.toLowerCase()) {
+    throw new Error("Sign in to the account that owns this access key before revoking it.");
+  }
+  const response = await fetchJson("/v1/wallet/revoke-access-key", postBody({ request }));
+  const body = await response.json().catch(() => undefined);
+  if (!response.ok) throw new Error(workerError(body, "Unable to revoke this account key."));
+  rejectPrivateKeys(body);
+}
+
+function revocationAddress(request: unknown): string | undefined {
+  if (!isRecord(request) || request.method !== "wallet_revokeAccessKey"
+    || !Array.isArray(request.params) || request.params.length !== 1
+    || !isRecord(request.params[0])) return undefined;
+  const address = request.params[0].address;
+  return typeof address === "string" && /^0x[0-9a-fA-F]{40}$/.test(address)
+    ? address
+    : undefined;
+}
+
+function postBody(value: unknown) {
+  return {
+    body: JSON.stringify(value),
+    credentials: "include" as const,
+    headers: { "content-type": "application/json" } as const,
+    method: "POST" as const,
+  };
+}
+
+function responseResult(body: unknown): unknown {
+  return isRecord(body) && Object.hasOwn(body, "result") ? body.result : body;
+}
+
+function canonicalAddress(body: unknown, result: unknown): `0x${string}` | undefined {
+  const value = isRecord(body) && typeof body.address === "string"
+    ? body.address
+    : isRecord(body) && typeof body.account_address === "string"
+      ? body.account_address
+      : firstAccountAddress(result);
+  return typeof value === "string" && /^0x[0-9a-fA-F]{40}$/.test(value)
+    ? value as `0x${string}`
+    : undefined;
+}
+
+function firstAccountAddress(result: unknown): unknown {
+  return isRecord(result) && Array.isArray(result.accounts) && isRecord(result.accounts[0])
+    ? result.accounts[0].address
+    : undefined;
+}
+
+function authToken(body: unknown, result: unknown): string | undefined {
+  const topLevel = isRecord(body) && typeof body.token === "string" ? body.token : undefined;
+  const account = isRecord(result) && Array.isArray(result.accounts) && isRecord(result.accounts[0])
+    ? result.accounts[0]
+    : undefined;
+  const nested = account && isRecord(account.capabilities) && isRecord(account.capabilities.auth)
+    && typeof account.capabilities.auth.token === "string"
+    ? account.capabilities.auth.token
+    : undefined;
+  const value = topLevel ?? nested;
+  return value && value.length <= 4_096 ? value : undefined;
+}
+
+function rejectPrivateKeys(value: unknown): void {
+  if (Array.isArray(value)) {
+    value.forEach(rejectPrivateKeys);
+    return;
+  }
+  if (!isRecord(value)) return;
+  for (const [key, nested] of Object.entries(value)) {
+    if (key.replaceAll(/[-_]/g, "").toLowerCase().includes("privatekey")) {
+      throw new Error("The account Worker returned private key material.");
+    }
+    rejectPrivateKeys(nested);
+  }
+}
+
+function workerError(body: unknown, fallback: string) {
+  return isRecord(body) && isRecord(body.error) && typeof body.error.message === "string"
+    ? body.error.message
+    : fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/js/nanocodex-connect-ui/styles.css
+++ b/js/nanocodex-connect-ui/styles.css
@@ -1114,6 +1114,72 @@ dd {
   border: 1px solid var(--border-strong);
 }
 
+.sms-otp-form {
+  display: grid;
+  margin-top: 14px;
+  padding: 14px;
+  border: 1px solid var(--border-strong);
+  gap: 7px;
+}
+
+.sms-otp-form > label {
+  font-size: 10px;
+  font-weight: 500;
+}
+
+.sms-otp-form > p {
+  color: var(--muted);
+  font-size: 8px;
+  line-height: 1.5;
+}
+
+.sms-otp-input-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+}
+
+.sms-otp-input-row input {
+  min-width: 0;
+  min-height: 38px;
+  padding: 0 10px;
+  border: 1px solid var(--border-strong);
+  outline: none;
+  background: var(--surface-raised);
+  color: var(--text);
+  font: inherit;
+}
+
+.sms-otp-input-row input:focus {
+  border-color: var(--text);
+}
+
+.sms-otp-input-row button {
+  min-height: 38px;
+  padding: 0 14px;
+  border: 1px solid var(--text);
+  background: var(--text);
+  color: var(--surface);
+  cursor: pointer;
+  font: inherit;
+}
+
+.sms-otp-input-row button:disabled,
+.sms-otp-change:disabled {
+  cursor: default;
+  opacity: 0.48;
+}
+
+.sms-otp-change {
+  justify-self: start;
+  padding: 2px 0;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 8px;
+}
+
 .wizard-account-choice {
   display: grid;
   width: 100%;

--- a/js/nanocodex-connect-ui/test/walletWorker.test.mjs
+++ b/js/nanocodex-connect-ui/test/walletWorker.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  requestManagedWalletConnect,
+  requestManagedWalletRevocation,
+} from "../dist/walletWorker.mjs";
+
+const address = "0x1234567890123456789012345678901234567890";
+const approval = "a".repeat(43);
+
+test("the SMS wallet helper posts a same-origin request and returns only the sanitized result", async () => {
+  let call;
+  const connected = await requestManagedWalletConnect({ method: "wallet_connect" }, true, async (url, init) => {
+    call = { url, init };
+    return {
+      ok: true,
+      json: async () => ({
+        accounts: [{
+            address,
+            capabilities: {
+              auth: { approval_id: approval, token: "browser-only-token" },
+              keyAuthorization: { signed: true },
+              personalSign: { keyAuthorization: "0x12" },
+            },
+        }],
+      }),
+    };
+  });
+  assert.deepEqual(call, {
+    url: "/v1/wallet/connect",
+    init: {
+      body: JSON.stringify({ request: { method: "wallet_connect" } }),
+      credentials: "include",
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    },
+  });
+  assert.equal(connected.authToken, "browser-only-token");
+  assert.deepEqual(connected.result, {
+    accounts: [{
+      address,
+      capabilities: {
+        auth: { approval_id: approval },
+        keyAuthorization: { signed: true },
+        personalSign: { keyAuthorization: "0x12" },
+      },
+    }],
+  });
+});
+
+test("the Worker helper rejects a private key and revokes through the same-origin Worker", async () => {
+  await assert.rejects(
+    requestManagedWalletConnect({ method: "wallet_connect" }, false, async () => ({
+      ok: true,
+      json: async () => ({ private_key: "never" }),
+    })),
+    /private key material/,
+  );
+  let call;
+  const request = {
+    method: "wallet_revokeAccessKey",
+    params: [{ address, accessKeyAddress: "0x2222222222222222222222222222222222222222" }],
+  };
+  const result = await requestManagedWalletRevocation(request, address, async (url, init) => {
+    call = { url, init };
+    return { ok: true, json: async () => ({ ok: true }) };
+  });
+  assert.equal(result, undefined);
+  assert.deepEqual(call, {
+    url: "/v1/wallet/revoke-access-key",
+    init: {
+      body: JSON.stringify({ request }),
+      credentials: "include",
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    },
+  });
+
+  await assert.rejects(
+    requestManagedWalletRevocation(
+      request,
+      "0x3333333333333333333333333333333333333333",
+      async () => { throw new Error("must not fetch"); },
+    ),
+    /owns this access key/,
+  );
+});

--- a/js/nanocodex/cloud/actions/connection.d.mts
+++ b/js/nanocodex/cloud/actions/connection.d.mts
@@ -73,7 +73,7 @@ export type AgentVisibility = Readonly<{
 export declare namespace connect {
   type Options = Readonly<{
     capabilities?: Capabilities | undefined;
-    /** Use account-hosted authorization with no access key, spending, or contract authority. */
+    /** Use account-hosted authorization with no access key, spending, or contract authority. @default "hosted" */
     authorization?: "access_key" | "hosted" | undefined;
     /** Let an owning UI close the dialog after its connected state commits. @default "auto" */
     dialog?: Readonly<{ close?: "auto" | "manual" | undefined }> | undefined;
@@ -112,6 +112,7 @@ export declare namespace reconnect {
   type Options = Readonly<{
     /** Reject a retained grant outside these app capability boundaries. */
     capabilities?: Pick<Capabilities, "agent" | "cloudAccounts"> | undefined;
+    /** Defaults to the retained connection mode, then to hosted. */
     authorization?: "access_key" | "hosted" | undefined;
     tools?: readonly NamedTool[] | undefined;
     /** Reject a retained grant issued for another permission preset. */

--- a/js/nanocodex/cloud/actions/connection.mjs
+++ b/js/nanocodex/cloud/actions/connection.mjs
@@ -58,7 +58,7 @@ export async function connect(client, options) {
   if (typeof permission !== "string" || permission.length === 0) throw new TypeError("connect permission must be a non-empty string");
   const requestedConnectors = normalizeCloudAccounts(options.capabilities?.cloudAccounts);
   const agentVisibility = normalizeAgentVisibility(options.capabilities?.agent);
-  const authorization = options.authorization ?? "hosted";
+  const authorization = options.authorization ?? (client.principal ? "hosted" : "access_key");
   if (authorization !== "access_key" && authorization !== "hosted") {
     throw new TypeError("connect authorization must be access_key or hosted");
   }
@@ -483,7 +483,7 @@ export async function reconnect(client, options = {}) {
   const authorization = options.authorization
     ?? (retainedAuthorization === "access_key" || retainedAuthorization === "hosted"
       ? retainedAuthorization
-      : "hosted");
+      : (client.principal ? "hosted" : "access_key"));
   if (client.principal && authorization !== "hosted") {
     client._clearSession();
     throw new TypeError("host principal connections require hosted authorization");

--- a/js/nanocodex/cloud/actions/connection.mjs
+++ b/js/nanocodex/cloud/actions/connection.mjs
@@ -58,7 +58,7 @@ export async function connect(client, options) {
   if (typeof permission !== "string" || permission.length === 0) throw new TypeError("connect permission must be a non-empty string");
   const requestedConnectors = normalizeCloudAccounts(options.capabilities?.cloudAccounts);
   const agentVisibility = normalizeAgentVisibility(options.capabilities?.agent);
-  const authorization = options.authorization ?? (client.principal ? "hosted" : "access_key");
+  const authorization = options.authorization ?? "hosted";
   if (authorization !== "access_key" && authorization !== "hosted") {
     throw new TypeError("connect authorization must be access_key or hosted");
   }
@@ -478,7 +478,12 @@ export async function disconnect(client, options = {}) {
 export async function reconnect(client, options = {}) {
   const session = client._getSession();
   if (!session) return undefined;
-  const authorization = options.authorization ?? (client.principal ? "hosted" : "access_key");
+  const retainedAuthorization = session.connection?.authorization_mode
+    ?? (session.connection?.access_key ? "access_key" : undefined);
+  const authorization = options.authorization
+    ?? (retainedAuthorization === "access_key" || retainedAuthorization === "hosted"
+      ? retainedAuthorization
+      : "hosted");
   if (client.principal && authorization !== "hosted") {
     client._clearSession();
     throw new TypeError("host principal connections require hosted authorization");

--- a/js/nanocodex/test/cloud-connect.test.mjs
+++ b/js/nanocodex/test/cloud-connect.test.mjs
@@ -1030,7 +1030,6 @@ test("Connect grants ChatGPT and an exact local tool catalog without delegated k
   });
 
   const connection = await client.connection.connect({
-    authorization: "hosted",
     capabilities: {
       cloudAccounts: { chatgpt: true },
       agent: {
@@ -1741,6 +1740,7 @@ test("Nanocodex Connect signs one witness-bound access key and enforces its MPP 
   });
 
   let connection = await Actions.connection.connect(client, {
+    authorization: "access_key",
     capabilities: {
       auth: { resources: [
         "repositories",

--- a/js/nanocodex/test/cloud-connect.test.mjs
+++ b/js/nanocodex/test/cloud-connect.test.mjs
@@ -1030,6 +1030,7 @@ test("Connect grants ChatGPT and an exact local tool catalog without delegated k
   });
 
   const connection = await client.connection.connect({
+    authorization: "hosted",
     capabilities: {
       cloudAccounts: { chatgpt: true },
       agent: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -359,6 +359,9 @@ importers:
 
   js/egress:
     dependencies:
+      accounts:
+        specifier: 0.17.0
+        version: 0.17.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(supports-color@10.2.2)(zod@4.5.4))(@types/react@19.2.14)(@wagmi/core@3.6.5)(express@5.2.1(supports-color@10.2.2))(immer@11.1.18)(react@19.2.8)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.8))(viem@2.55.19(typescript@5.9.3)(zod@4.5.4))(wagmi@3.7.7)
       nanocodex:
         specifier: workspace:*
         version: link:../nanocodex

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,9 @@ importers:
       nanocodex:
         specifier: workspace:*
         version: link:../nanocodex
+      viem:
+        specifier: ^2.54.0
+        version: 2.55.19(typescript@5.9.3)(zod@4.5.4)
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.22.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,3 +12,8 @@ allowBuilds:
   esbuild: true
   node-liblzma: false
   workerd: true
+
+minimumReleaseAgeExclude:
+  - "@ai-sdk/gateway@4.0.72"
+  - "@ai-sdk/provider-utils@5.0.36"
+  - "ai@7.0.90"


### PR DESCRIPTION
## Summary
- add first-party SMS OTP start, verify, logout, stable phone-to-account identity, and persistent sessions in the managed Cloudflare Worker
- support either a private `NANOCODEX_SMS_SEND` service binding or Twilio Messaging secrets
- replace the primary Account and Connect login UI with phone/code verification and make hosted authorization the default
- keep passkeys only as an explicit access-key/MPP step-up and preserve legacy passkey sessions
- generalize one-time hosted authorization to exact registered app resources and document deployment/security boundaries

## Security
- same-origin mutations, 1 KiB auth bodies, E.164 validation, five-minute codes, five attempts, 60-second resend delay, hourly phone/IP limits
- unbiased code generation, constant-time verification, one-time challenge consumption, HttpOnly SameSite cookies
- phone numbers and OTPs are stored only as keyed HMAC digests; delivery failures roll back the active challenge/cooldown

## Verification
- `pnpm --filter nanocodex-managed-service typecheck`
- `pnpm --filter nanocodex-managed-service test` (146 tests)
- `pnpm --filter nanocodex-connect-ui test` (15 tests)
- `pnpm --filter @nanocodex/connect-api typecheck`
- `pnpm --filter @nanocodex/connect-api test` (60 tests)
- `pnpm --filter nanocodex test:typecheck`
- `pnpm --filter nanocodex-web typecheck`
- focused Account UI render and hosted-default authorization assertions

Full WASM-backed web/package tests and Wrangler dry-run were not available in this workspace: `cargo` is absent, and Wrangler's network approval was unavailable.