### PR TITLE
feat(managed): route Code Mode execution by cwd namespace

### DIFF
--- a/bin/nanocodex/src/managed_server.rs
+++ b/bin/nanocodex/src/managed_server.rs
@@ -1630,7 +1630,7 @@ fn now() -> f64 {
         .map_or(0.0, |v| v.as_secs_f64())
 }
 fn capabilities() -> Value {
-    json!({"durable_turns":true,"resumable_events":true,"live_steer":true,"live_cancel":true,"workspace":"private-hosted-tools-v1","sandbox_escalation":false})
+    json!({"durable_turns":true,"resumable_events":true,"live_steer":true,"live_cancel":true,"workspace":"private-hosted-tools-v1","execution_namespace":"cwd-root-v1","native_cross_mounts":false})
 }
 fn parse_cursor(value: &str) -> ApiResult<i64> {
     if value.is_empty()

--- a/bin/nanocodex/tests/nanocodex2_managed.rs
+++ b/bin/nanocodex/tests/nanocodex2_managed.rs
@@ -585,7 +585,8 @@ fn agent_state_value(latest_event_cursor: &str) -> serde_json::Value {
             "live_steer": true,
             "live_cancel": true,
             "workspace": "private-hosted-tools-v1",
-            "sandbox_escalation": true
+            "execution_namespace": "cwd-root-v1",
+            "native_cross_mounts": false
         },
         "settings": agent_settings(),
         "latest_event_cursor": latest_event_cursor,
@@ -895,7 +896,8 @@ async fn agent_state(State(state): State<TestState>, headers: HeaderMap) -> impl
                 "live_steer": true,
                 "live_cancel": true,
                 "workspace": "private-hosted-tools-v1",
-                "sandbox_escalation": true
+                "execution_namespace": "cwd-root-v1",
+                "native_cross_mounts": false
             },
             "settings": agent_settings(),
             "latest_event_cursor": "0",
@@ -1058,7 +1060,8 @@ fn agent_capabilities() -> serde_json::Value {
         "live_steer": true,
         "live_cancel": true,
         "workspace": "cloudflare-computer",
-        "sandbox_escalation": false
+        "execution_namespace": "cwd-root-v1",
+        "native_cross_mounts": false
     })
 }
 

--- a/crates/nanocodex-managed/src/types.rs
+++ b/crates/nanocodex-managed/src/types.rs
@@ -294,8 +294,10 @@ pub struct AgentCapabilities {
     pub live_cancel: bool,
     /// Server-advertised workspace mode.
     pub workspace: String,
-    /// Whether sandbox escalation is available.
-    pub sandbox_escalation: bool,
+    /// Server-advertised logical execution namespace contract.
+    pub execution_namespace: String,
+    /// Whether native processes can access peer mounts through filesystem syscalls.
+    pub native_cross_mounts: bool,
 }
 
 /// Model and reasoning policy owned by one managed agent.

--- a/crates/nanocodex-managed/src/websocket.rs
+++ b/crates/nanocodex-managed/src/websocket.rs
@@ -556,7 +556,8 @@ mod tests {
                 "live_steer": true,
                 "live_cancel": true,
                 "workspace": "cloud",
-                "sandbox_escalation": false
+                "execution_namespace": "cwd-root-v1",
+                "native_cross_mounts": false
             },
             "latest_event_cursor": "0"
         });
@@ -573,5 +574,7 @@ mod tests {
         assert_eq!(parsed.settings.model, Model::Luna);
         assert_eq!(parsed.settings.thinking, Thinking::Low);
         assert!(parsed.settings.fast_mode);
+        assert_eq!(parsed.capabilities.execution_namespace, "cwd-root-v1");
+        assert!(!parsed.capabilities.native_cross_mounts);
     }
 }

--- a/crates/nanocodex-managed/tests/public_lifecycle.rs
+++ b/crates/nanocodex-managed/tests/public_lifecycle.rs
@@ -680,7 +680,8 @@ fn agent_state_json(agent_id: &str, latest_event_cursor: &str) -> Value {
             "live_steer": true,
             "live_cancel": true,
             "workspace": "cloud",
-            "sandbox_escalation": false
+            "execution_namespace": "cwd-root-v1",
+            "native_cross_mounts": false
         },
         "settings": {
             "model": "gpt-5.6-sol",

--- a/docs/DISTRIBUTED_EXECUTION_NAMESPACE.md
+++ b/docs/DISTRIBUTED_EXECUTION_NAMESPACE.md
@@ -1,0 +1,265 @@
+# Distributed execution namespace
+
+Status: contract plus cwd-routing milestone implemented locally; not deployed.
+Native cross-mount filesystem access (C2/C5) remains gated. This supersedes the
+proposed `environment` argument on execution tools.
+
+## Core contract
+
+Nanocodex presents every authorized hand as a mount in one private filesystem
+namespace:
+
+```text
+/
+├── brain/        durable brain scratch
+├── sandbox/      lazy Linux sandbox
+├── laptop/       connected user hand
+├── buildbox/     connected user hand
+└── .nanocodex/   synthetic namespace metadata
+```
+
+- **C1 — Placement:** the mount root containing a command's effective cwd
+  selects the hand that executes it.
+- **C2 — Access:** every process sees the same authorized mounts. Discovery,
+  read, and write rights are independent of placement.
+- **C3 — Stable tools:** `exec_command` and `write_stdin` keep their canonical
+  shapes; no environment, machine, host, or sandbox selector is added.
+- **C4 — Stable context:** a Code Mode cell has an immutable namespace and
+  default-cwd snapshot. Each command captures its cwd when scheduled.
+- **C5 — Native namespace:** arbitrary native children access mounts through
+  normal filesystem syscalls. Rewriting `workdir`, parsing shell text, or
+  copying/syncing trees is not conforming.
+- **C6 — Subagent inheritance:** each child gets a stable, capability-bounded
+  namespace and independently uses C1–C5, including concurrent use of hands.
+
+Thus both forms below execute on `laptop`, while Cargo and its children may use
+other authorized mounts:
+
+```js
+await tools.exec_command({ cmd: "cargo test", workdir: "/laptop/repo" });
+await tools.exec_command({ cmd: "cd /laptop/repo && cargo test" });
+```
+
+## Design basis and naming
+
+The design takes Plan 9's central idea: file servers expose trees, a protocol
+carries local or remote operations, and each process gets a private namespace
+composed from those trees. A 9P2000.L-like operation model and
+capability-secured mounts are useful foundations, but Plan 9's exact wire,
+authentication, caching, and Unix-compatibility choices are not the contract.
+FUSE, v9fs, virtio-fs, or an in-process VFS may be platform adapters.
+
+A **hand** exports files, executes processes, or both. An **export** is an
+explicitly configured physical directory, never an implicit OS root. A stable
+logical **mount root** such as `/laptop` names it; the mount root containing the
+cwd is the **execution root**.
+
+The broker creates an immutable cell manifest mapping each mount root to opaque
+hand and export identities, attachment generation, lease, and rights. Mount
+names are portable, unique, non-overlapping, and distinct from reserved roots
+such as `brain`, `sandbox`, `.nanocodex`, `dev`, `proc`, and `tmp`. Names and
+paths locate resources but never authorize them. `brain` and `sandbox` are
+broker-owned system roots; user-assigned roots cannot reuse any reserved name.
+`/laptop/a` means `a` beneath
+the configured export, not OS path `/a` unless the OS root was deliberately
+exported.
+
+A cell's name-to-identity mapping never changes. New connections appear only in
+a later cell; revocation may invalidate existing authority immediately.
+
+## Execution semantics
+
+The canonical tool schemas remain authoritative.
+
+- `workdir` sets the initial cwd; relative paths resolve against the cell's
+  captured default cwd. Shell `cd` is applied before external execution.
+- The longest component-boundary mount match of the effective cwd selects the
+  hand. Executable lookup, environment, architecture, and children belong to
+  that hand.
+- An external command started in a synthetic directory without an executor
+  fails; there is no default-hand fallback. `/brain` is storage unless it is
+  explicitly given a process executor.
+- Redirections use the namespace, and a pipeline may span hands.
+- Each parallel call captures cwd independently. Commands on different hands
+  run concurrently without a namespace-wide lock.
+- `write_stdin` uses a public session ID durably bound to the exact hand,
+  process, attachment generation, manifest, agent/turn, and output cursor.
+  Reconnect cannot retarget it.
+- Other placement-sensitive operations either resolve a canonical workdir or
+  bind to a process/session. There is no ambient "last selected hand."
+
+```js
+await Promise.all([
+  tools.exec_command({ cmd: "cargo test", workdir: "/laptop/repo" }),
+  tools.exec_command({ cmd: "cargo test", workdir: "/buildbox/repo" }),
+]);
+```
+
+## Subagents
+
+The canonical task tree and its tools, including `spawn_agent`, keep their
+schemas and authority rules. Spawning creates a model session, not a process on
+a hand, and adds no hand selector.
+
+At admission the runtime atomically binds the child to the invoking cell's
+manifest and generations, the parent's default logical cwd, necessary leases,
+task-tree/session/cancellation identities, and an authority ceiling no broader
+than the parent's effective rights. Exact inheritance is the compatibility
+default. Trusted host policy may attenuate mounts, subtrees, or write rights;
+grandchildren may only attenuate further. If the resulting scope cannot access
+the inherited cwd, spawn fails atomically. Roles, tasks, messages, paths, and
+mount names cannot grant authority.
+
+A child is not pinned to a hand. Every command is placed from that command's
+effective cwd, so one child may use several hands and siblings may fan out
+concurrently. Task text can suggest a cwd; ordinary `exec_command({workdir})` or
+shell `cd` performs placement under the server-bound authority.
+
+Parents and children share exported files subject to individual rights and
+filesystem consistency. Model sessions, conversation state, Code Mode stores,
+output cursors, and cancellation controllers remain private. Concurrent
+writers need disjoint worktrees/subtrees, a trusted write-scope policy, or
+ordinary filesystem locking; descriptive task text is not a write lease.
+
+Model capacity and hand capacity are independent. `max-subagents` bounds model
+turns; each hand separately bounds processes, sessions, filesystem requests,
+and bytes in flight. Model/thinking selection affects inference only, never
+execution placement.
+
+## Filesystem and capabilities
+
+Every full-capability execution hand receives an actual private root or mount
+namespace. Its own export should be a local mount; peer exports are remote
+mounts; immutable metadata is a synthetic overlay. Keeping the local root local
+prevents ordinary builds from becoming filesystem RPC workloads.
+
+The host-generic interface must cover ordinary development tools: lookup,
+open/close, stat and attributes, directory enumeration, offset I/O, create,
+truncate, mkdir, remove, rename, links, fsync, advisory locks, stable identity,
+version tokens, and cancellation. It must stream with bounded memory,
+backpressure, pagination, concurrent tagged requests, and per-mount isolation.
+
+- Owner-acknowledged writes become visible.
+- Same-export rename is atomic when supported; cross-mount rename and hard-link
+  return `EXDEV`.
+- Ambiguous mutations use operation IDs and durable receipts, never blind
+  replay.
+- Disconnect or stale generation returns bounded `ESTALE`, `EIO`, or
+  unavailable failure, never fallback.
+- Optional caches validate stable identity/version and do not silently weaken
+  consistency.
+
+An export server resolves beneath an already-open directory handle and prevents
+traversal or symlink escape. Absolute symlinks resolve in the client's logical
+namespace. A hand exports only its physical tree, never peer mounts, preventing
+recursive mount cycles.
+
+Initial server-issued capability classes cover namespace discovery, filesystem
+read/write, process execution/stdin, and network preview. They are projected as
+immutable discovery hints such as:
+
+```text
+/laptop/.nanocodex/status
+/laptop/.nanocodex/capabilities/<capability>
+```
+
+Every operation still rechecks an unforgeable grant, lease, and attachment
+generation at the authoritative server. Effective file access is the
+intersection of namespace rights and exporter filesystem policy. Cross-hand
+access is an explicit disclosure grant to the accessing hand, which receives
+filesystem operations, never the exporter's credentials.
+
+The binary, streaming filesystem data plane is separate from bounded JSON
+hosted-tool calls, though it may reuse attachment authentication and fencing.
+Full native conformance requires mounts visible to arbitrary native children:
+Linux may use mount/user namespaces plus FUSE or v9fs; sandboxes and VMs may use
+v9fs or virtio-fs; macOS/Windows may need a helper or VM. A browser VFS proves
+only interpreted behavior. Platforms without native mount visibility must not
+advertise full namespace `process.exec`.
+
+## Lifecycle and security
+
+One lifecycle mechanism governs mounts, handles, processes, previews, and
+sessions:
+
+| Event | Required behavior |
+| --- | --- |
+| Cell starts | Capture authorized mount mapping and default cwd |
+| Child spawns | Atomically bind inherited or attenuated namespace ceiling |
+| Message/steer/task replacement | Preserve namespace, cwd, and authority |
+| Process starts | Pin hand, manifest, rights, lease, and generation |
+| Disconnect/reconnect | Fail old work stale; reconnect creates a new generation |
+| Revocation | Reject new work and invalidate affected resources |
+| Cancel/interrupt/close | Stop native and descendant work; fence late results |
+| Ambiguous mutation | Consult its receipt; never retry blindly |
+| Cold recovery | Restore interrupted children unless exact live state is owner-fenced |
+
+Security invariants:
+
+1. Names, paths, mode bits, and reported capabilities never grant authority.
+2. Normalization and mount selection are one fenced, component-aware operation.
+3. Symlinks, links, mounts, junctions, devices, and special files cannot escape
+   an export or create cross-mount authority.
+4. Provider credentials and host secrets never enter namespaces or processes.
+5. Limits cover mounts, handles, requests, bytes, directory entries, duration,
+   processes, output, and retained receipts.
+6. Audit records exclude contents and credentials.
+7. Descendant rights never exceed parent ceiling intersected with trusted host
+   policy.
+8. Sessions are bound to task tree, agent, cancellation epoch, manifest, and
+   generation; numeric IDs are not transferable.
+
+Live recovery, if added, must durably restore and owner-fence topology,
+namespace/cwd bindings, grants, leases, sessions, cursors, and receipts. It must
+never reconstruct authority from current names or currently connected hands.
+
+## Acceptance journeys
+
+Unit tests and `workdir` routers are insufficient. Real native processes must
+prove:
+
+| Journey | Evidence |
+| --- | --- |
+| Inspect `/` and capability metadata | Safe discovery without identity/secret leakage |
+| Run via `workdir=/host1/repo` and shell `cd` | C1, C3, shell placement |
+| From host1, natively read/write `/host2` | C2, C5; no copy/sync |
+| Run host1 and host2 calls with `Promise.all` | C4 and concurrency |
+| Spawn siblings on host1 and host2 | C6, inheritance, independent capacity |
+| Have one child successively use two roots | Per-command placement, no pinning |
+| Share a permitted file but isolate model state | Export consistency and session privacy |
+| Attenuate a child read-only, then spawn its child | Recursive ceiling; no escalation |
+| Exercise read-only and denied host2 grants | Projection matches enforcement |
+| Rename within and across exports | Atomic local rename; cross-mount `EXDEV` |
+| Disconnect, revoke, and replace during I/O | Generation fencing and no fallback |
+| Yield, reload, reconnect, and poll a process | Durable session binding, no retargeting |
+| Cancel a cross-host pipeline/I/O | Bounded cleanup and isolated call state |
+| Interrupt/close a parent during remote work | Descendant cancellation; no orphan work |
+| Recover cold | Interrupted tombstones or exact owner-fenced restoration |
+
+End-to-end evidence must inspect ancestry, mounts, broker traffic, storage,
+sockets, and secret exposure.
+
+## Phased delivery
+
+1. Specify the manifest and host-generic filesystem interface. (Manifest and
+   authority substrate complete; filesystem operation interface pending.)
+2. Prove one rooted server and one native Linux namespace client.
+3. Add the streaming data plane, receipts, and lifecycle fencing.
+4. Mount two real hands and prove native cross-host read/write.
+5. Bind root and child sessions to namespace/cwd contexts; prove sibling fan-out.
+6. Replace environment-addressed execution with cwd-root placement. (Complete
+   for canonical `workdir`; shell `cd` requires the native adapter.)
+7. Add each platform adapter only after its conformance gate passes.
+8. Verify reload, reconnect, revocation, cross-account isolation, and secret
+   containment before deployment.
+
+Cwd routing may be an internal milestone, but the distributed namespace cannot
+ship until native processes can access peer mounts.
+
+## References
+
+- [Plan 9 from Bell Labs](https://9p.io/sys/doc/9.html)
+- [The Use of Name Spaces in Plan 9](https://9p.io/sys/doc/names.html)
+- [9P2000.L protocol](https://github.com/chaos/diod/blob/master/protocol.md)
+- [virtio-fs design](https://virtio-fs.gitlab.io/design.html)
+- [WASI capability design principles](https://github.com/WebAssembly/WASI/blob/main/docs/DesignPrinciples.md)

--- a/js/managed/Dockerfile
+++ b/js/managed/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update \
         cmake \
         curl \
         fd-find \
+        gh \
         git \
         git-lfs \
         jq \

--- a/js/managed/src/account-info.ts
+++ b/js/managed/src/account-info.ts
@@ -54,6 +54,8 @@ export type VaultEntry =
 
 export type AccountMachine = Readonly<HostedMachine & {
   kind: "sandbox" | "user";
+  /** Logical namespace root. Native host workspace paths are never projected. */
+  mount: string;
 }>;
 
 export type AccountInfo = Readonly<{

--- a/js/managed/src/index.ts
+++ b/js/managed/src/index.ts
@@ -25,6 +25,11 @@ import {
   proxyCloudflareSandboxPreview,
 } from "./sandbox-tools";
 import {
+  createNamespaceExecutionTools,
+  machineMountRoot,
+  type MachineToolResolver,
+} from "./namespace-tools";
+import {
   ContainerProxy,
   Sandbox,
 } from "./sandbox-runtime";
@@ -41,7 +46,7 @@ import {
   hostedToolCatalogEntryAllowed,
   isAppToolCatalogDigest,
 } from "./app-tool-catalog";
-import type { HostedToolCatalogEntry } from "./hosted-tools-protocol";
+import type { HostedMachine, HostedToolCatalogEntry } from "./hosted-tools-protocol";
 import {
   managedCapacitySnapshot,
   type ManagedCapacitySnapshot,
@@ -587,15 +592,16 @@ const AGENT_CAPABILITIES = Object.freeze({
   live_steer: true,
   live_cancel: true,
   workspace: "cloudflare-computer",
-  sandbox_tools: true,
-  sandbox_escalation: false,
+  execution_namespace: "cwd-root-v1",
+  native_cross_mounts: false,
 }) satisfies AgentCapabilities;
 
 const AGENT_SANDBOX_MACHINE = Object.freeze({
   id: "sandbox",
   name: "Agent sandbox",
   kind: "sandbox",
-  workspace: "/workspace",
+  mount: "/sandbox",
+  workspace: "/sandbox",
   capabilities: Object.freeze([
     "filesystem",
     "native-linux",
@@ -1539,7 +1545,7 @@ export async function routeSandboxPreviewRequest(
   );
 }
 
-export function createManagedSandboxTools(
+export function createManagedNamespaceTools(
   env: Pick<
     Env,
     "NANOCODEX_ADMIN_TOKEN" | "NANOCODEX_SANDBOXES" | "NANOCODEX_SANDBOX_LOCAL"
@@ -1547,13 +1553,20 @@ export function createManagedSandboxTools(
   session: { session_id: string; public_origin: string },
   isAccountOwnedTurn: () => boolean,
   createTools: typeof cloudflareSandboxTools = cloudflareSandboxTools,
+  machines: () => readonly HostedMachine[] = () => [],
+  resolveMachineTool: MachineToolResolver = () => undefined,
 ): NamedTool[] {
-  return Object.entries(createTools(
+  const sandboxTools = createTools(
     env.NANOCODEX_SANDBOXES,
     session.session_id,
     env.NANOCODEX_SANDBOX_LOCAL === "true",
     session.public_origin,
     env.NANOCODEX_ADMIN_TOKEN,
+  );
+  return Object.entries(createNamespaceExecutionTools(
+    sandboxTools,
+    machines,
+    resolveMachineTool,
   )).map(([name, tool]) => ({
     name,
     ...tool,
@@ -1561,8 +1574,8 @@ export function createManagedSandboxTools(
       if (!isAccountOwnedTurn()) {
         throw new ManagedRequestError(
           403,
-          "sandbox_forbidden",
-          "sandbox tools are available only to account-owned turns",
+          "namespace_forbidden",
+          "execution namespace tools are available only to account-owned turns",
         );
       }
       return tool.handler(input, context);
@@ -5253,15 +5266,18 @@ export class DurableAgentSession extends DurableComputerSession {
             (connectionId) => this.#activeTurnMcpAllowed(connectionId),
           ),
     };
-    const sandboxTools = multiplayer ? [] : createManagedSandboxTools(
+    const namespaceTools = multiplayer ? [] : createManagedNamespaceTools(
       this.env,
       session,
       () => this.#isAccountOwnedTurn(),
+      cloudflareSandboxTools,
+      () => this.#hostedTools.machines(),
+      (machineId, name) => this.#hostedTools.machineTool(machineId, name),
     );
     const cloudTools: NamedTool[] = [
       ...(browserRuntime?.tools ?? []),
       ...(multiplayer ? [computer.tool] : []),
-      ...sandboxTools,
+      ...namespaceTools,
       ...(multiplayer ? [] : [{
         name: "accountInfo",
         description: "Report live machine hands, account authentication, safe Vault references, stablecoin balances, and app authorization boundaries. Vault references may show usernames, addresses, phone numbers, and card last four, but never passwords or complete card data.",
@@ -5307,7 +5323,15 @@ export class DurableAgentSession extends DurableComputerSession {
           runtime: "cloudflare-durable-object",
           shell: multiplayer ? computer.descriptor.shell : "unavailable",
           shell_network: multiplayer ? computer.descriptor.network.mode : "unavailable",
-          sandbox: multiplayer ? "disabled" : "cloudflare-sandbox-tools",
+          namespace: multiplayer ? { status: "disabled" } : {
+            status: "cwd-placement",
+            default_cwd: "/sandbox",
+            native_cross_mounts: false,
+            mounts: this.#accountMachines(this.#activeTurnAuthorization()).map(({ id, mount }) => ({
+              id,
+              mount,
+            })),
+          },
           workspace: computer.descriptor.cwd,
           commands: multiplayer ? computer.descriptor.commands : [],
           custom_commands: multiplayer ? computer.descriptor.customCommands : [],
@@ -5375,9 +5399,9 @@ export class DurableAgentSession extends DurableComputerSession {
           ].join("\n\n")
           : [
             "You are the durable Nanocodex brain running on Cloudflare Workers. The brain does not execute shell commands. Its own /workspace is scratch storage for brain-owned artifacts only.",
-            "Hands are separate execution environments listed in accountInfo().machines. The account-owned sandbox is one lazy, retained Linux hand reached only through explicit sandbox_* tools. Zero or more user machines may be connected through deferred private tools; use tool_search when their capabilities require discovery.",
-            "Machine topology changes live as user machines connect or disconnect; the agent itself is not restarted. Call accountInfo immediately before work whose placement depends on an available hand, and do not use a machine that is no longer listed.",
-            "The brain, sandbox, and user-machine workspaces are independent. Never imply that files are synchronized or silently move work between them. Use only the tools and capabilities advertised for the selected hand.",
+            "Hands appear as logical top-level paths listed in accountInfo().machines. exec_command has its standard shape: set workdir to /sandbox/... or an exact connected-hand mount such as /laptop/...; the root of that cwd selects where the process runs. write_stdin remains pinned to the hand that created its session. There is no environment or host argument.",
+            "A Code Mode cell captures its mount mapping. Commands in Promise.all may run concurrently on different cwd roots, and subagents use the same cwd rule independently. A disconnect or reconnect never retargets an admitted command or session.",
+            "The current cwd router is a placement milestone, not a native shared filesystem: native_cross_mounts is false, so a process cannot yet reach peer mounts through ordinary filesystem syscalls. Do not imply files are synchronized or use shell cd to select another hand; select placement with exec_command.workdir until a conforming native namespace adapter is advertised.",
             "The browser_execute tool is the managed remote browser. Reuse its retained session when continuity matters. Never inspect, return, or persist cookies, authorization material, CDP connection URLs, provider URLs, or Live View URLs. If a login, MFA, CAPTCHA, or other human-only gate appears, stop and ask the user to complete it outside the model-visible browser tool; do not bypass or evade the gate.",
             "For ordinary account operations, accountInfo is not a prerequisite to an explicit gh, git, curl, or other shell command. Those commands use transparent authenticated egress when the current grant permits it. accountInfo is a tool, not a shell command.",
             "When accountInfo lists multiple connectorAccounts for a service, choose the appropriate connection by label and pass its exact id as X-Nanocodex-Connector-Connection on that provider request. Never invent a connection id. The egress proxy validates it against the active grant.",
@@ -5579,13 +5603,17 @@ export class DurableAgentSession extends DurableComputerSession {
     if (!this.#isAccountOwnedTurn(authorization)) return [];
     return Object.freeze([
       AGENT_SANDBOX_MACHINE,
-      ...this.#hostedTools.machines().map((machine) => Object.freeze({
-        id: `user:${machine.id}`,
-        name: machine.name,
-        kind: "user" as const,
-        workspace: machine.workspace,
-        capabilities: machine.capabilities,
-      })),
+      ...this.#hostedTools.machines().map((machine) => {
+        const mount = machineMountRoot(machine.id);
+        return Object.freeze({
+          id: `user:${machine.id}`,
+          name: machine.name,
+          kind: "user" as const,
+          mount,
+          workspace: mount,
+          capabilities: machine.capabilities,
+        });
+      }),
     ]);
   }
 

--- a/js/managed/src/namespace-tools.ts
+++ b/js/managed/src/namespace-tools.ts
@@ -1,0 +1,330 @@
+import type { ToolMap } from "nanocodex";
+import {
+  createNamespaceManifest,
+  createNamespaceScope,
+  EXEC_COMMAND_PARAMETERS,
+  EXECUTION_OUTPUT_SCHEMA,
+  namespaceMountRoot,
+  PREVIEW_OUTPUT_SCHEMA,
+  routeNamespaceCwd,
+  WRITE_STDIN_PARAMETERS,
+  type HostedMachineToolName,
+  type NamespaceRight,
+  type NamespaceScope,
+  type ToolContext,
+} from "nanocodex-tools";
+
+const TOOL_RESULT = Symbol.for("nanocodex.toolResult");
+const DEFAULT_CWD = "/sandbox";
+
+type RoutedTool = Readonly<{
+  handler(input: unknown, context: ToolContext): unknown | Promise<unknown>;
+}>;
+
+export type NamespaceMachine = Readonly<{
+  id: string;
+  workspace: string;
+}>;
+
+export type MachineToolResolver = (
+  machineId: string,
+  name: HostedMachineToolName,
+) => RoutedTool | undefined;
+
+type MountedHand = Readonly<{
+  mountId: string;
+  machineId?: string;
+  root: string;
+  workspace: string;
+  exec?: RoutedTool;
+  writeStdin?: RoutedTool;
+  preview?: RoutedTool;
+}>;
+
+type CellBinding = Readonly<{
+  scope: NamespaceScope;
+  hands: ReadonlyMap<string, MountedHand>;
+}>;
+
+type ProcessBinding = Readonly<{
+  ownerSessionId: string;
+  providerSessionId: number;
+  writeStdin: RoutedTool;
+}>;
+
+/**
+ * Routes the canonical process tools by the root of their logical cwd. The
+ * binding captured for a Code Mode call owns its exact attached tool handles,
+ * so a disconnect or reconnect cannot retarget an admitted command.
+ */
+export function createNamespaceExecutionTools(
+  sandboxTools: ToolMap,
+  machines: () => readonly NamespaceMachine[],
+  resolveMachineTool: MachineToolResolver = () => undefined,
+): ToolMap {
+  const sandbox = Object.freeze({
+    mountId: "mount:sandbox",
+    root: "/sandbox",
+    workspace: "/workspace",
+    exec: requiredTool(sandboxTools, "exec_command"),
+    writeStdin: requiredTool(sandboxTools, "write_stdin"),
+    preview: requiredTool(sandboxTools, "preview"),
+  }) satisfies MountedHand;
+  const cells = new Map<string, CellBinding>();
+  const sessions = new Map<number, ProcessBinding>();
+
+  const cell = (context: ToolContext): CellBinding => {
+    const key = `${context.sessionId}\u0000${context.parentCallId}`;
+    const retained = cells.get(key);
+    if (retained !== undefined) return retained;
+    const created = createCellBinding(sandbox, machines(), resolveMachineTool, key);
+    cells.set(key, created);
+    return created;
+  };
+
+  const releaseSession = (ownerSessionId: string): void => {
+    const cellPrefix = `${ownerSessionId}\u0000`;
+    for (const key of cells.keys()) {
+      if (key.startsWith(cellPrefix)) cells.delete(key);
+    }
+    for (const [sessionId, binding] of sessions) {
+      if (binding.ownerSessionId === ownerSessionId) sessions.delete(sessionId);
+    }
+  };
+  const dispose = (): void => {
+    cells.clear();
+    sessions.clear();
+  };
+
+  return {
+    exec_command: {
+      description: "Run a command on the hand that owns the root of workdir. workdir is a logical namespace path such as /sandbox/repo or /laptop/repo; it defaults to /sandbox.",
+      parameters: EXEC_COMMAND_PARAMETERS,
+      outputSchema: EXECUTION_OUTPUT_SCHEMA,
+      handler: async (input, context) => {
+        const value = record(input);
+        const binding = cell(context);
+        const route = routeNamespaceCwd(binding.scope, optionalString(value.workdir, "workdir"));
+        const hand = binding.hands.get(route.mount.mountId);
+        if (hand?.exec === undefined) {
+          throw new Error(`namespace mount ${route.mount.root} is not executable`);
+        }
+        const result = await hand.exec.handler({
+          ...without(value, "workdir"),
+          workdir: nativeWorkdir(hand.workspace, route.relativePath),
+        }, context);
+        const structured = executionResult(result);
+        if (structured?.session_id === undefined) return result;
+        if (hand.writeStdin === undefined) {
+          throw new Error(`namespace mount ${route.mount.root} cannot retain process sessions`);
+        }
+        const providerSessionId = positiveSessionId(structured.session_id);
+        const publicSessionId = reserveSessionId(sessions);
+        sessions.set(publicSessionId, Object.freeze({
+          ownerSessionId: context.sessionId,
+          providerSessionId,
+          writeStdin: hand.writeStdin,
+        }));
+        return replaceExecutionResult(result, { ...structured, session_id: publicSessionId });
+      },
+      releaseSession,
+      dispose,
+    },
+    write_stdin: {
+      description: "Write characters to or poll a session returned by exec_command. The session remains pinned to its original hand and namespace binding.",
+      parameters: WRITE_STDIN_PARAMETERS,
+      outputSchema: EXECUTION_OUTPUT_SCHEMA,
+      handler: async (input, context) => {
+        const value = record(input);
+        const publicSessionId = positiveSessionId(value.session_id);
+        const binding = sessions.get(publicSessionId);
+        if (binding === undefined || binding.ownerSessionId !== context.sessionId) {
+          throw new Error("unknown or stale namespace process session");
+        }
+        const result = await binding.writeStdin.handler({
+          ...without(value, "session_id"),
+          session_id: binding.providerSessionId,
+        }, context);
+        const structured = executionResult(result);
+        if (structured?.session_id === undefined) {
+          sessions.delete(publicSessionId);
+          return result;
+        }
+        if (positiveSessionId(structured.session_id) !== binding.providerSessionId) {
+          sessions.delete(publicSessionId);
+          throw new Error("execution hand changed its bound process session");
+        }
+        return replaceExecutionResult(result, { ...structured, session_id: publicSessionId });
+      },
+      releaseSession,
+      dispose,
+    },
+    preview: {
+      description: "Expose an HTTP server from the hand that owns the logical workdir when that hand supports previews.",
+      parameters: {
+        type: "object",
+        properties: {
+          workdir: { type: "string", description: "Logical namespace path selecting the server's hand; defaults to /sandbox." },
+          port: { type: "integer", minimum: 1024, maximum: 65_535 },
+        },
+        required: ["port"],
+        additionalProperties: false,
+      },
+      outputSchema: PREVIEW_OUTPUT_SCHEMA,
+      handler: async (input, context) => {
+        const value = record(input);
+        const binding = cell(context);
+        const route = routeNamespaceCwd(
+          binding.scope,
+          optionalString(value.workdir, "workdir"),
+          "network.preview",
+        );
+        const hand = binding.hands.get(route.mount.mountId);
+        if (hand?.preview === undefined) {
+          throw new Error(`namespace mount ${route.mount.root} does not provide preview`);
+        }
+        return hand.preview.handler(without(value, "workdir"), context);
+      },
+      releaseSession,
+      dispose,
+    },
+  };
+}
+
+export const machineMountRoot = namespaceMountRoot;
+
+function createCellBinding(
+  sandbox: MountedHand,
+  sourceMachines: readonly NamespaceMachine[],
+  resolveMachineTool: MachineToolResolver,
+  key: string,
+): CellBinding {
+  const hands: MountedHand[] = [sandbox];
+  const roots = new Set([sandbox.root]);
+  const keyHash = stableHash(key);
+  for (const machine of sourceMachines) {
+    const root = machineMountRoot(machine.id);
+    if (roots.has(root)) throw new Error(`duplicate namespace mount root ${root}`);
+    roots.add(root);
+    hands.push(Object.freeze({
+      mountId: `mount:user:${machine.id}`,
+      machineId: machine.id,
+      root,
+      workspace: machine.workspace,
+      exec: resolveMachineTool(machine.id, "exec_command"),
+      writeStdin: resolveMachineTool(machine.id, "write_stdin"),
+      preview: resolveMachineTool(machine.id, "preview"),
+    }));
+  }
+  const manifest = createNamespaceManifest({
+    manifestId: `manifest:${keyHash}:${stableHash(hands.map(({ mountId }) => mountId).join("\u0000"))}`,
+    mounts: hands.map((hand) => ({
+      root: hand.root,
+      mountId: hand.mountId,
+      handId: hand.machineId === undefined ? "hand:sandbox" : `hand:user:${hand.machineId}`,
+      exportId: hand.machineId === undefined ? "export:sandbox-workspace" : `export:user:${hand.machineId}`,
+      generation: `cell:${keyHash}:${stableHash(hand.mountId)}`,
+      rights: handRights(hand),
+    })),
+  });
+  const scope = createNamespaceScope(manifest, DEFAULT_CWD);
+  return Object.freeze({
+    scope,
+    hands: new Map(hands.map((hand) => [hand.mountId, hand])),
+  });
+}
+
+function handRights(hand: MountedHand): readonly NamespaceRight[] {
+  const rights: NamespaceRight[] = ["namespace.discover"];
+  if (hand.exec !== undefined) rights.push("process.exec");
+  if (hand.writeStdin !== undefined) rights.push("process.stdin");
+  if (hand.preview !== undefined) rights.push("network.preview");
+  return rights;
+}
+
+function nativeWorkdir(workspace: string, relativePath: string): string {
+  if (typeof workspace !== "string" || workspace.length === 0 || workspace.includes("\0")) {
+    throw new Error("execution hand published an invalid workspace root");
+  }
+  if (relativePath === "/") return workspace;
+  return `${workspace.replace(/\/$/, "")}/${relativePath.slice(1)}`;
+}
+
+function requiredTool(tools: ToolMap, name: string): NonNullable<ToolMap[string]> {
+  const tool = tools[name];
+  if (tool === undefined) throw new Error(`sandbox tool source is missing ${name}`);
+  return tool;
+}
+
+function executionResult(value: unknown): Record<string, unknown> | undefined {
+  const result = isToolResult(value) ? value.structuredResult : value;
+  return result !== null && typeof result === "object" && !Array.isArray(result)
+    ? result as Record<string, unknown>
+    : undefined;
+}
+
+function replaceExecutionResult(original: unknown, structured: Record<string, unknown>): unknown {
+  if (!isToolResult(original)) return structured;
+  return Object.freeze({
+    [TOOL_RESULT]: true,
+    metadata: original.metadata,
+    output: original.output,
+    structuredResult: structured,
+    success: original.success,
+    value: structured,
+  });
+}
+
+function isToolResult(value: unknown): value is Readonly<{
+  metadata: unknown;
+  output: unknown;
+  structuredResult: unknown;
+  success: boolean;
+}> {
+  return Boolean((value as Record<PropertyKey, unknown> | null)?.[TOOL_RESULT]);
+}
+
+function reserveSessionId(sessions: ReadonlyMap<number, unknown>): number {
+  for (let attempt = 0; attempt < 64; attempt += 1) {
+    const bytes = crypto.getRandomValues(new Uint32Array(1));
+    const candidate = (bytes[0]! & 0x7fff_ffff) || 1;
+    if (!sessions.has(candidate)) return candidate;
+  }
+  throw new Error("could not allocate a namespace process session");
+}
+
+function positiveSessionId(value: unknown): number {
+  if (!Number.isSafeInteger(value) || Number(value) <= 0) {
+    throw new TypeError("session_id must be a positive safe integer");
+  }
+  return Number(value);
+}
+
+function optionalString(value: unknown, name: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || value.length === 0) {
+    throw new TypeError(`${name} must be a non-empty string`);
+  }
+  return value;
+}
+
+function without(value: Record<string, unknown>, key: string): Record<string, unknown> {
+  const { [key]: _, ...rest } = value;
+  return rest;
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("tool input must be an object");
+  }
+  return value as Record<string, unknown>;
+}
+
+function stableHash(value: string): string {
+  let hash = 0xcbf29ce484222325n;
+  for (const byte of new TextEncoder().encode(value)) {
+    hash ^= BigInt(byte);
+    hash = BigInt.asUintN(64, hash * 0x100000001b3n);
+  }
+  return hash.toString(16).padStart(16, "0");
+}

--- a/js/managed/src/protocol.ts
+++ b/js/managed/src/protocol.ts
@@ -29,8 +29,8 @@ export type AgentCapabilities = Readonly<{
   live_steer: true;
   live_cancel: true;
   workspace: "cloudflare-computer";
-  sandbox_tools: true;
-  sandbox_escalation: boolean;
+  execution_namespace: "cwd-root-v1";
+  native_cross_mounts: false;
 }>;
 
 export type ServerMessage = (

--- a/js/managed/src/sandbox-smoke.ts
+++ b/js/managed/src/sandbox-smoke.ts
@@ -10,6 +10,7 @@ export async function cloudflareSandboxSmokeSetup(
   publicOrigin: string,
   previewSecret: string,
 ): Promise<Record<string, unknown>> {
+  requireProbeId(probeId);
   const started = Date.now();
   const marker = `CLOUDFLARE_SANDBOX_OK_${probeId}`;
   let tools = cloudflareSandboxTools(
@@ -23,103 +24,55 @@ export async function cloudflareSandboxSmokeSetup(
     // Wrangler's emulated R2 watcher takes its initial filesystem snapshot
     // asynchronously after mountBucket() returns. Let that baseline settle so
     // this write is observed as a change; production uses the direct R2 mount.
-    if (localBucket) await invoke(tools, "sandbox_exec", { command: "sleep 2" });
-    const write = record(await invoke(tools, "sandbox_write_file", {
-      path: "probe.txt",
-      content: marker,
-    }));
-    assert(write.bytes_written === marker.length, "write byte count mismatch");
+    if (localBucket) await exec(tools, "sleep 2");
+    const write = record(await exec(
+      tools,
+      `printf %s ${marker} > probe.txt && test "$(cat probe.txt)" = ${marker} && printf EXEC_OK`,
+    ));
+    assert(write.exit_code === 0 && write.output === "EXEC_OK", "shell write/read failed");
 
-    const exec = record(await invoke(tools, "sandbox_exec", {
-      command: `test "$(cat probe.txt)" = "${marker}" && printf EXEC_OK`,
-      timeout_ms: 10_000,
-    }));
-    assert(exec.success === true && exec.stdout === "EXEC_OK", "write was not visible to exec");
+    const list = record(await exec(tools, "find . -maxdepth 1 -name probe.txt -print"));
+    assert(list.output === "./probe.txt\n", "shell listing omitted probe.txt");
 
-    const read = record(await invoke(tools, "sandbox_read_file", { path: "probe.txt" }));
-    assert(read.content === marker, "read did not return written content");
-
-    const list = record(await invoke(tools, "sandbox_list_files", {}));
-    const entries = Array.isArray(list.entries) ? list.entries.map(record) : [];
-    assert(entries.some((entry) => entry.name === "probe.txt"), "list omitted probe.txt");
-
-    const nonzero = record(await invoke(tools, "sandbox_exec", {
-      command: "sh -c 'printf partial; printf failed >&2; exit 7'",
-    }));
+    const nonzero = record(await exec(tools, "sh -c 'printf partial; printf failed >&2; exit 7'"));
     assert(
-      nonzero.success === false
-        && nonzero.exit_code === 7
-        && nonzero.stdout === "partial"
-        && nonzero.stderr === "failed",
+      nonzero.exit_code === 7 && nonzero.output === "partialfailed",
       "non-zero command result was not preserved",
     );
 
-    const flood = record(await invoke(tools, "sandbox_exec", {
-      command: "node -e 'process.stdout.write(\"x\".repeat(140000)); process.stderr.write(\"y\".repeat(140000))'",
+    const yielded = record(await invoke(tools, "exec_command", {
+      cmd: "printf first; sleep 1; printf second",
+      yield_time_ms: 250,
     }));
     assert(
-      flood.stdout_truncated === true,
-      `stdout flood was not truncated: ${JSON.stringify({
-        success: flood.success,
-        exit_code: flood.exit_code,
-        stdout_bytes: new TextEncoder().encode(String(flood.stdout)).byteLength,
-        stderr_bytes: new TextEncoder().encode(String(flood.stderr)).byteLength,
-        stderr_truncated: flood.stderr_truncated,
-      })}`,
+      typeof yielded.session_id === "number" && yielded.output === "first",
+      "command did not yield a resumable session",
     );
-    assert(flood.stderr_truncated === true, "stderr flood was not truncated");
+    const resumed = record(await invoke(tools, "write_stdin", {
+      session_id: yielded.session_id,
+    }));
     assert(
-      new TextEncoder().encode(String(flood.stdout)).byteLength === 128 * 1024,
-      "stdout was not capped at 128 KiB",
+      resumed.exit_code === 0 && resumed.output === "second",
+      "session resume replayed or lost command output",
     );
 
-    const timeoutStarted = Date.now();
-    const timeoutError = await rejectedMessage(invoke(tools, "sandbox_exec", {
-      command: "sleep 5",
-      timeout_ms: 100,
-    }));
-    assert(/time|interrupt|abort/i.test(timeoutError), `unexpected timeout error: ${timeoutError}`);
-    assert(Date.now() - timeoutStarted < 4_000, "command timeout was not enforced promptly");
+    const flood = record(await exec(
+      tools,
+      "node -e 'process.stdout.write(\"x\".repeat(140000)); process.stderr.write(\"y\".repeat(140000))'",
+    ));
+    assert(
+      new TextEncoder().encode(String(flood.output)).byteLength === 40_000
+        && flood.original_token_count === 70_000,
+      "combined command output was not capped",
+    );
 
-    const traversalError = await rejectedMessage(invoke(tools, "sandbox_read_file", {
-      path: "../etc/passwd",
-    }));
-    assert(/must not contain/.test(traversalError), "path traversal was not rejected");
-
-    const oversizedError = await rejectedMessage(invoke(tools, "sandbox_write_file", {
-      path: "oversized.txt",
-      content: "😀".repeat(1024 * 1024 / 4 + 1),
-    }));
-    assert(/exceeds 1 MiB/.test(oversizedError), "oversized UTF-8 write was not rejected");
-
-    const background = record(await invoke(tools, "sandbox_start_process", {
-      command: "sh -c 'printf background-output; printf background-error >&2; exit 7'",
-    }));
-    const processId = String(background.process_id);
-    let backgroundResult: Record<string, unknown> | undefined;
-    for (let attempt = 0; attempt < 50; attempt += 1) {
-      backgroundResult = record(await invoke(tools, "sandbox_get_process", {
-        process_id: processId,
-      }));
-      if (backgroundResult.terminal === true) break;
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    }
-    assert(backgroundResult?.status === "failed", "background process did not reach failed state");
-    assert(backgroundResult.exit_code === 7, "background process exit code was not retained");
-    assert(backgroundResult.stdout === "background-output", "background stdout was not retained");
-    assert(backgroundResult.stderr === "background-error", "background stderr was not retained");
-
-    const process = record(await invoke(tools, "sandbox_start_process", {
-      command: "node -e 'require(\"http\").createServer((q,s)=>require(\"fs\").createReadStream(\"/workspace/probe.txt\").pipe(s)).listen(8000)'",
-      ready_port: 8000,
-      ready_timeout_ms: 10_000,
-    }));
-    assert(process.ready_port === 8000, "managed process did not report port readiness");
-    const server = record(await invoke(tools, "sandbox_get_process", {
-      process_id: process.process_id,
-    }));
-    assert(server.found === true && server.terminal === false, "preview process was not observable");
-    const preview = record(await invoke(tools, "sandbox_preview", { port: 8000 }));
+    const server = record(await exec(tools, [
+      "nohup node -e 'require(\"http\").createServer((q,s)=>require(\"fs\").createReadStream(\"/workspace/probe.txt\").pipe(s)).listen(8000)'",
+      ">/tmp/nanocodex-sandbox-smoke.log 2>&1 &",
+      "for i in $(seq 1 100); do curl -fsS http://127.0.0.1:8000/probe.txt >/dev/null && exit 0; sleep .1; done; exit 1",
+    ].join(" ")));
+    assert(server.exit_code === 0, "background preview server did not become ready");
+    const preview = record(await invoke(tools, "preview", { port: 8000 }));
     const previewUrl = new URL("probe.txt", String(preview.url));
     assert(previewUrl.protocol === "https:", `preview returned an invalid URL: ${previewUrl.href}`);
 
@@ -132,12 +85,9 @@ export async function cloudflareSandboxSmokeSetup(
         "write_exec_read",
         "directory_list",
         "nonzero_exit",
+        "session_resume",
         "bounded_output",
-        "command_timeout",
-        "path_confinement",
-        "write_size_limit",
-        "background_process_result",
-        "managed_process_preview",
+        "shell_managed_preview",
       ],
       duration_ms: Date.now() - started,
     };
@@ -152,14 +102,15 @@ export async function cloudflareSandboxSmokeFinish(
   probeId: string,
   localBucket: boolean,
 ): Promise<Record<string, unknown>> {
+  requireProbeId(probeId);
   const started = Date.now();
   const marker = `CLOUDFLARE_SANDBOX_OK_${probeId}`;
   try {
     await destroyCloudflareSandbox(namespace, probeId);
     const tools = cloudflareSandboxTools(namespace, probeId, localBucket);
-    const persisted = record(await invoke(tools, "sandbox_read_file", { path: "probe.txt" }));
-    assert(persisted.content === marker, "R2 workspace did not survive container destruction");
-    await invoke(tools, "sandbox_exec", { command: "rm -f probe.txt" });
+    const persisted = record(await exec(tools, "cat probe.txt"));
+    assert(persisted.output === marker, "R2 workspace did not survive container destruction");
+    await exec(tools, "rm -f probe.txt");
     return {
       status: "ok",
       probe_id: probeId,
@@ -169,6 +120,10 @@ export async function cloudflareSandboxSmokeFinish(
   } finally {
     await destroyCloudflareSandbox(namespace, probeId).catch(() => {});
   }
+}
+
+function exec(tools: ToolMap, cmd: string): Promise<unknown> {
+  return invoke(tools, "exec_command", { cmd });
 }
 
 async function invoke(tools: ToolMap, name: string, input: unknown): Promise<unknown> {
@@ -183,20 +138,17 @@ async function invoke(tools: ToolMap, name: string, input: unknown): Promise<unk
   });
 }
 
-async function rejectedMessage(operation: Promise<unknown>): Promise<string> {
-  try {
-    await operation;
-  } catch (error) {
-    return error instanceof Error ? error.message : String(error);
-  }
-  throw new Error("operation unexpectedly succeeded");
-}
-
 function record(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error("tool returned a non-object result");
   }
   return value as Record<string, unknown>;
+}
+
+function requireProbeId(value: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/.test(value)) {
+    throw new Error("sandbox smoke probe ID must be a safe identifier");
+  }
 }
 
 function assert(condition: boolean, message: string): asserts condition {

--- a/js/managed/src/sandbox-tools.ts
+++ b/js/managed/src/sandbox-tools.ts
@@ -1,15 +1,21 @@
 import { getSandbox } from "@cloudflare/sandbox";
 import type { ToolMap } from "nanocodex";
+import {
+  EXEC_COMMAND_PARAMETERS,
+  EXECUTION_OUTPUT_SCHEMA,
+  MACHINE_PREVIEW_PARAMETERS,
+  PREVIEW_OUTPUT_SCHEMA,
+  WRITE_STDIN_PARAMETERS,
+} from "nanocodex-tools/execution-contract";
 
 import { isPrivateEgressHeader } from "./managed-egress";
 import type { Sandbox } from "./sandbox-runtime";
 
 const WORKSPACE = "/workspace";
 const WORKSPACE_FLUSH_COMMAND = "sync -f /workspace";
-const MAX_COMMAND_CHARS = 32 * 1024;
-const MAX_FILE_BYTES = 1024 * 1024;
-const MAX_OUTPUT_BYTES = 128 * 1024;
-const MAX_LIST_ENTRIES = 512;
+const DEFAULT_MAX_OUTPUT_TOKENS = 10_000;
+const APPROXIMATE_BYTES_PER_TOKEN = 4;
+const OUTPUT_CURSOR_PREFIX = "sandbox-output-cursor:";
 const WORKSPACE_MOUNT_PROBE_TIMEOUT_MS = 10_000;
 const WORKSPACE_MOUNT_HEALTH_ATTEMPTS = 3;
 const PREVIEW_CAPABILITY_TTL_MS = 60 * 60 * 1_000;
@@ -48,24 +54,15 @@ type SandboxPreparation = {
   promise: Promise<Sandbox>;
 };
 
-type SandboxProcessStatus =
-  | "starting"
-  | "running"
-  | "completed"
-  | "failed"
-  | "killed"
-  | "error";
+type SandboxProcessStatus = "starting" | "running" | "completed" | "failed" | "killed" | "error";
 
 type SandboxProcess = {
   id: string;
-  pid?: number;
-  command: string;
   status: SandboxProcessStatus;
   exitCode?: number;
   kill(): Promise<void>;
   getStatus(): Promise<SandboxProcessStatus>;
   getLogs(): Promise<{ stdout: string; stderr: string }>;
-  waitForPort(port: number, options?: { timeout?: number }): Promise<void>;
   waitForExit(timeout?: number): Promise<{ exitCode: number }>;
 };
 
@@ -87,27 +84,18 @@ type SandboxToolClient = {
   }>;
   startProcess(
     command: string,
-    options: { cwd: string; autoCleanup: false },
+    options: { cwd: string; processId: string; autoCleanup: false },
   ): Promise<SandboxProcess>;
   getProcess(id: string): Promise<SandboxProcess | null>;
-  readFile(
-    path: string,
-    options: { encoding: "none" },
-  ): Promise<{ size: number; content: ReadableStream<Uint8Array> }>;
-  writeFile(
-    path: string,
-    content: string,
-    options: { encoding: "utf-8" },
-  ): Promise<unknown>;
-  listFiles(
-    path: string,
-    options: { includeHidden: true },
-  ): Promise<{
-    files: Array<{ name: string; type: string; size: number }>;
-  }>;
   tunnels: {
     get(port: number): Promise<{ url: string }>;
   };
+};
+
+type SandboxOutputCursorStorage = {
+  delete(key: string): void;
+  get(key: string): unknown;
+  put(key: string, value: unknown): void;
 };
 
 export function cloudflareSandboxTools(
@@ -116,6 +104,7 @@ export function cloudflareSandboxTools(
   localBucket = false,
   publicOrigin?: string,
   previewSecret?: string,
+  outputCursorStorage?: SandboxOutputCursorStorage,
 ): ToolMap {
   return createCloudflareSandboxTools(
     () => prepareSandbox(namespace, sessionId, localBucket),
@@ -131,6 +120,7 @@ export function cloudflareSandboxTools(
           ),
           persistent: false,
         }),
+    outputCursorStorage,
   );
 }
 
@@ -176,267 +166,91 @@ export async function deleteCloudflareSandboxWorkspace(
 export function createCloudflareSandboxTools(
   createSandbox: () => Promise<SandboxToolClient>,
   createPreview?: (port: number) => Promise<{ port: number; url: string; persistent: boolean }>,
+  outputCursorStorage: SandboxOutputCursorStorage = memoryOutputCursorStorage(),
 ): ToolMap {
   return {
-    sandbox_exec: {
-      description: "Run a foreground shell command in this session's isolated Cloudflare Sandbox workspace.",
-      parameters: {
-        type: "object",
-        properties: {
-          command: { type: "string", description: "Shell command to run." },
-          cwd: { type: "string", description: "Workspace-relative working directory." },
-          timeout_ms: {
-            type: "integer",
-            minimum: 1,
-            description: "Optional Sandbox SDK execution timeout in milliseconds.",
-          },
-        },
-        required: ["command"],
-        additionalProperties: false,
-      },
-      handler: async (input) => {
+    exec_command: {
+      description: "Run a shell command in the retained native Linux sandbox, returning a session when it remains live.",
+      parameters: EXEC_COMMAND_PARAMETERS,
+      outputSchema: EXECUTION_OUTPUT_SCHEMA,
+      handler: async (input, context) => {
         const value = objectInput(input);
-        const command = requiredString(value.command, "command", MAX_COMMAND_CHARS);
-        const cwd = workspacePath(optionalString(value.cwd, "cwd") ?? ".");
-        const timeout = optionalPositiveInteger(value.timeout_ms, "timeout_ms");
+        if (value.sandbox_permissions === "require_escalated") {
+          throw new Error("Cloudflare Sandbox exec_command does not support privilege escalation");
+        }
+        if (value.tty === true) throw new Error("Cloudflare Sandbox exec_command does not support TTY sessions");
+        if (value.shell !== undefined || value.login !== undefined) {
+          throw new Error("Cloudflare Sandbox exec_command does not support shell or login overrides");
+        }
+        const command = requiredString(value.cmd, "cmd");
+        const cwd = workspacePath(optionalString(value.workdir, "workdir") ?? ".");
+        const yieldTime = yieldMilliseconds(value.yield_time_ms, 10_000);
+        const outputByteLimit = requestedOutputBytes(value.max_output_tokens);
+        context?.signal.throwIfAborted();
         const sandbox = await createSandbox();
-        return withSandboxRpcResult(
-          sandbox.exec(command, {
+        context?.signal.throwIfAborted();
+        const sessionId = await availableSessionId(sandbox);
+        outputCursorStorage.put(`${OUTPUT_CURSOR_PREFIX}${sessionId}`, 0);
+        let process: SandboxProcess | undefined;
+        try {
+          process = await sandbox.startProcess(mergedShellCommand(command), {
             cwd,
-            ...(timeout === undefined ? {} : { timeout }),
-          }).catch(async (error: unknown) => {
-            try { await flushWorkspace(sandbox); } catch { /* Preserve the execution failure. */ }
-            throw error;
-          }),
-          async (result) => {
-            await flushWorkspace(sandbox);
-            return {
-              success: result.success,
-              exit_code: result.exitCode,
-              ...boundedOutput(result),
-              duration_ms: result.duration,
-            };
-          },
-        );
-      },
-    },
-    sandbox_read_file: {
-      description: "Read a UTF-8 text file from this session's isolated workspace (maximum 1 MiB).",
-      parameters: pathParameters(),
-      handler: async (input) => {
-        const path = workspacePath(requiredString(objectInput(input).path, "path", 1024));
-        return withSandboxRpcResult(
-          (await createSandbox()).readFile(path, { encoding: "none" }),
-          async (result) => {
-            if (result.size > MAX_FILE_BYTES) {
-              await cancelReadableStream(result.content, "file exceeds 1 MiB");
-              throw new Error("file exceeds 1 MiB");
-            }
-            return { path, content: await readBounded(result.content) };
-          },
-        );
-      },
-    },
-    sandbox_start_process: {
-      description: "Start a managed background process in this session's Cloudflare Sandbox, optionally waiting for an HTTP port to become ready.",
-      parameters: {
-        type: "object",
-        properties: {
-          command: { type: "string", description: "Command to start." },
-          cwd: { type: "string", description: "Workspace-relative working directory." },
-          ready_port: { type: "integer", minimum: 1024, maximum: 65_535 },
-          ready_timeout_ms: {
-            type: "integer",
-            minimum: 1,
-            description: "Optional Sandbox SDK port-readiness timeout in milliseconds.",
-          },
-        },
-        required: ["command"],
-        additionalProperties: false,
-      },
-      handler: async (input) => {
-        const value = objectInput(input);
-        const command = requiredString(value.command, "command", MAX_COMMAND_CHARS);
-        const cwd = workspacePath(optionalString(value.cwd, "cwd") ?? ".");
-        const readyPort = optionalPort(value.ready_port, "ready_port");
-        const readyTimeout = optionalPositiveInteger(
-          value.ready_timeout_ms,
-          "ready_timeout_ms",
-        );
-        const sandbox = await createSandbox();
-        return withSandboxRpcResult(
-          sandbox.startProcess(command, {
-            cwd,
+            processId: sandboxProcessId(sessionId),
             autoCleanup: false,
-          }),
-          async (process) => {
-            if (readyPort !== undefined) {
-              try {
-                await process.waitForPort(
-                  readyPort,
-                  readyTimeout === undefined ? undefined : { timeout: readyTimeout },
-                );
-              } catch (error) {
-                let status = await process.getStatus().catch(() => process.status);
-                let killError: string | undefined;
-                if (!isTerminalProcessStatus(status)) {
-                  try {
-                    await process.kill();
-                    status = await process.getStatus().catch(() => status);
-                  } catch (killFailure) {
-                    killError = errorMessage(killFailure);
-                  }
-                }
-                let flushError: string | undefined;
-                try {
-                  await flushWorkspace(sandbox);
-                } catch (flushFailure) {
-                  flushError = errorMessage(flushFailure);
-                }
-                return {
-                  process_id: process.id,
-                  pid: process.pid,
-                  command,
-                  status,
-                  terminal: isTerminalProcessStatus(status),
-                  ready_port: readyPort,
-                  ready: false,
-                  ready_error: errorMessage(error),
-                  ...(killError === undefined ? {} : { kill_error: killError }),
-                  ...(flushError === undefined ? {} : { flush_error: flushError }),
-                };
-              }
-            }
-            const status = await process.getStatus();
-            if (isTerminalProcessStatus(status)) await flushWorkspace(sandbox);
-            return {
-              process_id: process.id,
-              pid: process.pid,
-              command,
-              status,
-              ...(readyPort === undefined ? {} : { ready_port: readyPort, ready: true }),
-            };
-          },
+          });
+          return await observeProcess(
+            sandbox,
+            process,
+            sessionId,
+            yieldTime,
+            outputByteLimit,
+            outputCursorStorage,
+            context?.signal,
+          );
+        } catch (error) {
+          if (process === undefined) {
+            outputCursorStorage.delete(`${OUTPUT_CURSOR_PREFIX}${sessionId}`);
+            try { await flushWorkspace(sandbox); } catch { /* Preserve the execution failure. */ }
+          }
+          throw error;
+        }
+      },
+    },
+    write_stdin: {
+      description: "Poll a session returned by exec_command in the retained native Linux sandbox, or send Ctrl-C to terminate it.",
+      parameters: WRITE_STDIN_PARAMETERS,
+      outputSchema: EXECUTION_OUTPUT_SCHEMA,
+      handler: async (input, context) => {
+        const value = objectInput(input);
+        if (value.chars !== undefined && value.chars !== "" && value.chars !== "\u0003") {
+          throw new Error("Cloudflare Sandbox write_stdin supports only polling or Ctrl-C termination; stdin is unavailable");
+        }
+        const sessionId = requiredSessionId(value.session_id);
+        const yieldTime = yieldMilliseconds(value.yield_time_ms, 5_000);
+        const outputByteLimit = requestedOutputBytes(value.max_output_tokens);
+        context?.signal.throwIfAborted();
+        const sandbox = await createSandbox();
+        const process = await sandbox.getProcess(sandboxProcessId(sessionId));
+        if (process === null) throw new Error(`unknown sandbox session: ${sessionId}`);
+        if (value.chars === "\u0003") await process.kill().catch(() => {});
+        return observeProcess(
+          sandbox,
+          process,
+          sessionId,
+          yieldTime,
+          outputByteLimit,
+          outputCursorStorage,
+          context?.signal,
         );
       },
     },
-    sandbox_get_process: {
-      description: "Get authoritative status for a background process in this session's Cloudflare Sandbox. Terminal results include accumulated output; set include_output only when partial running output is needed.",
-      parameters: processIdParameters(true),
+    preview: {
+      description: "Expose an HTTP server from the retained native Linux sandbox.",
+      parameters: MACHINE_PREVIEW_PARAMETERS,
+      outputSchema: PREVIEW_OUTPUT_SCHEMA,
       handler: async (input) => {
         const value = objectInput(input);
-        const processId = requiredProcessId(value.process_id);
-        const sandbox = await createSandbox();
-        return withSandboxRpcResult(
-          sandbox.getProcess(processId),
-          async (process) => {
-            if (process === null) return { found: false, process_id: processId };
-            const terminal = isTerminalProcessStatus(process.status);
-            let output;
-            if (terminal || value.include_output === true) {
-              const logs = process.getLogs();
-              output = boundedOutput(await (terminal
-                ? Promise.all([logs, flushWorkspace(sandbox)]).then(([result]) => result)
-                : logs));
-            }
-            return {
-              found: true,
-              process_id: process.id,
-              pid: process.pid,
-              command: process.command,
-              status: process.status,
-              terminal,
-              exit_code: process.exitCode ?? null,
-              ...output,
-            };
-          },
-        );
-      },
-    },
-    sandbox_kill_process: {
-      description: "Terminate a running background process in this session's Cloudflare Sandbox.",
-      parameters: processIdParameters(),
-      handler: async (input) => {
-        const processId = requiredProcessId(objectInput(input).process_id);
-        const sandbox = await createSandbox();
-        return withSandboxRpcResult(
-          sandbox.getProcess(processId),
-          async (process) => {
-            if (process === null) return { found: false, process_id: processId };
-            let status = process.status;
-            const killRequested = !isTerminalProcessStatus(status);
-            if (killRequested) {
-              await process.kill();
-              status = await process.getStatus();
-            }
-            await flushWorkspace(sandbox);
-            return {
-              found: true,
-              process_id: process.id,
-              status,
-              terminal: isTerminalProcessStatus(status),
-              kill_requested: killRequested,
-            };
-          },
-        );
-      },
-    },
-    sandbox_write_file: {
-      description: "Write a UTF-8 text file inside this session's isolated workspace (maximum 1 MiB).",
-      parameters: {
-        type: "object",
-        properties: {
-          path: { type: "string", description: "Workspace-relative file path." },
-          content: { type: "string", description: "Complete UTF-8 file content." },
-        },
-        required: ["path", "content"],
-        additionalProperties: false,
-      },
-      handler: async (input) => {
-        const value = objectInput(input);
-        const path = workspacePath(requiredString(value.path, "path", 1024));
-        const content = requiredContent(value.content);
-        const bytes = new TextEncoder().encode(content).byteLength;
-        if (bytes > MAX_FILE_BYTES) throw new Error("content exceeds 1 MiB");
-        const sandbox = await createSandbox();
-        await sandbox.writeFile(path, content, { encoding: "utf-8" });
-        await flushWorkspace(sandbox);
-        return { path, bytes_written: bytes };
-      },
-    },
-    sandbox_list_files: {
-      description: "List files in a directory inside this session's isolated workspace.",
-      parameters: {
-        type: "object",
-        properties: {
-          path: { type: "string", description: "Workspace-relative directory; defaults to the workspace root." },
-        },
-        additionalProperties: false,
-      },
-      handler: async (input) => {
-        const value = objectInput(input);
-        const path = workspacePath(optionalString(value.path, "path") ?? ".");
-        return withSandboxRpcResult(
-          (await createSandbox()).listFiles(path, { includeHidden: true }),
-          (result) => ({
-            path,
-            entries: result.files.slice(0, MAX_LIST_ENTRIES).map((entry) => ({
-              name: entry.name,
-              type: entry.type,
-              size: entry.size,
-            })),
-            truncated: result.files.length > MAX_LIST_ENTRIES,
-          }),
-        );
-      },
-    },
-    sandbox_preview: {
-      // Keep this definition byte-stable so snapshots created before the
-      // Worker-fronted preview implementation can resume safely.
-      description: "Expose a server running in the sandbox through a temporary public Cloudflare Tunnel URL.",
-      parameters: portParameters(),
-      handler: async (input) => {
-        const port = requiredPort(objectInput(input).port);
+        const port = requiredPort(value.port);
         const prepared = await createSandbox();
         if (createPreview) return createPreview(port);
         return withSandboxRpcResult(
@@ -454,6 +268,7 @@ export async function cloudflareSandboxPreviewUrl(
   sessionId: string,
   port: number,
 ): Promise<string> {
+  requiredPort(port);
   const origin = new URL(publicOrigin);
   if (!["http:", "https:"].includes(origin.protocol)
     || origin.username
@@ -487,13 +302,15 @@ export async function openSandboxPreviewCapability(
   const [sessionId, rawPort, rawExpiresAt, ...extra] = new TextDecoder()
     .decode(plaintext)
     .split("\n");
-  const port = Number(rawPort);
+  let port: number;
+  try {
+    port = requiredPort(Number(rawPort));
+  } catch {
+    throw new Error("invalid preview capability");
+  }
   const expiresAt = Number(rawExpiresAt);
   if (!sessionId
     || extra.length > 0
-    || !Number.isInteger(port)
-    || port < 1024
-    || port > 65_535
     || !Number.isSafeInteger(expiresAt)
     || expiresAt <= Date.now()) {
     throw new Error("invalid preview capability");
@@ -508,6 +325,7 @@ export async function proxyCloudflareSandboxPreview(
   request: Request,
   path: string,
 ): Promise<Response> {
+  requiredPort(port);
   const incoming = new URL(request.url);
   const targetPath = path.startsWith("/") ? path : `/${path}`;
   const target = new URL(`http://sandbox.internal${targetPath}${incoming.search}`);
@@ -798,7 +616,11 @@ function objectInput(input: unknown): Record<string, unknown> {
   return input as Record<string, unknown>;
 }
 
-function requiredString(value: unknown, name: string, maxChars: number): string {
+function requiredString(
+  value: unknown,
+  name: string,
+  maxChars = Number.MAX_SAFE_INTEGER,
+): string {
   if (typeof value !== "string" || value.length === 0) throw new Error(`${name} must be a non-empty string`);
   if (value.length > maxChars) throw new Error(`${name} is too long`);
   return value;
@@ -807,6 +629,117 @@ function requiredString(value: unknown, name: string, maxChars: number): string 
 function optionalString(value: unknown, name: string): string | undefined {
   if (value === undefined) return undefined;
   return requiredString(value, name, 1024);
+}
+
+function requiredSessionId(value: unknown): number {
+  if (!Number.isSafeInteger(value) || Number(value) < 1) {
+    throw new Error("session_id must be a positive safe integer");
+  }
+  return Number(value);
+}
+
+function yieldMilliseconds(value: unknown, defaultValue: number): number {
+  if (value === undefined) return defaultValue;
+  if (!Number.isSafeInteger(value) || Number(value) < 0) {
+    throw new Error("yield_time_ms must be a non-negative safe integer");
+  }
+  return Number(value);
+}
+
+function sandboxProcessId(sessionId: number): string {
+  return `nanocodex-${sessionId}`;
+}
+
+async function availableSessionId(sandbox: SandboxToolClient): Promise<number> {
+  for (let attempt = 0; attempt < 32; attempt += 1) {
+    const sessionId = crypto.getRandomValues(new Uint32Array(1))[0]! || 1;
+    if (await sandbox.getProcess(sandboxProcessId(sessionId)) === null) return sessionId;
+  }
+  throw new Error("could not allocate a sandbox command session");
+}
+
+async function observeProcess(
+  sandbox: SandboxToolClient,
+  initial: SandboxProcess,
+  sessionId: number,
+  yieldTimeMs: number,
+  outputByteLimit: number,
+  outputCursorStorage: SandboxOutputCursorStorage,
+  signal?: AbortSignal,
+): Promise<Record<string, unknown>> {
+  const startedAt = performance.now();
+  let process = initial;
+  let refreshed: SandboxProcess | undefined;
+  try {
+    let status = await process.getStatus();
+    if (!isTerminalProcessStatus(status) && yieldTimeMs > 0) {
+      await waitForProcessExit(process, yieldTimeMs, signal);
+      status = await process.getStatus();
+    }
+    if (isTerminalProcessStatus(status)) {
+      refreshed = await sandbox.getProcess(initial.id) ?? undefined;
+      process = refreshed ?? process;
+    }
+    const logs = await process.getLogs();
+    const accumulatedOutput = `${logs.stdout}${logs.stderr}`;
+    const cursorKey = `${OUTPUT_CURSOR_PREFIX}${sessionId}`;
+    const retainedCursor = outputCursorStorage.get(cursorKey);
+    const delivered = Math.min(
+      Number.isSafeInteger(retainedCursor) && Number(retainedCursor) >= 0
+        ? Number(retainedCursor)
+        : 0,
+      accumulatedOutput.length,
+    );
+    const terminal = isTerminalProcessStatus(status);
+    const chunk = boundedOutput(accumulatedOutput, delivered, outputByteLimit, terminal);
+    const nextCursor = delivered + chunk.consumedCharacters;
+    const result: Record<string, unknown> = {
+      output: chunk.text,
+      chunk_id: `${sessionId}:${nextCursor}`,
+      wall_time_seconds: Math.max(0, (performance.now() - startedAt) / 1_000),
+    };
+    if (chunk.truncated) result.original_token_count = chunk.originalTokenCount;
+    if (terminal) {
+      await flushWorkspace(sandbox);
+      outputCursorStorage.delete(cursorKey);
+      if (typeof process.exitCode === "number") result.exit_code = process.exitCode;
+    } else {
+      outputCursorStorage.put(cursorKey, nextCursor);
+      result.session_id = sessionId;
+    }
+    return result;
+  } catch (error) {
+    await process.kill().catch(() => {});
+    outputCursorStorage.delete(`${OUTPUT_CURSOR_PREFIX}${sessionId}`);
+    try { await flushWorkspace(sandbox); } catch { /* Preserve the process observation failure. */ }
+    throw error;
+  } finally {
+    if (refreshed !== undefined && refreshed !== initial) disposeSandboxRpcValue(refreshed);
+    disposeSandboxRpcValue(initial);
+  }
+}
+
+async function waitForProcessExit(
+  process: SandboxProcess,
+  milliseconds: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  signal?.throwIfAborted();
+  let removeAbort = () => {};
+  const aborted = new Promise<never>((_resolve, reject) => {
+    const abort = () => {
+      reject(signal?.reason ?? new Error("sandbox command cancelled"));
+    };
+    signal?.addEventListener("abort", abort, { once: true });
+    removeAbort = () => signal?.removeEventListener("abort", abort);
+  });
+  try {
+    await Promise.race([process.waitForExit(milliseconds), aborted]);
+  } catch (error) {
+    if (!(error instanceof Error && error.name === "ProcessReadyTimeoutError")) throw error;
+  } finally {
+    removeAbort();
+  }
 }
 
 function optionalInteger(
@@ -822,100 +755,15 @@ function optionalInteger(
   return value as number;
 }
 
-function optionalPositiveInteger(value: unknown, name: string): number | undefined {
-  if (value === undefined) return undefined;
-  if (!Number.isSafeInteger(value) || Number(value) < 1) {
-    throw new Error(`${name} must be a positive integer`);
-  }
-  return Number(value);
-}
-
 function requiredPort(value: unknown): number {
   const port = optionalPort(value, "port");
   if (port === undefined) throw new Error("port is required");
+  if (port === 3_000) throw new Error("port 3000 is reserved for the sandbox control plane");
   return port;
 }
 
 function optionalPort(value: unknown, name: string): number | undefined {
   return optionalInteger(value, name, 1024, 65_535);
-}
-
-function pathParameters(): Record<string, unknown> {
-  return {
-    type: "object",
-    properties: { path: { type: "string", description: "Workspace-relative file path." } },
-    required: ["path"],
-    additionalProperties: false,
-  };
-}
-
-function portParameters(): Record<string, unknown> {
-  return {
-    type: "object",
-    properties: { port: { type: "integer", minimum: 1024, maximum: 65_535 } },
-    required: ["port"],
-    additionalProperties: false,
-  };
-}
-
-function processIdParameters(includeOutput = false): Record<string, unknown> {
-  return {
-    type: "object",
-    properties: {
-      process_id: {
-        type: "string",
-        description: "Process ID returned by sandbox_start_process.",
-      },
-      ...(includeOutput ? {
-        include_output: {
-          type: "boolean",
-          description: "Include accumulated output before the process reaches a terminal state.",
-        },
-      } : {}),
-    },
-    required: ["process_id"],
-    additionalProperties: false,
-  };
-}
-
-async function readBounded(stream: ReadableStream<Uint8Array>): Promise<string> {
-  const reader = stream.getReader();
-  const chunks: Uint8Array[] = [];
-  let size = 0;
-  let completed = false;
-  let cancelled = false;
-  try {
-    while (true) {
-      const next = await reader.read();
-      if (next.done) {
-        completed = true;
-        break;
-      }
-      size += next.value.byteLength;
-      if (size > MAX_FILE_BYTES) {
-        cancelled = true;
-        await cancelReader(reader, "file exceeds 1 MiB");
-        throw new Error("file exceeds 1 MiB");
-      }
-      chunks.push(next.value);
-    }
-  } catch (error) {
-    if (!completed && !cancelled) await cancelReader(reader, error);
-    throw error;
-  } finally {
-    reader.releaseLock();
-  }
-  const content = new Uint8Array(size);
-  let offset = 0;
-  for (const chunk of chunks) {
-    content.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  try {
-    return new TextDecoder("utf-8", { fatal: true, ignoreBOM: false }).decode(content);
-  } catch {
-    throw new Error("file is not valid UTF-8");
-  }
 }
 
 async function withSandboxRpcResult<T, R>(
@@ -944,70 +792,109 @@ function disposeSandboxRpcValue(value: unknown): void {
   if (typeof dispose === "function") dispose.call(value);
 }
 
-async function cancelReadableStream(stream: ReadableStream<Uint8Array>, reason: unknown): Promise<void> {
-  try {
-    await stream.cancel(reason);
-  } catch {
-    // Preserve the result or decoding failure when cancellation also fails.
-  }
-}
-
-async function cancelReader(reader: ReadableStreamDefaultReader<Uint8Array>, reason: unknown): Promise<void> {
-  try {
-    await reader.cancel(reason);
-  } catch {
-    // Preserve the result or decoding failure when cancellation also fails.
-  }
-}
-
-function truncate(value: string): { text: string; truncated: boolean } {
+function boundedOutput(
+  accumulated: string,
+  deliveredCharacters: number,
+  outputByteLimit: number,
+  terminal: boolean,
+): {
+  text: string;
+  truncated: boolean;
+  consumedCharacters: number;
+  originalTokenCount: number;
+} {
+  const value = accumulated.slice(deliveredCharacters);
   const encoded = new TextEncoder().encode(value);
-  if (encoded.byteLength <= MAX_OUTPUT_BYTES) return { text: value, truncated: false };
-  let end = MAX_OUTPUT_BYTES;
+  const originalTokenCount = Math.ceil(encoded.byteLength / APPROXIMATE_BYTES_PER_TOKEN);
+  if (encoded.byteLength <= outputByteLimit) {
+    return {
+      text: value,
+      truncated: false,
+      consumedCharacters: value.length,
+      originalTokenCount,
+    };
+  }
+  if (terminal) {
+    const marker = new TextEncoder().encode("\n… output truncated …\n");
+    if (outputByteLimit <= marker.byteLength) {
+      return {
+        text: decodeUtf8Prefix(encoded, outputByteLimit),
+        truncated: true,
+        consumedCharacters: value.length,
+        originalTokenCount,
+      };
+    }
+    const retainedBytes = outputByteLimit - marker.byteLength;
+    const headBytes = Math.ceil(retainedBytes / 2);
+    const head = decodeUtf8Prefix(encoded, headBytes);
+    const tail = decodeUtf8Suffix(encoded, retainedBytes - new TextEncoder().encode(head).byteLength);
+    return {
+      text: `${head}\n… output truncated …\n${tail}`,
+      truncated: true,
+      consumedCharacters: value.length,
+      originalTokenCount,
+    };
+  }
+  const text = decodeUtf8Prefix(encoded, outputByteLimit);
+  return {
+    text,
+    truncated: true,
+    consumedCharacters: text.length,
+    originalTokenCount,
+  };
+}
+
+function decodeUtf8Prefix(encoded: Uint8Array, limit: number): string {
+  let end = Math.min(encoded.byteLength, limit);
   while (end > 0) {
     try {
-      return {
-        text: new TextDecoder("utf-8", { fatal: true, ignoreBOM: false }).decode(encoded.subarray(0, end)),
-        truncated: true,
-      };
+      return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true })
+        .decode(encoded.subarray(0, end));
     } catch {
       end -= 1;
     }
   }
-  return { text: "", truncated: true };
+  return "";
 }
 
-function boundedOutput(output: { stdout: string; stderr: string }): {
-  stdout: string;
-  stderr: string;
-  stdout_truncated: boolean;
-  stderr_truncated: boolean;
-} {
-  const stdout = truncate(output.stdout);
-  const stderr = truncate(output.stderr);
+function decodeUtf8Suffix(encoded: Uint8Array, limit: number): string {
+  let start = Math.max(0, encoded.byteLength - limit);
+  while (start < encoded.byteLength) {
+    try {
+      return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true })
+        .decode(encoded.subarray(start));
+    } catch {
+      start += 1;
+    }
+  }
+  return "";
+}
+
+function requestedOutputBytes(value: unknown): number {
+  if (value !== undefined && (!Number.isSafeInteger(value) || Number(value) < 0)) {
+    throw new Error("max_output_tokens must be a non-negative safe integer");
+  }
+  return Math.min(
+    Number.MAX_SAFE_INTEGER,
+    Number(value ?? DEFAULT_MAX_OUTPUT_TOKENS) * APPROXIMATE_BYTES_PER_TOKEN,
+  );
+}
+
+function memoryOutputCursorStorage(): SandboxOutputCursorStorage {
+  const cursors = new Map<string, unknown>();
   return {
-    stdout: stdout.text,
-    stderr: stderr.text,
-    stdout_truncated: stdout.truncated,
-    stderr_truncated: stderr.truncated,
+    delete: (key) => { cursors.delete(key); },
+    get: (key) => cursors.get(key),
+    put: (key, value) => { cursors.set(key, value); },
   };
+}
+
+function mergedShellCommand(command: string): string {
+  return `exec 2>&1\n${command}`;
 }
 
 function isTerminalProcessStatus(status: SandboxProcessStatus): boolean {
   return status !== "starting" && status !== "running";
-}
-
-function requiredContent(value: unknown): string {
-  if (typeof value !== "string") throw new Error("content must be a string");
-  if (value.length > MAX_FILE_BYTES) throw new Error("content exceeds 1 MiB");
-  return value;
-}
-
-function requiredProcessId(value: unknown): string {
-  if (typeof value !== "string" || !/^[A-Za-z0-9][A-Za-z0-9_-]*$/.test(value)) {
-    throw new Error("process_id must be a safe Sandbox process ID");
-  }
-  return value;
 }
 
 function errorMessage(error: unknown): string {

--- a/js/managed/test/account-info.test.ts
+++ b/js/managed/test/account-info.test.ts
@@ -16,7 +16,8 @@ describe("managed account info", () => {
       id: "sandbox",
       name: "Agent sandbox",
       kind: "sandbox" as const,
-      workspace: "/workspace",
+      mount: "/sandbox",
+      workspace: "/sandbox",
       capabilities: ["filesystem", "native-linux"],
     }];
     const info = await accountInfo(
@@ -48,6 +49,7 @@ describe("managed account info", () => {
       authorizations: [],
       vault: [],
     });
+    expect(info.machines[0]).toMatchObject({ mount: "/sandbox", workspace: "/sandbox" });
     expect(JSON.stringify(info)).not.toMatch(/access_token|secret/);
     expect(fetch).toHaveBeenCalledWith(
       "https://broker.internal/users/user%2Fwith%20spaces/connectors",
@@ -110,7 +112,8 @@ describe("managed account info", () => {
       id: "sandbox",
       name: "Agent sandbox",
       kind: "sandbox" as const,
-      workspace: "/workspace",
+      mount: "/sandbox",
+      workspace: "/sandbox",
       capabilities: ["native-linux"],
     }];
     const info = await accountInfo(

--- a/js/managed/test/hosted-tools-broker.test.ts
+++ b/js/managed/test/hosted-tools-broker.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { hostedToolCatalogDigest } from "nanocodex/tools/hosted-catalog";
+import {
+  EXEC_COMMAND_PARAMETERS,
+  EXECUTION_OUTPUT_SCHEMA,
+  MACHINE_PREVIEW_PARAMETERS,
+  PREVIEW_OUTPUT_SCHEMA,
+  WRITE_STDIN_PARAMETERS,
+} from "nanocodex-tools/execution-contract";
 
 import {
   HostedToolsBroker,
@@ -111,31 +118,32 @@ describe("HostedToolsBroker socket-owned protocol", () => {
     }]);
   });
 
-  it("qualifies same-name machine tools, dispatches wire names, and disconnects independently", async () => {
+  it("reserves canonical machine tools, resolves exact machines, and disconnects independently", async () => {
     const fixture = createFixture();
     const routeB = fixture.socket();
     await fixture.broker.message(routeB.webSocket, JSON.stringify({
       type: "catalog",
       attachment_id: "machine-b",
-      tools: [entry("exec_command")],
+      tools: [machineEntry("exec_command")],
       machines: [{ id: "machine-b", name: "Machine B", workspace: "/b", capabilities: ["shell"] }],
     }));
     const routeA = fixture.socket();
     await fixture.broker.message(routeA.webSocket, JSON.stringify({
       type: "catalog",
       attachment_id: "machine-a",
-      tools: [entry("exec_command")],
+      tools: [machineEntry("exec_command")],
       machines: [{ id: "machine-a", name: "Machine A", workspace: "/a", capabilities: ["filesystem"] }],
     }));
 
     expect(fixture.broker.provider().definitions().map((definition) => definition.name))
-      .toEqual(["user_machine-a_exec_command", "user_machine-b_exec_command"]);
+      .toEqual([]);
+    expect(fixture.broker.provider().resolve("user_machine-a_exec_command")).toBeUndefined();
     expect(fixture.broker.machines().map((machine) => machine.id)).toEqual(["machine-a", "machine-b"]);
 
-    const pendingA = fixture.broker.provider().resolve("user_machine-a_exec_command")!.handler({}, {
+    const pendingA = fixture.broker.machineTool("machine-a", "exec_command")!.handler({ cmd: "pwd" }, {
       sessionId: "session:1", callId: "source:a",
     });
-    const pendingB = fixture.broker.provider().resolve("user_machine-b_exec_command")!.handler({}, {
+    const pendingB = fixture.broker.machineTool("machine-b", "exec_command")!.handler({ cmd: "pwd" }, {
       sessionId: "session:1", callId: "source:b",
     });
     const callA = routeA.sent.find((frame) => frame.type === "call")!;
@@ -165,13 +173,13 @@ describe("HostedToolsBroker socket-owned protocol", () => {
     await fixture.broker.message(replacementA.webSocket, JSON.stringify({
       type: "catalog",
       attachment_id: "machine-a",
-      tools: [entry("exec_command")],
+      tools: [machineEntry("exec_command")],
       machines: [{ id: "machine-a", name: "Machine A2", workspace: "/a2", capabilities: ["filesystem"] }],
     }));
     expect(routeA.closed).toMatchObject({ code: 1008 });
     expect(routeB.closed).toBeUndefined();
     expect(fixture.broker.provider().definitions().map((definition) => definition.name))
-      .toEqual(["user_machine-a_exec_command", "user_machine-b_exec_command"]);
+      .toEqual([]);
 
     fixture.persistence.routes.get("user:machine-a")!.lease_expires_at = NOW + 1;
     const routeBExpiry = fixture.persistence.routes.get("user:machine-b")!.lease_expires_at;
@@ -181,14 +189,82 @@ describe("HostedToolsBroker socket-owned protocol", () => {
     expect(fixture.persistence.routes.get("user:machine-b")!.lease_expires_at).toBe(routeBExpiry);
 
     await fixture.broker.message(replacementA.webSocket, JSON.stringify({ type: "drain" }));
-    expect(fixture.broker.provider().definitions().map((definition) => definition.name)).toEqual(["user_machine-b_exec_command"]);
+    expect(fixture.broker.machineTool("machine-a", "exec_command")).toBeUndefined();
+    expect(fixture.broker.machineTool("machine-b", "exec_command")).toBeDefined();
     expect(fixture.broker.machines().map((machine) => machine.id)).toEqual(["machine-b"]);
     fixture.broker.webSocketClose(replacementA.webSocket, 1000, "done");
-    expect(fixture.broker.provider().definitions().map((definition) => definition.name)).toEqual(["user_machine-b_exec_command"]);
+    expect(fixture.broker.machineTool("machine-b", "exec_command")).toBeDefined();
 
     fixture.broker.webSocketClose(routeB.webSocket, 1000, "done");
     expect(fixture.broker.provider().definitions()).toEqual([]);
     expect(fixture.broker.machines()).toEqual([]);
+  });
+
+  it("keeps a resolved canonical machine tool pinned to its admitted generation", async () => {
+    const fixture = createFixture();
+    const first = fixture.socket();
+    await fixture.broker.message(first.webSocket, JSON.stringify({
+      type: "catalog",
+      attachment_id: "machine-a",
+      tools: [machineEntry("exec_command")],
+      machines: [{ id: "machine-a", name: "Machine A", workspace: "/a", capabilities: ["shell"] }],
+    }));
+    const selected = fixture.broker.machineTool("machine-a", "exec_command")!;
+
+    const replacement = fixture.socket();
+    await fixture.broker.message(replacement.webSocket, JSON.stringify({
+      type: "catalog",
+      attachment_id: "machine-a",
+      tools: [machineEntry("exec_command")],
+      machines: [{ id: "machine-a", name: "Machine A2", workspace: "/a2", capabilities: ["shell"] }],
+    }));
+
+    const outcome = await selected.handler({ cmd: "pwd" }, {
+      sessionId: "session:1", callId: "source:stale",
+    });
+    expect((outcome as Record<PropertyKey, unknown>)[HOSTED_TOOLS_PRE_ADMISSION_UNAVAILABLE]).toBe(true);
+    expect(replacement.sent.some((frame) => frame.type === "call")).toBe(false);
+    expect(fixture.persistence.callBySource("session:1", "source:stale")).toBeUndefined();
+  });
+
+  it("admits only canonical selector-free machine primitive schemas", async () => {
+    const fixture = createFixture();
+    const host = fixture.socket();
+    const tools = [
+      machineEntry("exec_command"),
+      machineEntry("write_stdin"),
+      machineEntry("preview"),
+    ];
+    await fixture.broker.message(host.webSocket, JSON.stringify({
+      type: "catalog",
+      attachment_id: "machine-a",
+      tools,
+      machines: [{ id: "machine-a", name: "Machine A", workspace: "/a", capabilities: ["shell"] }],
+    }));
+
+    expect(host.closed).toBeUndefined();
+    expect(fixture.broker.provider().definitions()).toEqual([]);
+    for (const tool of tools) {
+      expect(tool.definition.parameters.properties).not.toHaveProperty("environment");
+      expect(tool.definition.parameters.properties).not.toHaveProperty("machine");
+      expect(tool.definition.parameters.properties).not.toHaveProperty("host");
+      expect(fixture.broker.machineTool("machine-a", tool.definition.name)).toBeDefined();
+    }
+
+    const invalid = createFixture();
+    const invalidHost = invalid.socket();
+    const invalidExec = machineEntry("exec_command");
+    (invalidExec.definition.parameters.properties as Record<string, unknown>).environment = { type: "string" };
+    await invalid.broker.message(invalidHost.webSocket, JSON.stringify({
+      type: "catalog",
+      attachment_id: "machine-b",
+      tools: [invalidExec],
+      machines: [{ id: "machine-b", name: "Machine B", workspace: "/b", capabilities: ["shell"] }],
+    }));
+    expect(invalidHost.closed).toMatchObject({
+      code: 1008,
+      reason: expect.stringContaining("machine tool exec_command"),
+    });
   });
 
   it("expires only the named route whose lease elapsed", async () => {
@@ -830,6 +906,37 @@ function entry(name = "fixture__lookup") {
     },
     parallel_safe: true,
     summary: "Fixture lookup",
+    timeout_ms: 30_000,
+  };
+}
+
+function machineEntry(name: "exec_command" | "write_stdin" | "preview") {
+  const definitions = {
+    exec_command: {
+      parameters: EXEC_COMMAND_PARAMETERS,
+      output_schema: EXECUTION_OUTPUT_SCHEMA,
+    },
+    write_stdin: {
+      parameters: WRITE_STDIN_PARAMETERS,
+      output_schema: EXECUTION_OUTPUT_SCHEMA,
+    },
+    preview: {
+      parameters: MACHINE_PREVIEW_PARAMETERS,
+      output_schema: PREVIEW_OUTPUT_SCHEMA,
+    },
+  };
+  return {
+    provider: "machine",
+    remote_name: name,
+    definition: {
+      type: "function" as const,
+      name,
+      description: `Canonical machine ${name}`,
+      strict: false,
+      ...structuredClone(definitions[name]),
+    },
+    parallel_safe: name !== "write_stdin",
+    summary: `Machine ${name}`,
     timeout_ms: 30_000,
   };
 }

--- a/js/managed/test/namespace-tools.test.ts
+++ b/js/managed/test/namespace-tools.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ToolMap } from "nanocodex";
+
+import {
+  createNamespaceExecutionTools,
+  machineMountRoot,
+} from "../src/namespace-tools";
+
+const context = (overrides: Partial<{
+  sessionId: string;
+  parentCallId: string;
+  callId: string;
+}> = {}) => ({
+  callId: overrides.callId ?? "call",
+  model: "gpt-5.6-sol",
+  parentCallId: overrides.parentCallId ?? "cell",
+  sessionId: overrides.sessionId ?? "root-session",
+  signal: new AbortController().signal,
+});
+
+describe("cwd-root namespace execution", () => {
+  it("keeps canonical schemas and routes the default logical cwd to the sandbox", async () => {
+    const sandboxExec = vi.fn(async () => ({
+      output: "/workspace\n",
+      wall_time_seconds: 0.01,
+      exit_code: 0,
+    }));
+    const tools = createNamespaceExecutionTools(sandboxTools(sandboxExec), () => []);
+
+    expect(tools.exec_command!.parameters).toMatchObject({
+      required: ["cmd"],
+      additionalProperties: false,
+    });
+    expect(JSON.stringify(tools.exec_command!.parameters)).not.toContain("environment");
+    expect(tools.write_stdin!.parameters).toMatchObject({
+      required: ["session_id"],
+      additionalProperties: false,
+    });
+    expect(JSON.stringify(tools.write_stdin!.parameters)).not.toMatch(/environment|host/);
+
+    await tools.exec_command!.handler({ cmd: "pwd" }, context());
+    expect(sandboxExec).toHaveBeenCalledWith(
+      { cmd: "pwd", workdir: "/workspace" },
+      expect.objectContaining({ sessionId: "root-session" }),
+    );
+  });
+
+  it("routes by a portable machine mount and translates only the workdir", async () => {
+    const exec = vi.fn(async () => ({ output: "ok", wall_time_seconds: 0, exit_code: 0 }));
+    const resolve = vi.fn((_id: string, name: string) => (
+      name === "exec_command" ? { handler: exec } : { handler: vi.fn() }
+    ));
+    const tools = createNamespaceExecutionTools(
+      sandboxTools(),
+      () => [{
+        id: "laptop",
+        workspace: "/Users/me/repo",
+      }],
+      resolve,
+    );
+
+    await tools.exec_command!.handler({
+      cmd: "cargo test",
+      workdir: "/laptop/crates/core",
+      yield_time_ms: 30_000,
+    }, context());
+
+    expect(exec).toHaveBeenCalledWith({
+      cmd: "cargo test",
+      workdir: "/Users/me/repo/crates/core",
+      yield_time_ms: 30_000,
+    }, expect.anything());
+    expect(resolve).toHaveBeenCalledWith("laptop", "exec_command");
+  });
+
+  it("captures one immutable machine binding per Code Mode cell", async () => {
+    let machines = [{ id: "laptop", workspace: "/old" }];
+    const oldExec = vi.fn(async (_input: unknown) => ({ output: "old", wall_time_seconds: 0, exit_code: 0 }));
+    const newExec = vi.fn(async (_input: unknown) => ({ output: "new", wall_time_seconds: 0, exit_code: 0 }));
+    let generation = "old";
+    const tools = createNamespaceExecutionTools(
+      sandboxTools(),
+      () => machines,
+      (_id, name) => ({
+        handler: name === "exec_command"
+          ? generation === "old" ? oldExec : newExec
+          : vi.fn(),
+      }),
+    );
+
+    await tools.exec_command!.handler({ cmd: "one", workdir: "/laptop" }, context());
+    generation = "new";
+    machines = [{ id: "laptop", workspace: "/new" }];
+    await tools.exec_command!.handler({ cmd: "two", workdir: "/laptop" }, context({ callId: "two" }));
+    await tools.exec_command!.handler(
+      { cmd: "three", workdir: "/laptop" },
+      context({ parentCallId: "next-cell", callId: "three" }),
+    );
+
+    expect(oldExec).toHaveBeenCalledTimes(2);
+    expect(oldExec.mock.calls[1]![0]).toMatchObject({ workdir: "/old" });
+    expect(newExec).toHaveBeenCalledTimes(1);
+    expect(newExec.mock.calls[0]![0]).toMatchObject({ workdir: "/new" });
+  });
+
+  it("rebinds provider-local sessions and rejects cross-agent use", async () => {
+    const machineWrite = vi.fn(async ({ session_id }: { session_id: number }) => ({
+      output: "more",
+      wall_time_seconds: 0,
+      session_id,
+    }));
+    const tools = createNamespaceExecutionTools(
+      sandboxTools(),
+      () => [{ id: "buildbox", workspace: "/srv/repo" }],
+      (_id, name) => ({
+        handler: name === "exec_command"
+          ? vi.fn(async () => ({ output: "start", wall_time_seconds: 0, session_id: 7 }))
+          : name === "write_stdin" ? machineWrite : vi.fn(),
+      }),
+    );
+    const started = await tools.exec_command!.handler(
+      { cmd: "long", workdir: "/buildbox" },
+      context(),
+    ) as { session_id: number };
+    expect(started.session_id).not.toBe(7);
+
+    const polled = await tools.write_stdin!.handler(
+      { session_id: started.session_id },
+      context({ callId: "poll" }),
+    ) as { session_id: number };
+    expect(polled.session_id).toBe(started.session_id);
+    expect(machineWrite).toHaveBeenCalledWith(
+      { session_id: 7 },
+      expect.anything(),
+    );
+    await expect(tools.write_stdin!.handler(
+      { session_id: started.session_id },
+      context({ sessionId: "sibling-session", callId: "steal" }),
+    )).rejects.toThrow("unknown or stale");
+  });
+
+  it("accepts many simultaneously retained process bindings", async () => {
+    let providerSessionId = 0;
+    const exec = vi.fn(async () => ({
+      output: "started",
+      wall_time_seconds: 0,
+      session_id: ++providerSessionId,
+    }));
+    const writeStdin = vi.fn(async ({ session_id }: { session_id: number }) => ({
+      output: "running",
+      wall_time_seconds: 0,
+      session_id,
+    }));
+    const tools = createNamespaceExecutionTools(
+      sandboxTools(),
+      () => [{ id: "buildbox", workspace: "/srv/repo" }],
+      (_id, name) => ({
+        handler: name === "exec_command"
+          ? exec
+          : name === "write_stdin" ? writeStdin : vi.fn(),
+      }),
+    );
+    const retainedSessionCount = 256;
+    const retained: number[] = [];
+
+    for (let index = 0; index < retainedSessionCount; index += 1) {
+      const result = await tools.exec_command!.handler(
+        { cmd: `long-${index}`, workdir: "/buildbox" },
+        context({ callId: `start-${index}` }),
+      ) as { session_id: number };
+      retained.push(result.session_id);
+    }
+
+    expect(new Set(retained).size).toBe(retainedSessionCount);
+    await expect(tools.write_stdin!.handler(
+      { session_id: retained.at(-1)! },
+      context({ callId: "poll-last" }),
+    )).resolves.toMatchObject({ session_id: retained.at(-1) });
+    expect(writeStdin).toHaveBeenLastCalledWith(
+      { session_id: retainedSessionCount },
+      expect.anything(),
+    );
+  });
+
+  it("retains every live Code Mode cell binding until lifecycle cleanup", async () => {
+    let generation: "old" | "new" = "old";
+    const oldExec = vi.fn(async () => ({ output: "old", wall_time_seconds: 0, exit_code: 0 }));
+    const newExec = vi.fn(async () => ({ output: "new", wall_time_seconds: 0, exit_code: 0 }));
+    const tools = createNamespaceExecutionTools(
+      sandboxTools(),
+      () => [{ id: "laptop", workspace: generation === "old" ? "/old" : "/new" }],
+      (_id, name) => ({
+        handler: name === "exec_command"
+          ? generation === "old" ? oldExec : newExec
+          : vi.fn(),
+      }),
+    );
+
+    for (let index = 0; index < 256; index += 1) {
+      await tools.exec_command!.handler(
+        { cmd: `cell-${index}`, workdir: "/laptop" },
+        context({ parentCallId: `cell-${index}`, callId: `call-${index}` }),
+      );
+    }
+    generation = "new";
+    await tools.exec_command!.handler(
+      { cmd: "revisit", workdir: "/laptop" },
+      context({ parentCallId: "cell-0", callId: "revisit" }),
+    );
+
+    expect(oldExec).toHaveBeenCalledTimes(257);
+    expect(oldExec).toHaveBeenLastCalledWith(
+      { cmd: "revisit", workdir: "/old" },
+      expect.anything(),
+    );
+    expect(newExec).not.toHaveBeenCalled();
+  });
+
+  it("releases retained cells and process bindings with the owner session", async () => {
+    let current = "old";
+    const oldExec = vi.fn(async () => ({
+      output: "started",
+      wall_time_seconds: 0,
+      session_id: 7,
+    }));
+    const newExec = vi.fn(async () => ({
+      output: "rebound",
+      wall_time_seconds: 0,
+      exit_code: 0,
+    }));
+    const tools = createNamespaceExecutionTools(
+      sandboxTools(),
+      () => [{ id: "laptop", workspace: current === "old" ? "/old" : "/new" }],
+      (_id, name) => ({
+        handler: name === "exec_command"
+          ? current === "old" ? oldExec : newExec
+          : vi.fn(async () => ({ output: "more", wall_time_seconds: 0, session_id: 7 })),
+      }),
+    );
+    const started = await tools.exec_command!.handler(
+      { cmd: "long", workdir: "/laptop" },
+      context(),
+    ) as { session_id: number };
+
+    tools.exec_command!.releaseSession?.("root-session");
+    current = "new";
+
+    await expect(tools.write_stdin!.handler(
+      { session_id: started.session_id },
+      context({ callId: "stale" }),
+    )).rejects.toThrow("unknown or stale");
+    await tools.exec_command!.handler(
+      { cmd: "fresh", workdir: "/laptop" },
+      context({ callId: "fresh" }),
+    );
+    expect(oldExec).toHaveBeenCalledTimes(1);
+    expect(newExec).toHaveBeenCalledWith(
+      { cmd: "fresh", workdir: "/new" },
+      expect.anything(),
+    );
+  });
+
+  it("lets sibling subagent sessions place work on separate hands concurrently", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const started: string[] = [];
+    const handler = (hand: string) => vi.fn(async () => {
+      started.push(hand);
+      await gate;
+      return { output: hand, wall_time_seconds: 0.01, exit_code: 0 };
+    });
+    const laptop = handler("laptop");
+    const buildbox = handler("buildbox");
+    const tools = createNamespaceExecutionTools(
+      sandboxTools(),
+      () => [
+        { id: "laptop", workspace: "/one" },
+        { id: "buildbox", workspace: "/two" },
+      ],
+      (id, name) => ({
+        handler: name === "exec_command"
+          ? id === "laptop" ? laptop : buildbox
+          : vi.fn(),
+      }),
+    );
+    const child = (sessionId: string, agentId: string) => ({
+      ...context({ sessionId, parentCallId: `cell-${agentId}`, callId: `call-${agentId}` }),
+      subagent: {
+        agentId,
+        parentAgentId: null,
+        sessionId,
+        role: "builder",
+        task: "test",
+      },
+    });
+
+    const pending = Promise.all([
+      tools.exec_command!.handler({ cmd: "test", workdir: "/laptop" }, child("child-a", "1")),
+      tools.exec_command!.handler({ cmd: "test", workdir: "/buildbox" }, child("child-b", "2")),
+    ]);
+    await vi.waitFor(() => expect(started).toHaveLength(2));
+    release();
+    await expect(pending).resolves.toHaveLength(2);
+    expect(laptop).toHaveBeenCalledTimes(1);
+    expect(buildbox).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed for unknown roots and derives safe deterministic mount names", async () => {
+    const tools = createNamespaceExecutionTools(sandboxTools(), () => []);
+    await expect(tools.exec_command!.handler(
+      { cmd: "pwd", workdir: "/missing/repo" },
+      context(),
+    )).rejects.toThrow("no mount owns");
+    expect(machineMountRoot("laptop")).toBe("/laptop");
+    expect(machineMountRoot("Build Box")).toMatch(/^\/hand-build-box-[0-9a-f]{8}$/);
+    expect(machineMountRoot("sandbox")).toMatch(/^\/hand-sandbox-/);
+  });
+});
+
+function sandboxTools(
+  exec = vi.fn(async () => ({ output: "", wall_time_seconds: 0, exit_code: 0 })),
+): ToolMap {
+  return {
+    exec_command: {
+      description: "sandbox exec",
+      handler: exec,
+    },
+    write_stdin: {
+      description: "sandbox stdin",
+      handler: vi.fn(async () => ({ output: "", wall_time_seconds: 0, exit_code: 0 })),
+    },
+    preview: {
+      description: "sandbox preview",
+      handler: vi.fn(async () => ({ port: 3000, url: "https://preview", persistent: false })),
+    },
+  };
+}

--- a/js/managed/test/sandbox-runtime.test.ts
+++ b/js/managed/test/sandbox-runtime.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../src/sandbox-runtime";
 import { cloudflareSandboxPreviewUrl } from "../src/sandbox-tools";
 import {
-  createManagedSandboxTools,
+  createManagedNamespaceTools,
   routeSandboxPreviewRequest,
 } from "../src/index";
 
@@ -61,7 +61,17 @@ describe("managed sandbox preview wiring", () => {
     const namespace = {} as DurableObjectNamespace<Sandbox>;
     const sourceHandler = vi.fn(async () => ({ ok: true }));
     const sourceTools: ToolMap = {
-      sandbox_preview: {
+      exec_command: {
+        description: "exec",
+        parameters: { type: "object", additionalProperties: false },
+        handler: sourceHandler,
+      },
+      write_stdin: {
+        description: "poll",
+        parameters: { type: "object", additionalProperties: false },
+        handler: sourceHandler,
+      },
+      preview: {
         description: "preview",
         parameters: { type: "object", additionalProperties: false },
         handler: sourceHandler,
@@ -69,7 +79,7 @@ describe("managed sandbox preview wiring", () => {
     };
     const factory = vi.fn(() => sourceTools) as unknown as typeof import("../src/sandbox-tools").cloudflareSandboxTools;
     let accountOwned = true;
-    const tools = createManagedSandboxTools({
+    const tools = createManagedNamespaceTools({
       NANOCODEX_ADMIN_TOKEN: "server-only-preview-secret",
       NANOCODEX_SANDBOXES: namespace,
       NANOCODEX_SANDBOX_LOCAL: "true",
@@ -85,13 +95,14 @@ describe("managed sandbox preview wiring", () => {
       "https://nanocodex.example",
       "server-only-preview-secret",
     );
-    await expect(tools[0]!.handler({}, toolContext())).resolves.toEqual({ ok: true });
+    expect(tools.map(({ name }) => name)).toEqual(["exec_command", "write_stdin", "preview"]);
+    await expect(tools[0]!.handler({ cmd: "pwd" }, toolContext())).resolves.toEqual({ ok: true });
     expect(sourceHandler).toHaveBeenCalledTimes(1);
 
     accountOwned = false;
     await expect(tools[0]!.handler({}, toolContext())).rejects.toMatchObject({
       status: 403,
-      code: "sandbox_forbidden",
+      code: "namespace_forbidden",
     });
     expect(sourceHandler).toHaveBeenCalledTimes(1);
   });

--- a/js/managed/test/sandbox-tools.test.ts
+++ b/js/managed/test/sandbox-tools.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const sandboxSdk = vi.hoisted(() => ({ getSandbox: vi.fn() }));
-
 vi.mock("@cloudflare/sandbox", () => ({ getSandbox: sandboxSdk.getSandbox }));
 
 import {
@@ -26,526 +25,273 @@ describe("Cloudflare sandbox tools", () => {
   beforeEach(() => sandboxSdk.getSandbox.mockReset());
   afterEach(() => vi.restoreAllMocks());
 
-  it("asks the sandbox provider to prepare before every tool operation", async () => {
-    const sandbox = fakeSandbox();
-    const create = vi.fn(async () => sandbox);
-    const tools = createCloudflareSandboxTools(create);
+  it("exposes only the canonical shell and preview tools without a host selector", () => {
+    const tools = createCloudflareSandboxTools(async () => fakeSandbox());
 
-    await Promise.all([
-      tools.sandbox_exec!.handler({ command: "uname -a" }, context),
-      tools.sandbox_write_file!.handler({ path: "proof.txt", content: "ok" }, context),
-    ]);
-
-    expect(create).toHaveBeenCalledTimes(2);
-    await tools.sandbox_list_files!.handler({}, context);
-    expect(create).toHaveBeenCalledTimes(3);
-    expect(sandbox.exec).toHaveBeenCalledWith("uname -a", {
-      cwd: "/workspace",
+    expect(Object.keys(tools)).toEqual(["exec_command", "write_stdin", "preview"]);
+    expect(tools.exec_command!.parameters).toMatchObject({
+      required: ["cmd"],
     });
-    expect(sandbox.exec.mock.calls.filter(([command]) => isWorkspaceFlush(command))).toHaveLength(2);
+    const parameters = tools.exec_command!.parameters as {
+      properties: Record<string, Record<string, unknown>>;
+    };
+    expect(parameters.properties.yield_time_ms!.maximum).toBeUndefined();
+    expect(parameters.properties.max_output_tokens!.maximum).toBeUndefined();
+    expect(parameters.properties.environment).toBeUndefined();
+    expect(parameters.properties.host).toBeUndefined();
+    expect(tools.exec_command!.outputSchema).toMatchObject({
+      required: ["wall_time_seconds", "output"],
+    });
+    expect(tools.write_stdin!.parameters).toMatchObject({ required: ["session_id"] });
+    expect(tools.preview!.parameters).toMatchObject({ required: ["port"] });
   });
 
-  it("acknowledges workspace writes only after the retained mount flushes", async () => {
+  it("does not impose command, wait, or output ceilings below the platform", async () => {
     const sandbox = fakeSandbox();
-    const order: string[] = [];
-    sandbox.writeFile.mockImplementation(async () => { order.push("write"); });
-    sandbox.exec.mockImplementation(async (command: string) => {
-      expect(command).toBe("sync -f /workspace");
-      order.push("flush");
-      return executionResult("");
-    });
+    const process = fakeProcess({ status: "completed", exitCode: 0 });
+    const output = "x".repeat(160 * 1024);
+    const command = "x".repeat(33 * 1024);
+    process.getLogs.mockResolvedValue({ stdout: output, stderr: "" });
+    sandbox.startProcess.mockResolvedValue(process);
+    sandbox.getProcess.mockImplementation(async (id: string) => id === process.id ? process : null);
     const tools = createCloudflareSandboxTools(async () => sandbox);
 
-    await expect(tools.sandbox_write_file!.handler({
-      path: "proof.txt",
-      content: "retained",
-    }, context)).resolves.toEqual({ path: "/workspace/proof.txt", bytes_written: 8 });
-
-    expect(order).toEqual(["write", "flush"]);
-  });
-
-  it("fails a workspace mutation when its retained flush fails", async () => {
-    const sandbox = fakeSandbox();
-    sandbox.exec.mockResolvedValue({
-      success: false,
-      exitCode: 1,
-      stdout: "",
-      stderr: "transport failed",
-      duration: 1,
+    await expect(tools.exec_command!.handler({
+      cmd: command,
+      yield_time_ms: 120_001,
+      max_output_tokens: 100_001,
+    }, context)).resolves.toMatchObject({
+      output,
+      exit_code: 0,
     });
-    const tools = createCloudflareSandboxTools(async () => sandbox);
-
-    await expect(tools.sandbox_write_file!.handler({
-      path: "proof.txt",
-      content: "not-yet-durable",
-    }, context)).rejects.toThrow("failed to flush the retained workspace: transport failed");
   });
 
-  it("attempts to flush partial writes when foreground execution rejects", async () => {
+  it("runs canonical exec_command in the retained workspace and flushes mutations", async () => {
     const sandbox = fakeSandbox();
-    const executionError = new Error("command transport stopped");
-    sandbox.exec
-      .mockRejectedValueOnce(executionError)
-      .mockResolvedValueOnce(executionResult(""));
-    const tools = createCloudflareSandboxTools(async () => sandbox);
-
-    await expect(tools.sandbox_exec!.handler({ command: "generate files" }, context))
-      .rejects.toBe(executionError);
-    expect(sandbox.exec.mock.calls).toEqual([
-      ["generate files", { cwd: "/workspace" }],
-      ["sync -f /workspace", { cwd: "/" }],
-    ]);
-  });
-
-  it("prepares one shared sandbox once across concurrent parent and child tool sets", async () => {
-    const namespace = fakeNamespace();
-    const sandbox = preparingSandbox("empty");
-    sandboxSdk.getSandbox.mockReturnValue(sandbox);
-    const parent = cloudflareSandboxTools(namespace, "shared-session");
-    const child = cloudflareSandboxTools(namespace, "shared-session");
-
-    await Promise.all([
-      parent.sandbox_exec!.handler({ command: "printf parent" }, context),
-      child.sandbox_exec!.handler({ command: "printf child" }, {
-        ...context,
-        sessionId: "child-session",
-        subagent: {
-          agentId: "1",
-          parentAgentId: null,
-          sessionId: "child-session",
-          role: "worker",
-          task: "exercise the shared sandbox",
-        },
-      }),
-    ]);
-
-    expect(sandboxSdk.getSandbox).toHaveBeenCalledTimes(1);
-    expect(sandbox.mountBucket).toHaveBeenCalledTimes(1);
-    expect(sandbox.mountBucket).toHaveBeenCalledWith(
-      "NANOCODEX_WORKSPACES",
-      "/workspace",
-      { prefix: "/sessions/shared-session/" },
-    );
-  });
-
-  it("reuses a healthy retained workspace after the managed host reconnects", async () => {
-    const sandbox = preparingSandbox("empty");
-    sandboxSdk.getSandbox.mockReturnValue(sandbox);
-
-    await cloudflareSandboxTools(fakeNamespace(), "retained-session")
-      .sandbox_exec!.handler({ command: "printf first" }, context);
-    await cloudflareSandboxTools(fakeNamespace(), "retained-session")
-      .sandbox_exec!.handler({ command: "printf reconnected" }, context);
-
-    expect(sandbox.mountBucket).toHaveBeenCalledTimes(1);
-    expect(sandbox.exec.mock.calls.filter(([command]) => isMountProbe(command))).toHaveLength(3);
-  });
-
-  it("retries a transient retained mount health failure during background work", async () => {
-    const sandbox = preparingSandbox("empty");
-    const probeStates: MountState[] = [
-      "empty",
-      "mounted",
-      "mounted-unhealthy",
-      "mounted",
-    ];
-    sandbox.exec.mockImplementation(async (command: string) => executionResult(
-      isMountProbe(command) ? probeStates.shift()! : "clone-visible",
+    const process = fakeProcess({ status: "failed", exitCode: 7 });
+    process.getLogs.mockResolvedValue({ stdout: "hello", stderr: "warning" });
+    sandbox.startProcess.mockResolvedValue(process);
+    sandbox.getProcess.mockImplementation(async (id: string) => (
+      id === process.id ? process : null
     ));
-    sandboxSdk.getSandbox.mockReturnValue(sandbox);
-    const tools = cloudflareSandboxTools(fakeNamespace(), "clone-session");
+    const tools = createCloudflareSandboxTools(async () => sandbox);
 
-    const clone = "git clone https://example.invalid/repo.git repo";
-    const started = await tools.sandbox_start_process!.handler({ command: clone }, context);
-    const result = await tools.sandbox_exec!.handler({ command: "git -C repo status" }, context);
-
-    expect(started).toMatchObject({ command: clone });
-    expect(result).toMatchObject({ success: true, stdout: "clone-visible" });
-    expect(sandbox.startProcess).toHaveBeenCalledWith(clone, {
-      cwd: "/workspace",
+    await expect(tools.exec_command!.handler({
+      cmd: "task",
+      workdir: "repo",
+    }, context)).resolves.toEqual({
+      output: "hellowarning",
+      chunk_id: expect.stringMatching(/^[1-9][0-9]*:12$/),
+      exit_code: 7,
+      wall_time_seconds: expect.any(Number),
+    });
+    expect(sandbox.startProcess).toHaveBeenCalledWith("exec 2>&1\ntask", {
+      cwd: "/workspace/repo",
+      processId: expect.stringMatching(/^nanocodex-[1-9][0-9]*$/),
       autoCleanup: false,
     });
-    expect(sandbox.exec.mock.calls.filter(([command]) => isMountProbe(command))).toHaveLength(4);
-    expect(sandbox.mountBucket).toHaveBeenCalledTimes(1);
+    expect(sandbox.exec).toHaveBeenCalledWith("sync -f /workspace", { cwd: "/" });
   });
 
-  it("remounts retained storage after a container replacement before the next command", async () => {
-    const sandbox = preparingSandbox("empty");
-    const events: string[] = [];
-    let retainedMarker = "";
-    sandbox.mountBucket.mockImplementation(async () => {
-      events.push("mount");
-      sandbox.setMountState("mounted");
-    });
-    sandbox.exec.mockImplementation(async (command: string) => {
-      if (isMountProbe(command)) {
-        events.push("probe");
-        return executionResult(sandbox.getMountState());
-      }
-      if (command === "printf retained-marker > marker.txt") {
-        events.push("write-marker");
-        retainedMarker = "retained-marker";
-        return executionResult("");
-      }
-      if (command === "cat marker.txt") {
-        events.push("read-marker");
-        return executionResult(
-          sandbox.getMountState() === "mounted" ? retainedMarker : "ephemeral-marker",
-        );
-      }
-      if (isWorkspaceFlush(command)) {
-        events.push("flush");
-        return executionResult("");
-      }
-      throw new Error(`unexpected command: ${command}`);
-    });
-    sandboxSdk.getSandbox.mockReturnValue(sandbox);
-    const tools = cloudflareSandboxTools(fakeNamespace(), "replacement-session");
-
-    await tools.sandbox_exec!.handler({
-      command: "printf retained-marker > marker.txt",
-    }, context);
-    sandbox.setMountState("empty");
-    const second = await tools.sandbox_exec!.handler({ command: "cat marker.txt" }, context);
-
-    expect(second).toMatchObject({ stdout: "retained-marker" });
-    expect(events).toEqual([
-      "probe",
-      "mount",
-      "probe",
-      "write-marker",
-      "flush",
-      "probe",
-      "mount",
-      "probe",
-      "read-marker",
-      "flush",
-    ]);
-    expect(sandbox.mountBucket).toHaveBeenCalledTimes(2);
-  });
-
-  it("accepts a concurrent mount winner only after the retained mount probes healthy", async () => {
-    const namespace = fakeNamespace();
-    const sandbox = preparingSandbox("empty");
-    const mountError = new Error("S3FS mount failed: MOUNTPOINT directory /workspace is not empty");
-    sandbox.mountBucket.mockImplementationOnce(async () => {
-      sandbox.setMountState("mounted");
-      throw mountError;
-    });
-    sandboxSdk.getSandbox.mockReturnValue(sandbox);
-
-    await expect(cloudflareSandboxTools(namespace, "raced-session")
-      .sandbox_exec!.handler({ command: "printf reused" }, context)).resolves.toMatchObject({
-        success: true,
-      });
-
-    expect(sandbox.mountBucket).toHaveBeenCalledTimes(1);
-    expect(sandbox.exec.mock.calls.filter(([command]) => isMountProbe(command))).toHaveLength(2);
-  });
-
-  it("retries preparation after a real mount failure", async () => {
-    const namespace = fakeNamespace();
-    const sandbox = preparingSandbox("empty");
-    const mountError = new Error("R2 mount unavailable");
-    sandbox.mountBucket
-      .mockRejectedValueOnce(mountError)
-      .mockImplementationOnce(async () => sandbox.setMountState("mounted"));
-    sandboxSdk.getSandbox.mockReturnValue(sandbox);
-    const tools = cloudflareSandboxTools(namespace, "retry-session");
-
-    await expect(tools.sandbox_exec!.handler({ command: "printf first" }, context))
-      .rejects.toBe(mountError);
-    await expect(tools.sandbox_exec!.handler({ command: "printf retry" }, context))
-      .resolves.toMatchObject({ success: true });
-
-    expect(sandboxSdk.getSandbox).toHaveBeenCalledTimes(2);
-    expect(sandbox.mountBucket).toHaveBeenCalledTimes(2);
-  });
-
-  it.each([
-    ["occupied", "unmounted /workspace directory is not empty"],
-    ["mounted-unhealthy", "existing /workspace mount is unhealthy"],
-  ] as const)("refuses to remount a %s workspace", async (state, message) => {
-    const sandbox = preparingSandbox(state);
-    sandboxSdk.getSandbox.mockReturnValue(sandbox);
-
-    await expect(cloudflareSandboxTools(fakeNamespace(), `${state}-session`)
-      .sandbox_exec!.handler({ command: "printf unsafe" }, context)).rejects.toThrow(message);
-
-    expect(sandbox.mountBucket).not.toHaveBeenCalled();
-    expect(sandbox.exec.mock.calls.filter(([command]) => isMountProbe(command))).toHaveLength(
-      state === "mounted-unhealthy" ? 3 : 1,
-    );
-  });
-
-  it("preserves the local R2 mount contract", async () => {
-    const sandbox = preparingSandbox("empty");
-    sandboxSdk.getSandbox.mockReturnValue(sandbox);
-
-    await cloudflareSandboxTools(fakeNamespace(), "local-session", true)
-      .sandbox_exec!.handler({ command: "printf local" }, context);
-
-    expect(sandbox.mountBucket).toHaveBeenCalledWith(
-      "NANOCODEX_WORKSPACES",
-      "/workspace",
-      { prefix: "/sessions/local-session/", localBucket: true },
-    );
-  });
-
-  it("does not impose command or readiness timeout limits", async () => {
+  it("persists the output cursor across tool reconstruction and preserves a terminal tail", async () => {
     const sandbox = fakeSandbox();
+    const process = fakeProcess({ status: "running" });
+    let status: "running" | "completed" = "running";
+    let stdout = "first";
+    process.getStatus.mockImplementation(async () => status);
+    process.getLogs.mockImplementation(async () => ({ stdout, stderr: "" }));
+    sandbox.startProcess.mockImplementation(async (_command: string, options: { processId: string }) => {
+      process.id = options.processId;
+      return process;
+    });
+    sandbox.getProcess.mockImplementation(async (id: string) => id === process.id ? process : null);
+    const cursors = new Map<string, unknown>();
+    const cursorStorage = {
+      delete: (key: string) => { cursors.delete(key); },
+      get: (key: string) => cursors.get(key),
+      put: (key: string, value: unknown) => { cursors.set(key, value); },
+    };
+    let tools = createCloudflareSandboxTools(async () => sandbox, undefined, cursorStorage);
+
+    const started = await tools.exec_command!.handler({
+      cmd: "task",
+      yield_time_ms: 0,
+    }, context) as { session_id: number; output: string };
+    expect(started.output).toBe("first");
+    stdout = "firstsecond";
+    tools = createCloudflareSandboxTools(async () => sandbox, undefined, cursorStorage);
+    await expect(tools.write_stdin!.handler({
+      session_id: started.session_id,
+      yield_time_ms: 0,
+    }, context)).resolves.toMatchObject({
+      output: "second",
+      session_id: started.session_id,
+    });
+
+    stdout += `${"x".repeat(100)}TAIL`;
+    status = "completed";
+    tools = createCloudflareSandboxTools(async () => sandbox, undefined, cursorStorage);
+    await expect(tools.write_stdin!.handler({
+      session_id: started.session_id,
+      max_output_tokens: 9,
+    }, context)).resolves.toMatchObject({
+      output: expect.stringMatching(/^x+\n… output truncated …\n.*TAIL$/),
+      original_token_count: 26,
+      exit_code: 0,
+    });
+    expect(cursors.size).toBe(0);
+  });
+
+  it("uses Ctrl-C as the canonical termination path for a yielded session", async () => {
+    const sandbox = fakeSandbox();
+    const process = fakeProcess({ id: "nanocodex-7", status: "killed", exitCode: 137 });
+    sandbox.getProcess.mockResolvedValue(process);
     const tools = createCloudflareSandboxTools(async () => sandbox);
 
-    await tools.sandbox_exec!.handler({
-      command: "cargo test",
-      timeout_ms: Number.MAX_SAFE_INTEGER,
-    }, context);
-    await tools.sandbox_start_process!.handler({
-      command: "cargo watch",
-      ready_port: 3_000,
-    }, context);
-
-    expect(sandbox.exec).toHaveBeenCalledWith("cargo test", {
-      cwd: "/workspace",
-      timeout: Number.MAX_SAFE_INTEGER,
-    });
-    const process = await sandbox.startProcess.mock.results[0]!.value;
-    expect(process.waitForPort).toHaveBeenCalledWith(3_000, undefined);
+    await expect(tools.write_stdin!.handler({
+      session_id: 7,
+      chars: "\u0003",
+    }, context)).resolves.toMatchObject({ exit_code: 137 });
+    expect(process.kill).toHaveBeenCalledTimes(1);
   });
 
-  it("returns the process identity when port readiness fails", async () => {
+  it("uses the sandbox exit stream once for an unrestricted yield", async () => {
     const sandbox = fakeSandbox();
-    const process = fakeProcess();
-    process.waitForPort.mockRejectedValue(new Error("port never became ready"));
-    process.getStatus.mockResolvedValue("running");
+    const process = fakeProcess({ status: "running" });
+    const timeout = Object.assign(new Error("still running"), {
+      name: "ProcessReadyTimeoutError",
+    });
+    process.waitForExit.mockRejectedValue(timeout);
     sandbox.startProcess.mockResolvedValue(process);
     const tools = createCloudflareSandboxTools(async () => sandbox);
 
-    await expect(tools.sandbox_start_process!.handler({
-      command: "start server",
-      ready_port: 3_000,
-    }, context)).resolves.toMatchObject({
-      process_id: "process",
-      status: "running",
-      terminal: false,
-      ready: false,
-      ready_error: "port never became ready",
-    });
-    expect(process.kill).toHaveBeenCalledOnce();
+    await expect(tools.exec_command!.handler({
+      cmd: "long-job",
+      yield_time_ms: 120_001,
+    }, context)).resolves.toMatchObject({ session_id: expect.any(Number) });
+    expect(process.waitForExit).toHaveBeenCalledOnce();
+    expect(process.waitForExit).toHaveBeenCalledWith(120_001);
     expect(process.getStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects escalation, PTYs, stdin, shell overrides, and escaped workdirs", async () => {
+    const tools = createCloudflareSandboxTools(async () => fakeSandbox());
+
+    await expect(tools.exec_command!.handler({
+      cmd: "pwd", sandbox_permissions: "require_escalated",
+    }, context)).rejects.toThrow("does not support privilege escalation");
+    await expect(tools.exec_command!.handler({ cmd: "pwd", tty: true }, context))
+      .rejects.toThrow("does not support TTY");
+    await expect(tools.exec_command!.handler({
+      cmd: "pwd", shell: "/bin/zsh",
+    }, context)).rejects.toThrow("does not support shell or login overrides");
+    await expect(tools.exec_command!.handler({
+      cmd: "pwd", workdir: "../outside",
+    }, context)).rejects.toThrow("must not contain '..'");
+    await expect(tools.write_stdin!.handler({
+      session_id: 7, chars: "input",
+    }, context)).rejects.toThrow("stdin is unavailable");
+  });
+
+  it("attempts a retained-workspace flush when command transport fails", async () => {
+    const sandbox = fakeSandbox();
+    const failure = new Error("transport stopped");
+    sandbox.startProcess.mockRejectedValueOnce(failure);
+    const tools = createCloudflareSandboxTools(async () => sandbox);
+
+    await expect(tools.exec_command!.handler({ cmd: "task" }, context))
+      .rejects.toBe(failure);
     expect(sandbox.exec).toHaveBeenLastCalledWith("sync -f /workspace", { cwd: "/" });
   });
 
-  it("runs the requested background command unchanged and flushes terminal observations", async () => {
-    const sandbox = fakeSandbox();
-    const tools = createCloudflareSandboxTools(async () => sandbox);
-    const command = "cargo test --workspace";
-
-    await expect(tools.sandbox_start_process!.handler({ command }, context))
-      .resolves.toMatchObject({ command });
-    expect(sandbox.startProcess.mock.calls[0]![0]).toBe(command);
-
-    sandbox.getProcess.mockResolvedValue(fakeProcess({
-      command,
-      status: "completed",
-      exitCode: 0,
-    }));
-    await expect(tools.sandbox_get_process!.handler({ process_id: "process" }, context))
-      .resolves.toMatchObject({ command, status: "completed", terminal: true });
-    expect(sandbox.exec).toHaveBeenLastCalledWith("sync -f /workspace", {
-      cwd: "/",
-    });
-  });
-
-  it("flushes a background process that finishes while it is starting", async () => {
+  it("kills and flushes a started process when observation fails", async () => {
     const sandbox = fakeSandbox();
     const process = fakeProcess({ status: "running" });
-    process.getStatus.mockResolvedValue("completed");
+    const failure = new Error("status transport stopped");
+    process.getStatus.mockRejectedValueOnce(failure);
     sandbox.startProcess.mockResolvedValue(process);
     const tools = createCloudflareSandboxTools(async () => sandbox);
 
-    await expect(tools.sandbox_start_process!.handler({ command: "quick task" }, context))
-      .resolves.toMatchObject({ command: "quick task", status: "completed" });
-    expect(sandbox.exec).toHaveBeenLastCalledWith("sync -f /workspace", {
-      cwd: "/",
-    });
+    await expect(tools.exec_command!.handler({ cmd: "task" }, context))
+      .rejects.toBe(failure);
+    expect(process.kill).toHaveBeenCalledTimes(1);
+    expect(sandbox.exec).toHaveBeenLastCalledWith("sync -f /workspace", { cwd: "/" });
   });
 
-  it("retrieves authoritative background process state and bounded logs", async () => {
-    const sandbox = fakeSandbox();
-    const process = fakeProcess({
-      id: "proc_123",
-      pid: 42,
-      command: "cargo test",
-      status: "failed" as const,
-      exitCode: 101,
-    });
-    process.getLogs.mockResolvedValue({
-      stdout: "compiled\n",
-      stderr: "test failed\n",
-    });
-    sandbox.getProcess.mockResolvedValue(process);
-    const tools = createCloudflareSandboxTools(async () => sandbox);
+  it("mounts one retained workspace and reuses it across tool reconstruction", async () => {
+    const sandbox = preparingSandbox("empty");
+    sandboxSdk.getSandbox.mockReturnValue(sandbox);
+    const namespace = fakeNamespace();
 
-    await expect(tools.sandbox_get_process!.handler({ process_id: "proc_123" }, context))
+    await cloudflareSandboxTools(namespace, "retained").exec_command!.handler(
+      { cmd: "printf first" }, context,
+    );
+    await cloudflareSandboxTools(namespace, "retained").exec_command!.handler(
+      { cmd: "printf second" }, context,
+    );
+
+    expect(sandboxSdk.getSandbox).toHaveBeenCalledTimes(2);
+    expect(sandbox.mountBucket).toHaveBeenCalledTimes(1);
+    expect(sandbox.mountBucket).toHaveBeenCalledWith(
+      "NANOCODEX_WORKSPACES", "/workspace", { prefix: "/sessions/retained/" },
+    );
+  });
+
+  it("preserves local R2 mount options and refuses unsafe remote remounts", async () => {
+    const local = preparingSandbox("empty");
+    sandboxSdk.getSandbox.mockReturnValueOnce(local);
+    await cloudflareSandboxTools(fakeNamespace(), "local", true).exec_command!.handler(
+      { cmd: "printf local" }, context,
+    );
+    expect(local.mountBucket).toHaveBeenCalledWith(
+      "NANOCODEX_WORKSPACES",
+      "/workspace",
+      { prefix: "/sessions/local/", localBucket: true },
+    );
+
+    const occupied = preparingSandbox("occupied");
+    sandboxSdk.getSandbox.mockReturnValueOnce(occupied);
+    await expect(cloudflareSandboxTools(fakeNamespace(), "occupied").exec_command!.handler(
+      { cmd: "printf unsafe" }, context,
+    )).rejects.toThrow("unmounted /workspace directory is not empty");
+    expect(occupied.mountBucket).not.toHaveBeenCalled();
+  });
+
+  it("creates a server-fronted preview without exposing its secret", async () => {
+    const tools = createCloudflareSandboxTools(
+      async () => fakeSandbox(),
+      async (port) => ({
+        port,
+        url: "https://nanocodex.example/sandbox-preview/sealed/",
+        persistent: false,
+      }),
+    );
+
+    await expect(tools.preview!.handler({ port: 8080 }, context))
       .resolves.toEqual({
-        found: true,
-        process_id: "proc_123",
-        pid: 42,
-        command: "cargo test",
-        status: "failed",
-        terminal: true,
-        exit_code: 101,
-        stdout: "compiled\n",
-        stderr: "test failed\n",
-        stdout_truncated: false,
-        stderr_truncated: false,
+        port: 8080,
+        url: "https://nanocodex.example/sandbox-preview/sealed/",
+        persistent: false,
       });
-    expect(sandbox.getProcess).toHaveBeenCalledWith("proc_123");
-    expect(process.getLogs).toHaveBeenCalledOnce();
   });
 
-  it("polls running and missing processes without repeatedly transferring logs", async () => {
-    const sandbox = fakeSandbox();
-    const running = fakeProcess({
-      id: "proc_running",
-      command: "cargo test",
-      status: "running" as const,
-    });
-    running.getLogs.mockResolvedValue({ stdout: "compiling", stderr: "" });
-    sandbox.getProcess
-      .mockResolvedValueOnce(running)
-      .mockResolvedValueOnce(null);
-    const tools = createCloudflareSandboxTools(async () => sandbox);
+  it("never exposes the sandbox control-plane port", async () => {
+    const tools = createCloudflareSandboxTools(async () => fakeSandbox());
 
-    await expect(tools.sandbox_get_process!.handler({ process_id: "proc_running" }, context))
-      .resolves.toEqual({
-        found: true,
-        process_id: "proc_running",
-        pid: 1,
-        command: "cargo test",
-        status: "running",
-        terminal: false,
-        exit_code: null,
-      });
-    expect(running.getLogs).not.toHaveBeenCalled();
-    await expect(tools.sandbox_get_process!.handler({ process_id: "proc_missing" }, context))
-      .resolves.toEqual({ found: false, process_id: "proc_missing" });
-    await expect(tools.sandbox_get_process!.handler({ process_id: "../other" }, context))
-      .rejects.toThrow("process_id must be a safe Sandbox process ID");
-  });
-
-  it("returns partial running output only when explicitly requested", async () => {
-    const sandbox = fakeSandbox();
-    const running = fakeProcess({ id: "proc_running", status: "running" });
-    running.getLogs.mockResolvedValue({ stdout: "compiling", stderr: "warning" });
-    sandbox.getProcess.mockResolvedValue(running);
-    const tools = createCloudflareSandboxTools(async () => sandbox);
-
-    await expect(tools.sandbox_get_process!.handler({
-      process_id: "proc_running",
-      include_output: true,
-    }, context)).resolves.toMatchObject({
-      terminal: false,
-      stdout: "compiling",
-      stderr: "warning",
-    });
-    expect(running.getLogs).toHaveBeenCalledOnce();
-  });
-
-  it("terminates a running background process and reports its refreshed status", async () => {
-    const sandbox = fakeSandbox();
-    const process = fakeProcess({ id: "proc_running", status: "running" });
-    process.getStatus.mockResolvedValue("killed");
-    sandbox.getProcess.mockResolvedValue(process);
-    const tools = createCloudflareSandboxTools(async () => sandbox);
-
-    await expect(tools.sandbox_kill_process!.handler(
-      { process_id: "proc_running" },
-      context,
-    )).resolves.toEqual({
-      found: true,
-      process_id: "proc_running",
-      status: "killed",
-      terminal: true,
-      kill_requested: true,
-    });
-    expect(process.kill).toHaveBeenCalledOnce();
-    expect(process.waitForExit).not.toHaveBeenCalled();
-    expect(process.getStatus).toHaveBeenCalledOnce();
-  });
-
-  it("reports an asynchronously stopping process without waiting indefinitely", async () => {
-    const sandbox = fakeSandbox();
-    const process = fakeProcess({ id: "proc_running", status: "running" });
-    process.getStatus.mockResolvedValue("running");
-    sandbox.getProcess.mockResolvedValue(process);
-    const tools = createCloudflareSandboxTools(async () => sandbox);
-
-    await expect(tools.sandbox_kill_process!.handler(
-      { process_id: "proc_running" },
-      context,
-    )).resolves.toMatchObject({
-      status: "running",
-      terminal: false,
-      kill_requested: true,
-    });
-    expect(process.waitForExit).not.toHaveBeenCalled();
-  });
-
-  it("does not kill missing or already-terminal background processes", async () => {
-    const sandbox = fakeSandbox();
-    const completed = fakeProcess({ id: "proc_completed", status: "completed" });
-    sandbox.getProcess
-      .mockResolvedValueOnce(completed)
-      .mockResolvedValueOnce(null);
-    const tools = createCloudflareSandboxTools(async () => sandbox);
-
-    await expect(tools.sandbox_kill_process!.handler(
-      { process_id: "proc_completed" },
-      context,
-    )).resolves.toEqual({
-      found: true,
-      process_id: "proc_completed",
-      status: "completed",
-      terminal: true,
-      kill_requested: false,
-    });
-    await expect(tools.sandbox_kill_process!.handler(
-      { process_id: "proc_missing" },
-      context,
-    )).resolves.toEqual({ found: false, process_id: "proc_missing" });
-    expect(completed.kill).not.toHaveBeenCalled();
-    expect(completed.getStatus).not.toHaveBeenCalled();
-  });
-
-  it("truncates background process stdout and stderr on UTF-8 boundaries", async () => {
-    const sandbox = fakeSandbox();
-    const process = fakeProcess({
-      id: "proc_flood",
-      command: "flood",
-      status: "completed" as const,
-      exitCode: 0,
-    });
-    process.getLogs.mockResolvedValue({
-      stdout: "🦀".repeat(40_000),
-      stderr: "λ".repeat(80_000),
-    });
-    sandbox.getProcess.mockResolvedValue(process);
-    const tools = createCloudflareSandboxTools(async () => sandbox);
-
-    const result = (await tools.sandbox_get_process!.handler(
-      { process_id: "proc_flood" },
-      context,
-    )) as Record<string, unknown>;
-    expect(result.stdout_truncated).toBe(true);
-    expect(result.stderr_truncated).toBe(true);
-    expect(new TextEncoder().encode(String(result.stdout)).byteLength).toBe(128 * 1024);
-    expect(new TextEncoder().encode(String(result.stderr)).byteLength).toBe(128 * 1024);
+    await expect(tools.preview!.handler({ port: 3_000 }, context))
+      .rejects.toThrow("reserved for the sandbox control plane");
+    await expect(cloudflareSandboxPreviewUrl(
+      "https://nanocodex.example", "secret", "preview-session", 3_000,
+    )).rejects.toThrow("reserved for the sandbox control plane");
+    await expect(proxyCloudflareSandboxPreview(
+      fakeNamespace(), "preview-session", 3_000,
+      new Request("https://nanocodex.example/sandbox-preview/capability/"),
+      "/api/execute",
+    )).rejects.toThrow("reserved for the sandbox control plane");
   });
 
   it("keeps account credentials and origin authority out of sandbox previews", async () => {
-    const containerFetch = vi.fn(async (_request: Request, _port: number) => new Response("preview", {
+    const containerFetch = vi.fn(async (_request: Request) => new Response("preview", {
       status: 201,
       headers: {
         "clear-site-data": '"cookies"',
@@ -554,195 +300,61 @@ describe("Cloudflare sandbox tools", () => {
         "set-cookie": "nanocodex=overwritten",
       },
     }));
-    sandboxSdk.getSandbox.mockReturnValue({
-      containerFetch,
-      wsConnect: vi.fn(),
-    });
+    sandboxSdk.getSandbox.mockReturnValue({ containerFetch, wsConnect: vi.fn() });
     const request = new Request("https://nanocodex.example/sandbox-preview/capability/app?q=kept", {
       method: "POST",
       headers: {
         authorization: "Bearer account-secret",
         cookie: "nanocodex=session-secret",
-        "cf-access-jwt-assertion": "access-secret",
-        "cf-ray": "private-ray",
-        forwarded: "host=nanocodex.example",
-        "forwarded-host": "nanocodex.example",
         host: "nanocodex.example",
         origin: "https://nanocodex.example",
         referer: "https://nanocodex.example/account",
-        "x-preview-token": "private-token",
         "x-forwarded-host": "nanocodex.example",
-        "x-nanocodex-owner-id": "account-id",
         "x-preview-header": "kept",
       },
       body: "payload",
     });
 
     const response = await proxyCloudflareSandboxPreview(
-      fakeNamespace(),
-      "preview-session",
-      8_080,
-      request,
-      "/app",
+      fakeNamespace(), "preview-session", 8_080, request, "/app",
     );
 
     const forwarded = containerFetch.mock.calls[0]![0];
     expect(forwarded.url).toBe("http://sandbox.internal/app?q=kept");
     expect(forwarded.headers.get("authorization")).toBeNull();
     expect(forwarded.headers.get("cookie")).toBeNull();
-    expect(forwarded.headers.get("cf-access-jwt-assertion")).toBeNull();
-    expect(forwarded.headers.get("cf-ray")).toBeNull();
-    expect(forwarded.headers.get("forwarded")).toBeNull();
-    expect(forwarded.headers.get("forwarded-host")).toBeNull();
     expect(forwarded.headers.get("host")).toBeNull();
     expect(forwarded.headers.get("origin")).toBeNull();
     expect(forwarded.headers.get("referer")).toBeNull();
-    expect(forwarded.headers.get("x-preview-token")).toBeNull();
     expect(forwarded.headers.get("x-forwarded-host")).toBeNull();
-    expect(forwarded.headers.get("x-nanocodex-owner-id")).toBeNull();
     expect(forwarded.headers.get("x-preview-header")).toBe("kept");
     expect(await forwarded.text()).toBe("payload");
     expect(response.status).toBe(201);
-    expect(await response.text()).toBe("preview");
     expect(response.headers.get("set-cookie")).toBeNull();
     expect(response.headers.get("clear-site-data")).toBeNull();
     expect(response.headers.get("content-security-policy-report-only")).toBeNull();
-    expect(response.headers.get("host")).toBeNull();
-    const policy = response.headers.get("content-security-policy")!;
-    expect(policy).toContain("sandbox");
-    expect(policy).toContain("allow-scripts");
-    expect(policy).not.toContain("allow-same-origin");
-    expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+    expect(response.headers.get("content-security-policy")).toContain("sandbox");
   });
 
-  it("preserves a WebSocket while allowing only handshake response headers", async () => {
-    const sockets = new WebSocketPair();
-    const wsConnect = vi.fn(async (_request: Request, _port: number) => ({
-      status: 101,
-      headers: new Headers({
-        connection: "Upgrade",
-        host: "sandbox.internal",
-        "sec-websocket-accept": "accepted",
-        "sec-websocket-protocol": "preview-v1",
-        "set-cookie": "nanocodex=overwritten",
-        upgrade: "websocket",
-        "x-preview-private": "not-forwarded",
-      }),
-      webSocket: sockets[0],
-    }) as unknown as Response);
-    sandboxSdk.getSandbox.mockReturnValue({
-      containerFetch: vi.fn(),
-      wsConnect,
-    });
-    const request = new Request("https://nanocodex.example/sandbox-preview/capability/socket", {
-      headers: {
-        connection: "Upgrade",
-        cookie: "nanocodex=session-secret",
-        host: "nanocodex.example",
-        origin: "https://nanocodex.example",
-        "sec-websocket-key": "socket-key",
-        "sec-websocket-protocol": "preview-v1",
-        "sec-websocket-version": "13",
-        upgrade: "websocket",
-        "x-forwarded-host": "nanocodex.example",
-      },
-    });
-
-    const response = await proxyCloudflareSandboxPreview(
-      fakeNamespace(),
-      "preview-session",
-      8_080,
-      request,
-      "/socket",
-    );
-
-    const forwarded = wsConnect.mock.calls[0]![0];
-    expect(forwarded.headers.get("connection")).toBe("Upgrade");
-    expect(forwarded.headers.get("upgrade")).toBe("websocket");
-    expect(forwarded.headers.get("sec-websocket-key")).toBe("socket-key");
-    expect(forwarded.headers.get("sec-websocket-protocol")).toBe("preview-v1");
-    expect(forwarded.headers.get("sec-websocket-version")).toBe("13");
-    expect(forwarded.headers.get("cookie")).toBeNull();
-    expect(forwarded.headers.get("host")).toBeNull();
-    expect(forwarded.headers.get("origin")).toBeNull();
-    expect(forwarded.headers.get("x-forwarded-host")).toBeNull();
-    expect(response.status).toBe(101);
-    expect(response.webSocket).toBe(sockets[0]);
-    expect(response.headers.get("connection")).toBe("Upgrade");
-    expect(response.headers.get("upgrade")).toBe("websocket");
-    expect(response.headers.get("sec-websocket-accept")).toBe("accepted");
-    expect(response.headers.get("sec-websocket-protocol")).toBe("preview-v1");
-    expect(response.headers.get("host")).toBeNull();
-    expect(response.headers.get("set-cookie")).toBeNull();
-    expect(response.headers.get("x-preview-private")).toBeNull();
-  });
-
-  it("does not manufacture a successful WebSocket upgrade from an upstream failure", async () => {
-    const wsConnect = vi.fn(async () => new Response("not ready", {
-      status: 503,
-      headers: { "set-cookie": "nanocodex=overwritten" },
-    }));
-    sandboxSdk.getSandbox.mockReturnValue({
-      containerFetch: vi.fn(),
-      wsConnect,
-    });
-    const response = await proxyCloudflareSandboxPreview(
-      fakeNamespace(),
-      "preview-session",
-      8_080,
-      new Request("https://nanocodex.example/sandbox-preview/capability/socket", {
-        headers: { upgrade: "websocket" },
-      }),
-      "/socket",
-    );
-
-    expect(response.status).toBe(503);
-    expect(await response.text()).toBe("not ready");
-    expect(response.webSocket).toBeNull();
-    expect(response.headers.get("set-cookie")).toBeNull();
-  });
-
-  it("rejects expired and malformed authenticated preview payloads", async () => {
+  it("rejects expired authenticated preview payloads", async () => {
     const secret = "preview-expiry-test-secret";
     const sessionId = "018f25e8-7b51-7a32-8c4d-abcdef012345";
-    const expired = await sealPreviewPayload(
-      secret,
-      `${sessionId}\n8080\n${Date.now() - 1}`,
-    );
-    const malformed = await sealPreviewPayload(
-      secret,
-      `${sessionId}\n8080\nnot-an-expiry`,
-    );
+    const expired = await sealPreviewPayload(secret, `${sessionId}\n8080\n${Date.now() - 1}`);
 
     await expect(openSandboxPreviewCapability(secret, expired))
       .rejects.toThrow("invalid preview capability");
-    await expect(openSandboxPreviewCapability(secret, malformed))
-      .rejects.toThrow("invalid preview capability");
   });
 
-  it("caches one derived preview key and replaces it when the secret rotates", async () => {
-    const digest = vi.spyOn(crypto.subtle, "digest");
+  it("round-trips valid preview capabilities", async () => {
+    const secret = "preview-round-trip-secret";
     const sessionId = "018f25e8-7b51-7a32-8c4d-fedcba987654";
-    const firstSecret = "preview-key-cache-first";
-    const secondSecret = "preview-key-cache-second";
-    const firstUrl = await cloudflareSandboxPreviewUrl(
-      "https://nanocodex.example",
-      firstSecret,
-      sessionId,
-      8_080,
+    const url = await cloudflareSandboxPreviewUrl(
+      "https://nanocodex.example", secret, sessionId, 8_080,
     );
-    const firstCapability = new URL(firstUrl).pathname.split("/")[2]!;
+    const capability = new URL(url).pathname.split("/")[2]!;
 
-    await openSandboxPreviewCapability(firstSecret, firstCapability);
-    await cloudflareSandboxPreviewUrl(
-      "https://nanocodex.example",
-      secondSecret,
-      sessionId,
-      8_081,
-    );
-    await openSandboxPreviewCapability(firstSecret, firstCapability);
-
-    expect(digest).toHaveBeenCalledTimes(3);
+    await expect(openSandboxPreviewCapability(secret, capability))
+      .resolves.toEqual({ sessionId, port: 8_080 });
   });
 
   it("deletes every persisted object owned by a removed sandbox", async () => {
@@ -759,103 +371,56 @@ describe("Cloudflare sandbox tools", () => {
     await deleteCloudflareSandboxWorkspace(bucket, "session");
 
     expect(bucket.list).toHaveBeenCalledTimes(3);
-    expect(bucket.list).toHaveBeenCalledWith({ prefix: "/sessions/session/", limit: 1_000 });
-    expect(bucket.delete).toHaveBeenCalledWith([
-      "/sessions/session/a",
-      "/sessions/session/b",
-    ]);
+    expect(bucket.delete).toHaveBeenCalledWith(["/sessions/session/a", "/sessions/session/b"]);
     expect(bucket.delete).toHaveBeenCalledWith(["/sessions/session/c"]);
   });
 });
 
-type FakeLookupProcess = {
-  id: string;
-  pid?: number;
-  command: string;
-  status: "starting" | "running" | "completed" | "failed" | "killed" | "error";
-  exitCode?: number;
-  kill(): Promise<void>;
-  getStatus(): Promise<"starting" | "running" | "completed" | "failed" | "killed" | "error">;
-  getLogs(): Promise<{ stdout: string; stderr: string }>;
-  waitForPort(port: number, options?: { timeout?: number }): Promise<void>;
-  waitForExit(timeout?: number): Promise<{ exitCode: number }>;
-};
-
 function fakeSandbox() {
   const process = fakeProcess();
   return {
-    exec: vi.fn(async (_command: string, _options?: { cwd: string; timeout?: number }) => ({
-      success: true,
-      exitCode: 0,
-      stdout: "",
-      stderr: "",
-      duration: 1,
+    exec: vi.fn(async (_command: string, _options?: { cwd: string }) => executionResult("")),
+    startProcess: vi.fn(async (_command: string, options: { processId: string }) => ({
+      ...process,
+      id: options.processId,
     })),
-    startProcess: vi.fn(async (command: string) => ({ ...process, command })),
-    getProcess: vi.fn(async (id: string): Promise<FakeLookupProcess | null> => (
-      id === process.id ? process : null
-    )),
-    readFile: vi.fn(async () => ({
-      size: 0,
-      content: new ReadableStream<Uint8Array>({ start(controller) { controller.close(); } }),
-    })),
-    writeFile: vi.fn(async () => {}),
-    listFiles: vi.fn(async () => ({ files: [] })),
+    getProcess: vi.fn(async (_id: string) => null as ReturnType<typeof fakeProcess> | null),
     tunnels: { get: vi.fn(async () => ({ url: "https://preview.example" })) },
   };
 }
 
-function fakeProcess(overrides: Partial<Pick<
-  FakeLookupProcess,
-  "id" | "pid" | "command" | "status" | "exitCode"
->> = {}) {
+function fakeProcess(overrides: {
+  id?: string;
+  status?: "starting" | "running" | "completed" | "failed" | "killed" | "error";
+  exitCode?: number;
+} = {}) {
+  const status = overrides.status ?? "completed";
   return {
-    id: "process",
-    pid: 1,
-    command: "",
-    status: "running" as const,
+    id: overrides.id ?? "process",
+    status,
+    exitCode: overrides.exitCode ?? 0,
     kill: vi.fn(async () => {}),
-    getStatus: vi.fn(async (): Promise<FakeLookupProcess["status"]> => "running"),
+    getStatus: vi.fn(async () => status),
     getLogs: vi.fn(async () => ({ stdout: "", stderr: "" })),
-    waitForPort: vi.fn(async () => {}),
-    waitForExit: vi.fn(async () => ({ exitCode: 0 })),
-    ...overrides,
+    waitForExit: vi.fn(async () => ({ exitCode: overrides.exitCode ?? 0 })),
   };
 }
 
-function preparingSandbox(initialState: MountState) {
+function preparingSandbox(initialState: "empty" | "mounted" | "occupied") {
   let mountState = initialState;
   const sandbox = {
     ...fakeSandbox(),
     mountBucket: vi.fn(async () => { mountState = "mounted"; }),
     destroy: vi.fn(async () => {}),
-    setMountState(state: MountState) { mountState = state; },
-    getMountState() { return mountState; },
   };
   sandbox.exec.mockImplementation(async (command: string) => executionResult(
-    isMountProbe(command) ? mountState : "",
+    command.startsWith("if mountpoint -q /workspace") ? mountState : "",
   ));
   return sandbox;
 }
 
-type MountState = "absent" | "empty" | "occupied" | "mounted" | "mounted-unhealthy";
-
-function isMountProbe(command: unknown): boolean {
-  return typeof command === "string" && command.startsWith("if mountpoint -q /workspace");
-}
-
-function isWorkspaceFlush(command: unknown): boolean {
-  return command === "sync -f /workspace";
-}
-
-function executionResult(stdout: string) {
-  return {
-    success: true,
-    exitCode: 0,
-    stdout,
-    stderr: "",
-    duration: 1,
-  };
+function executionResult(stdout: string, stderr = "", exitCode = 0, duration = 1) {
+  return { success: exitCode === 0, exitCode, stdout, stderr, duration };
 }
 
 function fakeNamespace(): DurableObjectNamespace<Sandbox> {
@@ -865,13 +430,7 @@ function fakeNamespace(): DurableObjectNamespace<Sandbox> {
 async function sealPreviewPayload(secret: string, payload: string): Promise<string> {
   const iv = crypto.getRandomValues(new Uint8Array(12));
   const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(secret));
-  const key = await crypto.subtle.importKey(
-    "raw",
-    digest,
-    { name: "AES-GCM" },
-    false,
-    ["encrypt"],
-  );
+  const key = await crypto.subtle.importKey("raw", digest, { name: "AES-GCM" }, false, ["encrypt"]);
   const ciphertext = new Uint8Array(await crypto.subtle.encrypt(
     {
       name: "AES-GCM",

--- a/js/nanocodex-tools/package.json
+++ b/js/nanocodex-tools/package.json
@@ -22,6 +22,10 @@
       "types": "./tools/dataset.d.mts",
       "import": "./tools/dataset.mjs"
     },
+    "./execution-contract": {
+      "types": "./tools/execution-contract.d.mts",
+      "import": "./tools/execution-contract.mjs"
+    },
     "./just-bash/browser": {
       "types": "./tools/just-bash-browser.d.mts",
       "import": "./tools/just-bash-browser.mjs"

--- a/js/nanocodex-tools/runtime/utf8.d.mts
+++ b/js/nanocodex-tools/runtime/utf8.d.mts
@@ -1,0 +1,2 @@
+/** Returns the UTF-8 size of a JavaScript string without allocating encoded bytes. */
+export function utf8ByteLength(value: string): number;

--- a/js/nanocodex-tools/src/hosted/broker-core.ts
+++ b/js/nanocodex-tools/src/hosted/broker-core.ts
@@ -12,6 +12,13 @@ import {
   type HostedToolsManagedFrame,
 } from "./protocol.js";
 import { hostedToolCatalogDigest } from "../../tools/hostedCatalog.mjs";
+import {
+  EXEC_COMMAND_PARAMETERS,
+  EXECUTION_OUTPUT_SCHEMA,
+  MACHINE_PREVIEW_PARAMETERS,
+  PREVIEW_OUTPUT_SCHEMA,
+  WRITE_STDIN_PARAMETERS,
+} from "../../tools/execution-contract.mjs";
 
 const SOCKET_TAG = "hosted-tools";
 const INVALID_CONNECT_GRANT_ID = "invalid-connect-grant";
@@ -21,6 +28,12 @@ const MAX_RETAINED_RECEIPTS = 512;
 const MAX_CALLS_PER_GENERATION = 512;
 const TOOL_RESULT = Symbol.for("nanocodex.toolResult");
 const LEGACY_ROUTE_ID = "$legacy";
+export const HOSTED_MACHINE_TOOL_NAMES = Object.freeze([
+  "exec_command",
+  "write_stdin",
+  "preview",
+] as const);
+const MACHINE_TOOL_NAMES: ReadonlySet<string> = new Set(HOSTED_MACHINE_TOOL_NAMES);
 const encoder = new TextEncoder();
 
 /**
@@ -162,6 +175,8 @@ export type HostedToolsCodeTool = Readonly<{
   ): Promise<unknown>;
 }>;
 
+export type HostedMachineToolName = (typeof HOSTED_MACHINE_TOOL_NAMES)[number];
+
 export interface HostedToolsDynamicProvider {
   definitions(): readonly HostedToolsCodeDefinition[];
   resolve(name: string): HostedToolsCodeTool | undefined;
@@ -267,7 +282,7 @@ export class HostedToolsBrokerCore {
       // only the current attached definitions, which stay deferred and can be
       // overlaid onto exact cloud contracts by that router.
       definitions: () => {
-        return this.#catalogBindings()
+        return this.#publicCatalogBindings()
           .filter((binding) => this.#entryAllowed(
             binding.entry,
             binding.connectGrantId,
@@ -285,51 +300,7 @@ export class HostedToolsBrokerCore {
           prepared.connectGrantId,
           prepared.appToolCatalogDigest,
         )) return undefined;
-        return Object.freeze({
-          name,
-          parallelSafe: prepared.entry.parallel_safe,
-          provider: prepared.entry.provider,
-          remoteName: prepared.entry.remote_name,
-          summary: prepared.entry.summary,
-          timeoutMs: prepared.entry.timeout_ms,
-          handler: async (
-            input: unknown,
-            context: { sessionId: string; callId: string; model?: string; signal?: AbortSignal },
-          ) => {
-            if (!this.#entryAllowed(
-              prepared.entry,
-              prepared.connectGrantId,
-              prepared.appToolCatalogDigest,
-            )) {
-              return toolResult("Hosted tool is outside the active grant", {
-                status: "unavailable",
-                message: "Hosted tool is outside the active grant",
-              }, false, null);
-            }
-            const outcome = await prepared.invoke({
-              sessionId: context.sessionId,
-              callId: context.callId,
-              model: context.model ?? "unknown",
-              input: input as Record<string, unknown> | string,
-              outputTokenBudget: 10_000,
-              ...(context.signal === undefined ? {} : { signal: context.signal }),
-            });
-            if (outcome.status === "completed") {
-              return wireToolResult(
-                outcome.output,
-                prepared.canonicalName,
-                prepared.machine,
-              );
-            }
-            const result = toolResult(outcome.message, outcome, false, null);
-            return outcome[HOSTED_TOOLS_PRE_ADMISSION_UNAVAILABLE] === true
-              ? Object.freeze({
-                  ...(result as Record<PropertyKey, unknown>),
-                  [HOSTED_TOOLS_PRE_ADMISSION_UNAVAILABLE]: true,
-                })
-              : result;
-          },
-        });
+        return this.#codeTool(name, prepared);
       },
       setCatalogValidator: (validator: HostedToolsCatalogValidator | undefined) => {
         this.#catalogValidator = validator;
@@ -358,6 +329,22 @@ export class HostedToolsBrokerCore {
   hasPendingCalls(): boolean { return this.#pending.size > 0; }
 
   provider(): HostedToolsDynamicProvider { return this.#provider; }
+
+  /** Resolves one canonical machine primitive against its exact admitted attachment generation. */
+  machineTool(machineId: string, name: HostedMachineToolName): HostedToolsCodeTool | undefined {
+    if (!MACHINE_TOOL_NAMES.has(name)) return undefined;
+    const binding = this.#catalogBindings().find((candidate) => (
+      candidate.machine?.id === machineId && candidate.wireName === name
+    ));
+    if (!binding) return undefined;
+    const prepared = this.#preparedTool(binding);
+    if (!this.#entryAllowed(
+      prepared.entry,
+      prepared.connectGrantId,
+      prepared.appToolCatalogDigest,
+    )) return undefined;
+    return this.#codeTool(name, prepared);
+  }
 
   /** Returns the live, non-secret user-machine snapshot for the account-owned host. */
   machines(): readonly HostedMachine[] {
@@ -548,7 +535,10 @@ export class HostedToolsBrokerCore {
     } satisfies HostedToolsSocketAttachment;
     this.context.writeAttachment(socket, candidate);
     const catalogJson = JSON.stringify(frame.tools);
-    const candidateEntries = frame.tools.map((entry) => exposedEntry(entry, frame.machines?.[0]));
+    const machine = frame.machines?.[0];
+    const candidateEntries = frame.tools
+      .filter((entry) => !reservedMachineEntry(entry, machine))
+      .map((entry) => exposedEntry(entry, machine));
     const candidateDefinitions = candidateEntries.map((entry) => Object.freeze({
       ...entry,
       definition: Object.freeze({
@@ -564,6 +554,7 @@ export class HostedToolsBrokerCore {
         && (frame.machines?.length !== 1 || frame.attachment_id !== frame.machines[0]?.id)) {
         throw new Error("an account machine route requires one machine whose id equals attachment_id");
       }
+      if (machine !== undefined) validateMachineToolContracts(frame.tools);
       if (initial.allowedMcpIds !== undefined) {
         if (!isConnectGrantId(initial.connectGrantId)) {
           throw new Error("Connect tool host is missing its exact grant binding");
@@ -587,7 +578,7 @@ export class HostedToolsBrokerCore {
           throw new Error("the app-local tool catalog does not match the signed Connect grant");
         }
       }
-      const otherBindings = this.#catalogBindings(routeId, true);
+      const otherBindings = this.#publicCatalogBindings(routeId, true);
       const exposedNames = new Set(otherBindings.map((binding) => binding.entry.definition.name));
       const duplicateTool = candidateEntries.find((entry) => exposedNames.has(entry.definition.name));
       if (duplicateTool) {
@@ -753,12 +744,17 @@ export class HostedToolsBrokerCore {
   }
 
   #definitions(): readonly HostedToolsProviderDefinition[] {
-    return this.#catalogBindings().map((binding) => binding.entry);
+    return this.#publicCatalogBindings().map((binding) => binding.entry);
   }
 
   #resolve(name: string): HostedToolsPreparedTool | undefined {
-    const binding = this.#catalogBindings().find((candidate) => candidate.entry.definition.name === name);
+    const binding = this.#publicCatalogBindings()
+      .find((candidate) => candidate.entry.definition.name === name);
     if (!binding) return undefined;
+    return this.#preparedTool(binding);
+  }
+
+  #preparedTool(binding: HostedToolsCatalogBinding): HostedToolsPreparedTool {
     return Object.freeze({
       ...(binding.connectGrantId === undefined ? {} : { connectGrantId: binding.connectGrantId }),
       ...(binding.appToolCatalogDigest === undefined
@@ -768,6 +764,54 @@ export class HostedToolsBrokerCore {
       ...(binding.machine === undefined ? {} : { machine: binding.machine }),
       entry: binding.entry,
       invoke: (request: HostedToolsInvokeRequest) => this.#invoke(binding, request),
+    });
+  }
+
+  #codeTool(name: string, prepared: HostedToolsPreparedTool): HostedToolsCodeTool {
+    return Object.freeze({
+      name,
+      parallelSafe: prepared.entry.parallel_safe,
+      provider: prepared.entry.provider,
+      remoteName: prepared.entry.remote_name,
+      summary: prepared.entry.summary,
+      timeoutMs: prepared.entry.timeout_ms,
+      handler: async (
+        input: unknown,
+        context: { sessionId: string; callId: string; model?: string; signal?: AbortSignal },
+      ) => {
+        if (!this.#entryAllowed(
+          prepared.entry,
+          prepared.connectGrantId,
+          prepared.appToolCatalogDigest,
+        )) {
+          return toolResult("Hosted tool is outside the active grant", {
+            status: "unavailable",
+            message: "Hosted tool is outside the active grant",
+          }, false, null);
+        }
+        const outcome = await prepared.invoke({
+          sessionId: context.sessionId,
+          callId: context.callId,
+          model: context.model ?? "unknown",
+          input: input as Record<string, unknown> | string,
+          outputTokenBudget: 10_000,
+          ...(context.signal === undefined ? {} : { signal: context.signal }),
+        });
+        if (outcome.status === "completed") {
+          return wireToolResult(
+            outcome.output,
+            prepared.canonicalName,
+            prepared.machine,
+          );
+        }
+        const result = toolResult(outcome.message, outcome, false, null);
+        return outcome[HOSTED_TOOLS_PRE_ADMISSION_UNAVAILABLE] === true
+          ? Object.freeze({
+              ...(result as Record<PropertyKey, unknown>),
+              [HOSTED_TOOLS_PRE_ADMISSION_UNAVAILABLE]: true,
+            })
+          : result;
+      },
     });
   }
 
@@ -1149,6 +1193,14 @@ export class HostedToolsBrokerCore {
     return bindings.filter((binding) => counts.get(binding.entry.definition.name) === 1);
   }
 
+  #publicCatalogBindings(
+    excludeRouteId?: string,
+    includeAmbiguous = false,
+  ): HostedToolsCatalogBinding[] {
+    return this.#catalogBindings(excludeRouteId, includeAmbiguous)
+      .filter((binding) => !reservedMachineBinding(binding));
+  }
+
   #machineIds(excludeRouteId?: string): string[] {
     const ids: string[] = [];
     for (const state of this.#sortedStates()) {
@@ -1189,6 +1241,105 @@ function emptyState(routeId: string): HostedToolsStateRow {
 
 function scopedRouteId(connectGrantId: string | undefined, attachmentId: string | undefined): string {
   return `${connectGrantId === undefined ? "user" : "connect"}:${attachmentId ?? LEGACY_ROUTE_ID}`;
+}
+
+function reservedMachineEntry(
+  entry: HostedToolCatalogEntry,
+  machine: HostedMachine | undefined,
+): boolean {
+  return machine !== undefined && MACHINE_TOOL_NAMES.has(entry.definition.name);
+}
+
+function reservedMachineBinding(binding: HostedToolsCatalogBinding): boolean {
+  return binding.machine !== undefined && MACHINE_TOOL_NAMES.has(binding.wireName);
+}
+
+function validateMachineToolContracts(entries: readonly HostedToolCatalogEntry[]): void {
+  for (const entry of entries) {
+    const name = entry.definition.name;
+    if (!MACHINE_TOOL_NAMES.has(name)) continue;
+    if (entry.definition.type !== "function") {
+      throw new Error(`machine tool ${name} must use its canonical function schema`);
+    }
+    switch (name) {
+      case "exec_command":
+        validateCanonicalObjectSchema(name, entry.definition.parameters, EXEC_COMMAND_PARAMETERS);
+        validateCanonicalObjectSchema(
+          `${name} output`,
+          entry.definition.output_schema,
+          EXECUTION_OUTPUT_SCHEMA,
+        );
+        break;
+      case "write_stdin":
+        validateCanonicalObjectSchema(name, entry.definition.parameters, WRITE_STDIN_PARAMETERS);
+        validateCanonicalObjectSchema(
+          `${name} output`,
+          entry.definition.output_schema,
+          EXECUTION_OUTPUT_SCHEMA,
+        );
+        break;
+      case "preview":
+        validateCanonicalObjectSchema(name, entry.definition.parameters, MACHINE_PREVIEW_PARAMETERS);
+        validateCanonicalObjectSchema(
+          `${name} output`,
+          entry.definition.output_schema,
+          PREVIEW_OUTPUT_SCHEMA,
+        );
+        break;
+    }
+  }
+}
+
+function validateCanonicalObjectSchema(
+  label: string,
+  schema: Record<string, unknown> | undefined,
+  canonical: Readonly<Record<string, unknown>>,
+): void {
+  const properties = objectRecord(canonical.properties);
+  const required = canonical.required;
+  if (properties === undefined || !Array.isArray(required)) {
+    throw new Error(`invalid canonical machine tool schema for ${label}`);
+  }
+  const propertyTypes = Object.fromEntries(Object.entries(properties).map(([name, property]) => {
+    const type = objectRecord(property)?.type;
+    if (typeof type !== "string") throw new Error(`invalid canonical type for ${label}.${name}`);
+    return [name, type];
+  }));
+  validateObjectSchema(label, schema, required as string[], propertyTypes);
+}
+
+function validateObjectSchema(
+  label: string,
+  schema: Record<string, unknown> | undefined,
+  required: readonly string[],
+  propertyTypes: Readonly<Record<string, string>>,
+): void {
+  const properties = objectRecord(schema?.properties);
+  const actualRequired = schema?.required;
+  if (schema?.type !== "object"
+    || schema?.additionalProperties !== false
+    || properties === undefined
+    || !Array.isArray(actualRequired)
+    || actualRequired.some((value) => typeof value !== "string")
+    || !sameStrings(actualRequired as string[], required)
+    || !sameStrings(Object.keys(properties), Object.keys(propertyTypes))) {
+    throw new Error(`machine tool ${label} must use its canonical object schema`);
+  }
+  for (const [property, type] of Object.entries(propertyTypes)) {
+    if (objectRecord(properties[property])?.type !== type) {
+      throw new Error(`machine tool ${label}.${property} must use canonical type ${type}`);
+    }
+  }
+}
+
+function objectRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function sameStrings(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value) => right.includes(value));
 }
 
 function exposedEntry(entry: HostedToolCatalogEntry, machine: HostedMachine | undefined): HostedToolCatalogEntry {

--- a/js/nanocodex-tools/src/index.ts
+++ b/js/nanocodex-tools/src/index.ts
@@ -20,9 +20,11 @@ export {
   createWorkspaceFilesystem,
   type WorkspaceStorageClient,
 } from "./workspace.js";
+export * from "./namespace.js";
 export * from "./memory.js";
 export * from "./hosted/index.js";
 export { namedTool } from "../tools/namedTool.mjs";
+export * from "../tools/execution-contract.mjs";
 export * from "../tools/artifact.mjs";
 export { dataset } from "../tools/dataset.mjs";
 export type { DatasetOptions } from "../tools/dataset.mjs";

--- a/js/nanocodex-tools/src/namespace.ts
+++ b/js/nanocodex-tools/src/namespace.ts
@@ -1,0 +1,469 @@
+import { utf8ByteLength } from "../runtime/utf8.mjs";
+
+export const MAX_NAMESPACE_MOUNTS = 64;
+export const MAX_NAMESPACE_GRANTS = 128;
+export const MAX_NAMESPACE_PATH_BYTES = 4_096;
+export const MAX_NAMESPACE_PATH_SEGMENTS = 256;
+export const MAX_NAMESPACE_SEGMENT_BYTES = 255;
+export const MAX_NAMESPACE_ID_BYTES = 256;
+
+export const NAMESPACE_RIGHTS = Object.freeze([
+  "namespace.discover",
+  "filesystem.read",
+  "filesystem.write",
+  "process.exec",
+  "process.stdin",
+  "network.preview",
+] as const);
+
+export type NamespaceRight = (typeof NAMESPACE_RIGHTS)[number];
+
+declare const namespaceIdentityBrand: unique symbol;
+export type NamespaceIdentity = string & {
+  readonly [namespaceIdentityBrand]: "NamespaceIdentity";
+};
+
+export type NamespaceMountInput = Readonly<{
+  root: string;
+  mountId: string;
+  handId: string;
+  exportId: string;
+  generation: string;
+  rights: readonly NamespaceRight[];
+}>;
+
+export type NamespaceManifestInput = Readonly<{
+  manifestId: string;
+  mounts: readonly NamespaceMountInput[];
+}>;
+
+export type NamespaceMount = Readonly<{
+  root: string;
+  mountId: NamespaceIdentity;
+  handId: NamespaceIdentity;
+  exportId: NamespaceIdentity;
+  generation: NamespaceIdentity;
+  rights: readonly NamespaceRight[];
+}>;
+
+export type NamespaceManifest = Readonly<{
+  manifestId: NamespaceIdentity;
+  mounts: readonly NamespaceMount[];
+}>;
+
+export type NamespaceGrant = Readonly<{
+  mountId: NamespaceIdentity;
+  path: string;
+  rights: readonly NamespaceRight[];
+}>;
+
+export type NamespaceScope = Readonly<{
+  manifest: NamespaceManifest;
+  defaultCwd: string;
+  grants: readonly NamespaceGrant[];
+}>;
+
+export type NamespaceAttenuation = Readonly<{
+  mountId: string;
+  path?: string;
+  rights?: readonly NamespaceRight[];
+}>;
+
+export type NamespaceRoute = Readonly<{
+  cwd: string;
+  relativePath: string;
+  mount: NamespaceMount;
+  rights: readonly NamespaceRight[];
+}>;
+
+export class NamespaceError extends Error {
+  constructor(
+    readonly code:
+      | "invalid_manifest"
+      | "invalid_path"
+      | "invalid_scope"
+      | "access_denied"
+      | "no_execution_root",
+    message: string,
+  ) {
+    super(message);
+    this.name = "NamespaceError";
+  }
+}
+
+const PORTABLE_ROOT = /^[a-z0-9](?:[a-z0-9._-]{0,61}[a-z0-9])?$/;
+const WINDOWS_DEVICE_ROOT = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/;
+const CONTROL_CHARACTER = /[\u0000-\u001f\u007f]/;
+const HASH_UTF8 = new TextEncoder();
+const RESERVED_ROOTS = new Set([
+  ".nanocodex",
+  "dev",
+  "proc",
+  "tmp",
+]);
+const RESERVED_HAND_ROOTS = new Set([
+  ...RESERVED_ROOTS,
+  "brain",
+  "sandbox",
+]);
+const RIGHT_SET: ReadonlySet<string> = new Set(NAMESPACE_RIGHTS);
+const admittedManifests = new WeakSet<object>();
+const admittedScopes = new WeakSet<object>();
+
+/**
+ * Admits and snapshots a mount table. Calling this function is an authority
+ * boundary: later APIs only preserve or attenuate mounts admitted here.
+ */
+export function createNamespaceManifest(input: NamespaceManifestInput): NamespaceManifest {
+  if (!isRecord(input) || !Array.isArray(input.mounts)) {
+    throw new NamespaceError("invalid_manifest", "namespace manifest must contain a mounts array");
+  }
+  if (input.mounts.length === 0 || input.mounts.length > MAX_NAMESPACE_MOUNTS) {
+    throw new NamespaceError(
+      "invalid_manifest",
+      `namespace manifest must contain 1 to ${MAX_NAMESPACE_MOUNTS} mounts`,
+    );
+  }
+
+  const manifestId = parseIdentity(input.manifestId, "manifestId");
+  const roots = new Set<string>();
+  const mountIds = new Set<string>();
+  const mounts = input.mounts.map((candidate, index) => {
+    if (!isRecord(candidate)) {
+      throw new NamespaceError("invalid_manifest", `mount ${index} must be an object`);
+    }
+    const root = parseMountRoot(candidate.root, index);
+    if (roots.has(root)) {
+      throw new NamespaceError("invalid_manifest", `duplicate mount root ${root}`);
+    }
+    roots.add(root);
+
+    const mountId = parseIdentity(candidate.mountId, `mount ${root} mountId`);
+    if (mountIds.has(mountId)) {
+      throw new NamespaceError("invalid_manifest", `duplicate mount identity for ${root}`);
+    }
+    mountIds.add(mountId);
+
+    return Object.freeze({
+      root,
+      mountId,
+      handId: parseIdentity(candidate.handId, `mount ${root} handId`),
+      exportId: parseIdentity(candidate.exportId, `mount ${root} exportId`),
+      generation: parseIdentity(candidate.generation, `mount ${root} generation`),
+      rights: parseRights(candidate.rights, `mount ${root}`),
+    });
+  });
+
+  // Canonical ordering makes the same admitted mapping stable regardless of
+  // discovery order. Routing never consults display or host names.
+  mounts.sort((left, right) => left.root.localeCompare(right.root, "en"));
+  const manifest = Object.freeze({ manifestId, mounts: Object.freeze(mounts) });
+  admittedManifests.add(manifest);
+  return manifest;
+}
+
+/** Derives a deterministic portable mount root from an opaque machine identity. */
+export function namespaceMountRoot(machineId: string): string {
+  if (typeof machineId !== "string" || machineId.length === 0) {
+    throw new TypeError("machine identity must be a non-empty string");
+  }
+  const exact = machineId.toLowerCase();
+  if (exact === machineId
+    && PORTABLE_ROOT.test(exact)
+    && !WINDOWS_DEVICE_ROOT.test(exact)
+    && !RESERVED_HAND_ROOTS.has(exact)) {
+    return `/${exact}`;
+  }
+  const slug = exact.replace(/[^a-z0-9._-]+/g, "-").replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, "")
+    .slice(0, 48) || "hand";
+  return `/hand-${slug}-${stableHash(machineId).slice(0, 8)}`;
+}
+
+/** Resolves an absolute logical path without consulting the host filesystem. */
+export function normalizeNamespacePath(path: string): string {
+  return normalizePath(path, undefined);
+}
+
+/** Resolves an optional workdir against a captured, absolute default cwd. */
+export function resolveNamespaceCwd(defaultCwd: string, workdir?: string): string {
+  const base = normalizeNamespacePath(defaultCwd);
+  if (workdir === undefined || workdir === "") return base;
+  return normalizePath(workdir, base);
+}
+
+/** Component-aware containment; lexical siblings such as /host2 never match /host. */
+export function isNamespacePathWithin(path: string, parent: string): boolean {
+  const normalizedPath = normalizeNamespacePath(path);
+  const normalizedParent = normalizeNamespacePath(parent);
+  return pathWithinNormalized(normalizedPath, normalizedParent);
+}
+
+/** Returns the longest component-boundary mount match, if one exists. */
+export function resolveNamespaceMount(
+  manifest: NamespaceManifest,
+  path: string,
+): NamespaceMount | undefined {
+  assertManifest(manifest);
+  const normalized = normalizeNamespacePath(path);
+  let match: NamespaceMount | undefined;
+  for (const mount of manifest.mounts) {
+    if (pathWithinNormalized(normalized, mount.root)
+      && (match === undefined || mount.root.length > match.root.length)) {
+      match = mount;
+    }
+  }
+  return match;
+}
+
+/** Creates the root scope with every right present in the admitted manifest. */
+export function createNamespaceScope(
+  manifest: NamespaceManifest,
+  defaultCwd: string,
+): NamespaceScope {
+  assertManifest(manifest);
+  const cwd = normalizeNamespacePath(defaultCwd);
+  const grants = manifest.mounts.map((mount) => Object.freeze({
+    mountId: mount.mountId,
+    path: mount.root,
+    rights: mount.rights,
+  }));
+  return admitScope(manifest, cwd, grants);
+}
+
+/**
+ * Creates a child snapshot. Omitted attenuation inherits exactly; supplied
+ * entries may only remove mounts, narrow paths, or remove rights.
+ */
+export function deriveChildNamespaceScope(
+  parent: NamespaceScope,
+  attenuation?: readonly NamespaceAttenuation[],
+): NamespaceScope {
+  assertScope(parent);
+  if (attenuation === undefined) {
+    return admitScope(parent.manifest, parent.defaultCwd, parent.grants);
+  }
+  if (!Array.isArray(attenuation) || attenuation.length > MAX_NAMESPACE_GRANTS) {
+    throw new NamespaceError(
+      "invalid_scope",
+      `child namespace may contain at most ${MAX_NAMESPACE_GRANTS} grants`,
+    );
+  }
+
+  const grants: NamespaceGrant[] = [];
+  const keys = new Set<string>();
+  for (const [index, request] of attenuation.entries()) {
+    if (!isRecord(request)) {
+      throw new NamespaceError("invalid_scope", `attenuation ${index} must be an object`);
+    }
+    const mountId = parseIdentity(request.mountId, `attenuation ${index} mountId`);
+    const mount = parent.manifest.mounts.find((candidate) => candidate.mountId === mountId);
+    if (mount === undefined) {
+      throw new NamespaceError("access_denied", "attenuation references an inaccessible mount");
+    }
+    if (request.path !== undefined && typeof request.path !== "string") {
+      throw new NamespaceError("invalid_scope", `attenuation ${index} path must be a string`);
+    }
+    const path = request.path === undefined
+      ? mount.root
+      : resolveNamespaceCwd(mount.root, request.path);
+    if (!pathWithinNormalized(path, mount.root)) {
+      throw new NamespaceError("access_denied", "attenuation path escapes its mount");
+    }
+
+    const available = effectiveRights(parent, mountId, path);
+    const rights = request.rights === undefined
+      ? available
+      : parseRights(request.rights, `attenuation ${index}`);
+    if (rights.some((right) => !available.includes(right))) {
+      throw new NamespaceError("access_denied", "child namespace rights exceed its parent scope");
+    }
+    const key = `${mountId}\u0000${path}`;
+    if (keys.has(key)) {
+      throw new NamespaceError("invalid_scope", "duplicate child namespace grant");
+    }
+    keys.add(key);
+    grants.push(Object.freeze({ mountId, path, rights }));
+  }
+
+  // Scope construction happens only after every requested grant is validated.
+  // Therefore an inaccessible inherited cwd rejects the whole derivation.
+  return admitScope(parent.manifest, parent.defaultCwd, grants);
+}
+
+/** Resolves and authorizes a cwd for process routing on its owning hand. */
+export function routeNamespaceCwd(
+  scope: NamespaceScope,
+  workdir?: string,
+  requiredRight: NamespaceRight = "process.exec",
+): NamespaceRoute {
+  assertScope(scope);
+  assertRight(requiredRight, "required right");
+  const cwd = resolveNamespaceCwd(scope.defaultCwd, workdir);
+  const mount = resolveNamespaceMount(scope.manifest, cwd);
+  if (mount === undefined) {
+    throw new NamespaceError("no_execution_root", `no mount owns namespace cwd ${cwd}`);
+  }
+  const rights = effectiveRights(scope, mount.mountId, cwd);
+  if (!rights.includes(requiredRight)) {
+    throw new NamespaceError("access_denied", `namespace cwd ${cwd} lacks ${requiredRight}`);
+  }
+  const relativePath = cwd === mount.root ? "/" : cwd.slice(mount.root.length);
+  return Object.freeze({ cwd, relativePath, mount, rights });
+}
+
+function admitScope(
+  manifest: NamespaceManifest,
+  defaultCwd: string,
+  sourceGrants: readonly NamespaceGrant[],
+): NamespaceScope {
+  const grants = Object.freeze(sourceGrants.map((grant) => Object.freeze({
+    mountId: grant.mountId,
+    path: grant.path,
+    rights: grant.rights,
+  })));
+  if (grants.length === 0 || !grants.some((grant) => pathWithinNormalized(defaultCwd, grant.path))) {
+    throw new NamespaceError("access_denied", "child namespace cannot access its inherited cwd");
+  }
+  const scope = Object.freeze({ manifest, defaultCwd, grants });
+  admittedScopes.add(scope);
+  return scope;
+}
+
+function effectiveRights(
+  scope: NamespaceScope,
+  mountId: NamespaceIdentity,
+  path: string,
+): readonly NamespaceRight[] {
+  const rights = new Set<NamespaceRight>();
+  for (const grant of scope.grants) {
+    if (grant.mountId === mountId && pathWithinNormalized(path, grant.path)) {
+      for (const right of grant.rights) rights.add(right);
+    }
+  }
+  return Object.freeze(NAMESPACE_RIGHTS.filter((right) => rights.has(right)));
+}
+
+function normalizePath(path: string, base: string | undefined): string {
+  if (typeof path !== "string") {
+    throw new NamespaceError("invalid_path", "namespace path must be a string");
+  }
+  assertByteLimit(path, MAX_NAMESPACE_PATH_BYTES, "namespace path", "invalid_path");
+  if (CONTROL_CHARACTER.test(path) || path.includes("\\")) {
+    throw new NamespaceError("invalid_path", "namespace path contains a non-portable character");
+  }
+  const absolute = path.startsWith("/");
+  if (!absolute && base === undefined) {
+    throw new NamespaceError("invalid_path", "namespace path must be absolute");
+  }
+  const parts = absolute ? [] : splitNormalizedBase(base!);
+  for (const part of path.split("/")) {
+    if (part === "" || part === ".") continue;
+    if (part === "..") {
+      if (parts.length === 0) {
+        throw new NamespaceError("invalid_path", "namespace path escapes logical root");
+      }
+      parts.pop();
+      continue;
+    }
+    assertByteLimit(part, MAX_NAMESPACE_SEGMENT_BYTES, "namespace path segment", "invalid_path");
+    parts.push(part);
+    if (parts.length > MAX_NAMESPACE_PATH_SEGMENTS) {
+      throw new NamespaceError(
+        "invalid_path",
+        `namespace path exceeds ${MAX_NAMESPACE_PATH_SEGMENTS} segments`,
+      );
+    }
+  }
+  const normalized = parts.length === 0 ? "/" : `/${parts.join("/")}`;
+  assertByteLimit(normalized, MAX_NAMESPACE_PATH_BYTES, "normalized namespace path", "invalid_path");
+  return normalized;
+}
+
+function splitNormalizedBase(base: string): string[] {
+  return base === "/" ? [] : base.slice(1).split("/");
+}
+
+function pathWithinNormalized(path: string, parent: string): boolean {
+  return parent === "/" || path === parent || path.startsWith(`${parent}/`);
+}
+
+function parseMountRoot(value: unknown, index: number): string {
+  if (typeof value !== "string" || !value.startsWith("/")) {
+    throw new NamespaceError("invalid_manifest", `mount ${index} root must be absolute`);
+  }
+  const normalized = normalizeNamespacePath(value);
+  const name = normalized.slice(1);
+  if (RESERVED_ROOTS.has(name)) {
+    throw new NamespaceError("invalid_manifest", `mount root ${value} is reserved`);
+  }
+  if (!PORTABLE_ROOT.test(name) || normalized !== value || WINDOWS_DEVICE_ROOT.test(name)) {
+    throw new NamespaceError("invalid_manifest", `mount root ${value} is not a portable top-level root`);
+  }
+  return normalized;
+}
+
+function parseIdentity(value: unknown, label: string): NamespaceIdentity {
+  if (typeof value !== "string" || value.length === 0 || value.trim() !== value
+    || CONTROL_CHARACTER.test(value)) {
+    throw new NamespaceError("invalid_manifest", `${label} must be a non-empty opaque identity`);
+  }
+  assertByteLimit(value, MAX_NAMESPACE_ID_BYTES, label, "invalid_manifest");
+  return value as NamespaceIdentity;
+}
+
+function parseRights(value: unknown, label: string): readonly NamespaceRight[] {
+  if (!Array.isArray(value) || value.length === 0 || value.length > NAMESPACE_RIGHTS.length) {
+    throw new NamespaceError("invalid_manifest", `${label} must contain a bounded non-empty rights set`);
+  }
+  const rights = new Set<NamespaceRight>();
+  for (const right of value) {
+    assertRight(right, label);
+    if (rights.has(right)) {
+      throw new NamespaceError("invalid_manifest", `${label} contains a duplicate right`);
+    }
+    rights.add(right);
+  }
+  return Object.freeze(NAMESPACE_RIGHTS.filter((right) => rights.has(right)));
+}
+
+function assertRight(value: unknown, label: string): asserts value is NamespaceRight {
+  if (typeof value !== "string" || !RIGHT_SET.has(value)) {
+    throw new NamespaceError("invalid_manifest", `${label} contains an unsupported namespace right`);
+  }
+}
+
+function assertManifest(value: NamespaceManifest): void {
+  if (!isRecord(value) || !admittedManifests.has(value)) {
+    throw new NamespaceError("invalid_manifest", "namespace manifest was not admitted by this runtime");
+  }
+}
+
+function assertScope(value: NamespaceScope): void {
+  if (!isRecord(value) || !admittedScopes.has(value)) {
+    throw new NamespaceError("invalid_scope", "namespace scope was not admitted by this runtime");
+  }
+}
+
+function assertByteLimit(
+  value: string,
+  maximum: number,
+  label: string,
+  code: "invalid_manifest" | "invalid_path",
+): void {
+  if (utf8ByteLength(value) > maximum) {
+    throw new NamespaceError(code, `${label} exceeds ${maximum} UTF-8 bytes`);
+  }
+}
+
+function stableHash(value: string): string {
+  let hash = 0xcbf29ce484222325n;
+  for (const byte of HASH_UTF8.encode(value)) {
+    hash ^= BigInt(byte);
+    hash = BigInt.asUintN(64, hash * 0x100000001b3n);
+  }
+  return hash.toString(16).padStart(16, "0");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/js/nanocodex-tools/test/namespace.test.mjs
+++ b/js/nanocodex-tools/test/namespace.test.mjs
@@ -1,0 +1,228 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createNamespaceManifest,
+  createNamespaceScope,
+  deriveChildNamespaceScope,
+  isNamespacePathWithin,
+  MAX_NAMESPACE_MOUNTS,
+  namespaceMountRoot,
+  normalizeNamespacePath,
+  resolveNamespaceCwd,
+  resolveNamespaceMount,
+  routeNamespaceCwd,
+} from "nanocodex-tools";
+
+const allRights = [
+  "namespace.discover",
+  "filesystem.read",
+  "filesystem.write",
+  "process.exec",
+  "process.stdin",
+  "network.preview",
+];
+
+function manifest() {
+  return createNamespaceManifest({
+    manifestId: "manifest:stable-snapshot",
+    mounts: [
+      {
+        root: "/laptop",
+        mountId: "mount:opaque-laptop",
+        handId: "hand:opaque-a",
+        exportId: "export:opaque-a",
+        generation: "generation:a:7",
+        rights: allRights,
+      },
+      {
+        root: "/buildbox",
+        mountId: "mount:opaque-buildbox",
+        handId: "hand:opaque-b",
+        exportId: "export:opaque-b",
+        generation: "generation:b:2",
+        rights: ["namespace.discover", "filesystem.read", "process.exec"],
+      },
+    ],
+  });
+}
+
+test("manifests are canonical immutable snapshots with opaque stable mappings", () => {
+  const input = {
+    manifestId: "manifest:one",
+    mounts: [{
+      root: "/zeta",
+      mountId: "mount:z",
+      handId: "hand:z",
+      exportId: "export:z",
+      generation: "generation:1",
+      rights: ["process.exec"],
+    }, {
+      root: "/alpha",
+      mountId: "mount:a",
+      handId: "hand:a",
+      exportId: "export:a",
+      generation: "generation:9",
+      rights: ["filesystem.read", "process.exec"],
+    }],
+  };
+  const snapshot = createNamespaceManifest(input);
+
+  assert.deepEqual(snapshot.mounts.map(({ root }) => root), ["/alpha", "/zeta"]);
+  assert.ok(Object.isFrozen(snapshot));
+  assert.ok(Object.isFrozen(snapshot.mounts));
+  assert.ok(snapshot.mounts.every(Object.isFrozen));
+  assert.ok(snapshot.mounts.every(({ rights }) => Object.isFrozen(rights)));
+  input.mounts[1].handId = "hand:replaced";
+  input.mounts[1].rights.push("filesystem.write");
+  assert.equal(snapshot.mounts[0].handId, "hand:a");
+  assert.deepEqual(snapshot.mounts[0].rights, ["filesystem.read", "process.exec"]);
+  assert.throws(() => { snapshot.mounts[0].root = "/renamed"; }, TypeError);
+});
+
+test("manifest admission rejects root ambiguity, aliases, reserved roots, and bounds", () => {
+  const mount = (root, mountId = `mount:${root}`) => ({
+    root,
+    mountId,
+    handId: `hand:${root}`,
+    exportId: `export:${root}`,
+    generation: "generation:1",
+    rights: ["process.exec"],
+  });
+  const make = (mounts) => createNamespaceManifest({ manifestId: "manifest:test", mounts });
+
+  for (const root of ["/.nanocodex", "/dev", "/proc", "/tmp"])
+    assert.throws(() => make([mount(root)]), /reserved/);
+  assert.doesNotThrow(() => make([mount("/brain"), mount("/sandbox")]));
+  for (const root of ["laptop", "/a/b", "/UPPER", "/two words", "/con", "/a/../b", "/a\\b"])
+    assert.throws(() => make([mount(root)]), /root|path/);
+  assert.throws(() => make([mount("/one"), mount("/one", "mount:two")]), /duplicate mount root/);
+  assert.throws(() => make([mount("/one", "same"), mount("/two", "same")]), /duplicate mount identity/);
+  assert.throws(
+    () => make(Array.from({ length: MAX_NAMESPACE_MOUNTS + 1 }, (_, index) => mount(`/m${index}`))),
+    /1 to 64 mounts/,
+  );
+});
+
+test("machine identities receive deterministic portable non-system roots", () => {
+  assert.equal(namespaceMountRoot("laptop"), "/laptop");
+  assert.match(namespaceMountRoot("Build Box"), /^\/hand-build-box-[0-9a-f]{8}$/);
+  assert.match(namespaceMountRoot("sandbox"), /^\/hand-sandbox-/);
+  assert.match(namespaceMountRoot("con"), /^\/hand-con-/);
+  assert.equal(namespaceMountRoot("Build Box"), namespaceMountRoot("Build Box"));
+  assert.throws(() => namespaceMountRoot(""), /non-empty/);
+});
+
+test("normalization resolves cwd and rejects traversal and host-dependent separators", () => {
+  assert.equal(normalizeNamespacePath("//laptop/./repo///src/../test"), "/laptop/repo/test");
+  assert.equal(resolveNamespaceCwd("/laptop/repo/src", "../test"), "/laptop/repo/test");
+  assert.equal(resolveNamespaceCwd("/laptop/repo", "/buildbox/work"), "/buildbox/work");
+  assert.equal(resolveNamespaceCwd("/laptop/repo", ""), "/laptop/repo");
+  assert.throws(() => normalizeNamespacePath("relative/path"), /must be absolute/);
+  assert.throws(() => normalizeNamespacePath("/../../escape"), /escapes logical root/);
+  assert.throws(() => normalizeNamespacePath("/laptop/evil\0path"), /non-portable/);
+  assert.throws(() => normalizeNamespacePath("/laptop\\..\\buildbox"), /non-portable/);
+  assert.equal(normalizeNamespacePath("/laptop/%2e%2e/buildbox"), "/laptop/%2e%2e/buildbox");
+});
+
+test("mount resolution uses segment boundaries and retains the admitted identity", () => {
+  const snapshot = manifest();
+  const laptop = resolveNamespaceMount(snapshot, "/laptop/repo");
+  assert.equal(laptop.mountId, "mount:opaque-laptop");
+  assert.equal(laptop.generation, "generation:a:7");
+  assert.equal(resolveNamespaceMount(snapshot, "/laptop2/repo"), undefined);
+  assert.equal(resolveNamespaceMount(snapshot, "/"), undefined);
+  assert.equal(isNamespacePathWithin("/laptop/repo", "/laptop"), true);
+  assert.equal(isNamespacePathWithin("/laptop2/repo", "/laptop"), false);
+});
+
+test("cwd routing is stable, relative, right-checked, and never inferred from names", () => {
+  const snapshot = manifest();
+  const scope = createNamespaceScope(snapshot, "/laptop/repo");
+  const route = routeNamespaceCwd(scope, "src/../test");
+  assert.deepEqual({
+    cwd: route.cwd,
+    relativePath: route.relativePath,
+    mountId: route.mount.mountId,
+    generation: route.mount.generation,
+  }, {
+    cwd: "/laptop/repo/test",
+    relativePath: "/repo/test",
+    mountId: "mount:opaque-laptop",
+    generation: "generation:a:7",
+  });
+  assert.ok(Object.isFrozen(route));
+
+  const readOnly = deriveChildNamespaceScope(scope, [{
+    mountId: "mount:opaque-buildbox",
+    path: "/buildbox/repo",
+    rights: ["filesystem.read"],
+  }, {
+    mountId: "mount:opaque-laptop",
+    path: "/laptop/repo",
+    rights: ["filesystem.read"],
+  }]);
+  assert.throws(() => routeNamespaceCwd(readOnly), /lacks process.exec/);
+  assert.equal(routeNamespaceCwd(readOnly, undefined, "filesystem.read").mount.handId, "hand:opaque-a");
+  assert.throws(
+    () => routeNamespaceCwd({
+      manifest: snapshot,
+      defaultCwd: "/laptop/repo",
+      grants: [{ mountId: "mount:opaque-laptop", path: "/laptop", rights: allRights }],
+    }),
+    /scope was not admitted/,
+  );
+});
+
+test("children and grandchildren can only attenuate identity, subtree, and rights", () => {
+  const parent = createNamespaceScope(manifest(), "/laptop/repo");
+  const child = deriveChildNamespaceScope(parent, [{
+    mountId: "mount:opaque-laptop",
+    path: "repo",
+    rights: ["filesystem.read", "process.exec"],
+  }]);
+  assert.ok(Object.isFrozen(child));
+  assert.ok(Object.isFrozen(child.grants));
+  assert.deepEqual(child.grants[0].rights, ["filesystem.read", "process.exec"]);
+  assert.equal(routeNamespaceCwd(child, "src").cwd, "/laptop/repo/src");
+  assert.throws(() => routeNamespaceCwd(child, "/laptop/other"), /lacks process.exec/);
+  assert.throws(() => deriveChildNamespaceScope(child, [{
+    mountId: "mount:opaque-laptop",
+    path: "/laptop",
+    rights: ["filesystem.read"],
+  }]), /exceed|inherited cwd/);
+  assert.throws(() => deriveChildNamespaceScope(child, [{
+    mountId: "mount:opaque-laptop",
+    path: "/laptop/repo",
+    rights: ["filesystem.write"],
+  }]), /exceed/);
+  assert.throws(() => deriveChildNamespaceScope(child, [{
+    mountId: "mount:opaque-buildbox",
+    path: "/buildbox",
+    rights: ["filesystem.read"],
+  }]), /exceed|inherited cwd/);
+
+  assert.throws(() => deriveChildNamespaceScope(child, [{
+    mountId: "mount:opaque-laptop",
+    path: "/laptop/repo/src",
+    rights: ["filesystem.read"],
+  }]), /inherited cwd/);
+});
+
+test("attenuation rejects an inaccessible inherited cwd atomically", () => {
+  const parent = createNamespaceScope(manifest(), "/laptop/repo");
+  assert.throws(() => deriveChildNamespaceScope(parent, []), /inherited cwd/);
+  assert.throws(() => deriveChildNamespaceScope(parent, [{
+    mountId: "mount:opaque-buildbox",
+    path: "/buildbox/project",
+    rights: ["filesystem.read"],
+  }]), /inherited cwd/);
+  assert.throws(() => deriveChildNamespaceScope(parent, [{
+    mountId: "/laptop",
+    rights: ["process.exec"],
+  }]), /inaccessible mount/);
+
+  const inherited = deriveChildNamespaceScope(parent);
+  assert.notEqual(inherited, parent);
+  assert.equal(routeNamespaceCwd(inherited).mount.mountId, "mount:opaque-laptop");
+});

--- a/js/nanocodex-tools/tools/bash.mjs
+++ b/js/nanocodex-tools/tools/bash.mjs
@@ -1,4 +1,8 @@
 import { namedTool } from "./namedTool.mjs";
+import {
+  EXEC_COMMAND_PARAMETERS,
+  EXECUTION_OUTPUT_SCHEMA,
+} from "./execution-contract.mjs";
 
 const DEFAULT_EXECUTION_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_ENTRIES = 2_000;
@@ -9,38 +13,6 @@ const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
 const DEVICES = new Set(["/dev/full", "/dev/null", "/dev/stderr", "/dev/stdout"]);
-
-const EXEC_PARAMETERS = Object.freeze({
-  type: "object",
-  properties: {
-    cmd: { type: "string", description: "Shell command to execute." },
-    justification: { type: "string", description: "User-facing approval question for `require_escalated`; omit otherwise." },
-    workdir: { type: "string", description: "Working directory for the command. Defaults to the turn cwd." },
-    shell: { type: "string", description: "Shell binary to launch. Defaults to the user's default shell." },
-    login: { type: "boolean", description: "True runs the shell with -l/-i semantics; false disables them. Defaults to true." },
-    tty: { type: "boolean", description: "True allocates a PTY for the command; false or omitted uses plain pipes." },
-    yield_time_ms: { type: "number", description: "Wait before yielding output. Defaults to 10000 ms; effective range is 250-30000 ms." },
-    max_output_tokens: { type: "number", description: "Output token budget. Defaults to 10000 tokens; larger requests may be capped by policy." },
-    prefix_rule: { type: "array", items: { type: "string" }, description: "Reusable approval prefix for `cmd`, only with `sandbox_permissions: \"require_escalated\"`; for example [\"git\", \"pull\"]." },
-    sandbox_permissions: { type: "string", enum: ["use_default", "require_escalated"], description: "Per-command sandbox override. Defaults to `use_default`; use `require_escalated` for unsandboxed execution." },
-  },
-  required: ["cmd"],
-  additionalProperties: false,
-});
-
-const EXEC_OUTPUT = Object.freeze({
-  type: "object",
-  properties: {
-    chunk_id: { type: "string", description: "Chunk identifier included when the response reports one." },
-    wall_time_seconds: { type: "number", description: "Elapsed wall time spent waiting for output in seconds." },
-    exit_code: { type: "number", description: "Process exit code when the command finished during this call." },
-    session_id: { type: "number", description: "Session identifier to pass to write_stdin when the process is still running." },
-    original_token_count: { type: "number", description: "Approximate token count before output truncation." },
-    output: { type: "string", description: "Command output text, possibly truncated." },
-  },
-  required: ["wall_time_seconds", "output"],
-  additionalProperties: false,
-});
 
 export async function justBash(options) {
   if (!options || typeof options !== "object" || Array.isArray(options)) {
@@ -161,8 +133,8 @@ export async function createJustBashRuntime(options) {
       ? {}
       : { supportsParallelToolCalls: options.supportsParallelToolCalls }),
     description: "Runs a shell command, returning output or a session ID for ongoing interaction.",
-    parameters: EXEC_PARAMETERS,
-    outputSchema: EXEC_OUTPUT,
+    parameters: EXEC_COMMAND_PARAMETERS,
+    outputSchema: EXECUTION_OUTPUT_SCHEMA,
     handler(input, context) {
       const execute = () => executeCommand({
         bash,

--- a/js/nanocodex-tools/tools/execution-contract.d.mts
+++ b/js/nanocodex-tools/tools/execution-contract.d.mts
@@ -1,0 +1,5 @@
+export const EXEC_COMMAND_PARAMETERS: Readonly<Record<string, unknown>>;
+export const WRITE_STDIN_PARAMETERS: Readonly<Record<string, unknown>>;
+export const EXECUTION_OUTPUT_SCHEMA: Readonly<Record<string, unknown>>;
+export const MACHINE_PREVIEW_PARAMETERS: Readonly<Record<string, unknown>>;
+export const PREVIEW_OUTPUT_SCHEMA: Readonly<Record<string, unknown>>;

--- a/js/nanocodex-tools/tools/execution-contract.mjs
+++ b/js/nanocodex-tools/tools/execution-contract.mjs
@@ -1,0 +1,63 @@
+export const EXEC_COMMAND_PARAMETERS = Object.freeze({
+  type: "object",
+  properties: {
+    cmd: { type: "string", description: "Shell command to execute." },
+    justification: { type: "string", description: "User-facing approval question for `require_escalated`; omit otherwise." },
+    workdir: { type: "string", description: "Working directory for the command." },
+    shell: { type: "string", description: "Shell binary to launch. Defaults to the selected hand's shell." },
+    login: { type: "boolean", description: "True runs with login-shell semantics when supported." },
+    tty: { type: "boolean", description: "True allocates a PTY when supported." },
+    yield_time_ms: { type: "number", description: "Wait before yielding output. Defaults to 10000 ms." },
+    max_output_tokens: { type: "number", description: "Output token budget. Defaults to 10000 tokens." },
+    prefix_rule: { type: "array", items: { type: "string" }, description: "Reusable approval prefix for `require_escalated`." },
+    sandbox_permissions: { type: "string", enum: ["use_default", "require_escalated"], description: "Per-command sandbox policy request." },
+  },
+  required: ["cmd"],
+  additionalProperties: false,
+});
+
+export const WRITE_STDIN_PARAMETERS = Object.freeze({
+  type: "object",
+  properties: {
+    session_id: { type: "number", description: "Session identifier returned by exec_command." },
+    chars: { type: "string", description: "Characters to write; omit or pass an empty string to poll." },
+    yield_time_ms: { type: "number", description: "Wait before yielding more output." },
+    max_output_tokens: { type: "number", description: "Output token budget." },
+  },
+  required: ["session_id"],
+  additionalProperties: false,
+});
+
+export const EXECUTION_OUTPUT_SCHEMA = Object.freeze({
+  type: "object",
+  properties: {
+    chunk_id: { type: "string", description: "Chunk identifier included when the response reports one." },
+    wall_time_seconds: { type: "number", description: "Elapsed wall time spent waiting for output in seconds." },
+    exit_code: { type: "number", description: "Process exit code when the command finished during this call." },
+    session_id: { type: "number", description: "Session identifier to pass to write_stdin when the process is still running." },
+    original_token_count: { type: "number", description: "Approximate token count before output truncation." },
+    output: { type: "string", description: "Command output text, possibly truncated." },
+  },
+  required: ["wall_time_seconds", "output"],
+  additionalProperties: false,
+});
+
+export const MACHINE_PREVIEW_PARAMETERS = Object.freeze({
+  type: "object",
+  properties: {
+    port: { type: "integer", minimum: 1024, maximum: 65_535, not: { const: 3_000 } },
+  },
+  required: ["port"],
+  additionalProperties: false,
+});
+
+export const PREVIEW_OUTPUT_SCHEMA = Object.freeze({
+  type: "object",
+  properties: {
+    port: { type: "integer" },
+    url: { type: "string" },
+    persistent: { type: "boolean" },
+  },
+  required: ["port", "url", "persistent"],
+  additionalProperties: false,
+});

--- a/js/nanocodex/managed/Agent.d.mts
+++ b/js/nanocodex/managed/Agent.d.mts
@@ -130,10 +130,10 @@ export type Capabilities = Readonly<{
   live_steer: true;
   live_cancel: true;
   workspace: "cloudflare-computer";
-  /** Explicit sandbox_* tools expose one separate, agent-owned Linux hand. */
-  sandbox_tools: true;
-  /** Legacy compatibility field; the brain's shell does not fall through automatically. */
-  sandbox_escalation: boolean;
+  /** Canonical commands select an execution hand from the root of their logical cwd. */
+  execution_namespace: "cwd-root-v1";
+  /** Native processes cannot yet access peer mounts through filesystem syscalls. */
+  native_cross_mounts: false;
 }>;
 
 export type State = Readonly<{

--- a/js/nanocodex/test/managed-agent.test.mjs
+++ b/js/nanocodex/test/managed-agent.test.mjs
@@ -305,8 +305,8 @@ test("managed Agent covers account-scoped create, list, get, and delete", async 
   assert.equal((await Agent.get(agentId, options)).id, agentId);
   const state = await created.state();
   assert.equal(state.latest_event_cursor, "4");
-  assert.equal(state.capabilities.sandbox_tools, true);
-  assert.equal(state.capabilities.sandbox_escalation, false);
+  assert.equal(state.capabilities.execution_namespace, "cwd-root-v1");
+  assert.equal(state.capabilities.native_cross_mounts, false);
   await created.delete();
   await Agent.delete(agentId, options);
 
@@ -1789,8 +1789,8 @@ function agentState() {
       live_steer: true,
       live_cancel: true,
       workspace: "cloudflare-computer",
-      sandbox_tools: true,
-      sandbox_escalation: false,
+      execution_namespace: "cwd-root-v1",
+      native_cross_mounts: false,
     },
     latest_event_cursor: "4",
     stream_error: null,

--- a/js/nanocodex/test/managed-types.test-d.mts
+++ b/js/nanocodex/test/managed-types.test-d.mts
@@ -17,8 +17,8 @@ const capabilities: Capabilities = {
   live_steer: true,
   live_cancel: true,
   workspace: "cloudflare-computer",
-  sandbox_tools: true,
-  sandbox_escalation: false,
+  execution_namespace: "cwd-root-v1",
+  native_cross_mounts: false,
 };
 void capabilities;
 


### PR DESCRIPTION
## Summary

- replace the public managed sandbox tool split with canonical `exec_command`, `write_stdin`, and `preview`
- select the execution hand from the root of the logical `workdir`
- publish deterministic namespace mounts for the sandbox and attached machines
- pin Code Mode cells and retained process sessions to immutable hand generations
- preserve cwd-root placement across subagents
- remove the obsolete workspace-shaped public schemas and document the Plan 9-inspired model

## Verification

- `pnpm --filter nanocodex-managed-service exec vitest run test/namespace-tools.test.ts test/sandbox-tools.test.ts test/hosted-tools-broker.test.ts test/browser-runtime.test.ts` — 60 passing
- `pnpm --filter nanocodex-tools test` — 10 passing
- `pnpm --filter nanocodex exec node --test test/attachment.test.mjs` — 27 passing
- local Wrangler stack with one sandbox and two attached browser hands
- 18/18 routed commands succeeded across all three hands
- traversal, unknown-root, segment-length, and segment-count rejection verified
- output truncation and retained-process polling verified

## Known gaps found by live testing

This is intentionally a draft because the current milestone is placement-only:

- namespace execution is globally serialized by the ToolRouter exclusive gate: three one-second commands on three hands took 3.244 seconds; two one-second commands split across distinct browser hands took 2.027 seconds
- `native_cross_mounts` is false: peer roots are not visible inside a hand filesystem, and shell `cd /other-hand/...` does not route execution
- managed subagent construction does not yet apply child namespace attenuation
- retained Code Mode cell and public process-session maps have no numeric cap
- the stress conversation grew to about 10.4 MB / 7,184 managed events before the default 16 MiB archive threshold

The next milestone should make namespace wrappers parallel-safe across independent hands, then implement or explicitly defer the shared native mount layer.