### PR TITLE
feat(chief-of-staff): add WhatsApp assistant

### DIFF
--- a/js/account/src/ChiefOfStaffDemo.css
+++ b/js/account/src/ChiefOfStaffDemo.css
@@ -25,7 +25,7 @@
 .chief-channel header span { font-size: 15px; }
 .chief-channel header small { color: var(--text-muted); font-size: 8px; text-transform: uppercase; }
 .chief-channel header strong { padding: 4px 6px; color: var(--text-muted); border: 1px solid var(--border-soft); font-size: 8px; font-weight: 400; text-transform: uppercase; white-space: nowrap; }
-.chief-channel.is-ready header strong { color: var(--positive); border-color: color-mix(in srgb, var(--positive) 40%, var(--border-soft)); }
+.chief-channel.is-ready header strong, .chief-channel.is-configured header strong { color: var(--positive); border-color: color-mix(in srgb, var(--positive) 40%, var(--border-soft)); }
 .chief-channel p { min-height: 52px; color: var(--text-muted); font-size: 10px; line-height: 1.65; }
 .chief-channel a { display: inline-flex; gap: 6px; align-items: center; width: fit-content; color: var(--text); font-size: 9px; text-decoration: none; }
 .chief-channel a:hover { text-decoration: underline; }

--- a/js/account/src/ChiefOfStaffDemo.tsx
+++ b/js/account/src/ChiefOfStaffDemo.tsx
@@ -1,10 +1,10 @@
-import { Bot, Check, Copy, ExternalLink, Plus, RefreshCw, Trash2 } from "lucide-react";
+import { Bot, Check, Copy, ExternalLink, MessageCircle, Plus, RefreshCw, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useAccountSession } from "./AccountSession";
 import "./ChiefOfStaffDemo.css";
 
 type Channel = Readonly<{
-  availability: "ready" | "setup_required" | "not_enabled";
+  availability: "ready" | "configured" | "setup_required" | "not_enabled";
   contract: "first_party" | "vendor_official";
   detail: string;
   id: "slack" | "whatsapp" | "imessage" | "viber";
@@ -28,7 +28,7 @@ type Readiness = Readonly<{
 const labels = { slack: "Slack", whatsapp: "WhatsApp", imessage: "iMessage", viber: "Viber" } as const;
 const docs = {
   slack: "https://chat-sdk.dev/adapters/slack",
-  whatsapp: "https://chat-sdk.dev/adapters/whatsapp",
+  whatsapp: "https://chat-sdk.dev/adapters/official/whatsapp",
   imessage: "https://chat-sdk.dev/adapters/photon",
   viber: "https://developers.viber.com/docs/api/rest-bot-api/",
 } as const;
@@ -91,7 +91,10 @@ export function ChiefOfStaffDemo() {
   }, []);
 
   const viber = readiness?.channels.find((channel) => channel.id === "viber");
-  const readyChannels = readiness?.channels.filter((channel) => channel.availability === "ready") ?? [];
+  const whatsapp = readiness?.channels.find((channel) => channel.id === "whatsapp");
+  const activeChannels = readiness?.channels.filter((channel) =>
+    channel.availability === "ready" || channel.availability === "configured"
+  ) ?? [];
 
   return (
     <article className="chief-demo page-grid">
@@ -99,14 +102,14 @@ export function ChiefOfStaffDemo() {
         <p className="eyebrow">Demos · Chat SDK integration</p>
         <h1>Chief of Staff</h1>
         <p>
-          Install a durable Nanocodex agent as its own messaging identity. Slack provides a
-          workspace AI teammate; Viber provides a branded chatbot. Every workspace, subscriber,
-          and conversation stays on its own route.
+          Install a durable Nanocodex agent as its own messaging identity across Slack,
+          WhatsApp, and Viber. Every workspace, phone, subscriber, and conversation stays on
+          its own isolated route.
         </p>
         <div className="chief-hero-status" aria-live="polite">
           <span className={`chief-status-dot${readiness?.configured ? " is-ready" : ""}`} />
-          <span>{loading ? "Checking deployment" : readyChannels.length > 0
-            ? `${readyChannels.map((channel) => labels[channel.id]).join(" + ")} ready`
+          <span>{loading ? "Checking deployment" : activeChannels.length > 0
+            ? `${activeChannels.map((channel) => labels[channel.id]).join(" + ")} configured`
             : "Messaging setup required"}</span>
           <button type="button" onClick={() => void refresh()} disabled={loading}>
             <RefreshCw aria-hidden="true" /> Refresh
@@ -128,6 +131,7 @@ export function ChiefOfStaffDemo() {
                 <small>{channel.contract === "first_party" ? "First-party adapter" : "Vendor adapter"}</small>
               </div>
               <strong>{channel.availability === "ready" ? "Ready"
+                : channel.availability === "configured" ? "Configured"
                 : channel.availability === "setup_required" ? "Setup required" : "Not enabled"}</strong>
             </header>
             <p>{channel.detail}</p>
@@ -204,13 +208,62 @@ export function ChiefOfStaffDemo() {
           isolated durable agent session, with replay-safe outbound delivery.
         </p>
       </section>
+
+      <section className="chief-setup" aria-labelledby="chief-whatsapp-title">
+        <header>
+          <div>
+            <p className="eyebrow">WhatsApp Cloud API</p>
+            <h2 id="chief-whatsapp-title">Connect Chief of Staff to WhatsApp</h2>
+          </div>
+          <MessageCircle aria-hidden="true" />
+        </header>
+        <div className="chief-install-action">
+          <div>
+            <strong>One business number, one durable assistant</strong>
+            <p>Meta verifies the callback and signs every inbound message. Access tokens and app secrets stay inside the integration Worker.</p>
+          </div>
+          <span className="chief-install-unavailable">
+            {whatsapp?.availability === "configured"
+              ? "Worker configured"
+              : "Operator setup required"}
+          </span>
+        </div>
+        <ol>
+          <li>
+            <span>01</span>
+            <div>
+              <strong>Add WhatsApp to the Meta business app</strong>
+              <p>Use a permanent System User access token for the production business phone number.</p>
+            </div>
+          </li>
+          <li>
+            <span>02</span>
+            <div>
+              <strong>Configure the callback</strong>
+              <p>Use the callback below and the same verify token configured as the Worker secret.</p>
+              <code>{whatsapp?.webhookUrl ?? "WhatsApp callback unavailable"}</code>
+            </div>
+          </li>
+          <li>
+            <span>03</span>
+            <div>
+              <strong>Subscribe message events</strong>
+              <p>Subscribe the webhook to <code>messages</code> and <code>user_id_update</code>, then send the business number a message.</p>
+            </div>
+          </li>
+        </ol>
+        <p className="chief-secret-note">
+          The assistant replies inside WhatsApp’s customer-service window. Business-initiated
+          conversations outside that window require a separately approved Meta template.
+        </p>
+      </section>
     </article>
   );
 }
 
 const fallbackChannels: readonly Channel[] = [
   { id: "slack", availability: "setup_required", contract: "first_party", detail: "Readiness has not been confirmed by the integration Worker." },
-  { id: "whatsapp", availability: "not_enabled", contract: "first_party", detail: "The SDK contract exists, but this deployment does not claim a configured Meta webhook." },
+  { id: "whatsapp", availability: "setup_required", contract: "first_party", detail: "Add the Meta app credentials and subscribe the shared webhook to enable WhatsApp." },
   { id: "imessage", availability: "not_enabled", contract: "vendor_official", detail: "Chat SDK catalogs vendor adapters; no iMessage provider is connected here." },
   { id: "viber", availability: "setup_required", contract: "first_party", detail: "Connect a commercial Viber chatbot to enable signed inbound messages and durable replies." },
 ];

--- a/js/chief-of-staff/README.md
+++ b/js/chief-of-staff/README.md
@@ -1,10 +1,10 @@
 # Nanocodex Chief of Staff
 
 An independently deployable [Vercel Chat SDK](https://chat-sdk.dev/) Worker. The
-Chief of Staff is a Slack AI bot installed into a workspace, like Devin. It is
-not the Nanocodex Slack connector: the connector authorizes actions as a human
-user, while this app has its own bot identity, OAuth installation, scopes,
-tokens, event ingress, and lifecycle.
+Chief of Staff is a Slack, WhatsApp, and Viber AI assistant backed by durable
+Nanocodex agents. It is not the Nanocodex Slack connector: the connector
+authorizes actions as a human user, while these channels have their own
+bot/business identity, credentials, signed event ingress, and lifecycle.
 
 An authenticated Nanocodex user selects **Add to Slack** once. Slack presents the
 workspace approval and returns to the account app. The Worker exchanges the code,
@@ -12,7 +12,7 @@ encrypts the workspace bot token in Durable Object state, records the workspace
 installation, and immediately accepts signed mentions and DMs. Users never copy a
 token or configure a webhook.
 
-Each account/workspace/conversation maps to a retained managed Nanocodex agent.
+Each account/channel/conversation maps to a retained managed Nanocodex agent.
 The account app receives only non-secret installation and readiness metadata
 through a service binding.
 
@@ -41,12 +41,12 @@ Configure the deployment once. `SLACK_ENCRYPTION_KEY` and
 `SLACK_OAUTH_STATE_SECRET` are independent base64url-encoded 32-byte keys.
 
 ```sh
-pnpm exec wrangler secret put NANOCODEX_API_KEY --config js/chief-of-staff/wrangler.jsonc
-pnpm exec wrangler secret put SLACK_CLIENT_ID --config js/chief-of-staff/wrangler.jsonc
-pnpm exec wrangler secret put SLACK_CLIENT_SECRET --config js/chief-of-staff/wrangler.jsonc
-pnpm exec wrangler secret put SLACK_SIGNING_SECRET --config js/chief-of-staff/wrangler.jsonc
-pnpm exec wrangler secret put SLACK_ENCRYPTION_KEY --config js/chief-of-staff/wrangler.jsonc
-pnpm exec wrangler secret put SLACK_OAUTH_STATE_SECRET --config js/chief-of-staff/wrangler.jsonc
+pnpm --filter @nanocodex/chief-of-staff exec wrangler secret put NANOCODEX_API_KEY --config wrangler.jsonc
+pnpm --filter @nanocodex/chief-of-staff exec wrangler secret put SLACK_CLIENT_ID --config wrangler.jsonc
+pnpm --filter @nanocodex/chief-of-staff exec wrangler secret put SLACK_CLIENT_SECRET --config wrangler.jsonc
+pnpm --filter @nanocodex/chief-of-staff exec wrangler secret put SLACK_SIGNING_SECRET --config wrangler.jsonc
+pnpm --filter @nanocodex/chief-of-staff exec wrangler secret put SLACK_ENCRYPTION_KEY --config wrangler.jsonc
+pnpm --filter @nanocodex/chief-of-staff exec wrangler secret put SLACK_OAUTH_STATE_SECRET --config wrangler.jsonc
 ```
 
 ## Configure Viber
@@ -55,11 +55,11 @@ Provision a commercial chatbot directly with Rakuten Viber or an official messag
 partner. Copy the bot token, display name, and stable bot URI into Worker secrets:
 
 ```sh
-pnpm exec wrangler secret put VIBER_AUTH_TOKEN --config js/chief-of-staff/wrangler.jsonc
-pnpm exec wrangler secret put VIBER_BOT_NAME --config js/chief-of-staff/wrangler.jsonc
-pnpm exec wrangler secret put VIBER_BOT_URI --config js/chief-of-staff/wrangler.jsonc
+pnpm --filter @nanocodex/chief-of-staff exec wrangler secret put VIBER_AUTH_TOKEN --config wrangler.jsonc
+pnpm --filter @nanocodex/chief-of-staff exec wrangler secret put VIBER_BOT_NAME --config wrangler.jsonc
+pnpm --filter @nanocodex/chief-of-staff exec wrangler secret put VIBER_BOT_URI --config wrangler.jsonc
 # Optional
-pnpm exec wrangler secret put VIBER_BOT_AVATAR --config js/chief-of-staff/wrangler.jsonc
+pnpm --filter @nanocodex/chief-of-staff exec wrangler secret put VIBER_BOT_AVATAR --config wrangler.jsonc
 ```
 
 `VIBER_BOT_NAME` must be at most 28 characters. `VIBER_BOT_URI` is the stable URI
@@ -80,6 +80,36 @@ callback; expired claims are recoverable after an interrupted send.
 OAuth installations are accepted only when initiated by that signed-in owner.
 Set both public origins in Wrangler when deploying under other names or domains.
 
+## Configure WhatsApp
+
+Follow the official [WhatsApp adapter guide](https://chat-sdk.dev/adapters/official/whatsapp)
+to add WhatsApp to a Meta business app and connect its production business phone
+number. Configure this callback URL and use the same verify token stored in the
+Worker:
+
+```text
+Callback: https://nanocodex-chief-of-staff.gakonst.workers.dev/webhooks/whatsapp
+Webhook fields: messages, user_id_update
+```
+
+Use a permanent System User token in production. Keep the access token, app
+secret, and verify token as Worker secrets. The business phone ID is a
+non-secret routing identifier, but this deployment also stores it out of band;
+none of these values belong in the account app or browser environment.
+
+```sh
+pnpm --filter @nanocodex/chief-of-staff exec wrangler secret put WHATSAPP_ACCESS_TOKEN --config wrangler.jsonc
+pnpm --filter @nanocodex/chief-of-staff exec wrangler secret put WHATSAPP_APP_SECRET --config wrangler.jsonc
+pnpm --filter @nanocodex/chief-of-staff exec wrangler secret put WHATSAPP_PHONE_NUMBER_ID --config wrangler.jsonc
+pnpm --filter @nanocodex/chief-of-staff exec wrangler secret put WHATSAPP_VERIFY_TOKEN --config wrangler.jsonc
+```
+
+Meta verifies `GET /webhooks/whatsapp` with the verify token. The official
+adapter verifies `X-Hub-Signature-256` on every POST before the message can reach
+an account-owned agent. Reactive replies are sent inside WhatsApp's 24-hour
+customer-service window; initiating a later conversation requires an approved
+message template.
+
 Deploy the managed service first, then this Worker, and the account application:
 
 ```sh
@@ -90,17 +120,18 @@ pnpm deploy:account
 
 ## Capability boundary
 
-- Chief of Staff: workspace-installed Slack app; bot token and bot scopes; reacts
-  to bot DMs, mentions, and subscribed threads.
+- Chief of Staff on Slack: workspace-installed app; bot token and bot scopes;
+  reacts to bot DMs, mentions, and subscribed threads.
+- Chief of Staff on WhatsApp: Meta Cloud API business number; signed DMs and
+  media placeholders; replies to the exact canonical WhatsApp user route.
 - Slack connector: separately authorized user token; acts on behalf of the human
   in only the exact workspaces granted through Connect.
 - Viber: official Bot REST API; branded bot identity; each subscriber receives an
   isolated durable conversation.
-- WhatsApp has a first-party Chat SDK adapter, but this deployment does not expose
-  or claim a Meta webhook yet.
 - iMessage is listed by Chat SDK through vendor adapters, not a first-party adapter;
   this deployment does not configure one.
 
-Run `pnpm --filter @nanocodex/chief-of-staff check` for OAuth state, Slack and Viber
-signatures, workspace fencing, idempotency, cross-account/channel isolation,
-durable two-turn, type, and dry-run deployment coverage.
+Run `pnpm --filter @nanocodex/chief-of-staff check` for OAuth state, Slack,
+WhatsApp, and Viber signatures, workspace fencing, idempotency,
+cross-account/channel isolation, durable two-turn, type, and dry-run deployment
+coverage.

--- a/js/chief-of-staff/package.json
+++ b/js/chief-of-staff/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@chat-adapter/slack": "4.39.0",
+    "@chat-adapter/whatsapp": "4.39.0",
     "chat": "4.39.0",
     "nanocodex": "workspace:*",
     "nanocodex-tools": "workspace:*"

--- a/js/chief-of-staff/src/conversation.ts
+++ b/js/chief-of-staff/src/conversation.ts
@@ -3,6 +3,9 @@ import { digest, sameChannelIdentity, type ChannelIdentity } from "./protocol.ts
 const MAX_INPUT_CHARS = 120_000;
 const MAX_SLACK_REPLY_CHARS = 35_000;
 const MAX_VIBER_REPLY_CHARS = 7_000;
+const MAX_WHATSAPP_REPLY_CHARS = 35_000;
+const WHATSAPP_USER_ID = /^(?:[0-9]{5,32}|[A-Z]{2}\.(?:ENT\.)?[A-Za-z0-9]{1,128})$/;
+const WHATSAPP_MESSAGE_ID = /^[A-Za-z0-9._=-]{1,512}$/;
 
 export interface ConversationStore {
   bindIdentity(identity: ChannelIdentity): Promise<boolean>;
@@ -141,18 +144,32 @@ function validateTurn(request: ConversationTurnRequest): void {
     if (!/^[0-9]+\.[0-9]+$/.test(request.messageId)) {
       throw new ConversationError(400, "invalid_message");
     }
-  } else {
+    return;
+  }
+  if (request.channel.platform === "viber") {
     if (request.actorId !== request.channel.userId) {
       throw new ConversationError(400, "invalid_actor");
     }
     if (!/^[0-9]+$/.test(request.messageId)) {
       throw new ConversationError(400, "invalid_message");
     }
+    return;
+  }
+  if (!WHATSAPP_USER_ID.test(request.actorId)
+    || request.actorId !== request.channel.userId) {
+    throw new ConversationError(400, "invalid_actor");
+  }
+  if (!WHATSAPP_MESSAGE_ID.test(request.messageId)) {
+    throw new ConversationError(400, "invalid_message");
   }
 }
 
 function chiefOfStaffPrompt(request: ConversationTurnRequest): string {
-  const platform = request.channel.platform === "slack" ? "Slack" : "Viber";
+  const platform = request.channel.platform === "slack"
+    ? "Slack"
+    : request.channel.platform === "viber"
+      ? "Viber"
+      : "WhatsApp";
   return [
     `You are the user's Chief of Staff in ${platform}.`,
     "Be concise, action-oriented, and explicit about uncertainty.",
@@ -165,8 +182,13 @@ function chiefOfStaffPrompt(request: ConversationTurnRequest): string {
 
 function normalizeReply(value: string, platform: ChannelIdentity["platform"]): string {
   const reply = value.trim() || "I completed the turn, but it did not produce a text response.";
-  const maxChars = platform === "slack" ? MAX_SLACK_REPLY_CHARS : MAX_VIBER_REPLY_CHARS;
+  const maxChars = platform === "viber"
+    ? MAX_VIBER_REPLY_CHARS
+    : platform === "whatsapp"
+      ? MAX_WHATSAPP_REPLY_CHARS
+      : MAX_SLACK_REPLY_CHARS;
   if (reply.length <= maxChars) return reply;
-  const suffix = `\n\n[Response truncated for ${platform === "slack" ? "Slack" : "Viber"}]`;
+  const platformName = platform === "slack" ? "Slack" : platform === "viber" ? "Viber" : "WhatsApp";
+  const suffix = `\n\n[Response truncated for ${platformName}]`;
   return `${reply.slice(0, maxChars - suffix.length)}${suffix}`;
 }

--- a/js/chief-of-staff/src/protocol.ts
+++ b/js/chief-of-staff/src/protocol.ts
@@ -7,14 +7,20 @@ const SLACK_THREAD_ID = /^slack:[CDG][A-Z0-9]+:(?:[0-9]+\.[0-9]+)?$/;
 const API_KEY = /^ncx_live_[A-Za-z0-9_-]{12}_[A-Za-z0-9_-]{43}$/;
 const SLACK_CLIENT_ID = /^[0-9]+\.[0-9]+$/;
 const BASE64_URL = /^[A-Za-z0-9_-]+$/;
+const WHATSAPP_PHONE_NUMBER_ID = /^[0-9]{5,32}$/;
+const WHATSAPP_PHONE_USER_ID = /^[0-9]{5,32}$/;
+const WHATSAPP_BUSINESS_USER_ID = /^[A-Z]{2}\.(?:ENT\.)?[A-Za-z0-9]{1,128}$/;
+const WHATSAPP_MESSAGE_ID = /^[A-Za-z0-9._=-]{1,512}$/;
 
-export type ChannelIdentity = Readonly<{
+export type SlackChannelIdentity = Readonly<{
   accountId: string;
   channelId: string;
   conversationId: string;
   platform: "slack";
   teamId: string;
-}> | Readonly<{
+}>;
+
+export type ViberChannelIdentity = Readonly<{
   accountId: string;
   botUri: string;
   conversationId: string;
@@ -22,9 +28,25 @@ export type ChannelIdentity = Readonly<{
   userId: string;
 }>;
 
+export type WhatsAppChannelIdentity = Readonly<{
+  accountId: string;
+  businessPhoneNumberId: string;
+  conversationId: string;
+  platform: "whatsapp";
+  userId: string;
+}>;
+
+export type ChannelIdentity = SlackChannelIdentity | ViberChannelIdentity | WhatsAppChannelIdentity;
+
 export type SlackMessageIdentity = Readonly<{
   actorId: string;
-  channel: ChannelIdentity;
+  channel: SlackChannelIdentity;
+  messageId: string;
+}>;
+
+export type WhatsAppMessageIdentity = Readonly<{
+  actorId: string;
+  channel: WhatsAppChannelIdentity;
   messageId: string;
 }>;
 
@@ -32,7 +54,7 @@ export type Readiness = Readonly<{
   accountMatch: boolean;
   channels: readonly Readonly<{
     id: "slack" | "whatsapp" | "imessage" | "viber";
-    availability: "ready" | "setup_required" | "not_enabled";
+    availability: "ready" | "configured" | "setup_required" | "not_enabled";
     contract: "first_party" | "vendor_official";
     detail: string;
     webhookUrl?: string | null;
@@ -99,6 +121,44 @@ export function slackMessageIdentity(
   };
 }
 
+export function whatsAppMessageIdentity(
+  raw: unknown,
+  threadId: string,
+  accountId: string,
+  expectedPhoneNumberId: string,
+): WhatsAppMessageIdentity {
+  if (!isRecord(raw) || !isRecord(raw.message)) {
+    throw new Error("WhatsApp message payload is missing");
+  }
+  const phoneNumberId = stringValue(raw.phoneNumberId);
+  const actorId = stringValue(raw.userId);
+  const messageId = stringValue(raw.message.id);
+  if (!phoneNumberId || !WHATSAPP_PHONE_NUMBER_ID.test(phoneNumberId)
+    || phoneNumberId !== expectedPhoneNumberId) {
+    throw new Error("WhatsApp business phone identity is invalid");
+  }
+  if (!actorId || !validWhatsAppUserId(actorId)) {
+    throw new Error("WhatsApp user identity is invalid");
+  }
+  if (!messageId || !WHATSAPP_MESSAGE_ID.test(messageId)) {
+    throw new Error("WhatsApp message identity is invalid");
+  }
+  if (threadId !== `whatsapp:${phoneNumberId}:${actorId}`) {
+    throw new Error("WhatsApp thread is not bound to its participants");
+  }
+  return {
+    actorId,
+    messageId,
+    channel: {
+      accountId,
+      businessPhoneNumberId: phoneNumberId,
+      conversationId: threadId,
+      platform: "whatsapp",
+      userId: actorId,
+    },
+  };
+}
+
 export function configurationReadiness(env: {
   CHIEF_OF_STAFF_PUBLIC_ORIGIN?: string;
   NANOCODEX_API_KEY?: string;
@@ -111,11 +171,16 @@ export function configurationReadiness(env: {
   VIBER_BOT_AVATAR?: string;
   VIBER_BOT_NAME?: string;
   VIBER_BOT_URI?: string;
+  WHATSAPP_ACCESS_TOKEN?: string;
+  WHATSAPP_APP_SECRET?: string;
+  WHATSAPP_PHONE_NUMBER_ID?: string;
+  WHATSAPP_VERIFY_TOKEN?: string;
 }): Readonly<{
   configured: boolean;
   slack: Readonly<{ configured: boolean; webhookUrl: string | null }>;
   viber: Readonly<{ configured: boolean; webhookUrl: string | null }>;
   webhookUrl: string | null;
+  whatsapp: Readonly<{ configured: boolean; webhookUrl: string | null }>;
 }> {
   let origin: URL | undefined;
   try {
@@ -147,6 +212,15 @@ export function configurationReadiness(env: {
     && validViberBotName(env.VIBER_BOT_NAME)
     && validViberBotUri(env.VIBER_BOT_URI),
   );
+  const whatsappConfigured = Boolean(
+    validOrigin
+    && validAccount
+    && (env.WHATSAPP_ACCESS_TOKEN?.length ?? 0) >= 32
+    && (env.WHATSAPP_APP_SECRET?.length ?? 0) >= 16
+    && WHATSAPP_PHONE_NUMBER_ID.test(env.WHATSAPP_PHONE_NUMBER_ID ?? "")
+    && (env.WHATSAPP_VERIFY_TOKEN?.length ?? 0) >= 16
+    && (env.WHATSAPP_VERIFY_TOKEN?.length ?? 0) <= 200
+  );
   const slackWebhookUrl = origin ? new URL("/webhooks/slack", origin).href : null;
   return {
     configured: slackConfigured,
@@ -156,6 +230,10 @@ export function configurationReadiness(env: {
       webhookUrl: origin ? new URL("/webhooks/viber", origin).href : null,
     },
     webhookUrl: slackWebhookUrl,
+    whatsapp: {
+      configured: whatsappConfigured,
+      webhookUrl: origin ? new URL("/webhooks/whatsapp", origin).href : null,
+    },
   };
 }
 
@@ -183,13 +261,15 @@ export async function digest(value: unknown): Promise<string> {
 export function sameChannelIdentity(left: ChannelIdentity, right: ChannelIdentity): boolean {
   if (left.platform !== right.platform || left.accountId !== right.accountId
     || left.conversationId !== right.conversationId) return false;
-  return left.platform === "slack"
-    ? right.platform === "slack"
-      && left.channelId === right.channelId
-      && left.teamId === right.teamId
-    : right.platform === "viber"
-      && left.botUri === right.botUri
-      && left.userId === right.userId;
+  if (left.platform === "slack" && right.platform === "slack") {
+    return left.channelId === right.channelId && left.teamId === right.teamId;
+  }
+  if (left.platform === "viber" && right.platform === "viber") {
+    return left.botUri === right.botUri && left.userId === right.userId;
+  }
+  return left.platform === "whatsapp" && right.platform === "whatsapp"
+    && left.businessPhoneNumberId === right.businessPhoneNumberId
+    && left.userId === right.userId;
 }
 
 function validViberToken(value: string | undefined): boolean {
@@ -242,4 +322,8 @@ function validBase64Key(value: unknown): boolean {
   } catch {
     return false;
   }
+}
+
+function validWhatsAppUserId(value: string): boolean {
+  return WHATSAPP_PHONE_USER_ID.test(value) || WHATSAPP_BUSINESS_USER_ID.test(value);
 }

--- a/js/chief-of-staff/src/worker.ts
+++ b/js/chief-of-staff/src/worker.ts
@@ -3,7 +3,11 @@ import {
   readSlackWebhook,
   type SlackWebhookPayload,
 } from "@chat-adapter/slack/webhook";
-import { Chat, type Message, type Thread } from "chat";
+import {
+  createWhatsAppAdapter,
+  type WhatsAppAdapter,
+} from "@chat-adapter/whatsapp";
+import { Chat, ConsoleLogger, type Message, type Thread } from "chat";
 import { NanocodexManagedGateway, requestingAccountId } from "./managed.ts";
 import {
   configurationReadiness,
@@ -11,8 +15,11 @@ import {
   slackMessageIdentity,
   slackTeamId,
   validSlackInstallationMetadata,
+  whatsAppMessageIdentity,
+  type SlackMessageIdentity,
   type Readiness,
   type SlackInstallationMetadata,
+  type WhatsAppMessageIdentity,
 } from "./protocol.ts";
 import { slackAuthorizationUrl, verifySlackInstallState } from "./slack-oauth.ts";
 import { DurableChatStateAdapter } from "./state-adapter.ts";
@@ -42,13 +49,24 @@ export interface Env {
   VIBER_BOT_AVATAR?: string;
   VIBER_BOT_NAME?: string;
   VIBER_BOT_URI?: string;
+  WHATSAPP_ACCESS_TOKEN?: string;
+  WHATSAPP_API_URL?: string;
+  WHATSAPP_APP_SECRET?: string;
+  WHATSAPP_PHONE_NUMBER_ID?: string;
+  WHATSAPP_VERIFY_TOKEN?: string;
 }
 
-type ChiefRuntime = Readonly<{ chat: Chat<{ slack: SlackAdapter }>; slack: SlackAdapter }>;
+type SlackRuntime = Readonly<{ chat: Chat<{ slack: SlackAdapter }>; slack: SlackAdapter }>;
+type WhatsAppRuntime = Readonly<{
+  chat: Chat<{ whatsapp: WhatsAppAdapter }>;
+  whatsapp: WhatsAppAdapter;
+}>;
 
-const runtimes = new WeakMap<object, ChiefRuntime>();
+const slackRuntimes = new WeakMap<object, SlackRuntime>();
+const whatsappRuntimes = new WeakMap<object, WhatsAppRuntime>();
 const ownerIds = new WeakMap<object, Promise<string | undefined>>();
-const INSTALLATIONS_OBJECT = "chat-sdk:slack";
+const SLACK_STATE_OBJECT = "chat-sdk:slack";
+const WHATSAPP_STATE_OBJECT = "chat-sdk:whatsapp";
 const SLACK_TEAM_ID = /^T[A-Z0-9]+$/;
 
 export default {
@@ -80,6 +98,12 @@ export default {
     if (url.pathname === "/webhooks/viber") {
       if (request.method !== "POST") return methodNotAllowed(["POST"]);
       return viberWebhook(request, env);
+    }
+    if (url.pathname === "/webhooks/whatsapp") {
+      if (request.method !== "GET" && request.method !== "POST") {
+        return methodNotAllowed(["GET", "POST"]);
+      }
+      return whatsappWebhook(request, env, context);
     }
     return json({ error: "not_found" }, { status: 404 });
   },
@@ -128,7 +152,7 @@ async function finishSlackInstall(request: Request, env: Env): Promise<Response>
     return json({ error: "invalid_oauth_state" }, { status: 400 });
   }
   try {
-    const runtime = chiefRuntime(env);
+    const runtime = slackRuntime(env);
     await runtime.chat.initialize();
     const result = await runtime.slack.handleOAuthCallback(request, {
       redirectUri: new URL("/v1/slack/callback", env.CHIEF_OF_STAFF_PUBLIC_ORIGIN).href,
@@ -170,7 +194,7 @@ async function removeSlackInstallation(
   if (metadata.accountId !== requester || await configuredOwnerId(env) !== requester) {
     return json({ error: "account_forbidden" }, { status: 403 });
   }
-  const runtime = chiefRuntime(env);
+  const runtime = slackRuntime(env);
   await runtime.chat.initialize();
   const installation = await runtime.slack.getInstallation(teamId);
   if (installation && env.SLACK_CLIENT_ID && env.SLACK_CLIENT_SECRET) {
@@ -220,14 +244,14 @@ async function slackWebhook(
     return json({ error: "workspace_forbidden" }, { status: 403 });
   }
   if (slackEventType(payload) === "app_uninstalled") {
-    const runtime = chiefRuntime(env);
+    const runtime = slackRuntime(env);
     await runtime.chat.initialize();
     await runtime.slack.deleteInstallation(teamId!);
     await writeInstallationMetadata(env, metadata, "DELETE");
     return json({ ok: true });
   }
   try {
-    return await chiefRuntime(env).chat.webhooks.slack(
+    return await slackRuntime(env).chat.webhooks.slack(
       request as unknown as Parameters<Chat["webhooks"]["slack"]>[0],
       {
         waitUntil(task) {
@@ -322,6 +346,40 @@ async function viberWebhook(request: Request, env: Env): Promise<Response> {
   }
 }
 
+async function whatsappWebhook(
+  request: Request,
+  env: Env,
+  context?: ExecutionContext,
+): Promise<Response> {
+  const config = configurationReadiness(env);
+  if (!config.whatsapp.configured) {
+    return json({ error: "channel_not_configured" }, { status: 503 });
+  }
+  if (request.method === "POST") {
+    const rejected = await rejectInvalidWhatsAppPost(request, env);
+    if (rejected) return rejected;
+  }
+  try {
+    return await whatsappRuntime(env).chat.webhooks.whatsapp(request, {
+      waitUntil(task) {
+        const handled = task.catch((error) => {
+          console.warn({
+            type: "chief_of_staff.whatsapp_delivery_failed",
+            error_kind: error instanceof Error ? error.name : typeof error,
+          });
+        });
+        if (context) context.waitUntil(handled);
+      },
+    });
+  } catch (error) {
+    console.warn({
+      type: "chief_of_staff.whatsapp_webhook_failed",
+      error_kind: error instanceof Error ? error.name : typeof error,
+    });
+    return json({ error: "channel_unavailable" }, { status: 503 });
+  }
+}
+
 async function deliverViberOnce(
   session: Fetcher,
   deliveryId: string,
@@ -363,10 +421,10 @@ function deliveryRequest(
   }));
 }
 
-function chiefRuntime(env: Env): ChiefRuntime {
-  const retained = runtimes.get(env as object);
+function slackRuntime(env: Env): SlackRuntime {
+  const retained = slackRuntimes.get(env as object);
   if (retained) return retained;
-  const stateObject = env.CHIEF_OF_STAFF_STATE.getByName(INSTALLATIONS_OBJECT);
+  const stateObject = env.CHIEF_OF_STAFF_STATE.getByName(SLACK_STATE_OBJECT);
   const slack = createSlackAdapter({
     agentView: true,
     apiUrl: env.SLACK_API_URL,
@@ -393,32 +451,84 @@ function chiefRuntime(env: Env): ChiefRuntime {
       throw new Error("Slack installation owner is unavailable");
     }
     const identity = slackMessageIdentity(message.raw, thread.id, thread.isDM, metadata.accountId);
-    const routeDigest = await digest(identity.channel);
-    const session = env.CHIEF_OF_STAFF_STATE.getByName(`conversation:${routeDigest}`);
-    try {
-      await thread.startTyping("Working");
-    } catch { /* A Slack surface can omit Agent Session status support. */ }
-    const response = await session.fetch(new Request("https://state.internal/conversation/turn", {
-      body: JSON.stringify({
-        actorId: identity.actorId,
-        channel: identity.channel,
-        messageId: identity.messageId,
-        text: message.text,
-      }),
-      headers: { "content-type": "application/json" },
-      method: "POST",
-    }));
-    if (!response.ok) throw new Error(`Chief of Staff turn failed (${response.status})`);
-    const result = await response.json<{ finalMessage?: unknown }>();
-    if (typeof result.finalMessage !== "string") throw new Error("Chief of Staff turn was malformed");
-    await thread.post(result.finalMessage);
+    await deliverTurn(env, thread, message, identity);
   };
   chat.onDirectMessage(handle);
   chat.onNewMention(handle);
   chat.onSubscribedMessage(handle);
   const runtime = { chat, slack };
-  runtimes.set(env as object, runtime);
+  slackRuntimes.set(env as object, runtime);
   return runtime;
+}
+
+function whatsappRuntime(env: Env): WhatsAppRuntime {
+  const retained = whatsappRuntimes.get(env as object);
+  if (retained) return retained;
+  if (!env.WHATSAPP_ACCESS_TOKEN || !env.WHATSAPP_APP_SECRET
+    || !env.WHATSAPP_PHONE_NUMBER_ID || !env.WHATSAPP_VERIFY_TOKEN) {
+    throw new Error("WhatsApp channel is not configured");
+  }
+  const stateObject = env.CHIEF_OF_STAFF_STATE.getByName(WHATSAPP_STATE_OBJECT);
+  const whatsapp = createWhatsAppAdapter({
+    accessToken: env.WHATSAPP_ACCESS_TOKEN,
+    apiUrl: env.WHATSAPP_API_URL,
+    appSecret: env.WHATSAPP_APP_SECRET,
+    logger: new ConsoleLogger("warn"),
+    phoneNumberId: env.WHATSAPP_PHONE_NUMBER_ID,
+    userName: "chief-of-staff",
+    verifyToken: env.WHATSAPP_VERIFY_TOKEN,
+  });
+  const chat = new Chat({
+    adapters: { whatsapp },
+    concurrency: "concurrent",
+    dedupeTtlMs: 24 * 60 * 60 * 1_000,
+    logger: "warn",
+    state: new DurableChatStateAdapter(stateObject),
+    userName: "chief-of-staff",
+  });
+  const handle = async (thread: Thread, message: Message) => {
+    await thread.subscribe();
+    const owner = await configuredOwnerId(env);
+    if (!owner) throw new Error("WhatsApp account owner is unavailable");
+    const identity = whatsAppMessageIdentity(
+      message.raw,
+      thread.id,
+      owner,
+      env.WHATSAPP_PHONE_NUMBER_ID!,
+    );
+    await deliverTurn(env, thread, message, identity);
+  };
+  chat.onDirectMessage(handle);
+  const runtime = { chat, whatsapp };
+  whatsappRuntimes.set(env as object, runtime);
+  return runtime;
+}
+
+async function deliverTurn(
+  env: Env,
+  thread: Thread,
+  message: Message,
+  identity: SlackMessageIdentity | WhatsAppMessageIdentity,
+): Promise<void> {
+  const routeDigest = await digest(identity.channel);
+  const session = env.CHIEF_OF_STAFF_STATE.getByName(`conversation:${routeDigest}`);
+  try {
+    await thread.startTyping(identity.channel.platform === "slack" ? "Working" : undefined);
+  } catch { /* Typing/status support varies by channel surface. */ }
+  const response = await session.fetch(new Request("https://state.internal/conversation/turn", {
+    body: JSON.stringify({
+      actorId: identity.actorId,
+      channel: identity.channel,
+      messageId: identity.messageId,
+      text: message.text,
+    }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  }));
+  if (!response.ok) throw new Error(`Chief of Staff turn failed (${response.status})`);
+  const result = await response.json<{ finalMessage?: unknown }>();
+  if (typeof result.finalMessage !== "string") throw new Error("Chief of Staff turn was malformed");
+  await thread.post(result.finalMessage);
 }
 
 async function readiness(request: Request, env: Env): Promise<Response> {
@@ -428,7 +538,7 @@ async function readiness(request: Request, env: Env): Promise<Response> {
   const requester = await requestingAccountId(env.NANOCODEX_BACKEND, request);
   if (!requester) return json({ error: "unauthorized" }, { status: 401 });
   const config = configurationReadiness(env);
-  const owner = config.slack.configured || config.viber.configured
+  const owner = config.slack.configured || config.viber.configured || config.whatsapp.configured
     ? await configuredOwnerId(env)
     : undefined;
   const accountMatch = owner === requester;
@@ -437,20 +547,21 @@ async function readiness(request: Request, env: Env): Promise<Response> {
       .filter((installation) => installation.accountId === requester)
       .map(({ accountId: _, ...installation }) => installation)
     : [];
-  const ready = config.configured && accountMatch && installations.length > 0;
+  const slackReady = config.slack.configured && accountMatch && installations.length > 0;
   const viberReady = config.viber.configured && accountMatch;
+  const whatsappConfiguredForAccount = config.whatsapp.configured && accountMatch;
   const body: Readiness = {
     accountMatch,
-    configured: ready || viberReady,
+    configured: slackReady || viberReady || whatsappConfiguredForAccount,
     installations,
     installUrl: config.configured && accountMatch ? "/api/chief-of-staff/slack/install" : null,
     webhookUrl: config.webhookUrl,
     channels: [
       {
         id: "slack",
-        availability: ready ? "ready" : "setup_required",
+        availability: slackReady ? "ready" : "setup_required",
         contract: "first_party",
-        detail: ready
+        detail: slackReady
           ? `${installations.length} Slack workspace${installations.length === 1 ? "" : "s"} route bot events to account-owned durable agents.`
           : config.configured
             ? accountMatch
@@ -460,9 +571,14 @@ async function readiness(request: Request, env: Env): Promise<Response> {
       },
       {
         id: "whatsapp",
-        availability: "not_enabled",
+        availability: whatsappConfiguredForAccount ? "configured" : "setup_required",
         contract: "first_party",
-        detail: "The current SDK adapter is supported, but this deployment does not claim a configured Meta webhook.",
+        detail: whatsappConfiguredForAccount
+          ? "The Worker is configured; signed WhatsApp messages route to account-owned durable agents."
+          : config.whatsapp.configured
+            ? "This deployment is bound to a different Nanocodex account."
+            : "Add the Meta app credentials and subscribe the shared webhook to enable WhatsApp.",
+        webhookUrl: config.whatsapp.webhookUrl,
       },
       {
         id: "imessage",
@@ -523,7 +639,69 @@ async function writeInstallationMetadata(
 }
 
 function installationsObject(env: Env): Fetcher {
-  return env.CHIEF_OF_STAFF_STATE.getByName(INSTALLATIONS_OBJECT);
+  return env.CHIEF_OF_STAFF_STATE.getByName(SLACK_STATE_OBJECT);
+}
+
+async function rejectInvalidWhatsAppPost(request: Request, env: Env): Promise<Response | undefined> {
+  const signature = request.headers.get("x-hub-signature-256") ?? "";
+  if (!/^sha256=[0-9a-f]{64}$/.test(signature) || !env.WHATSAPP_APP_SECRET) {
+    return new Response("Invalid signature", {
+      status: 401,
+      headers: { "cache-control": "no-store", "x-content-type-options": "nosniff" },
+    });
+  }
+  const body = await request.clone().text();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(env.WHATSAPP_APP_SECRET),
+    { hash: "SHA-256", name: "HMAC" },
+    false,
+    ["sign"],
+  );
+  const signed = new Uint8Array(await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(body),
+  ));
+  const expected = `sha256=${[...signed]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")}`;
+  let mismatch = 0;
+  for (let index = 0; index < expected.length; index += 1) {
+    mismatch |= expected.charCodeAt(index) ^ signature.charCodeAt(index);
+  }
+  if (mismatch !== 0) {
+    return new Response("Invalid signature", {
+      status: 401,
+      headers: { "cache-control": "no-store", "x-content-type-options": "nosniff" },
+    });
+  }
+  let payload: unknown;
+  try { payload = JSON.parse(body); }
+  catch { return new Response("Invalid JSON", { status: 400 }); }
+  if (!isRecord(payload) || payload.object !== "whatsapp_business_account"
+    || !Array.isArray(payload.entry)) {
+    return json({ error: "invalid_webhook" }, { status: 400 });
+  }
+  for (const entry of payload.entry) {
+    if (!isRecord(entry) || !Array.isArray(entry.changes)) {
+      return json({ error: "invalid_webhook" }, { status: 400 });
+    }
+    for (const change of entry.changes) {
+      if (!isRecord(change) || typeof change.field !== "string") {
+        return json({ error: "invalid_webhook" }, { status: 400 });
+      }
+      if (change.field !== "messages" && change.field !== "user_id_update") continue;
+      if (!isRecord(change.value) || !isRecord(change.value.metadata)
+        || typeof change.value.metadata.phone_number_id !== "string") {
+        return json({ error: "invalid_webhook" }, { status: 400 });
+      }
+      if (change.value.metadata.phone_number_id !== env.WHATSAPP_PHONE_NUMBER_ID) {
+        return json({ error: "phone_number_forbidden" }, { status: 403 });
+      }
+    }
+  }
+  return undefined;
 }
 
 function logViberFailure(operation: string, error: unknown): void {

--- a/js/chief-of-staff/test/conversation.test.ts
+++ b/js/chief-of-staff/test/conversation.test.ts
@@ -51,6 +51,14 @@ const viberChannel: ChannelIdentity = {
   userId: "01234567890A=",
 };
 
+const whatsappChannel: ChannelIdentity = {
+  accountId: "account-a",
+  businessPhoneNumberId: "123456789012345",
+  conversationId: "whatsapp:123456789012345:15551234567",
+  platform: "whatsapp",
+  userId: "15551234567",
+};
+
 test("a durable conversation reuses one managed agent across two turns", async () => {
   const store = new MemoryConversationStore();
   const gateway = new RememberingGateway();
@@ -199,4 +207,48 @@ test("Viber replies are truncated to the provider text limit", async () => {
 
   assert.equal(result.finalMessage.length, 7_000);
   assert.equal(result.finalMessage.endsWith("[Response truncated for Viber]"), true);
+});
+
+test("a WhatsApp conversation keeps its own durable agent and channel-aware prompt", async () => {
+  const store = new MemoryConversationStore();
+  const gateway = new RememberingGateway();
+  const engine = new ConversationEngine(store, gateway);
+  await engine.turn({
+    actorId: "15551234567",
+    channel: whatsappChannel,
+    messageId: "wamid.first",
+    text: "Remember kiwi",
+  });
+  const second = await engine.turn({
+    actorId: "15551234567",
+    channel: whatsappChannel,
+    messageId: "wamid.second",
+    text: "What should you remember?",
+  });
+
+  assert.equal(second.finalMessage, "You asked me to remember kiwi.");
+  assert.match(second.turnId, /^whatsapp-/);
+  assert.match(gateway.turns[0]!.input, /Chief of Staff in WhatsApp/);
+  assert.equal(gateway.created.length, 1);
+});
+
+test("Slack and WhatsApp identities cannot share durable conversation state", async () => {
+  const engine = new ConversationEngine(new MemoryConversationStore(), new RememberingGateway());
+  await engine.turn({
+    actorId: "U123ABC",
+    channel,
+    messageId: "1700000000.000001",
+    text: "Remember kiwi",
+  });
+
+  await assert.rejects(
+    engine.turn({
+      actorId: "15551234567",
+      channel: whatsappChannel,
+      messageId: "wamid.second",
+      text: "What should you remember?",
+    }),
+    (error: unknown) => error instanceof ConversationError
+      && error.code === "channel_identity_conflict",
+  );
 });

--- a/js/chief-of-staff/test/webhook.test.ts
+++ b/js/chief-of-staff/test/webhook.test.ts
@@ -4,6 +4,8 @@ import test from "node:test";
 import worker, { type Env } from "../src/worker.ts";
 
 const signingSecret = "test-signing-secret-which-is-not-real";
+const whatsappAppSecret = "test-whatsapp-app-secret-not-real";
+const whatsappVerifyToken = "test-whatsapp-verify-token";
 const accountId = "00000000-0000-4000-8000-000000000001";
 const key = Buffer.alloc(32, 7).toString("base64url");
 
@@ -58,6 +60,176 @@ test("signed events from a different Slack workspace are fenced before routing",
 
   assert.equal(response.status, 403);
   assert.deepEqual(await response.json(), { error: "workspace_forbidden" });
+});
+
+test("WhatsApp webhook verification and POST signatures are enforced by the adapter", async () => {
+  const configured = withWhatsApp(env());
+  const accepted = await worker.fetch(new Request(
+    `https://chief.example/webhooks/whatsapp?hub.mode=subscribe&hub.verify_token=${whatsappVerifyToken}&hub.challenge=meta-challenge`,
+  ), configured);
+  assert.equal(accepted.status, 200);
+  assert.equal(await accepted.text(), "meta-challenge");
+
+  const rejectedChallenge = await worker.fetch(new Request(
+    "https://chief.example/webhooks/whatsapp?hub.mode=subscribe&hub.verify_token=wrong&hub.challenge=nope",
+  ), configured);
+  assert.equal(rejectedChallenge.status, 403);
+
+  const unsigned = await worker.fetch(new Request("https://chief.example/webhooks/whatsapp", {
+    body: JSON.stringify({ entry: [] }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  }), configured);
+  assert.equal(unsigned.status, 401);
+
+  const invalidJson = "{";
+  const malformed = await worker.fetch(new Request("https://chief.example/webhooks/whatsapp", {
+    body: invalidJson,
+    headers: { "x-hub-signature-256": await whatsappSignature(invalidJson) },
+    method: "POST",
+  }), configured);
+  assert.equal(malformed.status, 400);
+
+  const disallowed = await worker.fetch(new Request("https://chief.example/webhooks/whatsapp", {
+    method: "PUT",
+  }), configured);
+  assert.equal(disallowed.status, 405);
+});
+
+test("a signed webhook for another WhatsApp phone is fenced before state mutation", async () => {
+  const fixture = statefulEnv();
+  withWhatsApp(fixture.env);
+  const body = JSON.stringify({
+    object: "whatsapp_business_account",
+    entry: [{
+      changes: [{
+        field: "messages",
+        value: {
+          messaging_product: "whatsapp",
+          metadata: {
+            display_phone_number: "+1 555 999 9999",
+            phone_number_id: "999999999999999",
+          },
+        },
+      }],
+    }],
+  });
+
+  const response = await worker.fetch(new Request("https://chief.example/webhooks/whatsapp", {
+    body,
+    headers: { "x-hub-signature-256": await whatsappSignature(body) },
+    method: "POST",
+  }), fixture.env);
+
+  assert.equal(response.status, 403);
+  assert.equal(fixture.names.length, 0);
+  assert.equal(fixture.values.size, 0);
+  assert.equal(fixture.turns.length, 0);
+});
+
+test("a signed WhatsApp DM reaches the exact durable route and posts its reply", async () => {
+  const fixture = statefulEnv();
+  withWhatsApp(fixture.env);
+  const graphRequests: {
+    authorization: string | null;
+    body: Record<string, unknown>;
+    method: string | undefined;
+    path: string | undefined;
+  }[] = [];
+  const graph = createServer(async (request, response) => {
+    let body = "";
+    for await (const chunk of request) body += chunk;
+    graphRequests.push({
+      authorization: request.headers.authorization ?? null,
+      body: JSON.parse(body) as Record<string, unknown>,
+      method: request.method,
+      path: request.url,
+    });
+    response.setHeader("content-type", "application/json");
+    response.end(JSON.stringify({ messages: [{ id: `wamid.reply-${graphRequests.length}` }] }));
+  });
+  await new Promise<void>((resolve) => graph.listen(0, "127.0.0.1", resolve));
+  const address = graph.address();
+  if (!address || typeof address === "string") throw new Error("Graph fixture did not bind");
+  fixture.env.WHATSAPP_API_URL = `http://127.0.0.1:${address.port}`;
+  const body = JSON.stringify({
+    object: "whatsapp_business_account",
+    entry: [{
+      id: "business-account",
+      changes: [{
+        field: "messages",
+        value: {
+          contacts: [{ profile: { name: "Alice" }, wa_id: "15551234567" }],
+          messages: [{
+            from: "15551234567",
+            id: "wamid.inbound-1",
+            text: { body: "What is on my agenda?" },
+            timestamp: "1700000000",
+            type: "text",
+          }],
+          messaging_product: "whatsapp",
+          metadata: {
+            display_phone_number: "+1 555 000 0000",
+            phone_number_id: "123456789012345",
+          },
+        },
+      }],
+    }],
+  });
+  const tasks: Promise<unknown>[] = [];
+  try {
+    const response = await worker.fetch(new Request("https://chief.example/webhooks/whatsapp", {
+      body,
+      headers: {
+        "content-type": "application/json",
+        "x-hub-signature-256": await whatsappSignature(body),
+      },
+      method: "POST",
+    }), fixture.env, {
+      waitUntil(task: Promise<unknown>) { tasks.push(task); },
+    } as unknown as ExecutionContext);
+    assert.equal(response.status, 200);
+    await Promise.all(tasks);
+    assert.equal(fixture.turns.length, 1);
+    assert.equal(fixture.names.includes("chat-sdk:whatsapp"), true);
+    assert.equal(fixture.names.some((name) => name.startsWith("conversation:")), true);
+    assert.deepEqual(fixture.turns[0], {
+      actorId: "15551234567",
+      channel: {
+        accountId,
+        businessPhoneNumberId: "123456789012345",
+        conversationId: "whatsapp:123456789012345:15551234567",
+        platform: "whatsapp",
+        userId: "15551234567",
+      },
+      messageId: "wamid.inbound-1",
+      text: "What is on my agenda?",
+    });
+    const outbound = graphRequests.find(({ body: requestBody }) =>
+      isRecord(requestBody.text) && requestBody.text.body === "Your agenda is clear."
+    );
+    assert.ok(outbound);
+    assert.equal(outbound.authorization, `Bearer ${fixture.env.WHATSAPP_ACCESS_TOKEN}`);
+    assert.equal(outbound.method, "POST");
+    assert.equal(outbound.path, "/v25.0/123456789012345/messages");
+    assert.equal(outbound.body.to, "15551234567");
+
+    const firstGraphRequestCount = graphRequests.length;
+    const replayTasks: Promise<unknown>[] = [];
+    const replay = await worker.fetch(new Request("https://chief.example/webhooks/whatsapp", {
+      body,
+      headers: { "x-hub-signature-256": await whatsappSignature(body) },
+      method: "POST",
+    }), fixture.env, {
+      waitUntil(task: Promise<unknown>) { replayTasks.push(task); },
+    } as unknown as ExecutionContext);
+    await Promise.all(replayTasks);
+    assert.equal(replay.status, 200);
+    assert.equal(fixture.turns.length, 1);
+    assert.equal(graphRequests.length, firstGraphRequestCount);
+  } finally {
+    await new Promise<void>((resolve, reject) => graph.close((error) => error ? reject(error) : resolve()));
+  }
 });
 
 test("the authenticated owner gets a one-click Slack bot authorization redirect", async () => {
@@ -155,13 +327,13 @@ test("Slack app_uninstalled removes the bot installation without touching the us
 });
 
 test("readiness reports bot installations without returning provider credentials", async () => {
-  const configured = env([{
+  const configured = withWhatsApp(env([{
     accountId,
     botUserId: "U123ABC",
     installedAt: 1,
     teamId: "T123ABC",
     teamName: "Acme",
-  }]);
+  }]));
   configured.NANOCODEX_BACKEND = {
     async fetch() {
       return Response.json({ user: { id: accountId } });
@@ -177,6 +349,10 @@ test("readiness reports bot installations without returning provider credentials
   assert.equal(serialized.includes(configured.SLACK_ENCRYPTION_KEY!), false);
   assert.equal(serialized.includes(configured.SLACK_SIGNING_SECRET!), false);
   assert.equal(serialized.includes(configured.VIBER_AUTH_TOKEN!), false);
+  assert.equal(serialized.includes(configured.WHATSAPP_ACCESS_TOKEN!), false);
+  assert.equal(serialized.includes(configured.WHATSAPP_APP_SECRET!), false);
+  assert.equal(serialized.includes(configured.WHATSAPP_PHONE_NUMBER_ID!), false);
+  assert.equal(serialized.includes(configured.WHATSAPP_VERIFY_TOKEN!), false);
   const readiness = JSON.parse(serialized) as {
     channels: { id: string; availability: string }[];
     installations: { teamId: string; teamName: string }[];
@@ -189,7 +365,7 @@ test("readiness reports bot installations without returning provider credentials
   }]);
   assert.deepEqual(readiness.channels.map(({ id, availability }) => ({ id, availability })), [
     { id: "slack", availability: "ready" },
-    { id: "whatsapp", availability: "not_enabled" },
+    { id: "whatsapp", availability: "configured" },
     { id: "imessage", availability: "not_enabled" },
     { id: "viber", availability: "ready" },
   ]);
@@ -337,12 +513,17 @@ function statefulEnv(): {
     teamName: string;
   }>;
   values: Map<string, unknown>;
+  names: string[];
+  turns: unknown[];
 } {
   const metadata = new Map();
+  const names: string[] = [];
   const values = new Map<string, unknown>();
+  const turns: unknown[] = [];
   const configured = env([]);
   configured.CHIEF_OF_STAFF_STATE = {
-    getByName() {
+    getByName(name) {
+      names.push(name);
       return {
         async fetch(request) {
           const url = new URL(request.url);
@@ -362,18 +543,46 @@ function statefulEnv(): {
             return new Response(null, { status: 204 });
           }
           if (url.pathname === "/chat-sdk") {
-            const body = await request.json<{ key?: string; operation: string; value?: unknown }>();
+            const body = await request.json<{
+              key?: string;
+              operation: string;
+              threadId?: string;
+              value?: unknown;
+            }>();
             if (body.operation === "get") return Response.json({ value: values.get(body.key!) ?? null });
             if (body.operation === "set") values.set(body.key!, body.value);
             if (body.operation === "delete") values.delete(body.key!);
+            if (body.operation === "setIfNotExists") {
+              if (values.has(body.key!)) return Response.json({ value: false });
+              values.set(body.key!, body.value);
+              return Response.json({ value: true });
+            }
+            if (body.operation === "isSubscribed") {
+              return Response.json({ value: values.get(`subscription:${body.threadId}`) === true });
+            }
+            if (body.operation === "subscribe") {
+              values.set(`subscription:${body.threadId}`, true);
+            }
             return Response.json({ value: null });
+          }
+          if (url.pathname === "/conversation/turn" && request.method === "POST") {
+            turns.push(await request.json());
+            return Response.json({ finalMessage: "Your agenda is clear." });
           }
           return Response.json({ error: "not_found" }, { status: 404 });
         },
       };
     },
   };
-  return { env: configured, metadata, values };
+  return { env: configured, metadata, names, turns, values };
+}
+
+function withWhatsApp(configured: Env): Env {
+  configured.WHATSAPP_ACCESS_TOKEN = "test-access-token-which-is-long-enough-for-readiness";
+  configured.WHATSAPP_APP_SECRET = whatsappAppSecret;
+  configured.WHATSAPP_PHONE_NUMBER_ID = "123456789012345";
+  configured.WHATSAPP_VERIFY_TOKEN = whatsappVerifyToken;
+  return configured;
 }
 
 function slackRequest(body: string, timestamp: string, signed: string): Request {
@@ -414,4 +623,20 @@ async function viberSignature(body: string, token: string): Promise<string> {
   );
   const result = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(body));
   return Buffer.from(result).toString("hex");
+}
+
+async function whatsappSignature(body: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(whatsappAppSecret),
+    { hash: "SHA-256", name: "HMAC" },
+    false,
+    ["sign"],
+  );
+  const result = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(body));
+  return `sha256=${Buffer.from(result).toString("hex")}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/js/chief-of-staff/test/whatsapp.test.ts
+++ b/js/chief-of-staff/test/whatsapp.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { WhatsAppRawMessage } from "@chat-adapter/whatsapp";
+import {
+  configurationReadiness,
+  whatsAppMessageIdentity,
+} from "../src/protocol.ts";
+
+const raw = {
+  message: {
+    from: "15551234567",
+    id: "wamid.HBgLMTU1NTEyMzQ1NjcVAgARGBI3QkY=",
+    timestamp: "1700000000",
+    type: "text",
+    text: { body: "hello" },
+  },
+  phoneNumberId: "123456789012345",
+  userId: "15551234567",
+} as WhatsAppRawMessage;
+
+test("WhatsApp identity is bound to the configured business phone and canonical user", () => {
+  assert.deepEqual(
+    whatsAppMessageIdentity(
+      raw,
+      "whatsapp:123456789012345:15551234567",
+      "account-a",
+      "123456789012345",
+    ),
+    {
+      actorId: "15551234567",
+      messageId: raw.message.id,
+      channel: {
+        accountId: "account-a",
+        businessPhoneNumberId: "123456789012345",
+        conversationId: "whatsapp:123456789012345:15551234567",
+        platform: "whatsapp",
+        userId: "15551234567",
+      },
+    },
+  );
+
+  assert.throws(
+    () => whatsAppMessageIdentity(
+      raw,
+      "whatsapp:999999999999999:15551234567",
+      "account-a",
+      "123456789012345",
+    ),
+    /thread is not bound/,
+  );
+  assert.throws(
+    () => whatsAppMessageIdentity(
+      raw,
+      "whatsapp:123456789012345:15551234567",
+      "account-a",
+      "999999999999999",
+    ),
+    /business phone identity/,
+  );
+});
+
+test("WhatsApp readiness is independent from Slack configuration", () => {
+  const readiness = configurationReadiness({
+    CHIEF_OF_STAFF_PUBLIC_ORIGIN: "https://chief.example",
+    NANOCODEX_API_KEY: `ncx_live_${"a".repeat(12)}_${"b".repeat(43)}`,
+    WHATSAPP_ACCESS_TOKEN: "token".repeat(12),
+    WHATSAPP_APP_SECRET: "app-secret-which-is-long-enough",
+    WHATSAPP_PHONE_NUMBER_ID: "123456789012345",
+    WHATSAPP_VERIFY_TOKEN: "verify-token-which-is-long-enough",
+  });
+
+  assert.equal(readiness.configured, false);
+  assert.equal(readiness.whatsapp.configured, true);
+  assert.equal(readiness.whatsapp.webhookUrl, "https://chief.example/webhooks/whatsapp");
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,9 @@ importers:
       '@chat-adapter/slack':
         specifier: 4.39.0
         version: 4.39.0(debug@4.4.3(supports-color@10.2.2))(supports-color@10.2.2)(zod@4.5.4)
+      '@chat-adapter/whatsapp':
+        specifier: 4.39.0
+        version: 4.39.0(supports-color@10.2.2)(zod@4.5.4)
       chat:
         specifier: 4.39.0
         version: 4.39.0(supports-color@10.2.2)(zod@4.5.4)
@@ -663,6 +666,10 @@ packages:
 
   '@chat-adapter/slack@4.39.0':
     resolution: {integrity: sha512-nDBYFEmD9MUobUH+HJbOYwKYcaeoCFJDXVvd41flh5sslpixSUG2SFcz7F3py62jJ9c0YYNEdwprIExO20IyZQ==}
+    engines: {node: '>=20'}
+
+  '@chat-adapter/whatsapp@4.39.0':
+    resolution: {integrity: sha512-rI35+Iixl/S7J4UYDJEJJ4GhRtjaCDV2JLelMhRV6KJ2h5tQ07OMsTRtwT9PBv91C2bhMaGYOQ2alNkhzcdvVw==}
     engines: {node: '>=20'}
 
   '@chevrotain/types@11.1.2':
@@ -4848,6 +4855,16 @@ snapshots:
       - debug
       - supports-color
       - utf-8-validate
+      - workflow
+      - zod
+
+  '@chat-adapter/whatsapp@4.39.0(supports-color@10.2.2)(zod@4.5.4)':
+    dependencies:
+      '@chat-adapter/shared': 4.39.0(supports-color@10.2.2)(zod@4.5.4)
+      chat: 4.39.0(supports-color@10.2.2)(zod@4.5.4)
+    transitivePeerDependencies:
+      - ai
+      - supports-color
       - workflow
       - zod
 


### PR DESCRIPTION
Adds WhatsApp as a deployment-managed Chief of Staff channel using the official Chat SDK adapter.

- verifies Meta webhook challenges and exact-body HMAC signatures
- fences inbound events to the configured business phone before durable state mutation
- reuses retained managed-agent conversations with provider/account isolation and replay safety
- sends Graph API replies and exposes truthful configured readiness in the account demo
- preserves the existing Slack and Viber channels

Packages touched: @nanocodex/chief-of-staff, nanocodex-web, root lockfile.
LOC: +831 / -93 across 11 files.

Verified: Chief-of-Staff check (29 tests, typecheck, Wrangler dry-run), account tests (50), six-package account build, diff check.