### PR TITLE
feat(chief-of-staff): add one-click Slack app install

### DIFF
--- a/js/account/src/ChiefOfStaffDemo.css
+++ b/js/account/src/ChiefOfStaffDemo.css
@@ -36,6 +36,15 @@
 .chief-setup > header div { display: grid; gap: 7px; }
 .chief-setup h2 { font-size: clamp(20px, 3vw, 30px); font-weight: 400; }
 .chief-setup > header > svg { width: 25px; color: var(--positive); }
+.chief-install-action, .chief-installation { display: flex; gap: 16px; align-items: center; justify-content: space-between; padding: 18px 0; border-top: 1px solid var(--border-soft); }
+.chief-install-action > div, .chief-installation > div { display: grid; gap: 7px; }
+.chief-install-action strong, .chief-installation strong { font-size: 11px; font-weight: 400; }
+.chief-install-action p, .chief-installation p { color: var(--text-muted); font-size: 10px; line-height: 1.6; }
+.chief-add-slack, .chief-installation button { display: inline-flex; flex: 0 0 auto; gap: 7px; align-items: center; padding: 9px 12px; color: var(--surface); background: var(--text); border: 1px solid var(--text); cursor: pointer; font: 10px var(--font-mono); text-decoration: none; }
+.chief-installation button { color: var(--text); background: transparent; border-color: var(--border-soft); }
+.chief-add-slack svg, .chief-installation button svg { width: 12px; height: 12px; }
+.chief-installation button:disabled { cursor: wait; opacity: .55; }
+.chief-install-unavailable { color: var(--text-muted); font-size: 9px; text-transform: uppercase; }
 .chief-setup ol { display: grid; padding: 0; margin: 0; list-style: none; }
 .chief-setup li { display: grid; grid-template-columns: 42px minmax(0, 1fr) auto; gap: 12px; align-items: start; padding: 18px 0; border-top: 1px solid var(--border-soft); }
 .chief-setup li > span { color: var(--text-muted); font-size: 9px; }
@@ -55,10 +64,12 @@
   .chief-setup li { grid-template-columns: 32px minmax(0, 1fr); }
   .chief-setup li button { grid-column: 2; width: fit-content; }
   .chief-webhook { margin-left: 44px; }
+  .chief-install-action, .chief-installation { align-items: start; }
 }
 
 @media (pointer: coarse) {
-  .chief-hero-status button, .chief-channel a, .chief-error button, .chief-setup li button {
+  .chief-hero-status button, .chief-channel a, .chief-error button, .chief-setup li button,
+  .chief-add-slack, .chief-installation button {
     min-height: var(--coarse-target-size);
   }
 }

--- a/js/account/src/ChiefOfStaffDemo.tsx
+++ b/js/account/src/ChiefOfStaffDemo.tsx
@@ -1,4 +1,4 @@
-import { Check, Copy, ExternalLink, RefreshCw, ShieldCheck } from "lucide-react";
+import { Bot, ExternalLink, Plus, RefreshCw, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useAccountSession } from "./AccountSession";
 import "./ChiefOfStaffDemo.css";
@@ -14,6 +14,13 @@ type Readiness = Readonly<{
   accountMatch: boolean;
   channels: readonly Channel[];
   configured: boolean;
+  installations: readonly Readonly<{
+    botUserId: string | null;
+    installedAt: number;
+    teamId: string;
+    teamName: string;
+  }>[];
+  installUrl: string | null;
   webhookUrl: string | null;
 }>;
 
@@ -29,7 +36,7 @@ export function ChiefOfStaffDemo() {
   const [readiness, setReadiness] = useState<Readiness | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
-  const [copied, setCopied] = useState(false);
+  const [operation, setOperation] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -56,12 +63,23 @@ export function ChiefOfStaffDemo() {
     void refresh();
   }, [account.status, refresh]);
 
-  const copyWebhook = useCallback(async () => {
-    if (!readiness?.webhookUrl) return;
-    await navigator.clipboard.writeText(readiness.webhookUrl);
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 1_500);
-  }, [readiness?.webhookUrl]);
+  const removeInstallation = useCallback(async (teamId: string) => {
+    if (operation) return;
+    setOperation(teamId);
+    setError(null);
+    try {
+      const response = await fetch(
+        `/api/chief-of-staff/slack/installations/${encodeURIComponent(teamId)}`,
+        { method: "DELETE", credentials: "same-origin" },
+      );
+      if (!response.ok) throw new Error("Couldn’t remove the Slack app.");
+      await refresh();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Couldn’t remove the Slack app.");
+    } finally {
+      setOperation(null);
+    }
+  }, [operation, refresh]);
 
   return (
     <article className="chief-demo page-grid">
@@ -69,9 +87,9 @@ export function ChiefOfStaffDemo() {
         <p className="eyebrow">Demos · Chat SDK integration</p>
         <h1>Chief of Staff</h1>
         <p>
-          Bring one account-owned, durable Nanocodex agent into supported messaging channels.
-          The integration Worker verifies provider traffic and keeps every account, workspace,
-          channel, and conversation on its own route.
+          Install a durable Nanocodex agent into Slack as its own AI teammate. It has a bot
+          identity, receives mentions and DMs, and keeps every workspace and conversation on
+          its own route.
         </p>
         <div className="chief-hero-status" aria-live="polite">
           <span className={`chief-status-dot${readiness?.configured ? " is-ready" : ""}`} />
@@ -111,31 +129,40 @@ export function ChiefOfStaffDemo() {
       <section className="chief-setup" aria-labelledby="chief-setup-title">
         <header>
           <div>
-            <p className="eyebrow">Slack deployment</p>
-            <h2 id="chief-setup-title">Wire the signed ingress</h2>
+            <p className="eyebrow">Slack AI bot</p>
+            <h2 id="chief-setup-title">Add Chief of Staff to Slack</h2>
           </div>
-          <ShieldCheck aria-hidden="true" />
+          <Bot aria-hidden="true" />
         </header>
-        <ol>
-          <li>
-            <span>01</span>
-            <div><strong>Bind the account</strong><p>Set the Worker-only <code>NANOCODEX_API_KEY</code>. Its account must match this page’s signed-in account.</p></div>
-          </li>
-          <li>
-            <span>02</span>
-            <div><strong>Configure Slack</strong><p>Set <code>SLACK_BOT_TOKEN</code>, <code>SLACK_SIGNING_SECRET</code>, <code>SLACK_BOT_USER_ID</code>, and <code>SLACK_TEAM_ID</code> as Worker secrets.</p></div>
-          </li>
-          <li>
-            <span>03</span>
-            <div><strong>Register the webhook</strong><p>Use this URL for Slack Events API requests. Subscribe to app mentions and message events for each enabled channel type.</p></div>
-            {readiness?.webhookUrl ? <button type="button" onClick={() => void copyWebhook()}>
-              {copied ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}
-              {copied ? "Copied" : "Copy URL"}
-            </button> : null}
-          </li>
-        </ol>
-        {readiness?.webhookUrl ? <code className="chief-webhook">{readiness.webhookUrl}</code> : null}
-        <p className="chief-secret-note">Credential values stay inside Worker bindings and are never returned to this application.</p>
+        <div className="chief-install-action">
+          <div>
+            <strong>One workspace approval</strong>
+            <p>Slack shows the bot permissions, then installs the app and returns you here. No token or webhook setup.</p>
+          </div>
+          {readiness?.installUrl ? <a className="chief-add-slack" href={readiness.installUrl}>
+            <Plus aria-hidden="true" /> Add to Slack
+          </a> : <span className="chief-install-unavailable">Deployment setup required</span>}
+        </div>
+        {(readiness?.installations ?? []).map((installation) => (
+          <div className="chief-installation" key={installation.teamId}>
+            <div>
+              <strong>{installation.teamName}</strong>
+              <p>Bot installed{installation.botUserId ? ` as ${installation.botUserId}` : ""}</p>
+            </div>
+            <button
+              type="button"
+              disabled={operation !== null}
+              onClick={() => void removeInstallation(installation.teamId)}
+            >
+              <Trash2 aria-hidden="true" />
+              {operation === installation.teamId ? "Removing" : "Remove"}
+            </button>
+          </div>
+        ))}
+        <p className="chief-secret-note">
+          This installs the AI bot. The separate Slack connector acts as your own Slack user and
+          has its own authorization, tokens, and workspace grants.
+        </p>
       </section>
     </article>
   );

--- a/js/account/worker/chiefOfStaffProxy.test.ts
+++ b/js/account/worker/chiefOfStaffProxy.test.ts
@@ -22,6 +22,30 @@ test("the account route preserves browser identity and targets only readiness", 
   assert.equal(forwarded!.headers.get("origin"), "https://nanocodex.example");
 });
 
+test("the account route exposes the bot install and exact workspace removal journeys", async () => {
+  const forwarded: string[] = [];
+  const binding = {
+    async fetch(request: Request) {
+      forwarded.push(`${request.method} ${new URL(request.url).pathname}`);
+      return new Response(null, { status: request.method === "GET" ? 302 : 204 });
+    },
+  };
+  const installUrl = new URL("https://nanocodex.example/api/chief-of-staff/slack/install");
+  const removeUrl = new URL("https://nanocodex.example/api/chief-of-staff/slack/installations/T123ABC");
+
+  await routeChiefOfStaff(new Request(installUrl), { CHIEF_OF_STAFF: binding }, installUrl);
+  await routeChiefOfStaff(
+    new Request(removeUrl, { method: "DELETE" }),
+    { CHIEF_OF_STAFF: binding },
+    removeUrl,
+  );
+
+  assert.deepEqual(forwarded, [
+    "GET /v1/slack/install",
+    "DELETE /v1/slack/installations/T123ABC",
+  ]);
+});
+
 test("the account route fences methods and missing bindings", async () => {
   const endpoint = "https://nanocodex.example/api/chief-of-staff/status";
   const post = await routeChiefOfStaff(

--- a/js/account/worker/chiefOfStaffProxy.ts
+++ b/js/account/worker/chiefOfStaffProxy.ts
@@ -2,24 +2,37 @@ export type ChiefOfStaffProxyEnv = {
   CHIEF_OF_STAFF?: Readonly<{ fetch(request: Request): Promise<Response> }>;
 };
 
-const browserPath = "/api/chief-of-staff/status";
+const statusPath = "/api/chief-of-staff/status";
+const installPath = "/api/chief-of-staff/slack/install";
+const installationPath = /^\/api\/chief-of-staff\/slack\/installations\/(T[A-Z0-9]+)$/;
 
 export async function routeChiefOfStaff(
   request: Request,
   env: ChiefOfStaffProxyEnv,
   url: URL,
 ): Promise<Response | undefined> {
-  if (url.pathname !== browserPath) return undefined;
-  if (request.method !== "GET") {
-    return json({ error: "method_not_allowed" }, { status: 405, headers: { allow: "GET" } });
+  const installation = url.pathname.match(installationPath);
+  const target = url.pathname === statusPath
+    ? { method: "GET", path: "/v1/readiness" }
+    : url.pathname === installPath
+      ? { method: "GET", path: "/v1/slack/install" }
+      : installation
+        ? { method: "DELETE", path: `/v1/slack/installations/${installation[1]}` }
+        : undefined;
+  if (!target) return undefined;
+  if (request.method !== target.method) {
+    return json({ error: "method_not_allowed" }, {
+      status: 405,
+      headers: { allow: target.method },
+    });
   }
   if (!env.CHIEF_OF_STAFF) {
     return json({ error: "chief_of_staff_unavailable" }, { status: 503 });
   }
   try {
     return await env.CHIEF_OF_STAFF.fetch(new Request(
-      "https://chief-of-staff.internal/v1/readiness",
-      { headers: request.headers, method: "GET" },
+      new URL(target.path, "https://chief-of-staff.internal"),
+      { headers: request.headers, method: target.method },
     ));
   } catch (error) {
     console.error({

--- a/js/chief-of-staff/README.md
+++ b/js/chief-of-staff/README.md
@@ -1,42 +1,55 @@
 # Nanocodex Chief of Staff
 
-An independently deployable [Vercel Chat SDK](https://chat-sdk.dev/) Worker. The first
-complete channel is Slack: the Worker verifies Slack signatures and timestamps,
-fences one configured workspace, persists Chat SDK replay/subscription state, maps
-each account/workspace/conversation to a Durable Object, and routes turns to one
-retained managed Nanocodex agent.
+An independently deployable [Vercel Chat SDK](https://chat-sdk.dev/) Worker. The
+Chief of Staff is a Slack AI bot installed into a workspace, like Devin. It is
+not the Nanocodex Slack connector: the connector authorizes actions as a human
+user, while this app has its own bot identity, OAuth installation, scopes,
+tokens, event ingress, and lifecycle.
 
-The account app receives only readiness metadata through a service binding. It does
-not receive provider credentials or the Nanocodex API key.
+An authenticated Nanocodex user selects **Add to Slack** once. Slack presents the
+workspace approval and returns to the account app. The Worker exchanges the code,
+encrypts the workspace bot token in Durable Object state, records the workspace
+installation, and immediately accepts signed mentions and DMs. Users never copy a
+token or configure a webhook.
 
-## Configure Slack
+Each account/workspace/conversation maps to a retained managed Nanocodex agent.
+The account app receives only non-secret installation and readiness metadata
+through a service binding.
 
-Create a single-workspace Slack app following the current official
-[Slack adapter guide](https://chat-sdk.dev/adapters/slack). Enable `agent_view`, add
+## Configure the shared Slack app
+
+Create one distributable Slack app from `slack-app-manifest.yaml`, following the
+official [Slack adapter guide](https://chat-sdk.dev/adapters/slack). Enable `agent_view`, add
 the `assistant:write`, `app_mentions:read`, `chat:write`, `channels:history`,
 `groups:history`, `im:history`, `mpim:history`, and `users:read` bot scopes, and
-subscribe to `app_mention`, `message.channels`, `message.groups`, `message.im`, `message.mpim`,
-`app_home_opened`, `app_context_changed`, `agent_session_stopped`, and
-`agent_session_title_changed`. Use the deployed `/webhooks/slack` URL as the Events
-API request URL.
+subscribe to `app_mention`, `message.channels`, `message.groups`, `message.im`,
+`message.mpim`, `app_home_opened`, `app_context_changed`,
+`app_uninstalled`, `agent_session_stopped`, and `agent_session_title_changed`.
 
-Configure every credential as a Worker secret:
+Configure these URLs in Slack:
+
+```text
+OAuth redirect: https://nanocodex-chief-of-staff.gakonst.workers.dev/v1/slack/callback
+Events request: https://nanocodex-chief-of-staff.gakonst.workers.dev/webhooks/slack
+```
+
+Configure the deployment once. `SLACK_ENCRYPTION_KEY` and
+`SLACK_OAUTH_STATE_SECRET` are independent base64url-encoded 32-byte keys.
 
 ```sh
 pnpm exec wrangler secret put NANOCODEX_API_KEY --config js/chief-of-staff/wrangler.jsonc
-pnpm exec wrangler secret put SLACK_BOT_TOKEN --config js/chief-of-staff/wrangler.jsonc
+pnpm exec wrangler secret put SLACK_CLIENT_ID --config js/chief-of-staff/wrangler.jsonc
+pnpm exec wrangler secret put SLACK_CLIENT_SECRET --config js/chief-of-staff/wrangler.jsonc
 pnpm exec wrangler secret put SLACK_SIGNING_SECRET --config js/chief-of-staff/wrangler.jsonc
-pnpm exec wrangler secret put SLACK_BOT_USER_ID --config js/chief-of-staff/wrangler.jsonc
-pnpm exec wrangler secret put SLACK_TEAM_ID --config js/chief-of-staff/wrangler.jsonc
+pnpm exec wrangler secret put SLACK_ENCRYPTION_KEY --config js/chief-of-staff/wrangler.jsonc
+pnpm exec wrangler secret put SLACK_OAUTH_STATE_SECRET --config js/chief-of-staff/wrangler.jsonc
 ```
 
-`NANOCODEX_API_KEY` binds the deployment to its owning Nanocodex account. The
-readiness endpoint reports Slack ready only when the signed-in account matches that
-owner. Set `CHIEF_OF_STAFF_PUBLIC_ORIGIN` in Wrangler configuration when deploying
-under another Worker name or custom domain.
+`NANOCODEX_API_KEY` binds this deployment to its owning Nanocodex account. Slack
+OAuth installations are accepted only when initiated by that signed-in owner.
+Set both public origins in Wrangler when deploying under other names or domains.
 
-Deploy the managed service first, then this Worker, and the account application
-last:
+Deploy the managed service first, then this Worker, and the account application:
 
 ```sh
 pnpm deploy:managed
@@ -46,12 +59,15 @@ pnpm deploy:account
 
 ## Capability boundary
 
-- Slack uses the first-party `@chat-adapter/slack` contract and is implemented.
+- Chief of Staff: workspace-installed Slack app; bot token and bot scopes; reacts
+  to bot DMs, mentions, and subscribed threads.
+- Slack connector: separately authorized user token; acts on behalf of the human
+  in only the exact workspaces granted through Connect.
 - WhatsApp has a first-party Chat SDK adapter, but this deployment does not expose
   or claim a Meta webhook yet.
 - iMessage is listed by Chat SDK through vendor adapters, not a first-party adapter;
   this deployment does not configure one.
 
-Run `pnpm --filter @nanocodex/chief-of-staff check` for signature, workspace fence,
-idempotency, cross-account/channel isolation, durable two-turn, type, and dry-run
-deployment coverage.
+Run `pnpm --filter @nanocodex/chief-of-staff check` for OAuth state, signature,
+workspace fencing, idempotency, cross-account/channel isolation, durable two-turn,
+type, and dry-run deployment coverage.

--- a/js/chief-of-staff/slack-app-manifest.yaml
+++ b/js/chief-of-staff/slack-app-manifest.yaml
@@ -1,0 +1,44 @@
+display_information:
+  name: Nanocodex Chief of Staff
+  description: A durable AI teammate for your Slack workspace
+  background_color: "#111111"
+
+features:
+  bot_user:
+    display_name: Chief of Staff
+    always_online: true
+
+oauth_config:
+  redirect_urls:
+    - https://nanocodex-chief-of-staff.gakonst.workers.dev/v1/slack/callback
+  scopes:
+    bot:
+      - assistant:write
+      - app_mentions:read
+      - channels:history
+      - chat:write
+      - groups:history
+      - im:history
+      - mpim:history
+      - users:read
+
+settings:
+  event_subscriptions:
+    request_url: https://nanocodex-chief-of-staff.gakonst.workers.dev/webhooks/slack
+    bot_events:
+      - app_mention
+      - message.channels
+      - message.groups
+      - message.im
+      - message.mpim
+      - app_home_opened
+      - app_context_changed
+      - app_uninstalled
+      - agent_session_stopped
+      - agent_session_title_changed
+  interactivity:
+    is_enabled: true
+    request_url: https://nanocodex-chief-of-staff.gakonst.workers.dev/webhooks/slack
+  org_deploy_enabled: false
+  socket_mode_enabled: false
+  token_rotation_enabled: false

--- a/js/chief-of-staff/src/protocol.ts
+++ b/js/chief-of-staff/src/protocol.ts
@@ -5,7 +5,8 @@ const SLACK_CHANNEL_ID = /^[CDG][A-Z0-9]+$/;
 const SLACK_USER_ID = /^[UW][A-Z0-9]+$/;
 const SLACK_THREAD_ID = /^slack:[CDG][A-Z0-9]+:(?:[0-9]+\.[0-9]+)?$/;
 const API_KEY = /^ncx_live_[A-Za-z0-9_-]{12}_[A-Za-z0-9_-]{43}$/;
-const BOT_TOKEN = /^xoxb-[A-Za-z0-9-]+$/;
+const SLACK_CLIENT_ID = /^[0-9]+\.[0-9]+$/;
+const BASE64_URL = /^[A-Za-z0-9_-]+$/;
 
 export type ChannelIdentity = Readonly<{
   accountId: string;
@@ -30,8 +31,20 @@ export type Readiness = Readonly<{
     detail: string;
   }>[];
   configured: boolean;
+  installations: readonly SlackInstallationSummary[];
+  installUrl: string | null;
   webhookUrl: string | null;
 }>;
+
+export type SlackInstallationMetadata = Readonly<{
+  accountId: string;
+  botUserId: string | null;
+  installedAt: number;
+  teamId: string;
+  teamName: string;
+}>;
+
+export type SlackInstallationSummary = Omit<SlackInstallationMetadata, "accountId">;
 
 export function slackTeamId(payload: SlackWebhookPayload): string | undefined {
   if ("teamId" in payload && SLACK_TEAM_ID.test(payload.teamId ?? "")) {
@@ -42,14 +55,6 @@ export function slackTeamId(payload: SlackWebhookPayload): string | undefined {
   const candidate = stringValue(event?.team_id) ?? stringValue(event?.team)
     ?? stringValue(payload.raw.team_id);
   return candidate && SLACK_TEAM_ID.test(candidate) ? candidate : undefined;
-}
-
-export function slackPayloadIsFenced(
-  payload: SlackWebhookPayload,
-  configuredTeamId: string,
-): boolean {
-  if (payload.kind === "url_verification") return true;
-  return slackTeamId(payload) === configuredTeamId;
 }
 
 export function slackMessageIdentity(
@@ -90,10 +95,11 @@ export function slackMessageIdentity(
 export function configurationReadiness(env: {
   CHIEF_OF_STAFF_PUBLIC_ORIGIN?: string;
   NANOCODEX_API_KEY?: string;
-  SLACK_BOT_TOKEN?: string;
-  SLACK_BOT_USER_ID?: string;
+  SLACK_CLIENT_ID?: string;
+  SLACK_CLIENT_SECRET?: string;
+  SLACK_ENCRYPTION_KEY?: string;
+  SLACK_OAUTH_STATE_SECRET?: string;
   SLACK_SIGNING_SECRET?: string;
-  SLACK_TEAM_ID?: string;
 }): Readonly<{ configured: boolean; webhookUrl: string | null }> {
   let origin: URL | undefined;
   try {
@@ -109,15 +115,31 @@ export function configurationReadiness(env: {
     && !origin.search
     && !origin.hash
     && API_KEY.test(env.NANOCODEX_API_KEY ?? "")
-    && BOT_TOKEN.test(env.SLACK_BOT_TOKEN ?? "")
-    && SLACK_USER_ID.test(env.SLACK_BOT_USER_ID ?? "")
+    && SLACK_CLIENT_ID.test(env.SLACK_CLIENT_ID ?? "")
+    && (env.SLACK_CLIENT_SECRET?.length ?? 0) >= 16
+    && validBase64Key(env.SLACK_ENCRYPTION_KEY)
+    && validBase64Key(env.SLACK_OAUTH_STATE_SECRET)
     && (env.SLACK_SIGNING_SECRET?.length ?? 0) >= 16
-    && SLACK_TEAM_ID.test(env.SLACK_TEAM_ID ?? ""),
   );
   return {
     configured,
     webhookUrl: origin ? new URL("/webhooks/slack", origin).href : null,
   };
+}
+
+export function validSlackInstallationMetadata(value: unknown): value is SlackInstallationMetadata {
+  return isRecord(value)
+    && typeof value.accountId === "string"
+    && value.accountId.length > 0
+    && (value.botUserId === null || (typeof value.botUserId === "string" && SLACK_USER_ID.test(value.botUserId)))
+    && typeof value.installedAt === "number"
+    && Number.isSafeInteger(value.installedAt)
+    && value.installedAt > 0
+    && typeof value.teamId === "string"
+    && SLACK_TEAM_ID.test(value.teamId)
+    && typeof value.teamName === "string"
+    && value.teamName.trim().length > 0
+    && value.teamName.length <= 200;
 }
 
 export async function digest(value: unknown): Promise<string> {
@@ -149,4 +171,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value ? value : undefined;
+}
+
+function validBase64Key(value: unknown): boolean {
+  if (typeof value !== "string" || !BASE64_URL.test(value)) return false;
+  try {
+    const base64 = value.replaceAll("-", "+").replaceAll("_", "/");
+    return atob(base64.padEnd(Math.ceil(base64.length / 4) * 4, "=")).length === 32;
+  } catch {
+    return false;
+  }
 }

--- a/js/chief-of-staff/src/slack-oauth.ts
+++ b/js/chief-of-staff/src/slack-oauth.ts
@@ -1,0 +1,115 @@
+const STATE_TTL_MS = 10 * 60 * 1_000;
+const ACCOUNT_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const STATE_SECRET_BYTES = 32;
+
+export const SLACK_BOT_SCOPES = Object.freeze([
+  "assistant:write",
+  "app_mentions:read",
+  "chat:write",
+  "channels:history",
+  "groups:history",
+  "im:history",
+  "mpim:history",
+  "users:read",
+] as const);
+
+type InstallState = Readonly<{
+  accountId: string;
+  expiresAt: number;
+  nonce: string;
+  version: 1;
+}>;
+
+export async function slackAuthorizationUrl(options: Readonly<{
+  accountId: string;
+  clientId: string;
+  redirectUri: string;
+  stateSecret: string;
+  now?: number;
+}>): Promise<URL> {
+  if (!ACCOUNT_ID.test(options.accountId)) throw new Error("Slack install account is invalid");
+  const redirect = new URL(options.redirectUri);
+  if (redirect.protocol !== "https:") throw new Error("Slack redirect URI must use HTTPS");
+  const state = await signInstallState({
+    accountId: options.accountId,
+    expiresAt: (options.now ?? Date.now()) + STATE_TTL_MS,
+    nonce: crypto.randomUUID(),
+    version: 1,
+  }, options.stateSecret);
+  const authorization = new URL("https://slack.com/oauth/v2/authorize");
+  authorization.searchParams.set("client_id", options.clientId);
+  authorization.searchParams.set("scope", SLACK_BOT_SCOPES.join(","));
+  authorization.searchParams.set("redirect_uri", redirect.href);
+  authorization.searchParams.set("state", state);
+  return authorization;
+}
+
+export async function verifySlackInstallState(
+  value: string,
+  stateSecret: string,
+  now = Date.now(),
+): Promise<InstallState | undefined> {
+  const [encoded, signature, extra] = value.split(".");
+  if (!encoded || !signature || extra !== undefined) return undefined;
+  const supplied = decodeBase64Url(signature);
+  if (!supplied) return undefined;
+  const key = await stateKey(stateSecret);
+  if (!(await crypto.subtle.verify("HMAC", key, supplied, new TextEncoder().encode(encoded)))) {
+    return undefined;
+  }
+  const bytes = decodeBase64Url(encoded);
+  if (!bytes) return undefined;
+  let state: unknown;
+  try { state = JSON.parse(new TextDecoder().decode(bytes)); }
+  catch { return undefined; }
+  if (!isRecord(state)
+    || state.version !== 1
+    || typeof state.accountId !== "string"
+    || !ACCOUNT_ID.test(state.accountId)
+    || typeof state.expiresAt !== "number"
+    || !Number.isSafeInteger(state.expiresAt)
+    || state.expiresAt < now
+    || state.expiresAt > now + STATE_TTL_MS
+    || typeof state.nonce !== "string"
+    || !/^[0-9a-f-]{36}$/.test(state.nonce)) return undefined;
+  return state as InstallState;
+}
+
+async function signInstallState(state: InstallState, secret: string): Promise<string> {
+  const encoded = encodeBase64Url(new TextEncoder().encode(JSON.stringify(state)));
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    await stateKey(secret),
+    new TextEncoder().encode(encoded),
+  );
+  return `${encoded}.${encodeBase64Url(new Uint8Array(signature))}`;
+}
+
+async function stateKey(secret: string): Promise<CryptoKey> {
+  const bytes = decodeBase64Url(secret);
+  if (!bytes || bytes.length !== STATE_SECRET_BYTES) {
+    throw new Error("Slack OAuth state secret must be 32 base64url bytes");
+  }
+  return crypto.subtle.importKey("raw", bytes, { hash: "SHA-256", name: "HMAC" }, false, ["sign", "verify"]);
+}
+
+function encodeBase64Url(value: Uint8Array): string {
+  let binary = "";
+  for (const byte of value) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function decodeBase64Url(value: string): Uint8Array | undefined {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) return undefined;
+  try {
+    const base64 = value.replaceAll("-", "+").replaceAll("_", "/");
+    const binary = atob(base64.padEnd(Math.ceil(base64.length / 4) * 4, "="));
+    return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+  } catch {
+    return undefined;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/js/chief-of-staff/src/state-object.ts
+++ b/js/chief-of-staff/src/state-object.ts
@@ -7,7 +7,12 @@ import {
   type ConversationTurnRequest,
 } from "./conversation.ts";
 import { NanocodexManagedGateway } from "./managed.ts";
-import { sameChannelIdentity, type ChannelIdentity } from "./protocol.ts";
+import {
+  sameChannelIdentity,
+  validSlackInstallationMetadata,
+  type ChannelIdentity,
+  type SlackInstallationMetadata,
+} from "./protocol.ts";
 import type { Env } from "./worker.ts";
 
 type ExpiringValue = Readonly<{ expiresAt: number | null; value: unknown }>;
@@ -15,10 +20,34 @@ type ExpiringValue = Readonly<{ expiresAt: number | null; value: unknown }>;
 export class ChiefOfStaffState extends DurableObject<Env> {
   async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
-    if (request.method !== "POST") return json({ error: "method_not_allowed" }, 405);
-    if (url.pathname === "/chat-sdk") return this.chatState(request);
-    if (url.pathname === "/conversation/turn") return this.conversationTurn(request);
+    if (url.pathname === "/chat-sdk" && request.method === "POST") return this.chatState(request);
+    if (url.pathname === "/conversation/turn" && request.method === "POST") return this.conversationTurn(request);
+    if (url.pathname === "/slack/installations") return this.slackInstallations(request);
     return json({ error: "not_found" }, 404);
+  }
+
+  private async slackInstallations(request: Request): Promise<Response> {
+    if (request.method === "GET") {
+      const retained = await this.ctx.storage.list<SlackInstallationMetadata>({ prefix: "slack:metadata:" });
+      const installations = [...retained.values()]
+        .filter(validSlackInstallationMetadata)
+        .sort((left, right) => right.installedAt - left.installedAt);
+      return json({ installations }, 200);
+    }
+    let body: unknown;
+    try { body = await request.json(); }
+    catch { return json({ error: "invalid_request" }, 400); }
+    if (!validSlackInstallationMetadata(body)) return json({ error: "invalid_request" }, 400);
+    const key = `slack:metadata:${body.teamId}`;
+    if (request.method === "PUT") {
+      await this.ctx.storage.put(key, body);
+      return new Response(null, { status: 204 });
+    }
+    if (request.method === "DELETE") {
+      await this.ctx.storage.delete(key);
+      return new Response(null, { status: 204 });
+    }
+    return json({ error: "method_not_allowed" }, 405);
   }
 
   private async conversationTurn(request: Request): Promise<Response> {

--- a/js/chief-of-staff/src/worker.ts
+++ b/js/chief-of-staff/src/worker.ts
@@ -1,4 +1,4 @@
-import { createSlackAdapter } from "@chat-adapter/slack";
+import { createSlackAdapter, type SlackAdapter } from "@chat-adapter/slack";
 import {
   readSlackWebhook,
   type SlackWebhookPayload,
@@ -9,27 +9,37 @@ import {
   configurationReadiness,
   digest,
   slackMessageIdentity,
-  slackPayloadIsFenced,
+  slackTeamId,
+  validSlackInstallationMetadata,
   type Readiness,
+  type SlackInstallationMetadata,
 } from "./protocol.ts";
+import { slackAuthorizationUrl, verifySlackInstallState } from "./slack-oauth.ts";
 import { DurableChatStateAdapter } from "./state-adapter.ts";
 
 type Fetcher = Readonly<{ fetch(request: Request): Promise<Response> }>;
 type StateNamespace = Readonly<{ getByName(name: string): Fetcher }>;
 
 export interface Env {
+  CHIEF_OF_STAFF_ACCOUNT_ORIGIN?: string;
   CHIEF_OF_STAFF_PUBLIC_ORIGIN?: string;
   CHIEF_OF_STAFF_STATE: StateNamespace;
   NANOCODEX_API_KEY?: string;
   NANOCODEX_BACKEND?: Fetcher;
-  SLACK_BOT_TOKEN?: string;
-  SLACK_BOT_USER_ID?: string;
+  SLACK_API_URL?: string;
+  SLACK_CLIENT_ID?: string;
+  SLACK_CLIENT_SECRET?: string;
+  SLACK_ENCRYPTION_KEY?: string;
+  SLACK_OAUTH_STATE_SECRET?: string;
   SLACK_SIGNING_SECRET?: string;
-  SLACK_TEAM_ID?: string;
 }
 
-const chats = new WeakMap<object, Chat>();
+type ChiefRuntime = Readonly<{ chat: Chat<{ slack: SlackAdapter }>; slack: SlackAdapter }>;
+
+const runtimes = new WeakMap<object, ChiefRuntime>();
 const ownerIds = new WeakMap<object, Promise<string | undefined>>();
+const INSTALLATIONS_OBJECT = "chat-sdk:slack";
+const SLACK_TEAM_ID = /^T[A-Z0-9]+$/;
 
 export default {
   async fetch(request: Request, env: Env, context?: ExecutionContext): Promise<Response> {
@@ -40,6 +50,19 @@ export default {
     if (url.pathname === "/v1/readiness" && request.method === "GET") {
       return readiness(request, env);
     }
+    if (url.pathname === "/v1/slack/install") {
+      if (request.method !== "GET") return methodNotAllowed(["GET"]);
+      return beginSlackInstall(request, env);
+    }
+    if (url.pathname === "/v1/slack/callback") {
+      if (request.method !== "GET") return methodNotAllowed(["GET"]);
+      return finishSlackInstall(request, env);
+    }
+    const slackInstallation = url.pathname.match(/^\/v1\/slack\/installations\/(T[A-Z0-9]+)$/);
+    if (slackInstallation) {
+      if (request.method !== "DELETE") return methodNotAllowed(["DELETE"]);
+      return removeSlackInstallation(request, env, slackInstallation[1]!);
+    }
     if (url.pathname === "/webhooks/slack") {
       if (request.method !== "POST") return methodNotAllowed(["POST"]);
       return slackWebhook(request, env, context);
@@ -48,13 +71,119 @@ export default {
   },
 };
 
+async function beginSlackInstall(request: Request, env: Env): Promise<Response> {
+  const config = configurationReadiness(env);
+  if (!config.configured || !env.NANOCODEX_BACKEND || !env.SLACK_CLIENT_ID
+    || !env.SLACK_OAUTH_STATE_SECRET || !env.CHIEF_OF_STAFF_PUBLIC_ORIGIN) {
+    return json({ error: "slack_app_not_configured" }, { status: 503 });
+  }
+  const requester = await requestingAccountId(env.NANOCODEX_BACKEND, request);
+  if (!requester) return json({ error: "unauthorized" }, { status: 401 });
+  if (await configuredOwnerId(env) !== requester) {
+    return json({ error: "account_forbidden" }, { status: 403 });
+  }
+  const redirectUri = new URL("/v1/slack/callback", env.CHIEF_OF_STAFF_PUBLIC_ORIGIN).href;
+  const authorization = await slackAuthorizationUrl({
+    accountId: requester,
+    clientId: env.SLACK_CLIENT_ID,
+    redirectUri,
+    stateSecret: env.SLACK_OAUTH_STATE_SECRET,
+  });
+  return new Response(null, {
+    status: 302,
+    headers: {
+      "cache-control": "no-store",
+      location: authorization.href,
+      "referrer-policy": "no-referrer",
+    },
+  });
+}
+
+async function finishSlackInstall(request: Request, env: Env): Promise<Response> {
+  const config = configurationReadiness(env);
+  if (!config.configured || !env.SLACK_OAUTH_STATE_SECRET || !env.CHIEF_OF_STAFF_PUBLIC_ORIGIN) {
+    return json({ error: "slack_app_not_configured" }, { status: 503 });
+  }
+  const url = new URL(request.url);
+  if (url.searchParams.has("error")) return installationReturn(env, "cancelled");
+  const state = await verifySlackInstallState(
+    url.searchParams.get("state") ?? "",
+    env.SLACK_OAUTH_STATE_SECRET,
+  );
+  if (!state || await configuredOwnerId(env) !== state.accountId) {
+    return json({ error: "invalid_oauth_state" }, { status: 400 });
+  }
+  try {
+    const runtime = chiefRuntime(env);
+    await runtime.chat.initialize();
+    const result = await runtime.slack.handleOAuthCallback(request, {
+      redirectUri: new URL("/v1/slack/callback", env.CHIEF_OF_STAFF_PUBLIC_ORIGIN).href,
+    });
+    if (result.isEnterpriseInstall || !SLACK_TEAM_ID.test(result.teamId)) {
+      await runtime.slack.deleteInstallation(result.teamId);
+      return installationReturn(env, "workspace_required");
+    }
+    const metadata = {
+      accountId: state.accountId,
+      botUserId: result.installation.botUserId ?? null,
+      installedAt: Date.now(),
+      teamId: result.teamId,
+      teamName: result.installation.teamName?.trim() || result.teamId,
+    } satisfies SlackInstallationMetadata;
+    await writeInstallationMetadata(env, metadata, "PUT");
+    return installationReturn(env, "installed");
+  } catch (error) {
+    console.warn({
+      type: "chief_of_staff.slack_install_failed",
+      error_kind: error instanceof Error ? error.name : typeof error,
+    });
+    return installationReturn(env, "failed");
+  }
+}
+
+async function removeSlackInstallation(
+  request: Request,
+  env: Env,
+  teamId: string,
+): Promise<Response> {
+  if (!env.NANOCODEX_BACKEND) {
+    return json({ error: "managed_service_unavailable" }, { status: 503 });
+  }
+  const requester = await requestingAccountId(env.NANOCODEX_BACKEND, request);
+  if (!requester) return json({ error: "unauthorized" }, { status: 401 });
+  const metadata = await installationMetadata(env, teamId);
+  if (!metadata) return json({ error: "not_found" }, { status: 404 });
+  if (metadata.accountId !== requester || await configuredOwnerId(env) !== requester) {
+    return json({ error: "account_forbidden" }, { status: 403 });
+  }
+  const runtime = chiefRuntime(env);
+  await runtime.chat.initialize();
+  const installation = await runtime.slack.getInstallation(teamId);
+  if (installation && env.SLACK_CLIENT_ID && env.SLACK_CLIENT_SECRET) {
+    await runtime.slack.withBotToken(
+      installation.botToken,
+      () => runtime.slack.webClient.apps.uninstall({
+        client_id: env.SLACK_CLIENT_ID!,
+        client_secret: env.SLACK_CLIENT_SECRET!,
+      }),
+      { installationId: teamId },
+    );
+  }
+  await runtime.slack.deleteInstallation(teamId);
+  await writeInstallationMetadata(env, metadata, "DELETE");
+  return new Response(null, {
+    status: 204,
+    headers: { "cache-control": "no-store", "x-content-type-options": "nosniff" },
+  });
+}
+
 async function slackWebhook(
   request: Request,
   env: Env,
   context?: ExecutionContext,
 ): Promise<Response> {
   const config = configurationReadiness(env);
-  if (!config.configured || !env.SLACK_SIGNING_SECRET || !env.SLACK_TEAM_ID) {
+  if (!config.configured || !env.SLACK_SIGNING_SECRET) {
     return json({ error: "channel_not_configured" }, { status: 503 });
   }
   let payload: SlackWebhookPayload;
@@ -68,22 +197,36 @@ async function slackWebhook(
       headers: { "cache-control": "no-store", "x-content-type-options": "nosniff" },
     });
   }
-  if (!slackPayloadIsFenced(payload, env.SLACK_TEAM_ID)) {
+  if (payload.kind === "url_verification") {
+    return json({ challenge: payload.challenge });
+  }
+  const teamId = slackTeamId(payload);
+  const metadata = teamId ? await installationMetadata(env, teamId) : undefined;
+  if (!metadata || metadata.accountId !== await configuredOwnerId(env)) {
     return json({ error: "workspace_forbidden" }, { status: 403 });
   }
+  if (slackEventType(payload) === "app_uninstalled") {
+    const runtime = chiefRuntime(env);
+    await runtime.chat.initialize();
+    await runtime.slack.deleteInstallation(teamId!);
+    await writeInstallationMetadata(env, metadata, "DELETE");
+    return json({ ok: true });
+  }
   try {
-    const webhookRequest = request as unknown as Parameters<Chat["webhooks"]["slack"]>[0];
-    return await chiefChat(env).webhooks.slack(webhookRequest, {
-      waitUntil(task) {
-        const handled = task.catch((error) => {
-          console.warn({
-            type: "chief_of_staff.slack_delivery_failed",
-            error_kind: error instanceof Error ? error.name : typeof error,
+    return await chiefRuntime(env).chat.webhooks.slack(
+      request as unknown as Parameters<Chat["webhooks"]["slack"]>[0],
+      {
+        waitUntil(task) {
+          const handled = task.catch((error) => {
+            console.warn({
+              type: "chief_of_staff.slack_delivery_failed",
+              error_kind: error instanceof Error ? error.name : typeof error,
+            });
           });
-        });
-        if (context) context.waitUntil(handled);
+          if (context) context.waitUntil(handled);
+        },
       },
-    });
+    );
   } catch (error) {
     console.warn({
       type: "chief_of_staff.slack_webhook_failed",
@@ -93,19 +236,21 @@ async function slackWebhook(
   }
 }
 
-function chiefChat(env: Env): Chat {
-  const retained = chats.get(env as object);
+function chiefRuntime(env: Env): ChiefRuntime {
+  const retained = runtimes.get(env as object);
   if (retained) return retained;
-  const stateObject = env.CHIEF_OF_STAFF_STATE.getByName("chat-sdk:slack");
+  const stateObject = env.CHIEF_OF_STAFF_STATE.getByName(INSTALLATIONS_OBJECT);
   const slack = createSlackAdapter({
     agentView: true,
-    botToken: env.SLACK_BOT_TOKEN!,
-    botUserId: env.SLACK_BOT_USER_ID!,
+    apiUrl: env.SLACK_API_URL,
+    clientId: env.SLACK_CLIENT_ID,
+    clientSecret: env.SLACK_CLIENT_SECRET,
+    encryptionKey: env.SLACK_ENCRYPTION_KEY,
     logger: undefined,
     signingSecret: undefined,
     webhookVerifier: () => true,
   });
-  const bot = new Chat({
+  const chat = new Chat({
     adapters: { slack },
     concurrency: "concurrent",
     dedupeTtlMs: 24 * 60 * 60 * 1_000,
@@ -115,9 +260,12 @@ function chiefChat(env: Env): Chat {
   });
   const handle = async (thread: Thread, message: Message) => {
     await thread.subscribe();
-    const ownerId = await configuredOwnerId(env);
-    if (!ownerId) throw new Error("Configured Nanocodex account is unavailable");
-    const identity = slackMessageIdentity(message.raw, thread.id, thread.isDM, ownerId);
+    const teamId = messageTeamId(message.raw);
+    const metadata = teamId ? await installationMetadata(env, teamId) : undefined;
+    if (!metadata || metadata.accountId !== await configuredOwnerId(env)) {
+      throw new Error("Slack installation owner is unavailable");
+    }
+    const identity = slackMessageIdentity(message.raw, thread.id, thread.isDM, metadata.accountId);
     const routeDigest = await digest(identity.channel);
     const session = env.CHIEF_OF_STAFF_STATE.getByName(`conversation:${routeDigest}`);
     try {
@@ -138,11 +286,12 @@ function chiefChat(env: Env): Chat {
     if (typeof result.finalMessage !== "string") throw new Error("Chief of Staff turn was malformed");
     await thread.post(result.finalMessage);
   };
-  bot.onDirectMessage(handle);
-  bot.onNewMention(handle);
-  bot.onSubscribedMessage(handle);
-  chats.set(env as object, bot);
-  return bot;
+  chat.onDirectMessage(handle);
+  chat.onNewMention(handle);
+  chat.onSubscribedMessage(handle);
+  const runtime = { chat, slack };
+  runtimes.set(env as object, runtime);
+  return runtime;
 }
 
 async function readiness(request: Request, env: Env): Promise<Response> {
@@ -154,26 +303,36 @@ async function readiness(request: Request, env: Env): Promise<Response> {
   const config = configurationReadiness(env);
   const owner = config.configured ? await configuredOwnerId(env) : undefined;
   const accountMatch = owner === requester;
+  const installations = accountMatch
+    ? (await installationMetadataList(env))
+      .filter((installation) => installation.accountId === requester)
+      .map(({ accountId: _, ...installation }) => installation)
+    : [];
+  const ready = config.configured && accountMatch && installations.length > 0;
   const body: Readiness = {
     accountMatch,
-    configured: config.configured && accountMatch,
+    configured: ready,
+    installations,
+    installUrl: config.configured && accountMatch ? "/api/chief-of-staff/slack/install" : null,
     webhookUrl: config.webhookUrl,
     channels: [
       {
         id: "slack",
-        availability: config.configured && accountMatch ? "ready" : "setup_required",
+        availability: ready ? "ready" : "setup_required",
         contract: "first_party",
-        detail: config.configured
-          ? accountMatch
-            ? "Signed Slack events route to account-owned durable agents."
-            : "This deployment is bound to a different Nanocodex account."
-          : "Worker secrets, workspace identity, or public origin are incomplete.",
+        detail: ready
+          ? `${installations.length} Slack workspace${installations.length === 1 ? "" : "s"} route bot events to account-owned durable agents.`
+          : config.configured
+            ? accountMatch
+              ? "Install the Chief of Staff bot into a Slack workspace."
+              : "This deployment is bound to a different Nanocodex account."
+            : "The shared Slack app is not configured by the deployment operator.",
       },
       {
         id: "whatsapp",
         availability: "not_enabled",
         contract: "first_party",
-        detail: "The current SDK adapter is supported, but this first deployment does not claim a configured Meta webhook.",
+        detail: "The current SDK adapter is supported, but this deployment does not claim a configured Meta webhook.",
       },
       {
         id: "imessage",
@@ -186,6 +345,46 @@ async function readiness(request: Request, env: Env): Promise<Response> {
   return json(body);
 }
 
+async function installationMetadataList(env: Env): Promise<SlackInstallationMetadata[]> {
+  const response = await installationsObject(env).fetch(
+    new Request("https://state.internal/slack/installations"),
+  );
+  if (!response.ok) throw new Error("Slack installation metadata is unavailable");
+  const body: unknown = await response.json();
+  if (!isRecord(body) || !Array.isArray(body.installations)) {
+    throw new Error("Slack installation metadata is malformed");
+  }
+  return body.installations.filter(validSlackInstallationMetadata);
+}
+
+async function installationMetadata(
+  env: Env,
+  teamId: string,
+): Promise<SlackInstallationMetadata | undefined> {
+  return (await installationMetadataList(env)).find((installation) => installation.teamId === teamId);
+}
+
+async function writeInstallationMetadata(
+  env: Env,
+  metadata: SlackInstallationMetadata,
+  method: "DELETE" | "PUT",
+): Promise<void> {
+  const response = await installationsObject(env).fetch(new Request(
+    "https://state.internal/slack/installations",
+    {
+      body: JSON.stringify(metadata),
+      headers: { "content-type": "application/json" },
+      method,
+    },
+  ));
+  if (!response.ok) throw new Error("Slack installation metadata update failed");
+  await response.body?.cancel();
+}
+
+function installationsObject(env: Env): Fetcher {
+  return env.CHIEF_OF_STAFF_STATE.getByName(INSTALLATIONS_OBJECT);
+}
+
 function configuredOwnerId(env: Env): Promise<string | undefined> {
   const retained = ownerIds.get(env as object);
   if (retained) return retained;
@@ -194,6 +393,32 @@ function configuredOwnerId(env: Env): Promise<string | undefined> {
     : Promise.resolve(undefined);
   ownerIds.set(env as object, loading);
   return loading;
+}
+
+function installationReturn(env: Env, result: string): Response {
+  let origin: URL;
+  try { origin = new URL(env.CHIEF_OF_STAFF_ACCOUNT_ORIGIN ?? ""); }
+  catch { return json({ error: `slack_install_${result}` }, { status: result === "installed" ? 200 : 400 }); }
+  if (origin.protocol !== "https:" || origin.pathname !== "/" || origin.search || origin.hash) {
+    return json({ error: `slack_install_${result}` }, { status: result === "installed" ? 200 : 400 });
+  }
+  const target = new URL("/demos/chief-of-staff", origin);
+  target.searchParams.set("slack", result);
+  return new Response(null, {
+    status: 303,
+    headers: { "cache-control": "no-store", location: target.href },
+  });
+}
+
+function messageTeamId(raw: unknown): string | undefined {
+  if (!isRecord(raw)) return undefined;
+  const value = raw.team_id ?? raw.team;
+  return typeof value === "string" && SLACK_TEAM_ID.test(value) ? value : undefined;
+}
+
+function slackEventType(payload: SlackWebhookPayload): string | undefined {
+  if (!isRecord(payload.raw) || !isRecord(payload.raw.event)) return undefined;
+  return typeof payload.raw.event.type === "string" ? payload.raw.event.type : undefined;
 }
 
 function methodNotAllowed(methods: readonly string[]): Response {
@@ -212,4 +437,8 @@ function json(body: unknown, init: ResponseInit = {}): Response {
       ...init.headers,
     },
   });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/js/chief-of-staff/test/slack-oauth.test.ts
+++ b/js/chief-of-staff/test/slack-oauth.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  SLACK_BOT_SCOPES,
+  slackAuthorizationUrl,
+  verifySlackInstallState,
+} from "../src/slack-oauth.ts";
+
+const accountId = "00000000-0000-4000-8000-000000000001";
+const stateSecret = Buffer.alloc(32, 11).toString("base64url");
+
+test("one-click Slack authorization requests only bot scopes and binds the callback", async () => {
+  const now = 1_800_000_000_000;
+  const authorization = await slackAuthorizationUrl({
+    accountId,
+    clientId: "123.456",
+    redirectUri: "https://chief.example/v1/slack/callback",
+    stateSecret,
+    now,
+  });
+
+  assert.equal(authorization.origin, "https://slack.com");
+  assert.equal(authorization.pathname, "/oauth/v2/authorize");
+  assert.equal(authorization.searchParams.get("client_id"), "123.456");
+  assert.equal(authorization.searchParams.get("scope"), SLACK_BOT_SCOPES.join(","));
+  assert.equal(
+    authorization.searchParams.get("redirect_uri"),
+    "https://chief.example/v1/slack/callback",
+  );
+  assert.equal(
+    (await verifySlackInstallState(authorization.searchParams.get("state")!, stateSecret, now))?.accountId,
+    accountId,
+  );
+});
+
+test("Slack install state rejects tampering, expiration, and the wrong signing key", async () => {
+  const now = 1_800_000_000_000;
+  const authorization = await slackAuthorizationUrl({
+    accountId,
+    clientId: "123.456",
+    redirectUri: "https://chief.example/v1/slack/callback",
+    stateSecret,
+    now,
+  });
+  const state = authorization.searchParams.get("state")!;
+
+  assert.equal(await verifySlackInstallState(`${state}x`, stateSecret, now), undefined);
+  assert.equal(
+    await verifySlackInstallState(state, Buffer.alloc(32, 12).toString("base64url"), now),
+    undefined,
+  );
+  assert.equal(await verifySlackInstallState(state, stateSecret, now + 10 * 60 * 1_000 + 1), undefined);
+});

--- a/js/chief-of-staff/test/webhook.test.ts
+++ b/js/chief-of-staff/test/webhook.test.ts
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
+import { createServer } from "node:http";
 import test from "node:test";
 import worker, { type Env } from "../src/worker.ts";
 
 const signingSecret = "test-signing-secret-which-is-not-real";
+const accountId = "00000000-0000-4000-8000-000000000001";
+const key = Buffer.alloc(32, 7).toString("base64url");
 
 test("Slack URL verification requires a valid, fresh signature", async () => {
   const body = JSON.stringify({
@@ -57,14 +60,111 @@ test("signed events from a different Slack workspace are fenced before routing",
   assert.deepEqual(await response.json(), { error: "workspace_forbidden" });
 });
 
-test("readiness reports capabilities without returning provider credentials", async () => {
-  const configured = env();
+test("the authenticated owner gets a one-click Slack bot authorization redirect", async () => {
+  const response = await worker.fetch(new Request("https://chief.example/v1/slack/install", {
+    headers: {
+      cookie: "nanocodex_account=opaque",
+      origin: "https://nanocodex.example",
+    },
+  }), env());
+
+  assert.equal(response.status, 302);
+  const location = new URL(response.headers.get("location")!);
+  assert.equal(location.origin, "https://slack.com");
+  assert.equal(location.pathname, "/oauth/v2/authorize");
+  assert.equal(location.searchParams.has("user_scope"), false);
+  assert.equal(
+    location.searchParams.get("redirect_uri"),
+    "https://chief.example/v1/slack/callback",
+  );
+});
+
+test("the Slack callback stores an encrypted bot installation and returns to the account", async () => {
+  const fixture = statefulEnv();
+  const start = await worker.fetch(new Request("https://chief.example/v1/slack/install"), fixture.env);
+  const state = new URL(start.headers.get("location")!).searchParams.get("state")!;
+  const slack = createServer((request, response) => {
+    if (request.url === "/api/oauth.v2.access") {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({
+        access_token: "xoxb-workspace-secret",
+        app_id: "A123ABC",
+        bot_user_id: "U123ABC",
+        ok: true,
+        scope: "chat:write",
+        team: { id: "T123ABC", name: "Acme" },
+        token_type: "bot",
+      }));
+      return;
+    }
+    response.statusCode = 404;
+    response.end();
+  });
+  await new Promise<void>((resolve) => slack.listen(0, "127.0.0.1", resolve));
+  const address = slack.address();
+  if (!address || typeof address === "string") throw new Error("Slack fixture did not bind");
+  fixture.env.SLACK_API_URL = `http://127.0.0.1:${address.port}/api/`;
+  try {
+    const callback = await worker.fetch(new Request(
+      `https://chief.example/v1/slack/callback?code=oauth-code&state=${encodeURIComponent(state)}`,
+    ), fixture.env);
+    assert.equal(callback.status, 303);
+    assert.equal(
+      callback.headers.get("location"),
+      "https://nanocodex.example/demos/chief-of-staff?slack=installed",
+    );
+    assert.deepEqual([...fixture.metadata.values()].map(({ accountId: _, ...value }) => value), [{
+      botUserId: "U123ABC",
+      installedAt: [...fixture.metadata.values()][0]!.installedAt,
+      teamId: "T123ABC",
+      teamName: "Acme",
+    }]);
+    assert.equal(JSON.stringify([...fixture.values.values()]).includes("xoxb-workspace-secret"), false);
+  } finally {
+    await new Promise<void>((resolve, reject) => slack.close((error) => error ? reject(error) : resolve()));
+  }
+});
+
+test("Slack app_uninstalled removes the bot installation without touching the user connector", async () => {
+  const fixture = statefulEnv();
+  fixture.metadata.set("T123ABC", {
+    accountId,
+    botUserId: "U123ABC",
+    installedAt: 1,
+    teamId: "T123ABC",
+    teamName: "Acme",
+  });
+  fixture.values.set("slack:installation:T123ABC", { botToken: "encrypted-token" });
+  const body = JSON.stringify({
+    event: { type: "app_uninstalled" },
+    event_id: "Ev123ABC",
+    event_time: 1700000000,
+    team_id: "T123ABC",
+    type: "event_callback",
+  });
+  const timestamp = Math.floor(Date.now() / 1_000).toString();
+
+  const response = await worker.fetch(
+    slackRequest(body, timestamp, await signature(timestamp, body)),
+    fixture.env,
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(fixture.metadata.size, 0);
+  assert.equal(fixture.values.has("slack:installation:T123ABC"), false);
+});
+
+test("readiness reports bot installations without returning provider credentials", async () => {
+  const configured = env([{
+    accountId,
+    botUserId: "U123ABC",
+    installedAt: 1,
+    teamId: "T123ABC",
+    teamName: "Acme",
+  }]);
   configured.NANOCODEX_BACKEND = {
-    async fetch(request) {
-      const authorization = request.headers.get("authorization");
-      return Response.json({ user: { id: authorization?.startsWith("Bearer ncx_live_")
-        ? "account-a"
-        : "account-a" } });
+    async fetch() {
+      return Response.json({ user: { id: accountId } });
     },
   };
   const response = await worker.fetch(new Request("https://chief.example/v1/readiness", {
@@ -73,9 +173,19 @@ test("readiness reports capabilities without returning provider credentials", as
   const serialized = await response.text();
 
   assert.equal(response.status, 200);
-  assert.equal(serialized.includes(configured.SLACK_BOT_TOKEN!), false);
+  assert.equal(serialized.includes(configured.SLACK_CLIENT_SECRET!), false);
+  assert.equal(serialized.includes(configured.SLACK_ENCRYPTION_KEY!), false);
   assert.equal(serialized.includes(configured.SLACK_SIGNING_SECRET!), false);
-  const readiness = JSON.parse(serialized) as { channels: { id: string; availability: string }[] };
+  const readiness = JSON.parse(serialized) as {
+    channels: { id: string; availability: string }[];
+    installations: { teamId: string; teamName: string }[];
+  };
+  assert.deepEqual(readiness.installations, [{
+    botUserId: "U123ABC",
+    installedAt: 1,
+    teamId: "T123ABC",
+    teamName: "Acme",
+  }]);
   assert.deepEqual(readiness.channels.map(({ id, availability }) => ({ id, availability })), [
     { id: "slack", availability: "ready" },
     { id: "whatsapp", availability: "not_enabled" },
@@ -83,21 +193,86 @@ test("readiness reports capabilities without returning provider credentials", as
   ]);
 });
 
-function env(): Env {
+function env(installations: readonly unknown[] = [{
+  accountId,
+  botUserId: "U123ABC",
+  installedAt: 1,
+  teamId: "T123ABC",
+  teamName: "Acme",
+}]): Env {
   return {
+    CHIEF_OF_STAFF_ACCOUNT_ORIGIN: "https://nanocodex.example",
     CHIEF_OF_STAFF_PUBLIC_ORIGIN: "https://chief.example",
     CHIEF_OF_STAFF_STATE: {
       getByName() {
-        return { async fetch() { return Response.json({ value: null }); } };
+        return {
+          async fetch(request) {
+            const url = new URL(request.url);
+            if (url.pathname === "/slack/installations" && request.method === "GET") {
+              return Response.json({ installations });
+            }
+            return Response.json({ value: null });
+          },
+        };
       },
     },
     NANOCODEX_API_KEY: `ncx_live_${"a".repeat(12)}_${"b".repeat(43)}`,
-    NANOCODEX_BACKEND: { async fetch() { return Response.json({ user: { id: "account-a" } }); } },
-    SLACK_BOT_TOKEN: "xoxb-test-token",
-    SLACK_BOT_USER_ID: "U123ABC",
+    NANOCODEX_BACKEND: { async fetch() { return Response.json({ user: { id: accountId } }); } },
+    SLACK_CLIENT_ID: "123.456",
+    SLACK_CLIENT_SECRET: "test-client-secret",
+    SLACK_ENCRYPTION_KEY: key,
+    SLACK_OAUTH_STATE_SECRET: key,
     SLACK_SIGNING_SECRET: signingSecret,
-    SLACK_TEAM_ID: "T123ABC",
   };
+}
+
+function statefulEnv(): {
+  env: Env;
+  metadata: Map<string, {
+    accountId: string;
+    botUserId: string | null;
+    installedAt: number;
+    teamId: string;
+    teamName: string;
+  }>;
+  values: Map<string, unknown>;
+} {
+  const metadata = new Map();
+  const values = new Map<string, unknown>();
+  const configured = env([]);
+  configured.CHIEF_OF_STAFF_STATE = {
+    getByName() {
+      return {
+        async fetch(request) {
+          const url = new URL(request.url);
+          if (url.pathname === "/slack/installations") {
+            if (request.method === "GET") {
+              return Response.json({ installations: [...metadata.values()] });
+            }
+            const body = await request.json<{
+              accountId: string;
+              botUserId: string | null;
+              installedAt: number;
+              teamId: string;
+              teamName: string;
+            }>();
+            if (request.method === "PUT") metadata.set(body.teamId, body);
+            if (request.method === "DELETE") metadata.delete(body.teamId);
+            return new Response(null, { status: 204 });
+          }
+          if (url.pathname === "/chat-sdk") {
+            const body = await request.json<{ key?: string; operation: string; value?: unknown }>();
+            if (body.operation === "get") return Response.json({ value: values.get(body.key!) ?? null });
+            if (body.operation === "set") values.set(body.key!, body.value);
+            if (body.operation === "delete") values.delete(body.key!);
+            return Response.json({ value: null });
+          }
+          return Response.json({ error: "not_found" }, { status: 404 });
+        },
+      };
+    },
+  };
+  return { env: configured, metadata, values };
 }
 
 function slackRequest(body: string, timestamp: string, signed: string): Request {

--- a/js/chief-of-staff/wrangler.jsonc
+++ b/js/chief-of-staff/wrangler.jsonc
@@ -41,6 +41,7 @@
     }
   ],
   "vars": {
+    "CHIEF_OF_STAFF_ACCOUNT_ORIGIN": "https://nanocodex.gakonst.workers.dev",
     "CHIEF_OF_STAFF_PUBLIC_ORIGIN": "https://nanocodex-chief-of-staff.gakonst.workers.dev"
   },
   "env": {
@@ -62,6 +63,7 @@
         ]
       },
       "vars": {
+        "CHIEF_OF_STAFF_ACCOUNT_ORIGIN": "https://nanocodex.gakonst.workers.dev",
         "CHIEF_OF_STAFF_PUBLIC_ORIGIN": "https://nanocodex-chief-of-staff.gakonst.workers.dev"
       }
     }


### PR DESCRIPTION
## What changed

- turn the Chief of Staff Slack surface into a distributable workspace-installed AI bot, separate from the user-token Slack connector
- add a one-click **Add to Slack** OAuth flow with signed, expiring account-bound state and an exact callback
- use Chat SDK multi-workspace installations with AES-256-GCM encrypted bot tokens in Durable Object state
- route signed Slack events only for installed workspaces and preserve account/workspace/conversation isolation
- add per-workspace status and uninstall controls, including cleanup on Slack `app_uninstalled`
- add the deployable Slack app manifest and replace the manual bot-token/webhook setup instructions

The existing `slack:<workspace>` connector and its user OAuth scopes/tokens are untouched.

## Verification

- `pnpm --filter @nanocodex/chief-of-staff typecheck`
- `pnpm --filter @nanocodex/chief-of-staff test` (12 passing)
- `node --experimental-strip-types --test js/account/worker/chiefOfStaffProxy.test.ts` (3 passing)
- `git diff --check`
