### PR TITLE
feat(chief-of-staff): add Viber channel

### DIFF
--- a/js/account/src/ChiefOfStaffDemo.css
+++ b/js/account/src/ChiefOfStaffDemo.css
@@ -17,7 +17,7 @@
 .chief-status-dot.is-ready { background: var(--positive); box-shadow: 0 0 0 3px color-mix(in srgb, var(--positive) 15%, transparent); }
 .chief-error { display: flex; justify-content: space-between; gap: 12px; align-items: center; padding: 12px 14px; color: var(--negative); border: 1px solid color-mix(in srgb, var(--negative) 35%, var(--border-soft)); font-size: 10px; }
 
-.chief-channel-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); border: 1px solid var(--border-soft); }
+.chief-channel-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); border: 1px solid var(--border-soft); }
 .chief-channel { display: grid; min-width: 0; gap: 20px; padding: 20px; }
 .chief-channel + .chief-channel { border-left: 1px solid var(--border-soft); }
 .chief-channel header { display: flex; gap: 12px; align-items: start; justify-content: space-between; }
@@ -40,9 +40,9 @@
 .chief-install-action > div, .chief-installation > div { display: grid; gap: 7px; }
 .chief-install-action strong, .chief-installation strong { font-size: 11px; font-weight: 400; }
 .chief-install-action p, .chief-installation p { color: var(--text-muted); font-size: 10px; line-height: 1.6; }
-.chief-add-slack, .chief-installation button { display: inline-flex; flex: 0 0 auto; gap: 7px; align-items: center; padding: 9px 12px; color: var(--surface); background: var(--text); border: 1px solid var(--text); cursor: pointer; font: 10px var(--font-mono); text-decoration: none; }
+.chief-add-slack, .chief-copy-viber, .chief-installation button { display: inline-flex; flex: 0 0 auto; gap: 7px; align-items: center; padding: 9px 12px; color: var(--surface); background: var(--text); border: 1px solid var(--text); cursor: pointer; font: 10px var(--font-mono); text-decoration: none; }
 .chief-installation button { color: var(--text); background: transparent; border-color: var(--border-soft); }
-.chief-add-slack svg, .chief-installation button svg { width: 12px; height: 12px; }
+.chief-add-slack svg, .chief-copy-viber svg, .chief-installation button svg { width: 12px; height: 12px; }
 .chief-installation button:disabled { cursor: wait; opacity: .55; }
 .chief-install-unavailable { color: var(--text-muted); font-size: 9px; text-transform: uppercase; }
 .chief-setup ol { display: grid; padding: 0; margin: 0; list-style: none; }
@@ -69,7 +69,7 @@
 
 @media (pointer: coarse) {
   .chief-hero-status button, .chief-channel a, .chief-error button, .chief-setup li button,
-  .chief-add-slack, .chief-installation button {
+  .chief-add-slack, .chief-copy-viber, .chief-installation button {
     min-height: var(--coarse-target-size);
   }
 }

--- a/js/account/src/ChiefOfStaffDemo.tsx
+++ b/js/account/src/ChiefOfStaffDemo.tsx
@@ -1,4 +1,4 @@
-import { Bot, ExternalLink, Plus, RefreshCw, Trash2 } from "lucide-react";
+import { Bot, Check, Copy, ExternalLink, Plus, RefreshCw, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useAccountSession } from "./AccountSession";
 import "./ChiefOfStaffDemo.css";
@@ -7,7 +7,8 @@ type Channel = Readonly<{
   availability: "ready" | "setup_required" | "not_enabled";
   contract: "first_party" | "vendor_official";
   detail: string;
-  id: "slack" | "whatsapp" | "imessage";
+  id: "slack" | "whatsapp" | "imessage" | "viber";
+  webhookUrl?: string | null;
 }>;
 
 type Readiness = Readonly<{
@@ -24,11 +25,12 @@ type Readiness = Readonly<{
   webhookUrl: string | null;
 }>;
 
-const labels = { slack: "Slack", whatsapp: "WhatsApp", imessage: "iMessage" } as const;
+const labels = { slack: "Slack", whatsapp: "WhatsApp", imessage: "iMessage", viber: "Viber" } as const;
 const docs = {
   slack: "https://chat-sdk.dev/adapters/slack",
   whatsapp: "https://chat-sdk.dev/adapters/whatsapp",
   imessage: "https://chat-sdk.dev/adapters/photon",
+  viber: "https://developers.viber.com/docs/api/rest-bot-api/",
 } as const;
 
 export function ChiefOfStaffDemo() {
@@ -37,6 +39,7 @@ export function ChiefOfStaffDemo() {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [operation, setOperation] = useState<string | null>(null);
+  const [copiedViber, setCopiedViber] = useState(false);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -81,21 +84,30 @@ export function ChiefOfStaffDemo() {
     }
   }, [operation, refresh]);
 
+  const copyViberWebhook = useCallback(async (webhookUrl: string) => {
+    await navigator.clipboard.writeText(webhookUrl);
+    setCopiedViber(true);
+    window.setTimeout(() => setCopiedViber(false), 1_500);
+  }, []);
+
+  const viber = readiness?.channels.find((channel) => channel.id === "viber");
+  const readyChannels = readiness?.channels.filter((channel) => channel.availability === "ready") ?? [];
+
   return (
     <article className="chief-demo page-grid">
       <header className="chief-hero">
         <p className="eyebrow">Demos · Chat SDK integration</p>
         <h1>Chief of Staff</h1>
         <p>
-          Install a durable Nanocodex agent into Slack as its own AI teammate. It has a bot
-          identity, receives mentions and DMs, and keeps every workspace and conversation on
-          its own route.
+          Install a durable Nanocodex agent as its own messaging identity. Slack provides a
+          workspace AI teammate; Viber provides a branded chatbot. Every workspace, subscriber,
+          and conversation stays on its own route.
         </p>
         <div className="chief-hero-status" aria-live="polite">
           <span className={`chief-status-dot${readiness?.configured ? " is-ready" : ""}`} />
-          <span>{loading ? "Checking deployment" : readiness?.configured
-            ? "Slack is ready"
-            : "Slack setup required"}</span>
+          <span>{loading ? "Checking deployment" : readyChannels.length > 0
+            ? `${readyChannels.map((channel) => labels[channel.id]).join(" + ")} ready`
+            : "Messaging setup required"}</span>
           <button type="button" onClick={() => void refresh()} disabled={loading}>
             <RefreshCw aria-hidden="true" /> Refresh
           </button>
@@ -120,7 +132,7 @@ export function ChiefOfStaffDemo() {
             </header>
             <p>{channel.detail}</p>
             <a href={docs[channel.id]} target="_blank" rel="noreferrer">
-              Official Chat SDK contract <ExternalLink aria-hidden="true" />
+              {channel.id === "viber" ? "Official Viber API" : "Official Chat SDK contract"} <ExternalLink aria-hidden="true" />
             </a>
           </article>
         ))}
@@ -164,6 +176,34 @@ export function ChiefOfStaffDemo() {
           has its own authorization, tokens, and workspace grants.
         </p>
       </section>
+
+      <section className="chief-setup" aria-labelledby="chief-viber-title">
+        <header>
+          <div>
+            <p className="eyebrow">Viber chatbot</p>
+            <h2 id="chief-viber-title">Connect the Viber bot</h2>
+          </div>
+          <Bot aria-hidden="true" />
+        </header>
+        <div className="chief-install-action">
+          <div>
+            <strong>Commercial bot webhook</strong>
+            <p>Configure the bot token, name, and URI once, then register this signed callback URL with Viber.</p>
+          </div>
+          {viber?.webhookUrl ? <button
+            className="chief-copy-viber"
+            type="button"
+            onClick={() => void copyViberWebhook(viber.webhookUrl!)}
+          >
+            {copiedViber ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}
+            {copiedViber ? "Copied" : "Copy webhook"}
+          </button> : <span className="chief-install-unavailable">Deployment setup required</span>}
+        </div>
+        <p className="chief-secret-note">
+          Callback signatures are verified before routing. Each Viber subscriber receives an
+          isolated durable agent session, with replay-safe outbound delivery.
+        </p>
+      </section>
     </article>
   );
 }
@@ -172,4 +212,5 @@ const fallbackChannels: readonly Channel[] = [
   { id: "slack", availability: "setup_required", contract: "first_party", detail: "Readiness has not been confirmed by the integration Worker." },
   { id: "whatsapp", availability: "not_enabled", contract: "first_party", detail: "The SDK contract exists, but this deployment does not claim a configured Meta webhook." },
   { id: "imessage", availability: "not_enabled", contract: "vendor_official", detail: "Chat SDK catalogs vendor adapters; no iMessage provider is connected here." },
+  { id: "viber", availability: "setup_required", contract: "first_party", detail: "Connect a commercial Viber chatbot to enable signed inbound messages and durable replies." },
 ];

--- a/js/chief-of-staff/README.md
+++ b/js/chief-of-staff/README.md
@@ -16,6 +16,10 @@ Each account/workspace/conversation maps to a retained managed Nanocodex agent.
 The account app receives only non-secret installation and readiness metadata
 through a service binding.
 
+The same Worker also exposes an official Viber Bot REST API channel. It verifies
+the raw callback HMAC, maps each bot/subscriber pair to a durable conversation,
+and returns the retained managed agent's reply through the configured Viber bot.
+
 ## Configure the shared Slack app
 
 Create one distributable Slack app from `slack-app-manifest.yaml`, following the
@@ -45,6 +49,33 @@ pnpm exec wrangler secret put SLACK_ENCRYPTION_KEY --config js/chief-of-staff/wr
 pnpm exec wrangler secret put SLACK_OAUTH_STATE_SECRET --config js/chief-of-staff/wrangler.jsonc
 ```
 
+## Configure Viber
+
+Provision a commercial chatbot directly with Rakuten Viber or an official messaging
+partner. Copy the bot token, display name, and stable bot URI into Worker secrets:
+
+```sh
+pnpm exec wrangler secret put VIBER_AUTH_TOKEN --config js/chief-of-staff/wrangler.jsonc
+pnpm exec wrangler secret put VIBER_BOT_NAME --config js/chief-of-staff/wrangler.jsonc
+pnpm exec wrangler secret put VIBER_BOT_URI --config js/chief-of-staff/wrangler.jsonc
+# Optional
+pnpm exec wrangler secret put VIBER_BOT_AVATAR --config js/chief-of-staff/wrangler.jsonc
+```
+
+`VIBER_BOT_NAME` must be at most 28 characters. `VIBER_BOT_URI` is the stable URI
+returned by Viber's `get_account_info` API; it keeps durable conversations attached
+to the same bot if its authentication token rotates. `VIBER_BOT_AVATAR` is an
+optional HTTPS avatar URL.
+
+Register `https://<chief-of-staff-origin>/webhooks/viber` with Viber's
+`set_webhook` endpoint. The Worker accepts only callbacks carrying a valid
+`X-Viber-Content-Signature`. Opening the bot produces a short welcome message;
+the first user message subscribes the user and creates their durable agent session.
+Text, image, video, file, URL, sticker, location, and contact inputs are normalized
+into turns. Replies respect Viber's 7,000-character text limit. A durable delivery
+claim suppresses duplicate outbound messages when Viber retries an already handled
+callback; expired claims are recoverable after an interrupted send.
+
 `NANOCODEX_API_KEY` binds this deployment to its owning Nanocodex account. Slack
 OAuth installations are accepted only when initiated by that signed-in owner.
 Set both public origins in Wrangler when deploying under other names or domains.
@@ -63,11 +94,13 @@ pnpm deploy:account
   to bot DMs, mentions, and subscribed threads.
 - Slack connector: separately authorized user token; acts on behalf of the human
   in only the exact workspaces granted through Connect.
+- Viber: official Bot REST API; branded bot identity; each subscriber receives an
+  isolated durable conversation.
 - WhatsApp has a first-party Chat SDK adapter, but this deployment does not expose
   or claim a Meta webhook yet.
 - iMessage is listed by Chat SDK through vendor adapters, not a first-party adapter;
   this deployment does not configure one.
 
-Run `pnpm --filter @nanocodex/chief-of-staff check` for OAuth state, signature,
-workspace fencing, idempotency, cross-account/channel isolation, durable two-turn,
-type, and dry-run deployment coverage.
+Run `pnpm --filter @nanocodex/chief-of-staff check` for OAuth state, Slack and Viber
+signatures, workspace fencing, idempotency, cross-account/channel isolation,
+durable two-turn, type, and dry-run deployment coverage.

--- a/js/chief-of-staff/src/conversation.ts
+++ b/js/chief-of-staff/src/conversation.ts
@@ -2,6 +2,7 @@ import { digest, sameChannelIdentity, type ChannelIdentity } from "./protocol.ts
 
 const MAX_INPUT_CHARS = 120_000;
 const MAX_SLACK_REPLY_CHARS = 35_000;
+const MAX_VIBER_REPLY_CHARS = 7_000;
 
 export interface ConversationStore {
   bindIdentity(identity: ChannelIdentity): Promise<boolean>;
@@ -77,14 +78,14 @@ export class ConversationEngine {
     }
 
     const agentId = retained?.agentId ?? await this.agent(channelDigest);
-    const turnId = retained?.turnId ?? `slack-${messageDigest.slice(0, 48)}`;
+    const turnId = retained?.turnId ?? `${request.channel.platform}-${messageDigest.slice(0, 48)}`;
     const record = { agentId, inputDigest, turnId } satisfies TurnRecord;
     if (!retained) await this.store.put(turnKey, record);
     const result = normalizeReply(await this.managed.runTurn(agentId, {
       id: turnId,
       idempotencyKey: `chief-turn:${channelDigest}:${messageDigest}`,
       input,
-    }));
+    }), request.channel.platform);
     await this.store.put(turnKey, { ...record, finalMessage: result });
     return { agentId, finalMessage: result, replayed: false, turnId };
   }
@@ -133,27 +134,39 @@ function validateTurn(request: ConversationTurnRequest): void {
   if (request.text.length > MAX_INPUT_CHARS) {
     throw new ConversationError(413, "message_too_large");
   }
-  if (!/^[UW][A-Z0-9]+$/.test(request.actorId)) {
-    throw new ConversationError(400, "invalid_actor");
-  }
-  if (!/^[0-9]+\.[0-9]+$/.test(request.messageId)) {
-    throw new ConversationError(400, "invalid_message");
+  if (request.channel.platform === "slack") {
+    if (!/^[UW][A-Z0-9]+$/.test(request.actorId)) {
+      throw new ConversationError(400, "invalid_actor");
+    }
+    if (!/^[0-9]+\.[0-9]+$/.test(request.messageId)) {
+      throw new ConversationError(400, "invalid_message");
+    }
+  } else {
+    if (request.actorId !== request.channel.userId) {
+      throw new ConversationError(400, "invalid_actor");
+    }
+    if (!/^[0-9]+$/.test(request.messageId)) {
+      throw new ConversationError(400, "invalid_message");
+    }
   }
 }
 
 function chiefOfStaffPrompt(request: ConversationTurnRequest): string {
+  const platform = request.channel.platform === "slack" ? "Slack" : "Viber";
   return [
-    "You are the user's Chief of Staff in Slack.",
+    `You are the user's Chief of Staff in ${platform}.`,
     "Be concise, action-oriented, and explicit about uncertainty.",
     "Never claim to have contacted people or changed external state unless tool evidence proves it.",
-    `Slack actor: ${request.actorId}`,
+    `${platform} actor: ${request.actorId}`,
     "User message:",
     request.text.trim(),
   ].join("\n");
 }
 
-function normalizeReply(value: string): string {
+function normalizeReply(value: string, platform: ChannelIdentity["platform"]): string {
   const reply = value.trim() || "I completed the turn, but it did not produce a text response.";
-  if (reply.length <= MAX_SLACK_REPLY_CHARS) return reply;
-  return `${reply.slice(0, MAX_SLACK_REPLY_CHARS - 31)}\n\n[Response truncated for Slack]`;
+  const maxChars = platform === "slack" ? MAX_SLACK_REPLY_CHARS : MAX_VIBER_REPLY_CHARS;
+  if (reply.length <= maxChars) return reply;
+  const suffix = `\n\n[Response truncated for ${platform === "slack" ? "Slack" : "Viber"}]`;
+  return `${reply.slice(0, maxChars - suffix.length)}${suffix}`;
 }

--- a/js/chief-of-staff/src/delivery.ts
+++ b/js/chief-of-staff/src/delivery.ts
@@ -1,0 +1,44 @@
+export type DeliveryRecord = Readonly<{
+  status: "completed";
+}> | Readonly<{
+  expiresAt: number;
+  status: "claimed";
+  token: string;
+}>;
+
+export type DeliveryClaim = Readonly<{
+  record: DeliveryRecord;
+  status: "claimed" | "completed" | "in_progress";
+  token?: string;
+}>;
+
+export function claimDelivery(
+  retained: DeliveryRecord | undefined,
+  now: number,
+  expiresAt: number,
+  token: string,
+): DeliveryClaim {
+  if (retained?.status === "completed") return { record: retained, status: "completed" };
+  if (retained?.status === "claimed" && retained.expiresAt > now) {
+    return { record: retained, status: "in_progress" };
+  }
+  const record = { expiresAt, status: "claimed", token } as const;
+  return { record, status: "claimed", token };
+}
+
+export function completeDelivery(
+  retained: DeliveryRecord | undefined,
+  token: string,
+): DeliveryRecord | undefined {
+  if (retained?.status === "completed") return retained;
+  return retained?.status === "claimed" && retained.token === token
+    ? { status: "completed" }
+    : undefined;
+}
+
+export function releaseDelivery(
+  retained: DeliveryRecord | undefined,
+  token: string,
+): boolean {
+  return retained?.status === "claimed" && retained.token === token;
+}

--- a/js/chief-of-staff/src/protocol.ts
+++ b/js/chief-of-staff/src/protocol.ts
@@ -14,6 +14,12 @@ export type ChannelIdentity = Readonly<{
   conversationId: string;
   platform: "slack";
   teamId: string;
+}> | Readonly<{
+  accountId: string;
+  botUri: string;
+  conversationId: string;
+  platform: "viber";
+  userId: string;
 }>;
 
 export type SlackMessageIdentity = Readonly<{
@@ -25,10 +31,11 @@ export type SlackMessageIdentity = Readonly<{
 export type Readiness = Readonly<{
   accountMatch: boolean;
   channels: readonly Readonly<{
-    id: "slack" | "whatsapp" | "imessage";
+    id: "slack" | "whatsapp" | "imessage" | "viber";
     availability: "ready" | "setup_required" | "not_enabled";
     contract: "first_party" | "vendor_official";
     detail: string;
+    webhookUrl?: string | null;
   }>[];
   configured: boolean;
   installations: readonly SlackInstallationSummary[];
@@ -100,7 +107,16 @@ export function configurationReadiness(env: {
   SLACK_ENCRYPTION_KEY?: string;
   SLACK_OAUTH_STATE_SECRET?: string;
   SLACK_SIGNING_SECRET?: string;
-}): Readonly<{ configured: boolean; webhookUrl: string | null }> {
+  VIBER_AUTH_TOKEN?: string;
+  VIBER_BOT_AVATAR?: string;
+  VIBER_BOT_NAME?: string;
+  VIBER_BOT_URI?: string;
+}): Readonly<{
+  configured: boolean;
+  slack: Readonly<{ configured: boolean; webhookUrl: string | null }>;
+  viber: Readonly<{ configured: boolean; webhookUrl: string | null }>;
+  webhookUrl: string | null;
+}> {
   let origin: URL | undefined;
   try {
     origin = env.CHIEF_OF_STAFF_PUBLIC_ORIGIN
@@ -109,21 +125,37 @@ export function configurationReadiness(env: {
   } catch {
     origin = undefined;
   }
-  const configured = Boolean(
-    origin?.protocol === "https:"
+  const validOrigin = Boolean(origin?.protocol === "https:"
     && origin.pathname === "/"
     && !origin.search
-    && !origin.hash
-    && API_KEY.test(env.NANOCODEX_API_KEY ?? "")
+    && !origin.hash);
+  const validAccount = API_KEY.test(env.NANOCODEX_API_KEY ?? "");
+  const slackConfigured = Boolean(
+    validOrigin
+    && validAccount
     && SLACK_CLIENT_ID.test(env.SLACK_CLIENT_ID ?? "")
     && (env.SLACK_CLIENT_SECRET?.length ?? 0) >= 16
     && validBase64Key(env.SLACK_ENCRYPTION_KEY)
     && validBase64Key(env.SLACK_OAUTH_STATE_SECRET)
     && (env.SLACK_SIGNING_SECRET?.length ?? 0) >= 16
   );
+  const viberConfigured = Boolean(
+    validOrigin
+    && validAccount
+    && validViberToken(env.VIBER_AUTH_TOKEN)
+    && validOptionalHttpsUrl(env.VIBER_BOT_AVATAR)
+    && validViberBotName(env.VIBER_BOT_NAME)
+    && validViberBotUri(env.VIBER_BOT_URI),
+  );
+  const slackWebhookUrl = origin ? new URL("/webhooks/slack", origin).href : null;
   return {
-    configured,
-    webhookUrl: origin ? new URL("/webhooks/slack", origin).href : null,
+    configured: slackConfigured,
+    slack: { configured: slackConfigured, webhookUrl: slackWebhookUrl },
+    viber: {
+      configured: viberConfigured,
+      webhookUrl: origin ? new URL("/webhooks/viber", origin).href : null,
+    },
+    webhookUrl: slackWebhookUrl,
   };
 }
 
@@ -149,11 +181,40 @@ export async function digest(value: unknown): Promise<string> {
 }
 
 export function sameChannelIdentity(left: ChannelIdentity, right: ChannelIdentity): boolean {
-  return left.accountId === right.accountId
-    && left.channelId === right.channelId
-    && left.conversationId === right.conversationId
-    && left.platform === right.platform
-    && left.teamId === right.teamId;
+  if (left.platform !== right.platform || left.accountId !== right.accountId
+    || left.conversationId !== right.conversationId) return false;
+  return left.platform === "slack"
+    ? right.platform === "slack"
+      && left.channelId === right.channelId
+      && left.teamId === right.teamId
+    : right.platform === "viber"
+      && left.botUri === right.botUri
+      && left.userId === right.userId;
+}
+
+function validViberToken(value: string | undefined): boolean {
+  return typeof value === "string"
+    && value.length >= 32
+    && value.length <= 256
+    && !/[\s\u0000-\u001f\u007f]/.test(value);
+}
+
+function validViberBotName(value: string | undefined): boolean {
+  return typeof value === "string" && value.trim() === value && value.length >= 1 && value.length <= 28;
+}
+
+function validViberBotUri(value: string | undefined): boolean {
+  return typeof value === "string" && /^[A-Za-z0-9_.-]{1,255}$/.test(value);
+}
+
+function validOptionalHttpsUrl(value: string | undefined): boolean {
+  if (value === undefined) return true;
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" && !url.username && !url.password;
+  } catch {
+    return false;
+  }
 }
 
 function canonicalJson(value: unknown): string {

--- a/js/chief-of-staff/src/state-object.ts
+++ b/js/chief-of-staff/src/state-object.ts
@@ -6,6 +6,12 @@ import {
   type ConversationStore,
   type ConversationTurnRequest,
 } from "./conversation.ts";
+import {
+  claimDelivery,
+  completeDelivery,
+  type DeliveryRecord,
+  releaseDelivery,
+} from "./delivery.ts";
 import { NanocodexManagedGateway } from "./managed.ts";
 import {
   sameChannelIdentity,
@@ -22,8 +28,52 @@ export class ChiefOfStaffState extends DurableObject<Env> {
     const url = new URL(request.url);
     if (url.pathname === "/chat-sdk" && request.method === "POST") return this.chatState(request);
     if (url.pathname === "/conversation/turn" && request.method === "POST") return this.conversationTurn(request);
+    if (url.pathname === "/conversation/delivery" && request.method === "POST") {
+      return this.conversationDelivery(request);
+    }
     if (url.pathname === "/slack/installations") return this.slackInstallations(request);
     return json({ error: "not_found" }, 404);
+  }
+
+  private async conversationDelivery(request: Request): Promise<Response> {
+    let body: Record<string, unknown>;
+    try { body = await request.json<Record<string, unknown>>(); }
+    catch { return json({ error: "invalid_request" }, 400); }
+    const deliveryId = typeof body.deliveryId === "string" ? body.deliveryId : "";
+    if (!/^viber:(?:reply|welcome):[0-9]+$/.test(deliveryId)) {
+      return json({ error: "invalid_request" }, 400);
+    }
+    const key = `delivery:${deliveryId}`;
+    switch (body.operation) {
+      case "claim": return this.ctx.storage.transaction(async (transaction) => {
+        const retained = await transaction.get<DeliveryRecord>(key);
+        const now = Date.now();
+        const claim = claimDelivery(retained, now, now + 45_000, crypto.randomUUID());
+        if (claim.status === "claimed") await transaction.put(key, claim.record);
+        return json({ status: claim.status, token: claim.token }, 200);
+      });
+      case "complete": {
+        if (typeof body.token !== "string") return json({ error: "invalid_request" }, 400);
+        const token = body.token;
+        const completed = await this.ctx.storage.transaction(async (transaction) => {
+          const record = completeDelivery(await transaction.get<DeliveryRecord>(key), token);
+          if (!record) return false;
+          await transaction.put(key, record);
+          return true;
+        });
+        return completed ? json({ status: "completed" }, 200) : json({ error: "claim_conflict" }, 409);
+      }
+      case "release": {
+        if (typeof body.token !== "string") return json({ error: "invalid_request" }, 400);
+        const token = body.token;
+        await this.ctx.storage.transaction(async (transaction) => {
+          const retained = await transaction.get<DeliveryRecord>(key);
+          if (releaseDelivery(retained, token)) await transaction.delete(key);
+        });
+        return json({ status: "released" }, 200);
+      }
+      default: return json({ error: "invalid_request" }, 400);
+    }
   }
 
   private async slackInstallations(request: Request): Promise<Response> {

--- a/js/chief-of-staff/src/viber.ts
+++ b/js/chief-of-staff/src/viber.ts
@@ -1,0 +1,265 @@
+import type { ChannelIdentity } from "./protocol.ts";
+
+const MAX_CALLBACK_CHARS = 256_000;
+const VIBER_SIGNATURE = /^[0-9a-f]{64}$/i;
+const VIBER_USER_ID = /^[A-Za-z0-9+/=_-]{1,256}$/;
+
+type Fetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+export type ViberCallback = Readonly<{
+  event: string;
+  kind: "ignored";
+}> | Readonly<{
+  kind: "conversation_started";
+  messageId: string;
+  userId: string;
+}> | Readonly<{
+  actorId: string;
+  kind: "message";
+  messageId: string;
+  text: string;
+}>;
+
+export async function readViberWebhook(request: Request, authToken: string): Promise<ViberCallback> {
+  const signature = request.headers.get("x-viber-content-signature") ?? "";
+  const body = await request.text();
+  if (body.length > MAX_CALLBACK_CHARS || !await verifyViberSignature(body, signature, authToken)) {
+    throw new ViberWebhookError("invalid_signature");
+  }
+  let payload: Record<string, unknown>;
+  try {
+    const decoded: unknown = JSON.parse(body);
+    if (!isRecord(decoded)) throw new Error("payload must be an object");
+    payload = decoded;
+  } catch {
+    throw new ViberWebhookError("invalid_payload");
+  }
+  const event = stringValue(payload.event);
+  if (!event) throw new ViberWebhookError("invalid_payload");
+  if (event === "conversation_started") {
+    const user = isRecord(payload.user) ? payload.user : undefined;
+    return {
+      kind: "conversation_started",
+      messageId: exactMessageToken(body),
+      userId: requiredUserId(user?.id),
+    };
+  }
+  if (event !== "message") return { event, kind: "ignored" };
+  const sender = isRecord(payload.sender) ? payload.sender : undefined;
+  const message = isRecord(payload.message) ? payload.message : undefined;
+  if (!message) throw new ViberWebhookError("invalid_payload");
+  const actorId = requiredUserId(sender?.id);
+  return {
+    actorId,
+    kind: "message",
+    messageId: exactMessageToken(body),
+    text: messageText(message),
+  };
+}
+
+export function viberChannelIdentity(
+  accountId: string,
+  botUri: string,
+  userId: string,
+): ChannelIdentity {
+  if (!VIBER_USER_ID.test(userId)) throw new ViberWebhookError("invalid_payload");
+  return {
+    accountId,
+    botUri,
+    conversationId: `dm:${userId}`,
+    platform: "viber",
+    userId,
+  };
+}
+
+export async function sendViberText(
+  input: Readonly<{
+    authToken: string;
+    avatar?: string;
+    botName: string;
+    receiver: string;
+    text: string;
+    trackingData?: string;
+  }>,
+  fetcher: Fetch = fetch,
+): Promise<void> {
+  if (!VIBER_USER_ID.test(input.receiver)
+    || input.botName.trim() !== input.botName
+    || input.botName.length < 1
+    || input.botName.length > 28
+    || input.text.length < 1
+    || input.text.length > 7_000
+    || (input.trackingData?.length ?? 0) > 4_096
+    || (input.avatar !== undefined && !isHttpsUrl(input.avatar))) {
+    throw new ViberDeliveryError(0, "invalid_request");
+  }
+  const response = await fetcher("https://chatapi.viber.com/pa/send_message", {
+    body: JSON.stringify({
+      receiver: input.receiver,
+      min_api_version: 1,
+      sender: {
+        name: input.botName,
+        ...(input.avatar ? { avatar: input.avatar } : {}),
+      },
+      ...(input.trackingData ? { tracking_data: input.trackingData } : {}),
+      type: "text",
+      text: input.text,
+    }),
+    headers: {
+      "content-type": "application/json",
+      "x-viber-auth-token": input.authToken,
+    },
+    method: "POST",
+  });
+  let result: unknown;
+  try { result = await response.json(); }
+  catch { throw new ViberDeliveryError(response.status, "malformed_response"); }
+  if (!response.ok || !isRecord(result) || result.status !== 0) {
+    const code = isRecord(result) && typeof result.status === "number"
+      ? `provider_status_${result.status}`
+      : `http_${response.status}`;
+    throw new ViberDeliveryError(response.status, code);
+  }
+}
+
+export async function verifyViberSignature(
+  body: string,
+  signature: string,
+  authToken: string,
+): Promise<boolean> {
+  if (!VIBER_SIGNATURE.test(signature)) return false;
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(authToken),
+    { hash: "SHA-256", name: "HMAC" },
+    false,
+    ["sign"],
+  );
+  const expected = new Uint8Array(await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(body),
+  ));
+  const received = hexBytes(signature);
+  let different = expected.length ^ received.length;
+  for (let index = 0; index < expected.length; index += 1) {
+    different |= expected[index]! ^ (received[index] ?? 0);
+  }
+  return different === 0;
+}
+
+export class ViberWebhookError extends Error {
+  readonly code: "invalid_payload" | "invalid_signature";
+
+  constructor(code: "invalid_payload" | "invalid_signature") {
+    super(code);
+    this.code = code;
+  }
+}
+
+export class ViberDeliveryError extends Error {
+  readonly code: string;
+  readonly status: number;
+
+  constructor(status: number, code: string) {
+    super(code);
+    this.code = code;
+    this.status = status;
+  }
+}
+
+function exactMessageToken(body: string): string {
+  const match = /"message_token"\s*:\s*(?:"([0-9]+)"|([0-9]+))/.exec(body);
+  const value = match?.[1] ?? match?.[2];
+  if (!value) throw new ViberWebhookError("invalid_payload");
+  return value;
+}
+
+function requiredUserId(value: unknown): string {
+  if (typeof value !== "string" || !VIBER_USER_ID.test(value)) {
+    throw new ViberWebhookError("invalid_payload");
+  }
+  return value;
+}
+
+function messageText(message: Record<string, unknown>): string {
+  const type = stringValue(message.type);
+  if (!type) throw new ViberWebhookError("invalid_payload");
+  const text = stringValue(message.text)?.trim();
+  switch (type) {
+    case "text":
+      if (!text) throw new ViberWebhookError("invalid_payload");
+      return text;
+    case "picture": return joined("[Viber image]", text, urlValue(message.media));
+    case "video": return joined("[Viber video]", text, urlValue(message.media));
+    case "file": return joined(
+      `[Viber file${stringValue(message.file_name) ? `: ${stringValue(message.file_name)}` : ""}]`,
+      text,
+      urlValue(message.media),
+    );
+    case "url": return joined("[Viber URL]", text, urlValue(message.media));
+    case "sticker": return `[Viber sticker${numberValue(message.sticker_id) !== undefined
+      ? `: ${numberValue(message.sticker_id)}` : ""}]`;
+    case "location": {
+      const location = isRecord(message.location) ? message.location : undefined;
+      const lat = numberValue(location?.lat);
+      const lon = numberValue(location?.lon);
+      if (lat === undefined || lon === undefined) throw new ViberWebhookError("invalid_payload");
+      return `[Viber location: ${lat}, ${lon}]`;
+    }
+    case "contact": {
+      const contact = isRecord(message.contact) ? message.contact : undefined;
+      const name = stringValue(contact?.name);
+      const phone = stringValue(contact?.phone_number);
+      if (!name && !phone) throw new ViberWebhookError("invalid_payload");
+      return joined("[Viber contact]", name, phone);
+    }
+    default: return `[Unsupported Viber message: ${type}]`;
+  }
+}
+
+function joined(...parts: (string | undefined)[]): string {
+  return parts.filter((part): part is string => Boolean(part)).join("\n");
+}
+
+function urlValue(value: unknown): string | undefined {
+  const candidate = stringValue(value);
+  if (!candidate) return undefined;
+  try {
+    const url = new URL(candidate);
+    return url.protocol === "https:" ? url.href : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isHttpsUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" && !url.username && !url.password;
+  } catch {
+    return false;
+  }
+}
+
+function hexBytes(value: string): Uint8Array {
+  const bytes = new Uint8Array(value.length / 2);
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Number.parseInt(value.slice(index * 2, index * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function numberValue(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() && Number.isFinite(Number(value))) return Number(value);
+  return undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value ? value : undefined;
+}

--- a/js/chief-of-staff/src/worker.ts
+++ b/js/chief-of-staff/src/worker.ts
@@ -16,6 +16,12 @@ import {
 } from "./protocol.ts";
 import { slackAuthorizationUrl, verifySlackInstallState } from "./slack-oauth.ts";
 import { DurableChatStateAdapter } from "./state-adapter.ts";
+import {
+  readViberWebhook,
+  sendViberText,
+  ViberWebhookError,
+  viberChannelIdentity,
+} from "./viber.ts";
 
 type Fetcher = Readonly<{ fetch(request: Request): Promise<Response> }>;
 type StateNamespace = Readonly<{ getByName(name: string): Fetcher }>;
@@ -32,6 +38,10 @@ export interface Env {
   SLACK_ENCRYPTION_KEY?: string;
   SLACK_OAUTH_STATE_SECRET?: string;
   SLACK_SIGNING_SECRET?: string;
+  VIBER_AUTH_TOKEN?: string;
+  VIBER_BOT_AVATAR?: string;
+  VIBER_BOT_NAME?: string;
+  VIBER_BOT_URI?: string;
 }
 
 type ChiefRuntime = Readonly<{ chat: Chat<{ slack: SlackAdapter }>; slack: SlackAdapter }>;
@@ -66,6 +76,10 @@ export default {
     if (url.pathname === "/webhooks/slack") {
       if (request.method !== "POST") return methodNotAllowed(["POST"]);
       return slackWebhook(request, env, context);
+    }
+    if (url.pathname === "/webhooks/viber") {
+      if (request.method !== "POST") return methodNotAllowed(["POST"]);
+      return viberWebhook(request, env);
     }
     return json({ error: "not_found" }, { status: 404 });
   },
@@ -183,7 +197,7 @@ async function slackWebhook(
   context?: ExecutionContext,
 ): Promise<Response> {
   const config = configurationReadiness(env);
-  if (!config.configured || !env.SLACK_SIGNING_SECRET) {
+  if (!config.slack.configured || !env.SLACK_SIGNING_SECRET) {
     return json({ error: "channel_not_configured" }, { status: 503 });
   }
   let payload: SlackWebhookPayload;
@@ -234,6 +248,119 @@ async function slackWebhook(
     });
     return json({ error: "channel_unavailable" }, { status: 503 });
   }
+}
+
+async function viberWebhook(request: Request, env: Env): Promise<Response> {
+  const config = configurationReadiness(env);
+  if (!config.viber.configured || !env.VIBER_AUTH_TOKEN || !env.VIBER_BOT_NAME
+    || !env.VIBER_BOT_URI) {
+    return json({ error: "channel_not_configured" }, { status: 503 });
+  }
+  let callback;
+  try {
+    callback = await readViberWebhook(request, env.VIBER_AUTH_TOKEN);
+  } catch (error) {
+    if (error instanceof ViberWebhookError) {
+      return json({ error: error.code }, { status: error.code === "invalid_signature" ? 401 : 400 });
+    }
+    return json({ error: "invalid_payload" }, { status: 400 });
+  }
+  if (callback.kind === "ignored") return json({ status: 0 });
+  const ownerId = await configuredOwnerId(env);
+  if (!ownerId) return json({ error: "channel_unavailable" }, { status: 503 });
+  const receiver = callback.kind === "message" ? callback.actorId : callback.userId;
+  const identity = viberChannelIdentity(ownerId, env.VIBER_BOT_URI, receiver);
+  const routeDigest = await digest(identity);
+  const session = env.CHIEF_OF_STAFF_STATE.getByName(`conversation:${routeDigest}`);
+  if (callback.kind === "conversation_started") {
+    try {
+      await deliverViberOnce(session, `viber:welcome:${callback.messageId}`, async () => {
+        await sendViberText({
+          authToken: env.VIBER_AUTH_TOKEN!,
+          avatar: env.VIBER_BOT_AVATAR,
+          botName: env.VIBER_BOT_NAME!,
+          receiver: callback.userId,
+          text: "Hi — I’m your Nanocodex Chief of Staff. Send me a message to get started.",
+          trackingData: `welcome:${callback.messageId}`,
+        });
+      });
+      return json({ status: 0 });
+    } catch (error) {
+      logViberFailure("welcome_failed", error);
+      return json({ error: "channel_unavailable" }, { status: 503 });
+    }
+  }
+  try {
+    const response = await session.fetch(new Request("https://state.internal/conversation/turn", {
+      body: JSON.stringify({
+        actorId: callback.actorId,
+        channel: identity,
+        messageId: callback.messageId,
+        text: callback.text,
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    }));
+    if (!response.ok) throw new Error(`Chief of Staff turn failed (${response.status})`);
+    const result = await response.json<{ finalMessage?: unknown }>();
+    if (typeof result.finalMessage !== "string") throw new Error("Chief of Staff turn was malformed");
+    const finalMessage = result.finalMessage;
+    await deliverViberOnce(session, `viber:reply:${callback.messageId}`, async () => {
+      await sendViberText({
+        authToken: env.VIBER_AUTH_TOKEN!,
+        avatar: env.VIBER_BOT_AVATAR,
+        botName: env.VIBER_BOT_NAME!,
+        receiver: callback.actorId,
+        text: finalMessage,
+        trackingData: `reply-to:${callback.messageId}`,
+      });
+    });
+    return json({ status: 0 });
+  } catch (error) {
+    logViberFailure("message_failed", error);
+    return json({ error: "channel_unavailable" }, { status: 503 });
+  }
+}
+
+async function deliverViberOnce(
+  session: Fetcher,
+  deliveryId: string,
+  send: () => Promise<void>,
+): Promise<void> {
+  const claimResponse = await deliveryRequest(session, { deliveryId, operation: "claim" });
+  if (!claimResponse.ok) throw new Error(`Viber delivery claim failed (${claimResponse.status})`);
+  const claim = await claimResponse.json<{ status?: unknown; token?: unknown }>();
+  if (claim.status === "completed") return;
+  if (claim.status !== "claimed" || typeof claim.token !== "string") {
+    throw new Error("Viber delivery is already in progress");
+  }
+  try {
+    await send();
+  } catch (error) {
+    try {
+      await deliveryRequest(session, { deliveryId, operation: "release", token: claim.token });
+    } catch { /* The expiring claim permits a later provider retry. */ }
+    throw error;
+  }
+  const completed = await deliveryRequest(session, {
+    deliveryId,
+    operation: "complete",
+    token: claim.token,
+  });
+  if (!completed.ok) {
+    console.warn({ type: "chief_of_staff.viber_delivery_checkpoint_failed" });
+  }
+}
+
+function deliveryRequest(
+  session: Fetcher,
+  body: Readonly<{ deliveryId: string; operation: "claim" | "complete" | "release"; token?: string }>,
+): Promise<Response> {
+  return session.fetch(new Request("https://state.internal/conversation/delivery", {
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  }));
 }
 
 function chiefRuntime(env: Env): ChiefRuntime {
@@ -301,7 +428,9 @@ async function readiness(request: Request, env: Env): Promise<Response> {
   const requester = await requestingAccountId(env.NANOCODEX_BACKEND, request);
   if (!requester) return json({ error: "unauthorized" }, { status: 401 });
   const config = configurationReadiness(env);
-  const owner = config.configured ? await configuredOwnerId(env) : undefined;
+  const owner = config.slack.configured || config.viber.configured
+    ? await configuredOwnerId(env)
+    : undefined;
   const accountMatch = owner === requester;
   const installations = accountMatch
     ? (await installationMetadataList(env))
@@ -309,9 +438,10 @@ async function readiness(request: Request, env: Env): Promise<Response> {
       .map(({ accountId: _, ...installation }) => installation)
     : [];
   const ready = config.configured && accountMatch && installations.length > 0;
+  const viberReady = config.viber.configured && accountMatch;
   const body: Readiness = {
     accountMatch,
-    configured: ready,
+    configured: ready || viberReady,
     installations,
     installUrl: config.configured && accountMatch ? "/api/chief-of-staff/slack/install" : null,
     webhookUrl: config.webhookUrl,
@@ -339,6 +469,17 @@ async function readiness(request: Request, env: Env): Promise<Response> {
         availability: "not_enabled",
         contract: "vendor_official",
         detail: "Chat SDK catalogs iMessage through vendor adapters; no first-party iMessage channel is enabled here.",
+      },
+      {
+        id: "viber",
+        availability: viberReady ? "ready" : "setup_required",
+        contract: "first_party",
+        detail: config.viber.configured
+          ? accountMatch
+            ? "Signed Viber callbacks route each subscriber to an account-owned durable agent."
+            : "This deployment is bound to a different Nanocodex account."
+          : "Viber bot token, bot identity, or public origin is incomplete.",
+        webhookUrl: config.viber.webhookUrl,
       },
     ],
   };
@@ -383,6 +524,13 @@ async function writeInstallationMetadata(
 
 function installationsObject(env: Env): Fetcher {
   return env.CHIEF_OF_STAFF_STATE.getByName(INSTALLATIONS_OBJECT);
+}
+
+function logViberFailure(operation: string, error: unknown): void {
+  console.warn({
+    type: `chief_of_staff.viber_${operation}`,
+    error_kind: error instanceof Error ? error.name : typeof error,
+  });
 }
 
 function configuredOwnerId(env: Env): Promise<string | undefined> {

--- a/js/chief-of-staff/test/conversation.test.ts
+++ b/js/chief-of-staff/test/conversation.test.ts
@@ -43,6 +43,14 @@ const channel: ChannelIdentity = {
   teamId: "T123ABC",
 };
 
+const viberChannel: ChannelIdentity = {
+  accountId: "account-a",
+  botUri: "nanocodex-chief",
+  conversationId: "dm:01234567890A=",
+  platform: "viber",
+  userId: "01234567890A=",
+};
+
 test("a durable conversation reuses one managed agent across two turns", async () => {
   const store = new MemoryConversationStore();
   const gateway = new RememberingGateway();
@@ -137,4 +145,58 @@ test("durable state cannot be rebound across accounts or Slack channels", async 
   }
   assert.notEqual(await digest(channel), await digest({ ...channel, accountId: "account-b" }));
   assert.notEqual(await digest(channel), await digest({ ...channel, channelId: "D999XYZ" }));
+});
+
+test("a Viber subscriber receives one durable agent across multiple messages", async () => {
+  const store = new MemoryConversationStore();
+  const gateway = new RememberingGateway();
+  const engine = new ConversationEngine(store, gateway);
+  await engine.turn({
+    actorId: "01234567890A=",
+    channel: viberChannel,
+    messageId: "5741311803571721087",
+    text: "Remember kiwi",
+  });
+  const second = await engine.turn({
+    actorId: "01234567890A=",
+    channel: viberChannel,
+    messageId: "5741311803571721088",
+    text: "What should you remember?",
+  });
+
+  assert.equal(second.finalMessage, "You asked me to remember kiwi.");
+  assert.equal(second.turnId.startsWith("viber-"), true);
+  assert.equal(gateway.created.length, 1);
+  assert.equal(gateway.turns[0]?.input.includes("Chief of Staff in Viber"), true);
+});
+
+test("Viber actors cannot cross another subscriber's durable route", async () => {
+  const engine = new ConversationEngine(new MemoryConversationStore(), new RememberingGateway());
+  await assert.rejects(
+    engine.turn({
+      actorId: "another-user=",
+      channel: viberChannel,
+      messageId: "5741311803571721087",
+      text: "Hello",
+    }),
+    (error: unknown) => error instanceof ConversationError
+      && error.status === 400
+      && error.code === "invalid_actor",
+  );
+});
+
+test("Viber replies are truncated to the provider text limit", async () => {
+  const gateway: ManagedAgentGateway = {
+    async createAgent() { return "agent-chief"; },
+    async runTurn() { return "x".repeat(8_000); },
+  };
+  const result = await new ConversationEngine(new MemoryConversationStore(), gateway).turn({
+    actorId: "01234567890A=",
+    channel: viberChannel,
+    messageId: "5741311803571721087",
+    text: "Write a long answer",
+  });
+
+  assert.equal(result.finalMessage.length, 7_000);
+  assert.equal(result.finalMessage.endsWith("[Response truncated for Viber]"), true);
 });

--- a/js/chief-of-staff/test/delivery.test.ts
+++ b/js/chief-of-staff/test/delivery.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { claimDelivery, completeDelivery, releaseDelivery } from "../src/delivery.ts";
+
+test("delivery claims fence concurrent callbacks until the lease expires", () => {
+  const first = claimDelivery(undefined, 100, 200, "first");
+  assert.equal(first.status, "claimed");
+  assert.equal(claimDelivery(first.record, 150, 250, "second").status, "in_progress");
+
+  const reclaimed = claimDelivery(first.record, 200, 300, "second");
+  assert.equal(reclaimed.status, "claimed");
+  assert.equal(reclaimed.token, "second");
+});
+
+test("only the active claim can complete or release a delivery", () => {
+  const claim = claimDelivery(undefined, 100, 200, "active");
+  assert.equal(completeDelivery(claim.record, "stale"), undefined);
+  assert.equal(releaseDelivery(claim.record, "stale"), false);
+
+  const completed = completeDelivery(claim.record, "active");
+  assert.deepEqual(completed, { status: "completed" });
+  assert.equal(claimDelivery(completed, 300, 400, "another").status, "completed");
+});

--- a/js/chief-of-staff/test/viber.test.ts
+++ b/js/chief-of-staff/test/viber.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  readViberWebhook,
+  sendViberText,
+  ViberDeliveryError,
+  ViberWebhookError,
+} from "../src/viber.ts";
+
+const authToken = "viber-test-token-that-is-long-enough-and-not-real";
+
+test("Viber verifies the exact callback body and preserves large message tokens", async () => {
+  const body = `{"event":"message","timestamp":1457764197627,"message_token":5741311803571721087,"sender":{"id":"01234567890A="},"message":{"type":"picture","text":"diagram","media":"https://example.com/diagram.png"}}`;
+  const callback = await readViberWebhook(new Request("https://chief.example/webhooks/viber", {
+    body,
+    headers: { "x-viber-content-signature": await signature(body) },
+    method: "POST",
+  }), authToken);
+
+  assert.deepEqual(callback, {
+    actorId: "01234567890A=",
+    kind: "message",
+    messageId: "5741311803571721087",
+    text: "[Viber image]\ndiagram\nhttps://example.com/diagram.png",
+  });
+});
+
+test("Viber rejects a valid signature if the callback body changes", async () => {
+  const original = `{"event":"message","message_token":1,"sender":{"id":"user="},"message":{"type":"text","text":"yes"}}`;
+  const changed = original.replace("yes", "no");
+
+  await assert.rejects(
+    readViberWebhook(new Request("https://chief.example/webhooks/viber", {
+      body: changed,
+      headers: { "x-viber-content-signature": await signature(original) },
+      method: "POST",
+    }), authToken),
+    (error: unknown) => error instanceof ViberWebhookError && error.code === "invalid_signature",
+  );
+});
+
+test("Viber outbound requests keep credentials in headers and check provider status", async () => {
+  let request: Request | undefined;
+  await sendViberText({
+    authToken,
+    botName: "Nanocodex",
+    receiver: "01234567890A=",
+    text: "Done",
+  }, async (input, init) => {
+    request = new Request(input, init);
+    return Response.json({ status: 0, status_message: "ok" });
+  });
+
+  assert.ok(request);
+  assert.equal(request.headers.get("x-viber-auth-token"), authToken);
+  assert.equal((await request.json() as { text?: unknown }).text, "Done");
+
+  await assert.rejects(
+    sendViberText({
+      authToken,
+      botName: "Nanocodex",
+      receiver: "01234567890A=",
+      text: "Done",
+    }, async () => Response.json({ status: 6, status_message: "notSubscribed" })),
+    (error: unknown) => error instanceof ViberDeliveryError
+      && error.code === "provider_status_6",
+  );
+});
+
+async function signature(body: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(authToken),
+    { hash: "SHA-256", name: "HMAC" },
+    false,
+    ["sign"],
+  );
+  const result = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(body));
+  return Buffer.from(result).toString("hex");
+}

--- a/js/chief-of-staff/test/webhook.test.ts
+++ b/js/chief-of-staff/test/webhook.test.ts
@@ -176,6 +176,7 @@ test("readiness reports bot installations without returning provider credentials
   assert.equal(serialized.includes(configured.SLACK_CLIENT_SECRET!), false);
   assert.equal(serialized.includes(configured.SLACK_ENCRYPTION_KEY!), false);
   assert.equal(serialized.includes(configured.SLACK_SIGNING_SECRET!), false);
+  assert.equal(serialized.includes(configured.VIBER_AUTH_TOKEN!), false);
   const readiness = JSON.parse(serialized) as {
     channels: { id: string; availability: string }[];
     installations: { teamId: string; teamName: string }[];
@@ -190,7 +191,104 @@ test("readiness reports bot installations without returning provider credentials
     { id: "slack", availability: "ready" },
     { id: "whatsapp", availability: "not_enabled" },
     { id: "imessage", availability: "not_enabled" },
+    { id: "viber", availability: "ready" },
   ]);
+});
+
+test("signed Viber messages preserve the exact token and route one replay-safe reply", async () => {
+  const configured = env();
+  const calls: { stateBody?: unknown; stateName?: string; viberBody?: unknown } = {};
+  let delivered = false;
+  let outboundCalls = 0;
+  configured.CHIEF_OF_STAFF_STATE = {
+    getByName(name) {
+      calls.stateName = name;
+      return {
+        async fetch(request) {
+          const url = new URL(request.url);
+          const body = await request.json<Record<string, unknown>>();
+          if (url.pathname === "/conversation/turn") {
+            calls.stateBody = body;
+            return Response.json({ finalMessage: "Your durable reply" });
+          }
+          if (body.operation === "claim") {
+            return Response.json(delivered
+              ? { status: "completed" }
+              : { status: "claimed", token: "delivery-claim" });
+          }
+          if (body.operation === "complete") delivered = true;
+          return Response.json({ status: body.operation });
+        },
+      };
+    },
+  };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    outboundCalls += 1;
+    assert.equal(input, "https://chatapi.viber.com/pa/send_message");
+    assert.equal(new Headers(init?.headers).get("x-viber-auth-token"), configured.VIBER_AUTH_TOKEN);
+    calls.viberBody = JSON.parse(String(init?.body));
+    return Response.json({ message_token: 1, status: 0, status_message: "ok" });
+  };
+  try {
+    const body = JSON.stringify({
+      event: "message",
+      message_token: 5741311803571721087,
+      sender: { id: "01234567890A=", name: "Ada" },
+      message: { type: "text", text: "Remember kiwi" },
+      timestamp: 1457764197627,
+    }).replace("5741311803571721000", "5741311803571721087");
+    const signedRequest = async () => new Request("https://chief.example/webhooks/viber", {
+      body,
+      headers: {
+        "content-type": "application/json",
+        "x-viber-content-signature": await viberSignature(body, configured.VIBER_AUTH_TOKEN!),
+      },
+      method: "POST",
+    });
+    const response = await worker.fetch(await signedRequest(), configured);
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), { status: 0 });
+    assert.deepEqual(calls.stateBody, {
+      actorId: "01234567890A=",
+      channel: {
+        accountId,
+        botUri: "nanocodex-chief",
+        conversationId: "dm:01234567890A=",
+        platform: "viber",
+        userId: "01234567890A=",
+      },
+      messageId: "5741311803571721087",
+      text: "Remember kiwi",
+    });
+    assert.match(calls.stateName ?? "", /^conversation:[0-9a-f]{64}$/);
+    assert.deepEqual(calls.viberBody, {
+      receiver: "01234567890A=",
+      min_api_version: 1,
+      sender: { name: "Nanocodex" },
+      tracking_data: "reply-to:5741311803571721087",
+      type: "text",
+      text: "Your durable reply",
+    });
+
+    const replay = await worker.fetch(await signedRequest(), configured);
+    assert.equal(replay.status, 200);
+    assert.equal(outboundCalls, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("Viber rejects callbacks before routing when the signature is invalid", async () => {
+  const response = await worker.fetch(new Request("https://chief.example/webhooks/viber", {
+    body: JSON.stringify({ event: "message" }),
+    headers: { "x-viber-content-signature": "0".repeat(64) },
+    method: "POST",
+  }), env());
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), { error: "invalid_signature" });
 });
 
 function env(installations: readonly unknown[] = [{
@@ -223,6 +321,9 @@ function env(installations: readonly unknown[] = [{
     SLACK_ENCRYPTION_KEY: key,
     SLACK_OAUTH_STATE_SECRET: key,
     SLACK_SIGNING_SECRET: signingSecret,
+    VIBER_AUTH_TOKEN: "viber-test-token-that-is-long-enough-and-not-real",
+    VIBER_BOT_NAME: "Nanocodex",
+    VIBER_BOT_URI: "nanocodex-chief",
   };
 }
 
@@ -301,4 +402,16 @@ async function signature(timestamp: string, body: string): Promise<string> {
     new TextEncoder().encode(`v0:${timestamp}:${body}`),
   );
   return `v0=${Buffer.from(result).toString("hex")}`;
+}
+
+async function viberSignature(body: string, token: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(token),
+    { hash: "SHA-256", name: "HMAC" },
+    false,
+    ["sign"],
+  );
+  const result = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(body));
+  return Buffer.from(result).toString("hex");
 }


### PR DESCRIPTION
## What changed

- add an official Viber Bot REST API webhook to the Chief of Staff Worker
- verify `X-Viber-Content-Signature` against the exact callback body before parsing
- preserve Viber's large numeric `message_token` lexically for idempotency
- route every bot/subscriber pair to an isolated durable Nanocodex agent
- normalize text, image, video, file, URL, sticker, location, and contact messages
- send welcome and agent replies through Viber with provider-status validation
- suppress duplicate outbound replies with expiring Durable Object delivery claims
- expose Viber setup/readiness and webhook copying in the account UI
- document commercial-bot secrets and webhook registration

Existing Slack channel identities and route digests remain unchanged.

## Verification

- `pnpm --filter @nanocodex/chief-of-staff check`
  - TypeScript: pass
  - 17 tests: pass
  - Wrangler production-config dry run: pass
- changed React surface bundled successfully with esbuild
- full `nanocodex-web` build was not runnable in this workspace because `cargo` is unavailable during the generated-WASM dependency build