### PR TITLE
feat(chief-of-staff): use private managed RPC

### DIFF
--- a/js/chief-of-staff/README.md
+++ b/js/chief-of-staff/README.md
@@ -12,9 +12,12 @@ encrypts the workspace bot token in Durable Object state, records the workspace
 installation, and immediately accepts signed mentions and DMs. Users never copy a
 token or configure a webhook.
 
-Each account/channel/conversation maps to a retained managed Nanocodex agent.
-The account app receives only non-secret installation and readiness metadata
-through a service binding.
+Each verified provider user maps to a private, persistent Nanocodex account and
+each conversation maps to one retained managed agent. The Chief Worker reaches
+the managed Worker through the capability-scoped `ChiefOfStaffBackend` service
+binding; it holds no Nanocodex bearer credential and cannot select a Nanocodex
+account ID. The account app receives only non-secret installation and readiness
+metadata.
 
 The same Worker also exposes an official Viber Bot REST API channel. It verifies
 the raw callback HMAC, maps each bot/subscriber pair to a durable conversation,
@@ -41,7 +44,6 @@ Configure the deployment once. `SLACK_ENCRYPTION_KEY` and
 `SLACK_OAUTH_STATE_SECRET` are independent base64url-encoded 32-byte keys.
 
 ```sh
-pnpm --filter @nanocodex/chief-of-staff exec wrangler secret put NANOCODEX_API_KEY --config wrangler.jsonc
 pnpm --filter @nanocodex/chief-of-staff exec wrangler secret put SLACK_CLIENT_ID --config wrangler.jsonc
 pnpm --filter @nanocodex/chief-of-staff exec wrangler secret put SLACK_CLIENT_SECRET --config wrangler.jsonc
 pnpm --filter @nanocodex/chief-of-staff exec wrangler secret put SLACK_SIGNING_SECRET --config wrangler.jsonc
@@ -76,9 +78,14 @@ into turns. Replies respect Viber's 7,000-character text limit. A durable delive
 claim suppresses duplicate outbound messages when Viber retries an already handled
 callback; expired claims are recoverable after an interrupted send.
 
-`NANOCODEX_API_KEY` binds this deployment to its owning Nanocodex account. Slack
-OAuth installations are accepted only when initiated by that signed-in owner.
-Set both public origins in Wrangler when deploying under other names or domains.
+Slack OAuth installation metadata remains owned by the signed-in Nanocodex user
+who installed it, so only that user can list or remove the installation. Runtime
+Slack actors are intentionally separate: `(team_id, event.user)` identifies the
+actor's managed account, including in shared channels. Viber uses `(bot URI,
+subscriber ID)` and WhatsApp uses `(phone-number ID, user ID)`. These mappings are
+persistent; uninstalling a provider stops new ingress but does not currently
+delete retained Nanocodex data. Set both public origins in Wrangler when deploying
+under other names or domains.
 
 ## Configure WhatsApp
 
@@ -106,7 +113,7 @@ pnpm --filter @nanocodex/chief-of-staff exec wrangler secret put WHATSAPP_VERIFY
 
 Meta verifies `GET /webhooks/whatsapp` with the verify token. The official
 adapter verifies `X-Hub-Signature-256` on every POST before the message can reach
-an account-owned agent. Reactive replies are sent inside WhatsApp's 24-hour
+the user's isolated agent. Reactive replies are sent inside WhatsApp's 24-hour
 customer-service window; initiating a later conversation requires an approved
 message template.
 
@@ -133,5 +140,5 @@ pnpm deploy:account
 
 Run `pnpm --filter @nanocodex/chief-of-staff check` for OAuth state, Slack,
 WhatsApp, and Viber signatures, workspace fencing, idempotency,
-cross-account/channel isolation, durable two-turn, type, and dry-run deployment
+cross-provider/user/channel isolation, durable two-turn, type, and dry-run deployment
 coverage.

--- a/js/chief-of-staff/README.md
+++ b/js/chief-of-staff/README.md
@@ -19,6 +19,14 @@ binding; it holds no Nanocodex bearer credential and cannot select a Nanocodex
 account ID. The account app receives only non-secret installation and readiness
 metadata.
 
+The egress Worker funds these generated accounts with one operator-owned OpenAI
+credential. It remains encrypted inside egress credential storage and never
+crosses the Chief RPC or browser boundary:
+
+```sh
+pnpm --filter nanocodex-egress-service exec wrangler secret put CHIEF_OF_STAFF_OPENAI_API_KEY --config wrangler.broker.jsonc
+```
+
 The same Worker also exposes an official Viber Bot REST API channel. It verifies
 the raw callback HMAC, maps each bot/subscriber pair to a durable conversation,
 and returns the retained managed agent's reply through the configured Viber bot.
@@ -117,9 +125,11 @@ the user's isolated agent. Reactive replies are sent inside WhatsApp's 24-hour
 customer-service window; initiating a later conversation requires an approved
 message template.
 
-Deploy the managed service first, then this Worker, and the account application:
+Deploy egress first, then the managed service, this Worker, and the account
+application:
 
 ```sh
+pnpm deploy:egress
 pnpm deploy:managed
 pnpm deploy:chief-of-staff
 pnpm deploy:account

--- a/js/chief-of-staff/src/managed.ts
+++ b/js/chief-of-staff/src/managed.ts
@@ -1,35 +1,31 @@
-import { Agent } from "nanocodex/managed";
 import type { ManagedAgentGateway } from "./conversation.ts";
 
-const MANAGED_ORIGIN = "https://managed.nanocodex.internal";
-const API_KEY = /^ncx_live_[A-Za-z0-9_-]{12}_[A-Za-z0-9_-]{43}$/;
-const AGENT_ID = /^[A-Za-z0-9._:-]{1,128}$/;
+const ACCOUNT_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const AGENT_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
-type Fetcher = Readonly<{ fetch(request: Request): Promise<Response> }>;
+export type ChiefOfStaffIdentity = Readonly<{
+  provider: "slack" | "viber" | "whatsapp";
+  subject: string;
+  tenant: string;
+}>;
+
+export type ManagedBackend = Readonly<{
+  createAgent(identity: unknown, idempotencyKey: unknown): Promise<string>;
+  requestingAccountId(request: Request): Promise<string | null>;
+  runTurn(identity: unknown, agentId: unknown, request: unknown): Promise<string>;
+}>;
 
 export class NanocodexManagedGateway implements ManagedAgentGateway {
-  private readonly fetch: typeof globalThis.fetch;
-  private readonly binding: Fetcher;
-  private readonly apiKey: string;
+  private readonly binding: ManagedBackend;
+  private readonly identity: ChiefOfStaffIdentity;
 
-  constructor(
-    binding: Fetcher,
-    apiKey: string,
-  ) {
-    if (!API_KEY.test(apiKey)) throw new Error("Nanocodex account credential is invalid");
+  constructor(binding: ManagedBackend, identity: ChiefOfStaffIdentity) {
     this.binding = binding;
-    this.apiKey = apiKey;
-    this.fetch = this.boundFetch.bind(this);
+    this.identity = identity;
   }
 
   async createAgent(idempotencyKey: string): Promise<string> {
-    const response = await this.fetch(new URL("/v1/agents", MANAGED_ORIGIN), {
-      method: "POST",
-      headers: { "idempotency-key": idempotencyKey },
-    });
-    if (!response.ok) throw await managedFailure(response);
-    const body: unknown = await response.json();
-    const agentId = isRecord(body) && typeof body.agent_id === "string" ? body.agent_id : "";
+    const agentId = await this.binding.createAgent(this.identity, idempotencyKey);
     if (!AGENT_ID.test(agentId)) throw new Error("Managed agent creation returned an invalid identity");
     return agentId;
   }
@@ -38,46 +34,16 @@ export class NanocodexManagedGateway implements ManagedAgentGateway {
     agentId: string,
     request: Readonly<{ id: string; idempotencyKey: string; input: string }>,
   ): Promise<string> {
-    const result = await Agent.open(agentId, {
-      apiKey: this.apiKey,
-      baseUrl: MANAGED_ORIGIN,
-      fetch: this.fetch,
-    }).turn.prompt(request).result();
-    return result.finalMessage;
-  }
-
-  async ownerId(headers?: Headers): Promise<string | undefined> {
-    const response = await this.binding.fetch(new Request(
-      new URL("/v1/me", MANAGED_ORIGIN),
-      { headers: headers ?? { authorization: `Bearer ${this.apiKey}` } },
-    ));
-    if (!response.ok) {
-      await response.body?.cancel();
-      return undefined;
+    const finalMessage = await this.binding.runTurn(this.identity, agentId, request);
+    if (typeof finalMessage !== "string") {
+      throw new Error("Managed agent turn returned an invalid result");
     }
-    const body: unknown = await response.json();
-    const user = isRecord(body) && isRecord(body.user) ? body.user : undefined;
-    return typeof user?.id === "string" ? user.id : undefined;
-  }
-
-  private async boundFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
-    const request = new Request(input, init);
-    const target = new URL(request.url);
-    if (target.origin !== MANAGED_ORIGIN) throw new Error("Managed request escaped its service binding");
-    const headers = new Headers(request.headers);
-    headers.set("authorization", `Bearer ${this.apiKey}`);
-    return this.binding.fetch(new Request(target, {
-      body: request.body,
-      headers,
-      method: request.method,
-      redirect: "manual",
-      signal: request.signal,
-    }));
+    return finalMessage;
   }
 }
 
 export async function requestingAccountId(
-  binding: Fetcher,
+  binding: ManagedBackend,
   request: Request,
 ): Promise<string | undefined> {
   const headers = new Headers();
@@ -85,27 +51,6 @@ export async function requestingAccountId(
     const value = request.headers.get(name);
     if (value) headers.set(name, value);
   }
-  const response = await binding.fetch(new Request(new URL("/v1/me", MANAGED_ORIGIN), { headers }));
-  if (!response.ok) {
-    await response.body?.cancel();
-    return undefined;
-  }
-  const body: unknown = await response.json();
-  const user = isRecord(body) && isRecord(body.user) ? body.user : undefined;
-  return typeof user?.id === "string" ? user.id : undefined;
-}
-
-async function managedFailure(response: Response): Promise<Error> {
-  let code = `http_${response.status}`;
-  try {
-    const body: unknown = await response.json();
-    if (isRecord(body) && typeof body.error === "string") code = body.error;
-  } catch {
-    await response.body?.cancel();
-  }
-  return new Error(`Managed agent request failed: ${code}`);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+  const accountId = await binding.requestingAccountId(new Request(request.url, { headers }));
+  return typeof accountId === "string" && ACCOUNT_ID.test(accountId) ? accountId : undefined;
 }

--- a/js/chief-of-staff/src/protocol.ts
+++ b/js/chief-of-staff/src/protocol.ts
@@ -4,7 +4,6 @@ const SLACK_TEAM_ID = /^T[A-Z0-9]+$/;
 const SLACK_CHANNEL_ID = /^[CDG][A-Z0-9]+$/;
 const SLACK_USER_ID = /^[UW][A-Z0-9]+$/;
 const SLACK_THREAD_ID = /^slack:[CDG][A-Z0-9]+:(?:[0-9]+\.[0-9]+)?$/;
-const API_KEY = /^ncx_live_[A-Za-z0-9_-]{12}_[A-Za-z0-9_-]{43}$/;
 const SLACK_CLIENT_ID = /^[0-9]+\.[0-9]+$/;
 const BASE64_URL = /^[A-Za-z0-9_-]+$/;
 const WHATSAPP_PHONE_NUMBER_ID = /^[0-9]{5,32}$/;
@@ -13,15 +12,14 @@ const WHATSAPP_BUSINESS_USER_ID = /^[A-Z]{2}\.(?:ENT\.)?[A-Za-z0-9]{1,128}$/;
 const WHATSAPP_MESSAGE_ID = /^[A-Za-z0-9._=-]{1,512}$/;
 
 export type SlackChannelIdentity = Readonly<{
-  accountId: string;
   channelId: string;
   conversationId: string;
   platform: "slack";
   teamId: string;
+  userId: string;
 }>;
 
 export type ViberChannelIdentity = Readonly<{
-  accountId: string;
   botUri: string;
   conversationId: string;
   platform: "viber";
@@ -29,7 +27,6 @@ export type ViberChannelIdentity = Readonly<{
 }>;
 
 export type WhatsAppChannelIdentity = Readonly<{
-  accountId: string;
   businessPhoneNumberId: string;
   conversationId: string;
   platform: "whatsapp";
@@ -90,7 +87,6 @@ export function slackMessageIdentity(
   raw: unknown,
   threadId: string,
   isDirectMessage: boolean,
-  accountId: string,
 ): SlackMessageIdentity {
   if (!isRecord(raw)) throw new Error("Slack message payload is missing");
   const teamId = stringValue(raw.team_id) ?? stringValue(raw.team);
@@ -112,11 +108,11 @@ export function slackMessageIdentity(
     actorId,
     messageId,
     channel: {
-      accountId,
       channelId,
       conversationId: isDirectMessage ? `dm:${actorId}` : threadId,
       platform: "slack",
       teamId,
+      userId: actorId,
     },
   };
 }
@@ -124,7 +120,6 @@ export function slackMessageIdentity(
 export function whatsAppMessageIdentity(
   raw: unknown,
   threadId: string,
-  accountId: string,
   expectedPhoneNumberId: string,
 ): WhatsAppMessageIdentity {
   if (!isRecord(raw) || !isRecord(raw.message)) {
@@ -150,7 +145,6 @@ export function whatsAppMessageIdentity(
     actorId,
     messageId,
     channel: {
-      accountId,
       businessPhoneNumberId: phoneNumberId,
       conversationId: threadId,
       platform: "whatsapp",
@@ -161,7 +155,6 @@ export function whatsAppMessageIdentity(
 
 export function configurationReadiness(env: {
   CHIEF_OF_STAFF_PUBLIC_ORIGIN?: string;
-  NANOCODEX_API_KEY?: string;
   SLACK_CLIENT_ID?: string;
   SLACK_CLIENT_SECRET?: string;
   SLACK_ENCRYPTION_KEY?: string;
@@ -194,10 +187,8 @@ export function configurationReadiness(env: {
     && origin.pathname === "/"
     && !origin.search
     && !origin.hash);
-  const validAccount = API_KEY.test(env.NANOCODEX_API_KEY ?? "");
   const slackConfigured = Boolean(
     validOrigin
-    && validAccount
     && SLACK_CLIENT_ID.test(env.SLACK_CLIENT_ID ?? "")
     && (env.SLACK_CLIENT_SECRET?.length ?? 0) >= 16
     && validBase64Key(env.SLACK_ENCRYPTION_KEY)
@@ -206,7 +197,6 @@ export function configurationReadiness(env: {
   );
   const viberConfigured = Boolean(
     validOrigin
-    && validAccount
     && validViberToken(env.VIBER_AUTH_TOKEN)
     && validOptionalHttpsUrl(env.VIBER_BOT_AVATAR)
     && validViberBotName(env.VIBER_BOT_NAME)
@@ -214,7 +204,6 @@ export function configurationReadiness(env: {
   );
   const whatsappConfigured = Boolean(
     validOrigin
-    && validAccount
     && (env.WHATSAPP_ACCESS_TOKEN?.length ?? 0) >= 32
     && (env.WHATSAPP_APP_SECRET?.length ?? 0) >= 16
     && WHATSAPP_PHONE_NUMBER_ID.test(env.WHATSAPP_PHONE_NUMBER_ID ?? "")
@@ -259,10 +248,11 @@ export async function digest(value: unknown): Promise<string> {
 }
 
 export function sameChannelIdentity(left: ChannelIdentity, right: ChannelIdentity): boolean {
-  if (left.platform !== right.platform || left.accountId !== right.accountId
-    || left.conversationId !== right.conversationId) return false;
+  if (left.platform !== right.platform || left.conversationId !== right.conversationId) return false;
   if (left.platform === "slack" && right.platform === "slack") {
-    return left.channelId === right.channelId && left.teamId === right.teamId;
+    return left.channelId === right.channelId
+      && left.teamId === right.teamId
+      && left.userId === right.userId;
   }
   if (left.platform === "viber" && right.platform === "viber") {
     return left.botUri === right.botUri && left.userId === right.userId;

--- a/js/chief-of-staff/src/state-adapter.ts
+++ b/js/chief-of-staff/src/state-adapter.ts
@@ -3,7 +3,7 @@ import type { Lock, QueueEntry, StateAdapter } from "chat";
 type Fetcher = Readonly<{ fetch(request: Request): Promise<Response> }>;
 
 export class DurableChatStateAdapter implements StateAdapter {
-  private readonly state: Fetcher;
+  protected readonly state: Fetcher;
 
   constructor(state: Fetcher) {
     this.state = state;
@@ -89,5 +89,36 @@ export class DurableChatStateAdapter implements StateAdapter {
     if (!response.ok) throw new Error(`Chat SDK state operation failed: ${operation}`);
     const result = await response.json<{ value: T }>();
     return result.value;
+  }
+}
+
+export class SlackInstallationOwnershipError extends Error {
+  constructor() { super("slack_workspace_already_installed"); }
+}
+
+export class SlackOAuthStateAdapter extends DurableChatStateAdapter {
+  private readonly accountId: string;
+
+  constructor(state: Fetcher, accountId: string) {
+    super(state);
+    this.accountId = accountId;
+  }
+
+  override async set<T = unknown>(key: string, value: T, ttlMs?: number): Promise<void> {
+    const teamId = /^slack:installation:(T[A-Z0-9]+)$/.exec(key)?.[1];
+    if (teamId) {
+      const claimed = await this.state.fetch(new Request(
+        "https://state.internal/slack/installations/claim",
+        {
+          body: JSON.stringify({ accountId: this.accountId, teamId }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        },
+      ));
+      if (claimed.status === 409) throw new SlackInstallationOwnershipError();
+      if (!claimed.ok) throw new Error("Slack installation ownership claim failed");
+      await claimed.body?.cancel();
+    }
+    await super.set(key, value, ttlMs);
   }
 }

--- a/js/chief-of-staff/src/state-object.ts
+++ b/js/chief-of-staff/src/state-object.ts
@@ -54,6 +54,9 @@ export class ChiefOfStaffState extends DurableObject<Env> {
     if (url.pathname === "/conversation/delivery" && request.method === "POST") {
       return this.conversationDelivery(request);
     }
+    if (url.pathname === "/slack/installations/claim" && request.method === "POST") {
+      return this.claimSlackInstallation(request);
+    }
     if (url.pathname === "/slack/installations") return this.slackInstallations(request);
     return json({ error: "not_found" }, 404);
   }
@@ -113,14 +116,55 @@ export class ChiefOfStaffState extends DurableObject<Env> {
     if (!validSlackInstallationMetadata(body)) return json({ error: "invalid_request" }, 400);
     const key = `slack:metadata:${body.teamId}`;
     if (request.method === "PUT") {
-      await this.ctx.storage.put(key, body);
-      return new Response(null, { status: 204 });
+      return this.ctx.storage.transaction(async (transaction) => {
+        const ownerKey = `slack:owner:${body.teamId}`;
+        const owner = await transaction.get<string>(ownerKey);
+        const current = await transaction.get<unknown>(key);
+        const expected = owner ?? (validSlackInstallationMetadata(current) ? current.accountId : undefined);
+        if (expected !== body.accountId) return json({ error: "account_forbidden" }, 409);
+        await transaction.put(key, body);
+        return new Response(null, { status: 204 });
+      });
     }
     if (request.method === "DELETE") {
-      await this.ctx.storage.delete(key);
-      return new Response(null, { status: 204 });
+      return this.ctx.storage.transaction(async (transaction) => {
+        const ownerKey = `slack:owner:${body.teamId}`;
+        const owner = await transaction.get<string>(ownerKey);
+        const current = await transaction.get<unknown>(key);
+        const expected = owner ?? (validSlackInstallationMetadata(current) ? current.accountId : undefined);
+        if (expected !== undefined && expected !== body.accountId) {
+          return json({ error: "account_forbidden" }, 409);
+        }
+        await Promise.all([transaction.delete(key), transaction.delete(ownerKey)]);
+        return new Response(null, { status: 204 });
+      });
     }
     return json({ error: "method_not_allowed" }, 405);
+  }
+
+  private async claimSlackInstallation(request: Request): Promise<Response> {
+    let body: unknown;
+    try { body = await request.json(); }
+    catch { return json({ error: "invalid_request" }, 400); }
+    if (!isRecord(body)
+      || Object.keys(body).length !== 2
+      || typeof body.accountId !== "string"
+      || !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(body.accountId)
+      || typeof body.teamId !== "string"
+      || !/^T[A-Z0-9]+$/.test(body.teamId)) {
+      return json({ error: "invalid_request" }, 400);
+    }
+    return this.ctx.storage.transaction(async (transaction) => {
+      const ownerKey = `slack:owner:${body.teamId}`;
+      const metadata = await transaction.get<unknown>(`slack:metadata:${body.teamId}`);
+      const owner = await transaction.get<string>(ownerKey)
+        ?? (validSlackInstallationMetadata(metadata) ? metadata.accountId : undefined);
+      if (owner !== undefined && owner !== body.accountId) {
+        return json({ error: "workspace_already_installed" }, 409);
+      }
+      if (owner === undefined) await transaction.put(ownerKey, body.accountId);
+      return new Response(null, { status: 204 });
+    });
   }
 
   private async conversationTurn(request: Request): Promise<Response> {

--- a/js/chief-of-staff/src/state-object.ts
+++ b/js/chief-of-staff/src/state-object.ts
@@ -12,7 +12,10 @@ import {
   type DeliveryRecord,
   releaseDelivery,
 } from "./delivery.ts";
-import { NanocodexManagedGateway } from "./managed.ts";
+import {
+  NanocodexManagedGateway,
+  type ChiefOfStaffIdentity,
+} from "./managed.ts";
 import {
   sameChannelIdentity,
   validSlackInstallationMetadata,
@@ -22,6 +25,26 @@ import {
 import type { Env } from "./worker.ts";
 
 type ExpiringValue = Readonly<{ expiresAt: number | null; value: unknown }>;
+
+function chiefIdentity(channel: ChannelIdentity): ChiefOfStaffIdentity {
+  switch (channel.platform) {
+    case "slack": return {
+      provider: "slack",
+      subject: channel.userId,
+      tenant: channel.teamId,
+    };
+    case "viber": return {
+      provider: "viber",
+      subject: channel.userId,
+      tenant: channel.botUri,
+    };
+    case "whatsapp": return {
+      provider: "whatsapp",
+      subject: channel.userId,
+      tenant: channel.businessPhoneNumberId,
+    };
+  }
+}
 
 export class ChiefOfStaffState extends DurableObject<Env> {
   async fetch(request: Request): Promise<Response> {
@@ -101,7 +124,7 @@ export class ChiefOfStaffState extends DurableObject<Env> {
   }
 
   private async conversationTurn(request: Request): Promise<Response> {
-    if (!this.env.NANOCODEX_BACKEND || !this.env.NANOCODEX_API_KEY) {
+    if (!this.env.NANOCODEX_BACKEND) {
       return json({ error: "managed_service_unavailable" }, 503);
     }
     let body: ConversationTurnRequest;
@@ -110,7 +133,7 @@ export class ChiefOfStaffState extends DurableObject<Env> {
     try {
       const engine = new ConversationEngine(
         new DurableConversationStore(this.ctx.storage),
-        new NanocodexManagedGateway(this.env.NANOCODEX_BACKEND, this.env.NANOCODEX_API_KEY),
+        new NanocodexManagedGateway(this.env.NANOCODEX_BACKEND, chiefIdentity(body.channel)),
       );
       return json(await engine.turn(body), 200);
     } catch (error) {

--- a/js/chief-of-staff/src/viber.ts
+++ b/js/chief-of-staff/src/viber.ts
@@ -58,13 +58,11 @@ export async function readViberWebhook(request: Request, authToken: string): Pro
 }
 
 export function viberChannelIdentity(
-  accountId: string,
   botUri: string,
   userId: string,
 ): ChannelIdentity {
   if (!VIBER_USER_ID.test(userId)) throw new ViberWebhookError("invalid_payload");
   return {
-    accountId,
     botUri,
     conversationId: `dm:${userId}`,
     platform: "viber",

--- a/js/chief-of-staff/src/worker.ts
+++ b/js/chief-of-staff/src/worker.ts
@@ -26,7 +26,11 @@ import {
   type WhatsAppMessageIdentity,
 } from "./protocol.ts";
 import { slackAuthorizationUrl, verifySlackInstallState } from "./slack-oauth.ts";
-import { DurableChatStateAdapter } from "./state-adapter.ts";
+import {
+  DurableChatStateAdapter,
+  SlackInstallationOwnershipError,
+  SlackOAuthStateAdapter,
+} from "./state-adapter.ts";
 import {
   readViberWebhook,
   sendViberText,
@@ -151,7 +155,7 @@ async function finishSlackInstall(request: Request, env: Env): Promise<Response>
     return json({ error: "invalid_oauth_state" }, { status: 400 });
   }
   try {
-    const runtime = slackRuntime(env);
+    const runtime = slackRuntime(env, state.accountId);
     await runtime.chat.initialize();
     const result = await runtime.slack.handleOAuthCallback(request, {
       redirectUri: new URL("/v1/slack/callback", env.CHIEF_OF_STAFF_PUBLIC_ORIGIN).href,
@@ -159,10 +163,6 @@ async function finishSlackInstall(request: Request, env: Env): Promise<Response>
     if (result.isEnterpriseInstall || !SLACK_TEAM_ID.test(result.teamId)) {
       await runtime.slack.deleteInstallation(result.teamId);
       return installationReturn(env, "workspace_required");
-    }
-    const retained = await installationMetadata(env, result.teamId);
-    if (retained && retained.accountId !== state.accountId) {
-      return installationReturn(env, "workspace_already_installed");
     }
     const metadata = {
       accountId: state.accountId,
@@ -174,6 +174,9 @@ async function finishSlackInstall(request: Request, env: Env): Promise<Response>
     await writeInstallationMetadata(env, metadata, "PUT");
     return installationReturn(env, "installed");
   } catch (error) {
+    if (error instanceof SlackInstallationOwnershipError) {
+      return installationReturn(env, "workspace_already_installed");
+    }
     console.warn({
       type: "chief_of_staff.slack_install_failed",
       error_kind: error instanceof Error ? error.name : typeof error,
@@ -422,10 +425,13 @@ function deliveryRequest(
   }));
 }
 
-function slackRuntime(env: Env): SlackRuntime {
-  const retained = slackRuntimes.get(env as object);
+function slackRuntime(env: Env, oauthAccountId?: string): SlackRuntime {
+  const retained = oauthAccountId === undefined ? slackRuntimes.get(env as object) : undefined;
   if (retained) return retained;
   const stateObject = env.CHIEF_OF_STAFF_STATE.getByName(SLACK_STATE_OBJECT);
+  const state = oauthAccountId === undefined
+    ? new DurableChatStateAdapter(stateObject)
+    : new SlackOAuthStateAdapter(stateObject, oauthAccountId);
   const slack = createSlackAdapter({
     agentView: true,
     apiUrl: env.SLACK_API_URL,
@@ -441,7 +447,7 @@ function slackRuntime(env: Env): SlackRuntime {
     concurrency: "concurrent",
     dedupeTtlMs: 24 * 60 * 60 * 1_000,
     logger: "warn",
-    state: new DurableChatStateAdapter(stateObject),
+    state,
     userName: "chief-of-staff",
   });
   const handle = async (thread: Thread, message: Message) => {
@@ -458,7 +464,7 @@ function slackRuntime(env: Env): SlackRuntime {
   chat.onNewMention(handle);
   chat.onSubscribedMessage(handle);
   const runtime = { chat, slack };
-  slackRuntimes.set(env as object, runtime);
+  if (oauthAccountId === undefined) slackRuntimes.set(env as object, runtime);
   return runtime;
 }
 

--- a/js/chief-of-staff/src/worker.ts
+++ b/js/chief-of-staff/src/worker.ts
@@ -8,7 +8,11 @@ import {
   type WhatsAppAdapter,
 } from "@chat-adapter/whatsapp";
 import { Chat, ConsoleLogger, type Message, type Thread } from "chat";
-import { NanocodexManagedGateway, requestingAccountId } from "./managed.ts";
+import {
+  NanocodexManagedGateway,
+  requestingAccountId,
+  type ManagedBackend,
+} from "./managed.ts";
 import {
   configurationReadiness,
   digest,
@@ -37,8 +41,7 @@ export interface Env {
   CHIEF_OF_STAFF_ACCOUNT_ORIGIN?: string;
   CHIEF_OF_STAFF_PUBLIC_ORIGIN?: string;
   CHIEF_OF_STAFF_STATE: StateNamespace;
-  NANOCODEX_API_KEY?: string;
-  NANOCODEX_BACKEND?: Fetcher;
+  NANOCODEX_BACKEND?: ManagedBackend;
   SLACK_API_URL?: string;
   SLACK_CLIENT_ID?: string;
   SLACK_CLIENT_SECRET?: string;
@@ -64,7 +67,6 @@ type WhatsAppRuntime = Readonly<{
 
 const slackRuntimes = new WeakMap<object, SlackRuntime>();
 const whatsappRuntimes = new WeakMap<object, WhatsAppRuntime>();
-const ownerIds = new WeakMap<object, Promise<string | undefined>>();
 const SLACK_STATE_OBJECT = "chat-sdk:slack";
 const WHATSAPP_STATE_OBJECT = "chat-sdk:whatsapp";
 const SLACK_TEAM_ID = /^T[A-Z0-9]+$/;
@@ -117,9 +119,6 @@ async function beginSlackInstall(request: Request, env: Env): Promise<Response> 
   }
   const requester = await requestingAccountId(env.NANOCODEX_BACKEND, request);
   if (!requester) return json({ error: "unauthorized" }, { status: 401 });
-  if (await configuredOwnerId(env) !== requester) {
-    return json({ error: "account_forbidden" }, { status: 403 });
-  }
   const redirectUri = new URL("/v1/slack/callback", env.CHIEF_OF_STAFF_PUBLIC_ORIGIN).href;
   const authorization = await slackAuthorizationUrl({
     accountId: requester,
@@ -148,7 +147,7 @@ async function finishSlackInstall(request: Request, env: Env): Promise<Response>
     url.searchParams.get("state") ?? "",
     env.SLACK_OAUTH_STATE_SECRET,
   );
-  if (!state || await configuredOwnerId(env) !== state.accountId) {
+  if (!state) {
     return json({ error: "invalid_oauth_state" }, { status: 400 });
   }
   try {
@@ -160,6 +159,10 @@ async function finishSlackInstall(request: Request, env: Env): Promise<Response>
     if (result.isEnterpriseInstall || !SLACK_TEAM_ID.test(result.teamId)) {
       await runtime.slack.deleteInstallation(result.teamId);
       return installationReturn(env, "workspace_required");
+    }
+    const retained = await installationMetadata(env, result.teamId);
+    if (retained && retained.accountId !== state.accountId) {
+      return installationReturn(env, "workspace_already_installed");
     }
     const metadata = {
       accountId: state.accountId,
@@ -191,7 +194,7 @@ async function removeSlackInstallation(
   if (!requester) return json({ error: "unauthorized" }, { status: 401 });
   const metadata = await installationMetadata(env, teamId);
   if (!metadata) return json({ error: "not_found" }, { status: 404 });
-  if (metadata.accountId !== requester || await configuredOwnerId(env) !== requester) {
+  if (metadata.accountId !== requester) {
     return json({ error: "account_forbidden" }, { status: 403 });
   }
   const runtime = slackRuntime(env);
@@ -240,7 +243,7 @@ async function slackWebhook(
   }
   const teamId = slackTeamId(payload);
   const metadata = teamId ? await installationMetadata(env, teamId) : undefined;
-  if (!metadata || metadata.accountId !== await configuredOwnerId(env)) {
+  if (!metadata) {
     return json({ error: "workspace_forbidden" }, { status: 403 });
   }
   if (slackEventType(payload) === "app_uninstalled") {
@@ -290,10 +293,8 @@ async function viberWebhook(request: Request, env: Env): Promise<Response> {
     return json({ error: "invalid_payload" }, { status: 400 });
   }
   if (callback.kind === "ignored") return json({ status: 0 });
-  const ownerId = await configuredOwnerId(env);
-  if (!ownerId) return json({ error: "channel_unavailable" }, { status: 503 });
   const receiver = callback.kind === "message" ? callback.actorId : callback.userId;
-  const identity = viberChannelIdentity(ownerId, env.VIBER_BOT_URI, receiver);
+  const identity = viberChannelIdentity(env.VIBER_BOT_URI, receiver);
   const routeDigest = await digest(identity);
   const session = env.CHIEF_OF_STAFF_STATE.getByName(`conversation:${routeDigest}`);
   if (callback.kind === "conversation_started") {
@@ -447,10 +448,10 @@ function slackRuntime(env: Env): SlackRuntime {
     await thread.subscribe();
     const teamId = messageTeamId(message.raw);
     const metadata = teamId ? await installationMetadata(env, teamId) : undefined;
-    if (!metadata || metadata.accountId !== await configuredOwnerId(env)) {
+    if (!metadata) {
       throw new Error("Slack installation owner is unavailable");
     }
-    const identity = slackMessageIdentity(message.raw, thread.id, thread.isDM, metadata.accountId);
+    const identity = slackMessageIdentity(message.raw, thread.id, thread.isDM);
     await deliverTurn(env, thread, message, identity);
   };
   chat.onDirectMessage(handle);
@@ -488,12 +489,9 @@ function whatsappRuntime(env: Env): WhatsAppRuntime {
   });
   const handle = async (thread: Thread, message: Message) => {
     await thread.subscribe();
-    const owner = await configuredOwnerId(env);
-    if (!owner) throw new Error("WhatsApp account owner is unavailable");
     const identity = whatsAppMessageIdentity(
       message.raw,
       thread.id,
-      owner,
       env.WHATSAPP_PHONE_NUMBER_ID!,
     );
     await deliverTurn(env, thread, message, identity);
@@ -538,23 +536,17 @@ async function readiness(request: Request, env: Env): Promise<Response> {
   const requester = await requestingAccountId(env.NANOCODEX_BACKEND, request);
   if (!requester) return json({ error: "unauthorized" }, { status: 401 });
   const config = configurationReadiness(env);
-  const owner = config.slack.configured || config.viber.configured || config.whatsapp.configured
-    ? await configuredOwnerId(env)
-    : undefined;
-  const accountMatch = owner === requester;
-  const installations = accountMatch
-    ? (await installationMetadataList(env))
-      .filter((installation) => installation.accountId === requester)
-      .map(({ accountId: _, ...installation }) => installation)
-    : [];
-  const slackReady = config.slack.configured && accountMatch && installations.length > 0;
-  const viberReady = config.viber.configured && accountMatch;
-  const whatsappConfiguredForAccount = config.whatsapp.configured && accountMatch;
+  const installations = (await installationMetadataList(env))
+    .filter((installation) => installation.accountId === requester)
+    .map(({ accountId: _, ...installation }) => installation);
+  const slackReady = config.slack.configured && installations.length > 0;
+  const viberReady = config.viber.configured;
+  const whatsappConfiguredForAccount = config.whatsapp.configured;
   const body: Readiness = {
-    accountMatch,
+    accountMatch: true,
     configured: slackReady || viberReady || whatsappConfiguredForAccount,
     installations,
-    installUrl: config.configured && accountMatch ? "/api/chief-of-staff/slack/install" : null,
+    installUrl: config.configured ? "/api/chief-of-staff/slack/install" : null,
     webhookUrl: config.webhookUrl,
     channels: [
       {
@@ -562,11 +554,9 @@ async function readiness(request: Request, env: Env): Promise<Response> {
         availability: slackReady ? "ready" : "setup_required",
         contract: "first_party",
         detail: slackReady
-          ? `${installations.length} Slack workspace${installations.length === 1 ? "" : "s"} route bot events to account-owned durable agents.`
+          ? `${installations.length} Slack workspace${installations.length === 1 ? "" : "s"} route each verified actor to an isolated durable Nanocodex account and agent.`
           : config.configured
-            ? accountMatch
-              ? "Install the Chief of Staff bot into a Slack workspace."
-              : "This deployment is bound to a different Nanocodex account."
+            ? "Install the Chief of Staff bot into a Slack workspace."
             : "The shared Slack app is not configured by the deployment operator.",
       },
       {
@@ -574,10 +564,8 @@ async function readiness(request: Request, env: Env): Promise<Response> {
         availability: whatsappConfiguredForAccount ? "configured" : "setup_required",
         contract: "first_party",
         detail: whatsappConfiguredForAccount
-          ? "The Worker is configured; signed WhatsApp messages route to account-owned durable agents."
-          : config.whatsapp.configured
-            ? "This deployment is bound to a different Nanocodex account."
-            : "Add the Meta app credentials and subscribe the shared webhook to enable WhatsApp.",
+          ? "The Worker is configured; each signed WhatsApp identity gets its own durable Nanocodex account and agent."
+          : "Add the Meta app credentials and subscribe the shared webhook to enable WhatsApp.",
         webhookUrl: config.whatsapp.webhookUrl,
       },
       {
@@ -591,9 +579,7 @@ async function readiness(request: Request, env: Env): Promise<Response> {
         availability: viberReady ? "ready" : "setup_required",
         contract: "first_party",
         detail: config.viber.configured
-          ? accountMatch
-            ? "Signed Viber callbacks route each subscriber to an account-owned durable agent."
-            : "This deployment is bound to a different Nanocodex account."
+          ? "Each signed Viber subscriber gets its own durable Nanocodex account and agent."
           : "Viber bot token, bot identity, or public origin is incomplete.",
         webhookUrl: config.viber.webhookUrl,
       },
@@ -709,16 +695,6 @@ function logViberFailure(operation: string, error: unknown): void {
     type: `chief_of_staff.viber_${operation}`,
     error_kind: error instanceof Error ? error.name : typeof error,
   });
-}
-
-function configuredOwnerId(env: Env): Promise<string | undefined> {
-  const retained = ownerIds.get(env as object);
-  if (retained) return retained;
-  const loading = env.NANOCODEX_BACKEND && env.NANOCODEX_API_KEY
-    ? new NanocodexManagedGateway(env.NANOCODEX_BACKEND, env.NANOCODEX_API_KEY).ownerId()
-    : Promise.resolve(undefined);
-  ownerIds.set(env as object, loading);
-  return loading;
 }
 
 function installationReturn(env: Env, result: string): Response {

--- a/js/chief-of-staff/test/conversation.test.ts
+++ b/js/chief-of-staff/test/conversation.test.ts
@@ -36,15 +36,14 @@ class RememberingGateway implements ManagedAgentGateway {
 }
 
 const channel: ChannelIdentity = {
-  accountId: "account-a",
   channelId: "D123ABC",
   conversationId: "dm:U123ABC",
   platform: "slack",
   teamId: "T123ABC",
+  userId: "U123ABC",
 };
 
 const viberChannel: ChannelIdentity = {
-  accountId: "account-a",
   botUri: "nanocodex-chief",
   conversationId: "dm:01234567890A=",
   platform: "viber",
@@ -52,7 +51,6 @@ const viberChannel: ChannelIdentity = {
 };
 
 const whatsappChannel: ChannelIdentity = {
-  accountId: "account-a",
   businessPhoneNumberId: "123456789012345",
   conversationId: "whatsapp:123456789012345:15551234567",
   platform: "whatsapp",
@@ -124,7 +122,7 @@ test("a replayed message id with altered input is fenced", async () => {
   );
 });
 
-test("durable state cannot be rebound across accounts or Slack channels", async () => {
+test("durable state cannot be rebound across Slack actors or channels", async () => {
   const store = new MemoryConversationStore();
   const gateway = new RememberingGateway();
   const engine = new ConversationEngine(store, gateway);
@@ -136,7 +134,7 @@ test("durable state cannot be rebound across accounts or Slack channels", async 
   });
 
   for (const conflicting of [
-    { ...channel, accountId: "account-b" },
+    { ...channel, userId: "U999XYZ" },
     { ...channel, channelId: "D999XYZ" },
   ]) {
     await assert.rejects(
@@ -151,7 +149,7 @@ test("durable state cannot be rebound across accounts or Slack channels", async 
         && error.code === "channel_identity_conflict",
     );
   }
-  assert.notEqual(await digest(channel), await digest({ ...channel, accountId: "account-b" }));
+  assert.notEqual(await digest(channel), await digest({ ...channel, userId: "U999XYZ" }));
   assert.notEqual(await digest(channel), await digest({ ...channel, channelId: "D999XYZ" }));
 });
 

--- a/js/chief-of-staff/test/managed.test.ts
+++ b/js/chief-of-staff/test/managed.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  NanocodexManagedGateway,
+  requestingAccountId,
+  type ChiefOfStaffIdentity,
+  type ManagedBackend,
+} from "../src/managed.ts";
+
+const identity: ChiefOfStaffIdentity = {
+  provider: "whatsapp",
+  subject: "15551234567",
+  tenant: "123456789012345",
+};
+
+test("the managed gateway uses narrow RPC without bearer credentials or account IDs", async () => {
+  const calls: unknown[][] = [];
+  const backend: ManagedBackend = {
+    async requestingAccountId() { return null; },
+    async createAgent(...args) {
+      calls.push(["create", ...args]);
+      return "01991e48-76d1-7000-8000-000000000001";
+    },
+    async runTurn(...args) {
+      calls.push(["turn", ...args]);
+      return "done";
+    },
+  };
+  const gateway = new NanocodexManagedGateway(backend, identity);
+  const agentId = await gateway.createAgent("chief-session:key");
+  const finalMessage = await gateway.runTurn(agentId, {
+    id: "whatsapp-turn",
+    idempotencyKey: "chief-turn:key",
+    input: "hello",
+  });
+
+  assert.equal(finalMessage, "done");
+  assert.deepEqual(calls, [
+    ["create", identity, "chief-session:key"],
+    ["turn", identity, agentId, {
+      id: "whatsapp-turn",
+      idempotencyKey: "chief-turn:key",
+      input: "hello",
+    }],
+  ]);
+  assert.equal(JSON.stringify(calls).includes("authorization"), false);
+  assert.equal(JSON.stringify(calls).includes("accountId"), false);
+});
+
+test("Slack installer authentication forwards only browser authentication headers", async () => {
+  let captured: Request | undefined;
+  const backend: ManagedBackend = {
+    async requestingAccountId(request) {
+      captured = request;
+      return "00000000-0000-4000-8000-000000000001";
+    },
+    async createAgent() { throw new Error("not used"); },
+    async runTurn() { throw new Error("not used"); },
+  };
+  const accountId = await requestingAccountId(backend, new Request("https://chief.example/readiness", {
+    headers: {
+      authorization: "Bearer browser-session",
+      cookie: "nanocodex_account=session",
+      origin: "https://nanocodex.example",
+      "x-forged-account-id": "victim",
+    },
+  }));
+
+  assert.equal(accountId, "00000000-0000-4000-8000-000000000001");
+  assert.equal(captured?.headers.get("cookie"), "nanocodex_account=session");
+  assert.equal(captured?.headers.get("x-forged-account-id"), null);
+});

--- a/js/chief-of-staff/test/webhook.test.ts
+++ b/js/chief-of-staff/test/webhook.test.ts
@@ -296,6 +296,63 @@ test("the Slack callback stores an encrypted bot installation and returns to the
   }
 });
 
+test("a second account cannot replace an owned Slack workspace installation", async () => {
+  const fixture = statefulEnv();
+  fixture.metadata.set("T123ABC", {
+    accountId,
+    botUserId: "U123ABC",
+    installedAt: 1,
+    teamId: "T123ABC",
+    teamName: "Acme",
+  });
+  fixture.values.set("slack:installation:T123ABC", "encrypted-original-installation");
+  fixture.env.NANOCODEX_BACKEND = {
+    async requestingAccountId() { return "00000000-0000-4000-8000-000000000002"; },
+    async createAgent() { throw new Error("not used"); },
+    async runTurn() { throw new Error("not used"); },
+  };
+  const start = await worker.fetch(new Request("https://chief.example/v1/slack/install"), fixture.env);
+  const state = new URL(start.headers.get("location")!).searchParams.get("state")!;
+  const slack = createServer((request, response) => {
+    if (request.url === "/api/oauth.v2.access") {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({
+        access_token: "xoxb-replacement-secret",
+        app_id: "A123ABC",
+        bot_user_id: "U999XYZ",
+        ok: true,
+        scope: "chat:write",
+        team: { id: "T123ABC", name: "Acme" },
+        token_type: "bot",
+      }));
+      return;
+    }
+    response.statusCode = 404;
+    response.end();
+  });
+  await new Promise<void>((resolve) => slack.listen(0, "127.0.0.1", resolve));
+  const address = slack.address();
+  if (!address || typeof address === "string") throw new Error("Slack fixture did not bind");
+  fixture.env.SLACK_API_URL = `http://127.0.0.1:${address.port}/api/`;
+  try {
+    const callback = await worker.fetch(new Request(
+      `https://chief.example/v1/slack/callback?code=oauth-code&state=${encodeURIComponent(state)}`,
+    ), fixture.env);
+    assert.equal(callback.status, 303);
+    assert.equal(
+      callback.headers.get("location"),
+      "https://nanocodex.example/demos/chief-of-staff?slack=workspace_already_installed",
+    );
+    assert.equal(fixture.metadata.get("T123ABC")?.accountId, accountId);
+    assert.equal(
+      fixture.values.get("slack:installation:T123ABC"),
+      "encrypted-original-installation",
+    );
+  } finally {
+    await new Promise<void>((resolve, reject) => slack.close((error) => error ? reject(error) : resolve()));
+  }
+});
+
 test("Slack app_uninstalled removes the bot installation without touching the user connector", async () => {
   const fixture = statefulEnv();
   fixture.metadata.set("T123ABC", {
@@ -528,6 +585,17 @@ function statefulEnv(): {
       return {
         async fetch(request) {
           const url = new URL(request.url);
+          if (url.pathname === "/slack/installations/claim" && request.method === "POST") {
+            const body = await request.json<{ accountId: string; teamId: string }>();
+            const ownerKey = `slack:owner:${body.teamId}`;
+            const current = values.get(ownerKey)
+              ?? (metadata.get(body.teamId) as { accountId?: string } | undefined)?.accountId;
+            if (current !== undefined && current !== body.accountId) {
+              return Response.json({ error: "workspace_already_installed" }, { status: 409 });
+            }
+            values.set(ownerKey, body.accountId);
+            return new Response(null, { status: 204 });
+          }
           if (url.pathname === "/slack/installations") {
             if (request.method === "GET") {
               return Response.json({ installations: [...metadata.values()] });
@@ -539,8 +607,17 @@ function statefulEnv(): {
               teamId: string;
               teamName: string;
             }>();
+            const ownerKey = `slack:owner:${body.teamId}`;
+            const owner = values.get(ownerKey)
+              ?? (metadata.get(body.teamId) as { accountId?: string } | undefined)?.accountId;
+            if (owner !== undefined && owner !== body.accountId) {
+              return Response.json({ error: "account_forbidden" }, { status: 409 });
+            }
             if (request.method === "PUT") metadata.set(body.teamId, body);
-            if (request.method === "DELETE") metadata.delete(body.teamId);
+            if (request.method === "DELETE") {
+              metadata.delete(body.teamId);
+              values.delete(ownerKey);
+            }
             return new Response(null, { status: 204 });
           }
           if (url.pathname === "/chat-sdk") {

--- a/js/chief-of-staff/test/webhook.test.ts
+++ b/js/chief-of-staff/test/webhook.test.ts
@@ -196,7 +196,6 @@ test("a signed WhatsApp DM reaches the exact durable route and posts its reply",
     assert.deepEqual(fixture.turns[0], {
       actorId: "15551234567",
       channel: {
-        accountId,
         businessPhoneNumberId: "123456789012345",
         conversationId: "whatsapp:123456789012345:15551234567",
         platform: "whatsapp",
@@ -335,9 +334,9 @@ test("readiness reports bot installations without returning provider credentials
     teamName: "Acme",
   }]));
   configured.NANOCODEX_BACKEND = {
-    async fetch() {
-      return Response.json({ user: { id: accountId } });
-    },
+    async requestingAccountId() { return accountId; },
+    async createAgent() { throw new Error("not used"); },
+    async runTurn() { throw new Error("not used"); },
   };
   const response = await worker.fetch(new Request("https://chief.example/v1/readiness", {
     headers: { authorization: "Bearer browser-session" },
@@ -429,7 +428,6 @@ test("signed Viber messages preserve the exact token and route one replay-safe r
     assert.deepEqual(calls.stateBody, {
       actorId: "01234567890A=",
       channel: {
-        accountId,
         botUri: "nanocodex-chief",
         conversationId: "dm:01234567890A=",
         platform: "viber",
@@ -490,8 +488,11 @@ function env(installations: readonly unknown[] = [{
         };
       },
     },
-    NANOCODEX_API_KEY: `ncx_live_${"a".repeat(12)}_${"b".repeat(43)}`,
-    NANOCODEX_BACKEND: { async fetch() { return Response.json({ user: { id: accountId } }); } },
+    NANOCODEX_BACKEND: {
+      async requestingAccountId() { return accountId; },
+      async createAgent() { throw new Error("not used"); },
+      async runTurn() { throw new Error("not used"); },
+    },
     SLACK_CLIENT_ID: "123.456",
     SLACK_CLIENT_SECRET: "test-client-secret",
     SLACK_ENCRYPTION_KEY: key,

--- a/js/chief-of-staff/test/whatsapp.test.ts
+++ b/js/chief-of-staff/test/whatsapp.test.ts
@@ -23,14 +23,12 @@ test("WhatsApp identity is bound to the configured business phone and canonical 
     whatsAppMessageIdentity(
       raw,
       "whatsapp:123456789012345:15551234567",
-      "account-a",
       "123456789012345",
     ),
     {
       actorId: "15551234567",
       messageId: raw.message.id,
       channel: {
-        accountId: "account-a",
         businessPhoneNumberId: "123456789012345",
         conversationId: "whatsapp:123456789012345:15551234567",
         platform: "whatsapp",
@@ -43,7 +41,6 @@ test("WhatsApp identity is bound to the configured business phone and canonical 
     () => whatsAppMessageIdentity(
       raw,
       "whatsapp:999999999999999:15551234567",
-      "account-a",
       "123456789012345",
     ),
     /thread is not bound/,
@@ -52,7 +49,6 @@ test("WhatsApp identity is bound to the configured business phone and canonical 
     () => whatsAppMessageIdentity(
       raw,
       "whatsapp:123456789012345:15551234567",
-      "account-a",
       "999999999999999",
     ),
     /business phone identity/,
@@ -62,7 +58,6 @@ test("WhatsApp identity is bound to the configured business phone and canonical 
 test("WhatsApp readiness is independent from Slack configuration", () => {
   const readiness = configurationReadiness({
     CHIEF_OF_STAFF_PUBLIC_ORIGIN: "https://chief.example",
-    NANOCODEX_API_KEY: `ncx_live_${"a".repeat(12)}_${"b".repeat(43)}`,
     WHATSAPP_ACCESS_TOKEN: "token".repeat(12),
     WHATSAPP_APP_SECRET: "app-secret-which-is-long-enough",
     WHATSAPP_PHONE_NUMBER_ID: "123456789012345",

--- a/js/chief-of-staff/wrangler.jsonc
+++ b/js/chief-of-staff/wrangler.jsonc
@@ -23,7 +23,8 @@
   "services": [
     {
       "binding": "NANOCODEX_BACKEND",
-      "service": "nanocodex-durable-agent"
+      "service": "nanocodex-durable-agent",
+      "entrypoint": "ChiefOfStaffBackend"
     }
   ],
   "durable_objects": {
@@ -51,6 +52,7 @@
         {
           "binding": "NANOCODEX_BACKEND",
           "service": "nanocodex-durable-agent",
+          "entrypoint": "ChiefOfStaffBackend",
           "remote": false
         }
       ],

--- a/js/egress/README.md
+++ b/js/egress/README.md
@@ -8,7 +8,9 @@ production evidence live in [../../AGENTS.md](../../AGENTS.md).
 
 - `wrangler.broker.jsonc` deploys `src/egress.ts` as `nanocodex-egress`.
   It has `workers_dev = false` and no public routes; managed services reach it
-  only through a Service Binding.
+  only through a Service Binding. Its named `ChiefOfStaffEgress` RPC can only
+  idempotently install the operator-funded model credential for a managed,
+  server-generated Chief user ID.
 - `wrangler.agent.jsonc` deploys `src/agent.ts` as the public
   `nanocodex-egress-agent-example`. Its `EGRESS` binding demonstrates the
   private call shape; it is not the broker or a production control surface.
@@ -24,6 +26,10 @@ connection material, and brokered SSH private keys. Durable Objects encrypt
 that state with AES-256-GCM before storage. Production requires
 `CREDENTIAL_ENCRYPTION_KEY`; a static Secrets Store binding can supply it, and
 `CREDENTIAL_ENCRYPTION_KEY_PREVIOUS` supports key rotation.
+
+Chief of Staff deployments also require `CHIEF_OF_STAFF_OPENAI_API_KEY` on
+this broker. The named RPC copies it directly into the generated user's
+encrypted credential vault; the value is never returned to managed or Chief.
 
 Credentials and encryption keys never enter browser code, managed Workers,
 agent configuration, tool output, or status/control responses. The managed

--- a/js/egress/src/broker.ts
+++ b/js/egress/src/broker.ts
@@ -33,6 +33,7 @@ const SUBJECT_TOMBSTONE_PREFIX = "!deleted:";
 
 export interface BrokerEnv extends CredentialVaultEnv {
   AGENT_SUBJECTS: DurableObjectNamespace<AgentSubjectDirectory>;
+  CHIEF_OF_STAFF_OPENAI_API_KEY?: string;
   CHATGPT_ISSUER?: string;
   ALLOW_LOCAL_CREDENTIAL_CLAIM?: string;
   LOCAL_CHATGPT_BOOTSTRAP?: string;
@@ -430,6 +431,25 @@ export class UserCredentialBroker extends DurableObject<BrokerEnv> {
         const secret = stringField(body, "api_key")?.trim();
         if (!secret || secret.length > 8_192 || /[\u0000-\u001f\u007f]/.test(secret)) {
           return jsonError(400, "invalid_openai_api_key");
+        }
+        this.#credentials.openai = {
+          secret,
+          createdAt: Date.now(),
+          revision: (this.#credentials.openai?.revision ?? -1) + 1,
+        };
+        this.#credentials.active = "openai";
+        await this.#persist();
+        return new Response(null, { status: 204, headers: noStoreHeaders() });
+      }
+      if (request.method === "PUT" && url.pathname === "/v1/chief-of-staff/openai-key") {
+        if (await hasRequestPayload(request)) return jsonError(400, "invalid_request");
+        const secret = this.#env.CHIEF_OF_STAFF_OPENAI_API_KEY?.trim();
+        if (!secret || secret.length > 8_192 || /[\u0000-\u001f\u007f]/.test(secret)) {
+          return jsonError(503, "chief_of_staff_credential_unavailable");
+        }
+        if (this.#credentials.active === "openai"
+          && this.#credentials.openai?.secret === secret) {
+          return new Response(null, { status: 204, headers: noStoreHeaders() });
         }
         this.#credentials.openai = {
           secret,

--- a/js/egress/src/egress.ts
+++ b/js/egress/src/egress.ts
@@ -1,3 +1,4 @@
+import { WorkerEntrypoint } from "cloudflare:workers";
 import {
   AgentSubjectDirectory,
   type BrokerEnv,
@@ -35,6 +36,7 @@ const SUBJECT_DIRECTORY_PREFIX = "agent-subject-v1:";
 const READINESS_SUBJECT_DIRECTORY_NAME = "agent-subject-readiness-v1";
 const SUBJECT = /^[A-Za-z0-9_-]{43,128}$/;
 const USER_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const CHIEF_USER_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const SUBJECT_HEADER = "x-nanocodex-subject";
 const PROVIDER_PLACEHOLDER = "Bearer NANOCODEX_PROVIDER_CREDENTIAL";
 const MODEL_STATUS_PATH = "/.well-known/nanocodex/model-status";
@@ -181,6 +183,23 @@ export interface EgressEnv extends BrokerEnv, ConnectorBrokerEnv {
   ALLOW_INSECURE_LOOPBACK_RELAY?: string;
   NANOCODEX_BROKER_PROBE_TOKEN?: string;
   DEPLOYMENT_SHA?: string;
+}
+
+export class ChiefOfStaffEgress extends WorkerEntrypoint<EgressEnv> {
+  async ensureCredential(userIdValue: unknown): Promise<void> {
+    if (typeof userIdValue !== "string" || !CHIEF_USER_ID.test(userIdValue)) {
+      throw new Error("invalid_chief_user");
+    }
+    const response = await userBroker(this.env, userIdValue).fetch(
+      "https://credentials.internal/v1/chief-of-staff/openai-key",
+      { method: "PUT" },
+    );
+    if (!response.ok) {
+      await response.body?.cancel();
+      throw new Error("chief_credential_unavailable");
+    }
+    await response.body?.cancel();
+  }
 }
 
 type ModelOperation = Readonly<{

--- a/js/egress/test/chief-of-staff-credential.test.ts
+++ b/js/egress/test/chief-of-staff-credential.test.ts
@@ -1,0 +1,43 @@
+import { env } from "cloudflare:workers";
+import { runInDurableObject, SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+import type { UserCredentialBroker } from "../src/broker";
+import type { EncryptedEnvelope } from "../src/credential-vault";
+import type { EgressEnv } from "../src/egress";
+
+const workerEnv = env as unknown as EgressEnv;
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+
+describe("Chief of Staff model authority", () => {
+  it("installs one service credential idempotently without exposing it publicly", async () => {
+    const stub = workerEnv.USER_CREDENTIALS.getByName(USER_ID);
+    const install = () => stub.fetch(
+      "https://credentials.internal/v1/chief-of-staff/openai-key",
+      { method: "PUT" },
+    );
+
+    expect((await install()).status).toBe(204);
+    expect((await install()).status).toBe(204);
+    const credential = await stub.fetch("https://credentials.internal/v1/credential", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ recover: false }),
+    });
+    expect(await credential.json()).toEqual({
+      kind: "openai",
+      revision: 0,
+      secret: "sk-chief-of-staff-test-secret",
+    });
+
+    await runInDurableObject(stub, async (_instance: UserCredentialBroker, state) => {
+      const row = await state.storage.get<{ envelope: EncryptedEnvelope }>("credential-state");
+      expect(JSON.stringify(row)).not.toContain("sk-chief-of-staff-test-secret");
+    });
+    const publicAttempt = await SELF.fetch(
+      `https://broker.internal/users/${USER_ID}/credentials/chief-of-staff/openai-key`,
+      { method: "PUT" },
+    );
+    expect(publicAttempt.status).not.toBe(204);
+  });
+});

--- a/js/egress/vitest.config.ts
+++ b/js/egress/vitest.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
         bindings: {
           ENVIRONMENT: "test",
           CREDENTIAL_ENCRYPTION_KEY: TEST_KEY,
+          CHIEF_OF_STAFF_OPENAI_API_KEY: "sk-chief-of-staff-test-secret",
           ALLOW_LOCAL_CREDENTIAL_CLAIM: "true",
           LOCAL_CHATGPT_BOOTSTRAP: JSON.stringify({
             access_token: jwt({ exp: 4_102_444_800, marker: "local-access" }),

--- a/js/managed/src/account-auth.ts
+++ b/js/managed/src/account-auth.ts
@@ -97,7 +97,7 @@ const OWNER_CAPABILITIES = [
 ] as const satisfies readonly OrganizationCapability[];
 
 export type Principal = Readonly<{
-  kind: "account_session" | "api_key" | "connect_grant";
+  kind: "account_session" | "api_key" | "connect_grant" | "service";
   userId: string;
   organizationId: string;
   teamId: string;
@@ -500,6 +500,20 @@ async function resolveUserPrincipal(
     subjectId: `user:${userId}`,
     credentialId,
   };
+}
+
+export async function resolveChiefOfStaffPrincipal(
+  env: AccountAuthEnv,
+  userId: string,
+  credentialId: string,
+): Promise<Principal | undefined> {
+  if (!isUserId(userId) || !/^chief:[a-f0-9]{64}$/.test(credentialId)) return undefined;
+  const principal = await resolveUserPrincipal(env, userId, credentialId);
+  return principal ? {
+    ...principal,
+    kind: "service",
+    capabilities: ["agents:read", "agents:write", "tools:use"],
+  } : undefined;
 }
 
 export async function authenticatePersistentAccount(

--- a/js/managed/src/chief-of-staff-principal.ts
+++ b/js/managed/src/chief-of-staff-principal.ts
@@ -20,13 +20,19 @@ export type ChiefOfStaffIdentity = Readonly<{
   tenant: string;
 }>;
 
+export interface ChiefOfStaffPrincipalEnv extends AccountAuthEnv {
+  NANOCODEX_CHIEF_EGRESS: Readonly<{
+    ensureCredential(userId: unknown): Promise<void>;
+  }>;
+}
+
 type IdentityMapping = ChiefOfStaffIdentity & Readonly<{
   digest: string;
   userId: string;
 }>;
 
 export async function resolveChiefOfStaffIdentity(
-  env: AccountAuthEnv,
+  env: ChiefOfStaffPrincipalEnv,
   value: unknown,
 ): Promise<Principal> {
   const identity = chiefOfStaffIdentity(value);
@@ -52,6 +58,7 @@ export async function resolveChiefOfStaffIdentity(
     throw new Error("chief_identity_conflict");
   }
   await ensureAccount(env, mapping.userId, true);
+  await env.NANOCODEX_CHIEF_EGRESS.ensureCredential(mapping.userId);
   const principal = await resolveChiefOfStaffPrincipal(
     env,
     mapping.userId,

--- a/js/managed/src/chief-of-staff-principal.ts
+++ b/js/managed/src/chief-of-staff-principal.ts
@@ -1,0 +1,107 @@
+import { Kv } from "accounts/server";
+
+import {
+  ensureAccount,
+  resolveChiefOfStaffPrincipal,
+  type AccountAuthEnv,
+  type Principal,
+} from "./account-auth";
+
+const SLACK_TEAM_ID = /^T[A-Z0-9]+$/;
+const SLACK_USER_ID = /^[UW][A-Z0-9]+$/;
+const WHATSAPP_PHONE_NUMBER_ID = /^[0-9]{5,32}$/;
+const WHATSAPP_USER_ID = /^(?:[0-9]{5,32}|[A-Z]{2}\.(?:ENT\.)?[A-Za-z0-9]{1,128})$/;
+const VIBER_BOT_URI = /^[A-Za-z0-9_.-]{1,255}$/;
+const VIBER_USER_ID = /^[A-Za-z0-9+/=_-]{1,256}$/;
+
+export type ChiefOfStaffIdentity = Readonly<{
+  provider: "slack" | "viber" | "whatsapp";
+  subject: string;
+  tenant: string;
+}>;
+
+type IdentityMapping = ChiefOfStaffIdentity & Readonly<{
+  digest: string;
+  userId: string;
+}>;
+
+export async function resolveChiefOfStaffIdentity(
+  env: AccountAuthEnv,
+  value: unknown,
+): Promise<Principal> {
+  const identity = chiefOfStaffIdentity(value);
+  if (!identity) throw new Error("invalid_chief_identity");
+  const identityDigest = await digest(
+    `chief-of-staff:v1\0${identity.provider}\0${identity.tenant}\0${identity.subject}`,
+  );
+  const key = `identity:${identityDigest}`;
+  const store = Kv.durableObject(
+    env.NANOCODEX_AUTH as unknown as Parameters<typeof Kv.durableObject>[0],
+    { name: "chief-of-staff-identities" },
+  );
+  let mapping = await store.get<unknown>(key);
+  if (mapping === undefined) {
+    const candidate = {
+      ...identity,
+      digest: identityDigest,
+      userId: crypto.randomUUID(),
+    } satisfies IdentityMapping;
+    mapping = await store.create?.(key, candidate) ? candidate : await store.get<unknown>(key);
+  }
+  if (!validMapping(mapping, identity, identityDigest)) {
+    throw new Error("chief_identity_conflict");
+  }
+  await ensureAccount(env, mapping.userId, true);
+  const principal = await resolveChiefOfStaffPrincipal(
+    env,
+    mapping.userId,
+    `chief:${identityDigest}`,
+  );
+  if (!principal) throw new Error("chief_identity_unavailable");
+  return principal;
+}
+
+export function chiefOfStaffIdentity(value: unknown): ChiefOfStaffIdentity | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  if (Object.keys(record).length !== 3
+    || typeof record.provider !== "string"
+    || typeof record.tenant !== "string"
+    || typeof record.subject !== "string") return undefined;
+  switch (record.provider) {
+    case "slack":
+      return SLACK_TEAM_ID.test(record.tenant) && SLACK_USER_ID.test(record.subject)
+        ? { provider: "slack", tenant: record.tenant, subject: record.subject }
+        : undefined;
+    case "viber":
+      return VIBER_BOT_URI.test(record.tenant) && VIBER_USER_ID.test(record.subject)
+        ? { provider: "viber", tenant: record.tenant, subject: record.subject }
+        : undefined;
+    case "whatsapp":
+      return WHATSAPP_PHONE_NUMBER_ID.test(record.tenant) && WHATSAPP_USER_ID.test(record.subject)
+        ? { provider: "whatsapp", tenant: record.tenant, subject: record.subject }
+        : undefined;
+    default: return undefined;
+  }
+}
+
+function validMapping(
+  value: unknown,
+  identity: ChiefOfStaffIdentity,
+  identityDigest: string,
+): value is IdentityMapping {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return Object.keys(record).length === 5
+    && record.provider === identity.provider
+    && record.tenant === identity.tenant
+    && record.subject === identity.subject
+    && record.digest === identityDigest
+    && typeof record.userId === "string"
+    && /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(record.userId);
+}
+
+async function digest(value: string): Promise<string> {
+  const bytes = new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value)));
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}

--- a/js/managed/src/index.ts
+++ b/js/managed/src/index.ts
@@ -154,6 +154,7 @@ import {
 import {
   chiefOfStaffIdentity,
   resolveChiefOfStaffIdentity,
+  type ChiefOfStaffPrincipalEnv,
 } from "./chief-of-staff-principal";
 import { routeBrowserModel } from "./browser-model";
 import { routeAccountLinkRequest } from "./account-links";
@@ -243,7 +244,7 @@ const MEMORY_TEAM_ASSERTION = "x-nanocodex-team-id";
 const MEMORY_SUBJECT_ASSERTION = "x-nanocodex-subject-id";
 const MEMORY_MUTATION_ASSERTION = "x-nanocodex-memory-mutation";
 
-export interface Env extends AccountAuthEnv, HostPrincipalEnv {
+export interface Env extends AccountAuthEnv, ChiefOfStaffPrincipalEnv, HostPrincipalEnv {
   NANOCODEX_SESSIONS: DurableObjectNamespace<DurableAgentSession>;
   NANOCODEX_ROOMS: DurableObjectNamespace<MultiplayerRoom>;
   NANOCODEX_MULTIPLAYER_QUOTA: DurableObjectNamespace<MultiplayerQuota>;

--- a/js/managed/src/index.ts
+++ b/js/managed/src/index.ts
@@ -1,4 +1,4 @@
-import { DurableObject } from "cloudflare:workers";
+import { DurableObject, WorkerEntrypoint } from "cloudflare:workers";
 import {
   getWorkspace,
   withWorkspace,
@@ -15,6 +15,7 @@ import type {
   Turn,
 } from "nanocodex";
 import { Agent as CloudflareAgent } from "nanocodex/cloudflare";
+import { Agent as ManagedAgent } from "nanocodex/managed";
 import { imageGeneration, updatePlan, viewImage, web } from "nanocodex/tools";
 import { managedCodeEvaluator } from "./code-evaluator";
 import {
@@ -150,6 +151,10 @@ import {
   type OrganizationCapability,
   type Principal,
 } from "./account-auth";
+import {
+  chiefOfStaffIdentity,
+  resolveChiefOfStaffIdentity,
+} from "./chief-of-staff-principal";
 import { routeBrowserModel } from "./browser-model";
 import { routeAccountLinkRequest } from "./account-links";
 import {
@@ -696,8 +701,12 @@ function observeManagedPrincipal(
   });
 }
 
-export default {
-  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+async function managedFetch(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+  trustedAgentPrincipal?: Principal,
+): Promise<Response> {
     const url = new URL(request.url);
     const browserModel = await routeBrowserModel(request, env, url);
     if (browserModel) return browserModel;
@@ -728,7 +737,7 @@ export default {
       return json({ service: "nanocodex", runtime: "cloudflare-durable-objects", status: "ok" });
     }
     if (request.method === "GET" && url.pathname === "/v1/agents") {
-      const principal = await authenticate(request, env, url);
+      const principal = trustedAgentPrincipal ?? await authenticate(request, env, url);
       if (!principal) return json({ error: "unauthorized" }, { status: 401 });
       if (!principal.capabilities.includes("agents:read")) return json({ error: "forbidden" }, { status: 403 });
       const agents = await listAgents(env, principal.userId);
@@ -818,7 +827,7 @@ export default {
     }
     if (request.method === "POST" && url.pathname === "/v1/agents") {
       if (url.search !== "") return json({ error: "invalid_request" }, { status: 400 });
-      const principal = await authenticate(request, env, url);
+      const principal = trustedAgentPrincipal ?? await authenticate(request, env, url);
       if (!principal) return json({ error: "unauthorized" }, { status: 401 });
       observeManagedPrincipal(env, "managed.agent.create_requested", principal, {
         method: request.method,
@@ -1075,7 +1084,7 @@ export default {
     }
     const agentId = match[1]!;
     const resource = match[2] ?? "";
-    const principal = await authenticate(request, env, url);
+    const principal = trustedAgentPrincipal ?? await authenticate(request, env, url);
     if (!principal) return json({ error: "unauthorized" }, { status: 401 });
     const routedTurnId = resource.match(/^turns\/([^/]+)/)?.[1];
     observeManagedPrincipal(env, "managed.agent.request", principal, {
@@ -1298,7 +1307,91 @@ export default {
       }
     }
     return json({ error: "method_not_allowed" }, { status: 405 });
-  },
+}
+
+export class ChiefOfStaffBackend extends WorkerEntrypoint<Env> {
+  async requestingAccountId(request: Request): Promise<string | null> {
+    const principal = await authenticate(
+      request,
+      this.env,
+      new URL("https://managed.nanocodex.internal/v1/me"),
+    );
+    return principal?.kind === "account_session" ? principal.userId : null;
+  }
+
+  async createAgent(identityValue: unknown, idempotencyKey: unknown): Promise<string> {
+    const identity = chiefOfStaffIdentity(identityValue);
+    if (!identity || typeof idempotencyKey !== "string" || !IDEMPOTENCY_KEY.test(idempotencyKey)) {
+      throw new Error("invalid_chief_request");
+    }
+    const principal = await resolveChiefOfStaffIdentity(this.env, identity);
+    const response = await managedFetch(new Request("https://chief-of-staff.internal/v1/agents", {
+      method: "POST",
+      headers: { "idempotency-key": idempotencyKey },
+    }), this.env, this.ctx, principal);
+    if (!response.ok) throw await chiefManagedFailure(response);
+    const body: unknown = await response.json();
+    const agentId = isRecord(body) && typeof body.agent_id === "string" ? body.agent_id : "";
+    if (!SESSION_ID.test(agentId)) throw new Error("invalid_chief_agent_response");
+    return agentId;
+  }
+
+  async runTurn(
+    identityValue: unknown,
+    agentIdValue: unknown,
+    requestValue: unknown,
+  ): Promise<string> {
+    const identity = chiefOfStaffIdentity(identityValue);
+    const request = chiefTurnRequest(requestValue);
+    if (!identity || typeof agentIdValue !== "string" || !SESSION_ID.test(agentIdValue) || !request) {
+      throw new Error("invalid_chief_request");
+    }
+    const principal = await resolveChiefOfStaffIdentity(this.env, identity);
+    const fetcher = (input: RequestInfo | URL, init?: RequestInit) => {
+      const outbound = new Request(input, init);
+      const url = new URL(outbound.url);
+      if (url.origin !== "https://chief-of-staff.internal"
+        || !url.pathname.startsWith(`/v1/agents/${agentIdValue}/`)) {
+        throw new Error("chief_managed_route_escape");
+      }
+      return managedFetch(outbound, this.env, this.ctx, principal);
+    };
+    const result = await ManagedAgent.open(agentIdValue, {
+      baseUrl: "https://chief-of-staff.internal",
+      fetch: fetcher,
+    }).turn.prompt(request).result();
+    return result.finalMessage;
+  }
+}
+
+type ChiefTurnRequest = Readonly<{
+  id: string;
+  idempotencyKey: string;
+  input: string;
+}>;
+
+function chiefTurnRequest(value: unknown): ChiefTurnRequest | undefined {
+  if (!isRecord(value) || Object.keys(value).length !== 3
+    || typeof value.id !== "string" || !TURN_ID.test(value.id)
+    || typeof value.idempotencyKey !== "string" || !IDEMPOTENCY_KEY.test(value.idempotencyKey)
+    || typeof value.input !== "string" || value.input.length === 0
+    || value.input.length > 120_000) return undefined;
+  return { id: value.id, idempotencyKey: value.idempotencyKey, input: value.input };
+}
+
+async function chiefManagedFailure(response: Response): Promise<Error> {
+  let code = `http_${response.status}`;
+  try {
+    const body: unknown = await response.json();
+    if (isRecord(body) && typeof body.error === "string") code = body.error;
+  } catch {
+    await response.body?.cancel();
+  }
+  return new Error(`chief_managed_${code}`);
+}
+
+export default {
+  fetch: managedFetch,
 };
 
 class DurableComputerObject extends DurableObject<Env> {

--- a/js/managed/test/account-auth.test.ts
+++ b/js/managed/test/account-auth.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   authenticate,
   ensureAccount,
+  resolveChiefOfStaffPrincipal,
   routeAccountRequest,
   type AccountAuthEnv,
 } from "../src/account-auth";
@@ -132,6 +133,20 @@ describe("connector route compatibility", () => {
 });
 
 describe("account provisioning", () => {
+  it("narrows Chief of Staff principals to the agent tool boundary", async () => {
+    const { env } = portableEnv();
+    const principal = await resolveChiefOfStaffPrincipal(env, USER_ID, `chief:${"a".repeat(64)}`);
+
+    expect(principal).toMatchObject({
+      kind: "service",
+      userId: USER_ID,
+      capabilities: ["agents:read", "agents:write", "tools:use"],
+    });
+    expect(principal?.capabilities).not.toContain("organization:write");
+    expect(principal?.capabilities).not.toContain("api_keys:write");
+    expect(principal?.capabilities).not.toContain("agents:portability");
+  });
+
   it("accepts a matching persistent account after a create conflict", async () => {
     const requests: string[] = [];
     const env = accountEnv(async (request) => {

--- a/js/managed/test/chief-of-staff-principal.test.ts
+++ b/js/managed/test/chief-of-staff-principal.test.ts
@@ -4,6 +4,7 @@ import type { AccountAuthEnv } from "../src/account-auth";
 import {
   chiefOfStaffIdentity,
   resolveChiefOfStaffIdentity,
+  type ChiefOfStaffPrincipalEnv,
 } from "../src/chief-of-staff-principal";
 
 describe("Chief of Staff provider identities", () => {
@@ -52,7 +53,7 @@ describe("Chief of Staff provider identities", () => {
   });
 });
 
-function identityEnv(): AccountAuthEnv {
+function identityEnv(): ChiefOfStaffPrincipalEnv {
   const authStores = new Map<string, Map<string, unknown>>();
   const accounts = new Map<string, { id: string; organizationId: string; persistent: boolean }>();
   const organizationId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
@@ -111,8 +112,15 @@ function identityEnv(): AccountAuthEnv {
   } as unknown as DurableObjectNamespace;
   return {
     NANOCODEX_AUTH: auth,
-    NANOCODEX_API_KEYS: {} as DurableObjectNamespace,
-    NANOCODEX_ORGANIZATIONS: organizations,
-    NANOCODEX_USERS: users,
+    NANOCODEX_API_KEYS: {} as AccountAuthEnv["NANOCODEX_API_KEYS"],
+    NANOCODEX_CHIEF_EGRESS: {
+      async ensureCredential(userId) {
+        if (typeof userId !== "string" || !accounts.has(userId)) {
+          throw new Error("credential provisioned before account");
+        }
+      },
+    },
+    NANOCODEX_ORGANIZATIONS: organizations as unknown as AccountAuthEnv["NANOCODEX_ORGANIZATIONS"],
+    NANOCODEX_USERS: users as unknown as AccountAuthEnv["NANOCODEX_USERS"],
   };
 }

--- a/js/managed/test/chief-of-staff-principal.test.ts
+++ b/js/managed/test/chief-of-staff-principal.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import type { AccountAuthEnv } from "../src/account-auth";
+import {
+  chiefOfStaffIdentity,
+  resolveChiefOfStaffIdentity,
+} from "../src/chief-of-staff-principal";
+
+describe("Chief of Staff provider identities", () => {
+  it.each([
+    { provider: "slack", tenant: "T123ABC", subject: "U123ABC" },
+    { provider: "viber", tenant: "nanocodex-chief", subject: "01234567890A=" },
+    { provider: "whatsapp", tenant: "123456789012345", subject: "15551234567" },
+  ])("accepts an exact $provider identity", (identity) => {
+    expect(chiefOfStaffIdentity(identity)).toEqual(identity);
+  });
+
+  it.each([
+    null,
+    { provider: "slack", tenant: "T123ABC", subject: "U123ABC", accountId: crypto.randomUUID() },
+    { provider: "slack", tenant: "not-a-team", subject: "U123ABC" },
+    { provider: "slack", tenant: "T123ABC", subject: "not-a-user" },
+    { provider: "whatsapp", tenant: "T123ABC", subject: "15551234567" },
+    { provider: "viber", tenant: "nanocodex chief", subject: "01234567890A=" },
+  ])("rejects malformed or authority-widening identity %#", (identity) => {
+    expect(chiefOfStaffIdentity(identity)).toBeUndefined();
+  });
+
+  it("maps equal identities stably and isolates provider, tenant, and subject", async () => {
+    const env = identityEnv();
+    const slack = { provider: "slack", tenant: "T123ABC", subject: "U123ABC" } as const;
+    const first = await resolveChiefOfStaffIdentity(env, slack);
+    const replay = await resolveChiefOfStaffIdentity(env, slack);
+    const otherSubject = await resolveChiefOfStaffIdentity(env, { ...slack, subject: "U999XYZ" });
+    const otherTenant = await resolveChiefOfStaffIdentity(env, { ...slack, tenant: "T999XYZ" });
+    const otherProvider = await resolveChiefOfStaffIdentity(env, {
+      provider: "viber",
+      tenant: "T123ABC",
+      subject: "U123ABC",
+    });
+
+    expect(replay.userId).toBe(first.userId);
+    expect(new Set([
+      first.userId,
+      otherSubject.userId,
+      otherTenant.userId,
+      otherProvider.userId,
+    ])).toHaveLength(4);
+    for (const principal of [first, replay, otherSubject, otherTenant, otherProvider]) {
+      expect(principal.capabilities).toEqual(["agents:read", "agents:write", "tools:use"]);
+    }
+  });
+});
+
+function identityEnv(): AccountAuthEnv {
+  const authStores = new Map<string, Map<string, unknown>>();
+  const accounts = new Map<string, { id: string; organizationId: string; persistent: boolean }>();
+  const organizationId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+  const teamId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+  const auth = {
+    idFromName(name: string) { return name; },
+    get(name: string) {
+      let store = authStores.get(name);
+      if (!store) {
+        store = new Map();
+        authStores.set(name, store);
+      }
+      return {
+        async fetch(input: RequestInfo | URL, init?: RequestInit) {
+          const request = new Request(input, init);
+          const url = new URL(request.url);
+          const key = url.searchParams.get("key")!;
+          if (url.pathname === "/get") return Response.json({ value: store!.get(key) });
+          if (url.pathname === "/create") {
+            const { value } = await request.json<{ value: unknown }>();
+            const created = !store!.has(key);
+            if (created) store!.set(key, value);
+            return Response.json({ created });
+          }
+          return new Response(null, { status: 404 });
+        },
+      };
+    },
+  } as unknown as DurableObjectNamespace;
+  const users = {
+    getByName(userId: string) {
+      return {
+        async fetch(input: RequestInfo | URL, init?: RequestInit) {
+          const request = new Request(input, init);
+          if (request.method === "PUT") {
+            accounts.set(userId, { id: userId, organizationId, persistent: true });
+          }
+          const account = accounts.get(userId);
+          return account
+            ? Response.json({ ...account, createdAt: 1, lastAuthenticatedAt: 1 })
+            : new Response(null, { status: 404 });
+        },
+      };
+    },
+  } as unknown as DurableObjectNamespace;
+  const organizations = {
+    getByName() {
+      return { fetch: async () => Response.json({
+        authorizationEpoch: 1,
+        capabilities: ["agents:read", "agents:write", "tools:use", "organization:write"],
+        organizationId,
+        role: "owner",
+        teamId,
+      }) };
+    },
+  } as unknown as DurableObjectNamespace;
+  return {
+    NANOCODEX_AUTH: auth,
+    NANOCODEX_API_KEYS: {} as DurableObjectNamespace,
+    NANOCODEX_ORGANIZATIONS: organizations,
+    NANOCODEX_USERS: users,
+  };
+}

--- a/js/managed/wrangler.jsonc
+++ b/js/managed/wrangler.jsonc
@@ -26,6 +26,11 @@
     {
       "binding": "NANOCODEX",
       "service": "nanocodex-egress"
+    },
+    {
+      "binding": "NANOCODEX_CHIEF_EGRESS",
+      "service": "nanocodex-egress",
+      "entrypoint": "ChiefOfStaffEgress"
     }
   ],
   "r2_buckets": [
@@ -110,7 +115,13 @@
     "development": {
       "name": "nanocodex-durable-agent",
       "services": [
-        { "binding": "NANOCODEX", "service": "nanocodex-egress", "remote": false }
+        { "binding": "NANOCODEX", "service": "nanocodex-egress", "remote": false },
+        {
+          "binding": "NANOCODEX_CHIEF_EGRESS",
+          "service": "nanocodex-egress",
+          "entrypoint": "ChiefOfStaffEgress",
+          "remote": false
+        }
       ],
       "r2_buckets": [
         { "binding": "NANOCODEX_HISTORY", "bucket_name": "nanocodex-managed-history" }


### PR DESCRIPTION
## Summary
- replace the Chief of Staff account API key with capability-scoped named Cloudflare Worker RPC entrypoints
- map verified Slack, WhatsApp, and Viber identities to stable random managed accounts inside the managed Worker
- provision those service identities with an encrypted operator-funded model credential owned entirely by egress
- isolate Slack actors within shared channels and atomically fence Slack installation ownership before token persistence
- retain one durable agent per conversation while denying caller-selected Nanocodex account IDs

## Packages touched
- @nanocodex/chief-of-staff
- nanocodex-managed-service
- nanocodex-egress-service

## LOC
- +845 / -206 across 23 files (net +639)
- @nanocodex/chief-of-staff: +371 / -195
- nanocodex-managed-service: +384 / -10
- nanocodex-egress-service: +90 / -1
- 242 added lines are focused RPC/identity and egress credential tests; the main deletions remove the generic API-key gateway and global-owner plumbing

## Verification
- pnpm --filter @nanocodex/chief-of-staff check (32 tests, typecheck, Wrangler dry-run)
- pnpm --filter nanocodex-managed-service typecheck
- pnpm --filter nanocodex-managed-service test (154 tests)
- pnpm turbo run build --filter=nanocodex-managed-service (dependency build + Wrangler dry-run)
- pnpm --filter nanocodex-egress-service typecheck
- pnpm --filter nanocodex-egress-service test (41 tests)
- pnpm --filter nanocodex-egress-service dry-run:broker
- git diff --check origin/master...HEAD

Production needs CHIEF_OF_STAFF_OPENAI_API_KEY set only on nanocodex-egress. It never crosses the service binding or enters Chief/browser state.