### PR TITLE
feat(web): add SMS-sponsored homepage trial

### DIFF
--- a/docs/MANAGED_FUNNEL.md
+++ b/docs/MANAGED_FUNNEL.md
@@ -1,0 +1,80 @@
+# Hosted homepage demo policy
+
+## Product boundary
+
+The deployment owner may sponsor model access only for the SMS-verified
+homepage browser demo. The journey is:
+
+```text
+SMS verification -> three free ephemeral prompts -> connect or fund Wallet
+```
+
+The sponsored demo gives each persistent SMS account exactly three prompts. It
+uses `gpt-5.6-luna` with thinking disabled. Its browser agent sets
+`durability: false`, creates a fresh thread ID for the mounted page, and does not
+expose conversation history. Reloading discards the model thread but does not
+reset the three-prompt allowance.
+
+When signed out, the homepage terminal itself renders the phone and one-time
+code steps in its composer area. Successful verification replaces that form
+with the ordinary prompt composer; users do not have to discover the account
+menu before starting the trial.
+
+The Durable Agent page is a separate product boundary. It requires the account's
+own connected ChatGPT subscription or OpenAI API key. The shared deployment-owner
+credential cannot create, open, resume, or fund a durable agent. A future paid
+Nanocodex plan may satisfy that gate through its own explicit entitlement, but a
+MACH wallet balance alone is not model authority.
+
+Chief of Staff, Attached Tools, Multiplayer, World, and other managed-agent
+surfaces are not sponsored by this homepage policy.
+
+## Credential routing
+
+The deployment owner signs into an ordinary Nanocodex account and connects
+ChatGPT through the existing Account surface. Egress retains that credential in
+the owner's encrypted `UserCredentialBroker`; it is not copied into demo users.
+Set `NANOCODEX_SPONSORED_CHATGPT_USER_ID` on the private egress Worker to that
+stable Nanocodex account ID.
+
+For model traffic, egress applies this precedence:
+
+1. use the requesting account's connected ChatGPT or OpenAI credential;
+2. if none exists, allow the deployment owner's ChatGPT credential only when the
+   subject is the exact 43-character browser-model identity;
+3. fail closed for the 64-character Durable Object identity used by managed
+   agents.
+
+The status response exposes only `source: "user"` or `source: "sponsored"` and,
+for sponsored access, the number of free prompts remaining.
+The sponsor's account ID, ChatGPT account ID, access token, and refresh token do
+not cross the egress boundary. Refresh remains centralized in the sponsor's
+credential broker.
+
+## Allowance enforcement
+
+The requesting account's credential Durable Object keeps the three accepted
+root prompt IDs. Reservations are serialized, so concurrent tabs cannot exceed
+the allowance. The egress Worker reserves and marks a root prompt before
+forwarding an actual Responses WebSocket generation. A completed root cannot
+be replayed. Each live attempt renews a broker-owned lease; an interrupted or
+orphaned in-flight root gets at most one transport retry, and stale attempt
+events cannot mutate its replacement.
+Provider-issued tool and tool-search continuation grants are single-use and
+survive the SDK's full-history WebSocket reconnect without consuming another
+prompt. Warmup frames do not consume a slot. Sponsored frames are canonicalized
+at egress to Luna, no thinking, and standard service before they reach the
+provider.
+
+After the third prompt completes, the homepage replaces the composer with
+`Connect` and `Fund Wallet` actions. Connect leads to the user's model
+connections; Fund Wallet leads to the existing dollar-denominated onramp. The
+server rejects a fourth distinct prompt even if a stale or modified client
+still submits it. Funding is presented separately and does not itself grant
+model authority in this iteration.
+
+## Deliberate non-goals
+
+This policy has no passkey grant, OpenAI MPP client, MACH payer switch, or
+durable sponsored thread. MACH wallet and onramp features remain separate until
+an explicit paid-agent entitlement is designed and implemented.

--- a/js/account/README.md
+++ b/js/account/README.md
@@ -8,12 +8,15 @@ or a second agent backend.
 
 ## User surfaces
 
-- **Home and Durable Agent** show the browser agent and its retained thread.
+- **Home** shows an ephemeral browser-agent demo. **Durable Agent** retains a
+  thread only after the user connects their own ChatGPT or OpenAI credential.
 - **Attached Tools**, **Multiplayer**, and **World** demonstrate browser-hosted
   tools, a shared managed-agent room, and an agent-populated world.
 - **Account** and **Connect** handle SMS OTP account login, connection, device,
   and request-scoped Connect journeys. The Connect dialog is served at
   `/connect-dialog`; the separate Connect API routes remain behind the Worker.
+- Signed-out visitors enter their phone and one-time code directly in the Home
+  terminal before its three-prompt sponsored composer appears.
 - **Docs**, **Evals**, **Source**, **Commits**, and **Changelog** present the
   product reference, evaluation evidence, and published repository data.
 
@@ -29,8 +32,16 @@ repository and thread Git data, evaluation reads, and credential-backed model
 operations. Provider credentials stay behind Worker bindings and are not part
 of browser configuration.
 
-Persistent SMS accounts use a Worker-owned secp256k1 root wallet. This app may
-display its public address and send exact `wallet_connect` or
+The deployment may sponsor exactly three prompts in the signed-in Home demo
+from one operator-connected ChatGPT account. The per-account allowance is
+reserved atomically at egress. That fallback is restricted to the ephemeral
+browser model subject, uses Luna with thinking disabled, and cannot authorize
+Durable Agent or the other managed demos. User-connected credentials take
+precedence and are not subject to the sponsored allowance.
+
+Persistent SMS accounts use a Worker-owned secp256k1 root wallet. The account
+UI presents it simply as `Wallet`, shows its dollar-denominated balance, and
+does not render the crypto address. The app may send exact `wallet_connect` or
 `wallet_revokeAccessKey` requests to the authenticated managed-Worker routes,
 but it never receives the root private key or its encrypted envelope. The key
 is custodial and server-side encrypted in the per-user egress Durable Object;

--- a/js/account/src/AccountMenu.tsx
+++ b/js/account/src/AccountMenu.tsx
@@ -19,17 +19,12 @@ import { deploymentHealth } from "./deploymentHealth";
 import { localDevelopmentCredential } from "./localDevelopmentCredential";
 import { ProfileConnectors } from "./ProfileConnectors";
 import {
-  classifyFundingOrder,
-  decodeFundingAttempt,
-  decodeMachineUsdConfig,
   decodeWalletBalance,
-  defaultFundingAmountCents,
   formatDollars,
   formatWalletBalance,
-  type FundingAttempt,
-  type MachineUsdConfig,
   type WalletBalance,
 } from "./walletFunding";
+import { useWalletFunding } from "./useWalletFunding";
 
 type ApiKeyMetadata = Readonly<{
   id: string;
@@ -70,12 +65,6 @@ type WalletBalanceRequest = Readonly<{
   promise: Promise<boolean>;
 }>;
 
-type WalletFundingRun = Readonly<{
-  accountId: string;
-  checkout: Window;
-  controller: AbortController;
-}>;
-
 const API_KEY_ID = /^[A-Za-z0-9_-]{12}$/;
 
 export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) {
@@ -84,19 +73,15 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
   const accountId = session.account?.id;
   const accountPersistent = session.account?.persistent === true;
   const [open, setOpen] = useState(() => inline || new URL(window.location.href).searchParams.has("connector_result"));
+  const walletFunding = useWalletFunding(inline || open);
   const [keys, setKeys] = useState<ApiKeyMetadata[] | null>(null);
   const [keyError, setKeyError] = useState<string | null>(null);
   const [keyOperation, setKeyOperation] = useState<string | null>(null);
   const [newKey, setNewKey] = useState<NewApiKey | null>(null);
   const [label, setLabel] = useState("");
   const [copied, setCopied] = useState(false);
-  const [walletCopied, setWalletCopied] = useState(false);
   const [walletBalance, setWalletBalance] = useState<WalletBalance | null>(null);
   const [walletBalanceError, setWalletBalanceError] = useState<string | null>(null);
-  const [walletFundingConfig, setWalletFundingConfig] = useState<MachineUsdConfig | null>(null);
-  const [walletFundingError, setWalletFundingError] = useState<string | null>(null);
-  const [walletFundingSuccess, setWalletFundingSuccess] = useState<string | null>(null);
-  const [walletFundingOperation, setWalletFundingOperation] = useState<"prepare" | "payment" | null>(null);
   const [credentials, setCredentials] = useState<CredentialStatus | null>(null);
   const [credentialError, setCredentialError] = useState<string | null>(null);
   const [providerOperation, setProviderOperation] = useState<string | null>(null);
@@ -107,23 +92,12 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
   const keyRequest = useRef<AccountDataRequest | undefined>(undefined);
   const credentialRequest = useRef<AccountDataRequest | undefined>(undefined);
   const walletBalanceRequest = useRef<WalletBalanceRequest | undefined>(undefined);
-  const walletFundingConfigRequest = useRef<AccountDataRequest | undefined>(undefined);
-  const walletFundingRun = useRef<WalletFundingRun | undefined>(undefined);
-
-  const cancelWalletFunding = useCallback(() => {
-    const run = walletFundingRun.current;
-    walletFundingRun.current = undefined;
-    run?.controller.abort();
-    run?.checkout.close();
-  }, []);
 
   const close = useCallback(() => {
-    cancelWalletFunding();
     setOpen(false);
     setNewKey(null);
     setCopied(false);
-    setWalletFundingOperation(null);
-  }, [cancelWalletFunding]);
+  }, []);
 
   const loadKeys = useCallback((): Promise<void> => {
     if (!accountId) return Promise.resolve();
@@ -222,13 +196,13 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
           await refreshSession();
           return false;
         }
-        if (!response.ok) throw await responseFailure(response, "Couldn’t load the MACH balance.");
+        if (!response.ok) throw await responseFailure(response, "Couldn’t load the Wallet balance.");
         const balance = decodeWalletBalance(await response.json(), address);
         if (cachedAccountId.current === accountId) setWalletBalance(balance);
         return true;
       } catch (cause) {
         if (!controller.signal.aborted && cachedAccountId.current === accountId) {
-          setWalletBalanceError(failureMessage(cause, "Couldn’t load the MACH balance."));
+          setWalletBalanceError(failureMessage(cause, "Couldn’t load the Wallet balance."));
         }
         return false;
       }
@@ -241,71 +215,30 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
     return current;
   }, [accountId, refreshSession, session.account?.address]);
 
-  const loadWalletFundingConfig = useCallback((): Promise<void> => {
-    if (!accountId || walletFundingConfig) return Promise.resolve();
-    if (walletFundingConfigRequest.current?.accountId === accountId) {
-      return walletFundingConfigRequest.current.promise;
-    }
-    setWalletFundingError(null);
-    let current!: Promise<void>;
-    current = (async () => {
-      try {
-        const response = await apiRequest("/v1/machine-usd/config");
-        if (!response.ok) throw await responseFailure(response, "Couldn’t load the MACH onramp.");
-        const config = decodeMachineUsdConfig(await response.json());
-        if (cachedAccountId.current === accountId) setWalletFundingConfig(config);
-      } catch (cause) {
-        if (cachedAccountId.current === accountId) {
-          setWalletFundingError(failureMessage(cause, "Couldn’t load the MACH onramp."));
-        }
-      }
-    })().finally(() => {
-      if (walletFundingConfigRequest.current?.promise === current) {
-        walletFundingConfigRequest.current = undefined;
-      }
-    });
-    walletFundingConfigRequest.current = { accountId, promise: current };
-    return current;
-  }, [accountId, walletFundingConfig]);
-
   useEffect(() => {
     if (!accountId) {
-      cancelWalletFunding();
       walletBalanceRequest.current?.controller.abort();
       walletBalanceRequest.current = undefined;
-      walletFundingConfigRequest.current = undefined;
       cachedAccountId.current = undefined;
       setKeys(null);
       setKeyError(null);
       setNewKey(null);
-      setWalletCopied(false);
       setWalletBalance(null);
       setWalletBalanceError(null);
-      setWalletFundingConfig(null);
-      setWalletFundingError(null);
-      setWalletFundingSuccess(null);
-      setWalletFundingOperation(null);
       setCredentials(null);
       setCredentialError(null);
       return;
     }
     const accountChanged = cachedAccountId.current !== accountId;
     if (accountChanged) {
-      cancelWalletFunding();
       walletBalanceRequest.current?.controller.abort();
       walletBalanceRequest.current = undefined;
-      walletFundingConfigRequest.current = undefined;
       cachedAccountId.current = accountId;
       setKeys(null);
       setKeyError(null);
       setNewKey(null);
-      setWalletCopied(false);
       setWalletBalance(null);
       setWalletBalanceError(null);
-      setWalletFundingConfig(null);
-      setWalletFundingError(null);
-      setWalletFundingSuccess(null);
-      setWalletFundingOperation(null);
       setCredentials(null);
       setCredentialError(null);
     }
@@ -314,14 +247,12 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
     if (accountChanged || keys === null) missing.push(loadKeys());
     if (accountChanged || credentials === null) missing.push(loadCredentials());
     if (accountChanged || walletBalance === null) missing.push(loadWalletBalance());
-    if (accountChanged || walletFundingConfig === null) missing.push(loadWalletFundingConfig());
     void Promise.all(missing);
-  }, [accountId, cancelWalletFunding, credentials, inline, keys, loadCredentials, loadKeys, loadWalletBalance, loadWalletFundingConfig, open, walletBalance, walletFundingConfig]);
+  }, [accountId, credentials, inline, keys, loadCredentials, loadKeys, loadWalletBalance, open, walletBalance]);
 
   useEffect(() => () => {
-    cancelWalletFunding();
     walletBalanceRequest.current?.controller.abort();
-  }, [cancelWalletFunding]);
+  }, []);
 
   useEffect(() => {
     if (!accountId || !session.account?.address || (!inline && !open)) return;
@@ -422,82 +353,6 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
     }
   };
 
-  const copyWalletAddress = async () => {
-    const address = session.account?.address;
-    if (!address) return;
-    try {
-      await navigator.clipboard.writeText(address);
-      setWalletCopied(true);
-    } catch {
-      setCredentialError("Couldn’t copy the wallet address. Select and copy it manually.");
-    }
-  };
-
-  const fundWallet = () => {
-    const address = session.account?.address;
-    const config = walletFundingConfig;
-    if (!accountId || !address || !config || !config.onrampEnabled || walletFundingOperation) return;
-    const checkout = window.open("about:blank", "nanocodex-mach-checkout");
-    if (!checkout) {
-      setWalletFundingError("Allow pop-ups for Nanocodex, then try again.");
-      return;
-    }
-    checkout.opener = null;
-    const controller = new AbortController();
-    const run: WalletFundingRun = { accountId, checkout, controller };
-    cancelWalletFunding();
-    walletFundingRun.current = run;
-    setWalletFundingOperation("prepare");
-    setWalletFundingError(null);
-    setWalletFundingSuccess(null);
-    void (async () => {
-      let navigated = false;
-      try {
-        const amount = defaultFundingAmountCents(config);
-        const orderToken = randomOrderToken();
-        const response = await apiRequest("/v1/machine-usd/orders", {
-          method: "POST",
-          headers: {
-            "content-type": "application/json",
-            "idempotency-key": crypto.randomUUID(),
-          },
-          body: JSON.stringify({
-            order_token: orderToken,
-            payment_mode: "hosted_checkout",
-            usd_amount_cents: amount,
-            wallet_address: address,
-          }),
-          signal: controller.signal,
-        });
-        if (!response.ok) throw await responseFailure(response, "Couldn’t create the MACH order.");
-        const attempt = decodeFundingAttempt(await response.json(), orderToken);
-        if (walletFundingRun.current !== run) return;
-        checkout.location.href = attempt.checkoutUrl;
-        navigated = true;
-        setWalletFundingOperation("payment");
-        await waitForFundingOrder(attempt, controller.signal, checkout);
-        if (walletFundingRun.current !== run) return;
-        setWalletFundingSuccess("MACH issued. Refreshing balance…");
-        const refreshed = await loadWalletBalance(true);
-        if (walletFundingRun.current === run) {
-          setWalletFundingSuccess(refreshed
-            ? "MACH added. Balance refreshed."
-            : "MACH issued. Refresh the balance to confirm it.");
-        }
-      } catch (cause) {
-        if (!navigated) checkout.close();
-        if (!controller.signal.aborted && walletFundingRun.current === run) {
-          setWalletFundingError(failureMessage(cause, "The MACH purchase did not complete."));
-        }
-      } finally {
-        if (walletFundingRun.current === run) {
-          walletFundingRun.current = undefined;
-          setWalletFundingOperation(null);
-        }
-      }
-    })();
-  };
-
   const connectOpenAi = async (event: FormEvent) => {
     event.preventDefault();
     if (!openAiKey.trim() || providerOperation) return;
@@ -581,14 +436,16 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
 
   if (inline && session.status !== "checking" && !accountPersistent) {
     return (
-      <AccountChooser
-        description={session.reauthenticationRequired
-          ? "Your session expired. Enter your phone number to restore this account’s memory and connections."
-          : "Enter your phone number to create or restore your Nanocodex account."}
-        disabled={session.operation !== null}
-        failure={session.error}
-        onChooseAccount={(selection) => void session.chooseAccount(selection)}
-      />
+      <div className="connect-onboarding terminal-sms-auth connect-route-sms-auth">
+        <AccountChooser
+          description={session.reauthenticationRequired
+            ? "Your session expired. Enter your phone number to restore this account’s memory and connections."
+            : "Verify by SMS to unlock three free Luna prompts. No ChatGPT connection is required."}
+          disabled={session.operation !== null}
+          failure={session.error}
+          onChooseAccount={(selection) => void session.chooseAccount(selection)}
+        />
+      </div>
     );
   }
 
@@ -665,14 +522,12 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
                 balance={walletBalanceError
                   ? walletBalance ? `${formatWalletBalance(walletBalance)} · refresh failed` : "Balance unavailable"
                   : walletBalance ? formatWalletBalance(walletBalance) : "Loading balance…"}
-                copied={walletCopied}
-                fundingAmountCents={walletFundingConfig ? defaultFundingAmountCents(walletFundingConfig) : 500}
-                fundingAvailable={walletFundingConfig?.onrampEnabled === true}
-                fundingError={walletFundingError}
-                fundingOperation={walletFundingOperation}
-                fundingSuccess={walletFundingSuccess}
-                onCopy={() => void copyWalletAddress()}
-                onFund={fundWallet}
+                fundingAmountCents={walletFunding.amountCents}
+                fundingAvailable={walletFunding.available}
+                fundingError={walletFunding.error}
+                fundingOperation={walletFunding.operation}
+                fundingSuccess={null}
+                onFund={walletFunding.fund}
               />
               {credentials ? (
                 <>
@@ -1070,45 +925,39 @@ export function AccountMenu({ inline = false }: Readonly<{ inline?: boolean }>) 
 function TempoWalletConnectionCard({
   address,
   balance,
-  copied,
   fundingAmountCents,
   fundingAvailable,
   fundingError,
   fundingOperation,
   fundingSuccess,
-  onCopy,
   onFund,
 }: Readonly<{
   address?: string | undefined;
   balance: string;
-  copied: boolean;
   fundingAmountCents: number;
   fundingAvailable: boolean;
   fundingError: string | null;
   fundingOperation: "prepare" | "payment" | null;
   fundingSuccess: string | null;
-  onCopy(): void;
   onFund(): void;
 }>) {
   const busy = fundingOperation !== null;
   return (
-    <div className="wizard-connector-card tempo-wallet-connection" role="listitem">
+    <div className="wizard-connector-card tempo-wallet-connection" id="wallet" role="listitem">
       <div className={`connection-card tempo-wallet-card${address ? " is-connected" : " is-unavailable"}`}>
         <ConnectionLogo id="tempo" />
         <span className="connection-card-copy">
-          <strong>{busy ? "Add MACH" : "Tempo Wallet"}</strong>
+          <strong>{busy ? "Add funds" : "Wallet"}</strong>
           <span className="tempo-wallet-balance" role={busy ? "status" : undefined}>{fundingOperation === "prepare"
             ? "Preparing secure checkout…"
             : fundingOperation === "payment"
               ? "Complete payment in Stripe"
               : balance}</span>
-          <code title={address}>{address ?? "Wallet unavailable"}</code>
           {fundingError ? <span className="tempo-wallet-message is-error" role="alert">{fundingError}</span> : null}
           {fundingSuccess ? <span className="tempo-wallet-message is-success" role="status">{fundingSuccess}</span> : null}
         </span>
         {busy ? <span className="tempo-wallet-payment-status" role="status">Waiting</span> : (
           <span className="tempo-wallet-card-actions">
-            <button disabled={!address} onClick={onCopy} type="button">{copied ? "Copied" : "Copy"}</button>
             <button disabled={!address || !fundingAvailable} onClick={onFund} type="button">
               {fundingAvailable ? `Add ${formatDollars(fundingAmountCents)}` : "Onramp unavailable"}
             </button>
@@ -1117,72 +966,6 @@ function TempoWalletConnectionCard({
       </div>
     </div>
   );
-}
-
-async function waitForFundingOrder(
-  attempt: FundingAttempt,
-  signal: AbortSignal,
-  checkout: Window,
-): Promise<void> {
-  const deadline = Date.now() + 15 * 60_000;
-  let checkoutClosedAt: number | undefined;
-  let retryDelayMs = 1_500;
-  while (Date.now() < deadline) {
-    signal.throwIfAborted();
-    if (checkout.closed) checkoutClosedAt ??= Date.now();
-    if (checkoutClosedAt && Date.now() - checkoutClosedAt >= 2 * 60_000) {
-      throw new Error("Payment status wasn’t confirmed after checkout closed. Check the balance before trying again.");
-    }
-    let response: Response;
-    try {
-      response = await apiRequest(`/v1/machine-usd/orders/${encodeURIComponent(attempt.id)}`, {
-        headers: { authorization: `Bearer ${attempt.orderToken}` },
-        signal,
-      });
-    } catch (cause) {
-      if (signal.aborted) throw cause;
-      retryDelayMs = Math.min(retryDelayMs * 2, 10_000);
-      await abortableDelay(retryDelayMs, signal);
-      continue;
-    }
-    if (!response.ok) {
-      if (response.status < 500) {
-        throw await responseFailure(response, "Couldn’t check the MACH order.");
-      }
-      await response.body?.cancel();
-      retryDelayMs = Math.min(retryDelayMs * 2, 10_000);
-    } else {
-      const body: unknown = await response.json();
-      if (!isRecord(body)) throw new Error("The MACH order response is invalid.");
-      const status = classifyFundingOrder(body.order);
-      if (status === "complete") return;
-      if (status === "failed") throw new Error("The MACH purchase did not complete.");
-      retryDelayMs = 1_500;
-    }
-    await abortableDelay(retryDelayMs, signal);
-  }
-  throw new Error("Payment status wasn’t confirmed. Check the balance before trying again.");
-}
-
-function abortableDelay(durationMs: number, signal: AbortSignal): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const onAbort = () => {
-      window.clearTimeout(timer);
-      reject(signal.reason);
-    };
-    const timer = window.setTimeout(() => {
-      signal.removeEventListener("abort", onAbort);
-      resolve();
-    }, durationMs);
-    signal.addEventListener("abort", onAbort, { once: true });
-  });
-}
-
-function randomOrderToken(): string {
-  const bytes = crypto.getRandomValues(new Uint8Array(32));
-  let binary = "";
-  for (const byte of bytes) binary += String.fromCharCode(byte);
-  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
 }
 
 async function apiRequest(path: string, init: RequestInit = {}): Promise<Response> {

--- a/js/account/src/AgentExperience.tsx
+++ b/js/account/src/AgentExperience.tsx
@@ -1,4 +1,17 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  lazy,
+  memo,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import type { AgentControllerEvent } from "nanocodex-react/agent";
+import { AccountChooser } from "nanocodex-connect-ui/AccountChooser";
+import { Link } from "react-router";
 import type { AgentStatus, AgentTerminalMode, AgentTerminalState } from "./agentTerminalTypes";
 import { AgentTerminal, ManagedAgentTerminal } from "./AgentTerminal";
 import { ConversationHistoryRail, TerminalTranscriptSurface } from "nanocodex-terminal";
@@ -17,9 +30,12 @@ import {
   listManagedConversations,
   type ManagedConversation,
 } from "./managedAgentRuntime";
+import "nanocodex-connect-ui/styles.css";
 import "./AgentTerminal.css";
 import "nanocodex-terminal/styles.css";
 import "./Home.css";
+import { formatDollars } from "./walletFunding";
+import { useWalletFunding } from "./useWalletFunding";
 
 /** Ephemeral homepage consumer and managed-durable Agent demo. */
 export const AgentExperience = memo(function AgentExperience({
@@ -33,7 +49,7 @@ export const AgentExperience = memo(function AgentExperience({
   mode: AgentTerminalMode;
   onAgentChange?(agentId: string, options?: { replace?: boolean }): void;
 }) {
-  const [ephemeralThreadId] = useState(() => crypto.randomUUID());
+  const [ephemeralThreadId, setEphemeralThreadId] = useState(() => crypto.randomUUID());
   const account = useAccountSession();
   const capabilityError = useMemo(() => browserAgentCapabilityError(), []);
   const [authStatus, setAuthStatus] = useState<ModelSessionStatus>();
@@ -46,7 +62,22 @@ export const AgentExperience = memo(function AgentExperience({
   const [managedError, setManagedError] = useState<string>();
   const [managedAttempt, setManagedAttempt] = useState(0);
   const [conversationPending, setConversationPending] = useState(false);
-  const hasCredential = credentialSource === "brokered" || credentialSource === "user";
+  const [freePromptsRemaining, setFreePromptsRemaining] = useState<number | null>(null);
+  const [sponsoredExhausted, setSponsoredExhausted] = useState(false);
+  const hasCredential = credentialSource === "brokered" || credentialSource === "sponsored";
+  const hasDurableCredential = credentialSource === "brokered";
+  const showHomepageSms = landing
+    && account.status !== "checking"
+    && account.account?.persistent !== true;
+  const showHomepageTrialActions = landing
+    && credentialSource === "sponsored"
+    && sponsoredExhausted;
+  const showHomepageTrialReset = landing && credentialSource === "sponsored";
+  const activeCapabilityError = landing ? capabilityError : undefined;
+  const canRun = landing
+    ? hasCredential && !(credentialSource === "sponsored" && sponsoredExhausted)
+    : hasDurableCredential;
+  const showHomepageTerminal = landing && hasCredential && !activeCapabilityError;
   const voiceEnabled = authStatus?.state === "ready" && authStatus.voiceEnabled === true;
 
   useEffect(() => {
@@ -55,14 +86,21 @@ export const AgentExperience = memo(function AgentExperience({
     setRuntimeState(undefined);
   }, [account.account?.id]);
   useEffect(() => {
-    if (landing || account.status !== "ready" || !account.account) return;
+    const remaining = authStatus?.state === "ready" && credentialSource === "sponsored"
+      ? authStatus.freePromptsRemaining
+      : null;
+    setFreePromptsRemaining(remaining);
+    setSponsoredExhausted(remaining === 0);
+  }, [account.account?.id, authStatus, credentialSource]);
+  useEffect(() => {
+    if (landing || account.status !== "ready" || !account.account || !hasDurableCredential) return;
     let cancelled = false;
     const accountId = account.account.id;
     setConversationPending(true);
     setManagedError(undefined);
     void listManagedConversations(accountId).then(async (listed) => {
       if (cancelled) return;
-      const next = listed.length || !hasCredential ? listed : [await createManagedConversation(accountId)];
+      const next = listed.length ? listed : [await createManagedConversation(accountId)];
       if (cancelled) return;
       setManagedConversations(next);
     }).catch((error) => {
@@ -71,7 +109,7 @@ export const AgentExperience = memo(function AgentExperience({
       if (!cancelled) setConversationPending(false);
     });
     return () => { cancelled = true; };
-  }, [account.account?.id, account.status, hasCredential, landing, managedAttempt]);
+  }, [account.account?.id, account.status, hasDurableCredential, landing, managedAttempt]);
 
   useEffect(() => {
     if (landing || !account.account || managedConversations.length === 0) return;
@@ -92,16 +130,21 @@ export const AgentExperience = memo(function AgentExperience({
     credentialSourceRef.current = source;
     setCredentialSource(source);
   }, []);
-  useModelSession({
+  const { retrySession: refreshModelSession } = useModelSession({
     onStatusChange: setAuthStatus,
     onSourceChange: changeCredentialSource,
   });
-  const activeCapabilityError = landing ? capabilityError : undefined;
-  const agentStatus: AgentStatus = !hasCredential || activeCapabilityError
+  const effectiveAuthStatus = useMemo(
+    () => authStatus?.state === "ready" && credentialSource === "sponsored"
+      ? { ...authStatus, freePromptsRemaining }
+      : authStatus,
+    [authStatus, credentialSource, freePromptsRemaining],
+  );
+  const agentStatus: AgentStatus = !canRun || activeCapabilityError
     ? "idle" : runtimeState?.status ?? "starting";
   const agentError = runtimeState?.error;
   const inactiveMessage = inactiveTerminalMessage({
-    agentError, agentStatus, authStatus, capabilityError: activeCapabilityError,
+    agentError, agentStatus, authStatus: effectiveAuthStatus, capabilityError: activeCapabilityError,
     runtime: landing ? "browser" : "managed", source: credentialSource,
   });
 
@@ -139,10 +182,25 @@ export const AgentExperience = memo(function AgentExperience({
       updatedAt: Date.now(),
     } : item).sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0)));
   }, [managedConversationId]);
+  const recordSponsoredActivity = useCallback(() => {
+    // The egress reservation, not local submission, owns the allowance.
+  }, []);
+  const observeSponsoredTerminal = useCallback((event: AgentControllerEvent) => {
+    if (credentialSource !== "sponsored"
+      || (event.type !== "prompt.completed" && event.type !== "prompt.failed")) return;
+    void refreshModelSession();
+  }, [credentialSource, refreshModelSession]);
+  const acceptSponsoredTrialReset = useCallback(async () => {
+    setFreePromptsRemaining(3);
+    setSponsoredExhausted(false);
+    setRuntimeState(undefined);
+    setEphemeralThreadId(crypto.randomUUID());
+    await refreshModelSession();
+  }, [refreshModelSession]);
 
   return <div className={`nanocodex-demo is-${mode}${landing ? " is-landing" : ""}`}>
     <div className="conversation-workspace">
-      {landing ? null : <ConversationHistoryRail
+      {landing || !hasDurableCredential ? null : <ConversationHistoryRail
         agentStatus={agentStatus}
         conversations={managedConversations} error={managedError}
         mobileOpen={railOpen} pending={conversationPending} runtime="managed" selectedId={managedConversationId}
@@ -151,18 +209,34 @@ export const AgentExperience = memo(function AgentExperience({
         onSelect={selectManaged}
       />}
       <div className="conversation-main">
-        {landing
+        {LOCAL_SPONSORED_TRIAL_RESET && showHomepageTrialReset ? (
+          <Suspense fallback={null}>
+            <LocalSponsoredTrialReset onReset={acceptSponsoredTrialReset} />
+          </Suspense>
+        ) : null}
+        {showHomepageTerminal
           ? <AgentTerminal
             key={`ephemeral:${account.account?.id ?? "anonymous"}:${ephemeralThreadId}`}
-            authStatus={authStatus}
+            authStatus={effectiveAuthStatus}
             capabilityError={activeCapabilityError}
-            enabled={hasCredential && !activeCapabilityError}
-            mode={mode} onConversationActivity={NO_CONVERSATION_ACTIVITY}
+            composer={showHomepageTrialActions ? <HomepageTrialActions /> : undefined}
+            enabled
+            mode={mode} onConversationActivity={recordSponsoredActivity}
+            onTerminalEvent={observeSponsoredTerminal}
             onStateChange={setRuntimeState} source={credentialSource} threadId={ephemeralThreadId}
             voiceEnabled={voiceEnabled}
-            welcome={HOME_TERMINAL_WELCOME}
+            welcome={homeTerminalWelcome(credentialSource, freePromptsRemaining)}
           />
-          : hasCredential && managedConversationId
+          : landing
+            ? <ReservedTerminal
+              composer={showHomepageSms
+                ? <HomepageSmsTerminal />
+                : showHomepageTrialActions ? <HomepageTrialActions /> : null}
+              message={showHomepageSms || showHomepageTrialActions ? "" : inactiveMessage}
+              mode={mode}
+              welcome={homeTerminalWelcome(credentialSource, freePromptsRemaining)}
+            />
+            : hasDurableCredential && managedConversationId
             ? <ManagedAgentTerminal
               key={managedConversationId} agentId={managedConversationId!} authStatus={authStatus}
               mode={mode} onConversationActivity={recordActivity} onStateChange={setRuntimeState}
@@ -176,17 +250,19 @@ export const AgentExperience = memo(function AgentExperience({
 });
 
 function ReservedTerminal({
+  composer = null,
   message,
   mode,
   welcome,
 }: {
+  composer?: ReactNode;
   message: string;
   mode: AgentTerminalMode;
   welcome?: string;
 }) {
   return <TerminalTranscriptSurface
     canLoadOlder={false}
-    composer={null}
+    composer={composer}
     entries={[]}
     inactiveMessage={message}
     isLoadingOlder={false}
@@ -197,8 +273,54 @@ function ReservedTerminal({
   />;
 }
 
+function HomepageSmsTerminal() {
+  const account = useAccountSession();
+  return <div className="connect-onboarding terminal-sms-auth">
+    <AccountChooser
+      description={account.reauthenticationRequired
+        ? "Your session expired. Enter your phone number to restore it and unlock your free prompts."
+        : "Verify by SMS to unlock three free Luna prompts. No ChatGPT connection is required."}
+      disabled={account.operation !== null}
+      failure={account.error}
+      onChooseAccount={(selection) => void account.chooseAccount(selection)}
+    />
+  </div>;
+}
+
+function HomepageTrialActions() {
+  const funding = useWalletFunding(true);
+  return <div className="homepage-trial-actions">
+    <div>
+      <strong>Your three free prompts are used.</strong>
+      <span>{funding.error ?? "Connect your own model account for durable agents, or add funds to your Wallet."}</span>
+    </div>
+    <nav aria-label="Continue after free prompts">
+      <Link to="/connect">Connect</Link>
+      <button
+        disabled={funding.loading || !funding.available || funding.operation !== null}
+        onClick={funding.fund}
+        type="button"
+      >
+        {funding.operation === "prepare"
+          ? "Preparing checkout…"
+          : funding.operation === "payment"
+            ? "Opening Stripe…"
+            : funding.loading
+              ? "Loading Wallet…"
+              : `Fund Wallet · ${formatDollars(funding.amountCents)}`}
+      </button>
+    </nav>
+  </div>;
+}
+
 const NO_OLDER_HISTORY = async () => false;
-const NO_CONVERSATION_ACTIVITY = () => {};
+const LOCAL_SPONSORED_TRIAL_RESET = typeof __NANOCODEX_LOCAL_SPONSORED_TRIAL_RESET__ !== "undefined"
+  && __NANOCODEX_LOCAL_SPONSORED_TRIAL_RESET__;
+const LocalSponsoredTrialReset = LOCAL_SPONSORED_TRIAL_RESET
+  ? lazy(async () => ({
+    default: (await import("./LocalSponsoredTrialReset")).LocalSponsoredTrialReset,
+  }))
+  : () => null;
 
 const HOME_TERMINAL_WELCOME = `# High-performance Codex SDK. Runs anywhere.
 
@@ -209,7 +331,26 @@ One agent keeps its WebSocket, typed history, tools, and context across turns.
 
 **Terminal-Bench 2.1 high · 82.2% · 890/890 runs**
 
-This is the local browser agent. Ask Nanocodex to do something.`;
+This is the local browser agent.`;
+
+function homeTerminalWelcome(
+  source: CredentialSource | undefined,
+  freePromptsRemaining: number | null,
+): string {
+  if (source === "brokered") {
+    return `${HOME_TERMINAL_WELCOME}
+
+This homepage demo uses your connected model account and is ephemeral: reloading discards the model thread.`;
+  }
+  const included = source === "sponsored" && freePromptsRemaining === 0
+    ? "Your three free Luna prompts are used."
+    : source === "sponsored" && freePromptsRemaining !== null
+      ? `${freePromptsRemaining} of 3 free Luna prompts remain.`
+      : "Verify your phone by SMS to get three free Luna prompts.";
+  return `${HOME_TERMINAL_WELCOME}
+
+${included} Free prompts use Luna without thinking and are ephemeral: reloading discards the model thread.`;
+}
 
 function managedSelectionKey(accountId: string) {
   return `nanocodex.managed-conversation.v2.${accountId}`;

--- a/js/account/src/AgentTerminal.css
+++ b/js/account/src/AgentTerminal.css
@@ -404,6 +404,177 @@
   margin-bottom: 0;
 }
 
+.nanocodex-demo.is-landing .conversation-main {
+  position: relative;
+}
+
+.terminal-sms-auth {
+  position: relative;
+  z-index: 6;
+  width: 100%;
+  padding: 12px clamp(14px, 3vw, 32px) 14px;
+  color: var(--terminal-foreground, var(--text));
+  background: var(--terminal-background, var(--surface));
+  border-top: 1px solid var(--terminal-border, var(--border-soft));
+  font-family: var(--terminal-font-sans);
+}
+
+.terminal-sms-auth .wizard-page {
+  width: min(100%, 836px);
+  margin: 0;
+  padding: 0;
+}
+
+.terminal-sms-auth .wizard-intro {
+  padding: 0 0 10px;
+}
+
+.terminal-sms-auth .wizard-app {
+  gap: 4px;
+}
+
+.terminal-sms-auth .wizard-app > span,
+.terminal-sms-auth .sms-auth-security {
+  display: none;
+}
+
+.terminal-sms-auth .wizard-app h1 {
+  color: var(--terminal-foreground, var(--text));
+  font-size: 12px;
+  letter-spacing: 0;
+}
+
+.terminal-sms-auth .wizard-app p,
+.terminal-sms-auth .sms-otp-form > p,
+.terminal-sms-auth .sms-otp-change {
+  color: var(--terminal-muted, var(--muted));
+  font-size: 10px;
+}
+
+.terminal-sms-auth .sms-otp-form {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  gap: 7px;
+}
+
+.terminal-sms-auth .sms-otp-form > label {
+  color: var(--terminal-secondary, var(--text-secondary));
+  font-size: 10px;
+}
+
+.terminal-sms-auth .sms-otp-input-row input {
+  min-height: 44px;
+  color: var(--terminal-foreground, var(--text));
+  background: transparent;
+  border-color: var(--terminal-border, var(--border-soft));
+}
+
+.terminal-sms-auth .sms-otp-input-row input:focus {
+  border-color: var(--terminal-foreground, var(--text));
+}
+
+.terminal-sms-auth .sms-otp-input-row button {
+  min-height: 44px;
+  color: var(--terminal-background, var(--surface));
+  background: var(--terminal-foreground, var(--text));
+  border-color: var(--terminal-foreground, var(--text));
+}
+
+.terminal-sms-auth .account-failure {
+  margin: 0 0 10px;
+  padding: 8px 10px;
+  border: 1px solid color-mix(in srgb, var(--terminal-negative, var(--negative)) 30%, var(--terminal-border, var(--border-soft)));
+}
+
+.homepage-trial-actions {
+  position: relative;
+  z-index: 6;
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px clamp(14px, 3vw, 32px);
+  border-top: 1px solid var(--terminal-border);
+  color: var(--terminal-foreground);
+  background: var(--terminal-background);
+  font-family: var(--terminal-font-sans);
+  gap: 18px;
+}
+
+.homepage-trial-actions > div {
+  display: grid;
+  gap: 4px;
+}
+
+.homepage-trial-actions strong {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.homepage-trial-actions span {
+  color: var(--terminal-muted);
+  font-size: 10px;
+}
+
+.homepage-trial-actions nav {
+  display: flex;
+  flex: none;
+  gap: 8px;
+}
+
+.homepage-trial-actions a,
+.homepage-trial-actions button {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 16px;
+  border: 1px solid var(--terminal-foreground);
+  color: var(--terminal-background);
+  background: var(--terminal-foreground);
+  font-size: 10px;
+  text-decoration: none;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.homepage-trial-actions a:first-child {
+  color: var(--terminal-foreground);
+  background: transparent;
+}
+
+.homepage-trial-actions a:hover,
+.homepage-trial-actions a:focus-visible,
+.homepage-trial-actions button:hover:not(:disabled),
+.homepage-trial-actions button:focus-visible {
+  outline: 2px solid var(--terminal-foreground);
+  outline-offset: 2px;
+}
+
+.homepage-trial-actions button:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
+
+@media (max-width: 520px) {
+  .terminal-sms-auth .sms-otp-input-row {
+    grid-template-columns: 1fr;
+  }
+
+  .homepage-trial-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .homepage-trial-actions nav,
+  .homepage-trial-actions a,
+  .homepage-trial-actions button {
+    flex: 1;
+  }
+
+}
+
 @media (max-width: 740px), (pointer: coarse) and (orientation: landscape) and (max-width: 950px) {
   .nanocodex-demo.is-full .artifact-dock:not(.is-collapsed) {
     position: fixed;

--- a/js/account/src/AgentTerminal.tsx
+++ b/js/account/src/AgentTerminal.tsx
@@ -1,5 +1,6 @@
 import {
   memo,
+  type ReactNode,
   useCallback,
   useEffect,
   useMemo,
@@ -10,6 +11,7 @@ import {
   createConfig,
   useNanocodex,
 } from "nanocodex-react";
+import type { AgentControllerEvent } from "nanocodex-react/agent";
 import type { ArtifactDocument } from "nanocodex/tools/artifact";
 import {
   AgentTerminalView,
@@ -39,9 +41,11 @@ export { AgentTerminalView } from "nanocodex-terminal";
 type AgentTerminalProps = Readonly<{
   authStatus: ModelSessionStatus | undefined;
   capabilityError?: string;
+  composer?: ReactNode;
   enabled: boolean;
   mode: AgentTerminalMode;
   onConversationActivity(input: string): void;
+  onTerminalEvent?(event: AgentControllerEvent): void;
   onStateChange(state: AgentTerminalState): void;
   source: CredentialSource | undefined;
   threadId: string;
@@ -93,9 +97,11 @@ const BrowserAgentTerminal = memo(function BrowserAgentTerminal({
   authStatus,
   accountMcpConnections,
   capabilityError,
+  composer,
   enabled,
   mode,
   onConversationActivity,
+  onTerminalEvent,
   onStateChange,
   source,
   threadId,
@@ -108,21 +114,30 @@ const BrowserAgentTerminal = memo(function BrowserAgentTerminal({
     agent: {
       mcp: browserMcpConfiguration(location.origin, threadId, accountMcpConnections),
       durability: false,
+      ...(source === "sponsored" ? {
+        model: "gpt-5.6-luna" as const,
+        thinking: "none" as const,
+        reasoningMode: "standard" as const,
+        fastMode: false,
+      } : {}),
     },
-  }), [accountMcpConnections, threadId]);
+  }), [accountMcpConnections, source, threadId]);
   const {
     data: agent,
     error,
     isError,
     refetch,
   } = useNanocodex({ config: agentConfig, enabled, threadId });
+  const refetchRef = useRef(refetch);
+  refetchRef.current = refetch;
   const retryAgent = useCallback(() => {
-    refetch();
-  }, [refetch]);
+    refetchRef.current();
+  }, []);
   return (
     <AgentTerminalView
       agent={agent}
       agentError={isError ? errorMessage(error) : undefined}
+      composer={composer}
       inactiveMessage={({ agentError, agentStatus }) => inactiveTerminalMessage({
         agentError,
         agentStatus,
@@ -132,6 +147,7 @@ const BrowserAgentTerminal = memo(function BrowserAgentTerminal({
       })}
       mode={mode}
       onConversationActivity={onConversationActivity}
+      onTerminalEvent={onTerminalEvent}
       onStateChange={onStateChange}
       retryAgent={retryAgent}
       voice={voiceEnabled}

--- a/js/account/src/DeviceConnect.css
+++ b/js/account/src/DeviceConnect.css
@@ -932,14 +932,6 @@
   font-size: 10px;
 }
 
-.connect-wizard .tempo-wallet-card code {
-  overflow: hidden;
-  color: var(--faint);
-  font-size: 8px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .connect-wizard .tempo-wallet-message {
   color: var(--faint);
   font-size: 9px;
@@ -1459,6 +1451,35 @@
   content: "";
 }
 
+.connect-wizard .connect-route-sms-auth .sms-auth-panel {
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.connect-wizard .connect-route-sms-auth .wizard-page {
+  width: min(100%, 836px);
+  margin: 0;
+  padding: 0;
+}
+
+.connect-wizard .connect-route-sms-auth .sms-otp-input-row {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.connect-wizard .connect-route-sms-auth .sms-otp-input-row input,
+.connect-wizard .connect-route-sms-auth .sms-otp-input-row button {
+  min-height: 44px;
+  border-radius: 0;
+}
+
+.connect-wizard .connect-route-sms-auth .sms-otp-input-row button {
+  width: auto;
+  min-width: 196px;
+}
+
 .vault-page {
   min-height: calc(100dvh - var(--header-height) - 42px);
 }
@@ -1880,6 +1901,14 @@
 }
 
 @media (max-width: 720px) {
+  .connect-wizard .connect-route-sms-auth .sms-otp-input-row {
+    grid-template-columns: 1fr;
+  }
+
+  .connect-wizard .connect-route-sms-auth .sms-otp-input-row button {
+    width: 100%;
+  }
+
   .connect-home-navigation {
     padding-inline: 16px;
   }

--- a/js/account/src/LocalSponsoredTrialReset.css
+++ b/js/account/src/LocalSponsoredTrialReset.css
@@ -1,0 +1,45 @@
+.homepage-trial-reset {
+  position: absolute;
+  z-index: 12;
+  top: 14px;
+  right: 58px;
+  display: flex;
+  align-items: center;
+  color: var(--terminal-negative);
+  font-family: var(--terminal-font-sans);
+  font-size: 10px;
+  gap: 8px;
+}
+
+.homepage-trial-reset button {
+  min-height: 32px;
+  padding: 0 10px;
+  border: 1px solid var(--terminal-border);
+  color: var(--terminal-secondary);
+  background: var(--terminal-background);
+  font: inherit;
+  cursor: pointer;
+}
+
+.homepage-trial-reset button:hover,
+.homepage-trial-reset button:focus-visible {
+  color: var(--terminal-foreground);
+  border-color: var(--terminal-foreground);
+  outline: 0;
+}
+
+.homepage-trial-reset button:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+
+.homepage-trial-reset span {
+  max-width: 240px;
+}
+
+@media (max-width: 520px) {
+  .homepage-trial-reset {
+    top: 8px;
+    right: 8px;
+  }
+}

--- a/js/account/src/LocalSponsoredTrialReset.tsx
+++ b/js/account/src/LocalSponsoredTrialReset.tsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import "./LocalSponsoredTrialReset.css";
+
+export function LocalSponsoredTrialReset({ onReset }: { onReset(): Promise<void> }) {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string>();
+
+  const reset = () => {
+    if (pending) return;
+    setPending(true);
+    setError(undefined);
+    void fetch("/api/dev/sponsored-trial/reset", {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { accept: "application/json" },
+    }).then(async (response) => {
+      if (!response.ok) {
+        await response.body?.cancel();
+        throw new Error("The local trial could not be reset.");
+      }
+      await response.body?.cancel();
+      await onReset();
+    }).catch((cause) => setError(errorMessage(cause)))
+      .finally(() => setPending(false));
+  };
+
+  return <div className="homepage-trial-reset">
+    <button disabled={pending} type="button" onClick={reset}>
+      {pending ? "Resetting…" : "Reset trial"}
+    </button>
+    {error ? <span role="alert">{error}</span> : null}
+  </div>;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/js/account/src/deploymentHealth.test.ts
+++ b/js/account/src/deploymentHealth.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createDeploymentHealthResource } from "./deploymentHealth.ts";
+
+test("projects sponsored homepage access without enabling voice", async () => {
+  const health = await createDeploymentHealthResource(async () => Response.json({
+    agent_configured: true,
+    credential_source: "sponsored",
+    free_prompts_remaining: 3,
+    voice_enabled: true,
+  })).read();
+
+  assert.deepEqual(health, {
+    agentConfigured: true,
+    credentialSource: "sponsored",
+    deploymentSha: undefined,
+    freePromptsRemaining: 3,
+    voiceEnabled: false,
+  });
+});
+
+test("retains user-owned and brokered credential projections", async () => {
+  for (const [wire, expected] of [
+    ["user", "brokered"],
+    ["subscription", "brokered"],
+    ["brokered", "brokered"],
+  ] as const) {
+    const health = await createDeploymentHealthResource(async () => Response.json({
+      agent_configured: true,
+      credential_source: wire,
+      voice_enabled: true,
+    })).read();
+    assert.equal(health.credentialSource, expected);
+    assert.equal(health.freePromptsRemaining, null);
+    assert.equal(health.voiceEnabled, true);
+  }
+});
+
+test("fails closed for sponsored access without a valid remaining prompt count", async () => {
+  const health = await createDeploymentHealthResource(async () => Response.json({
+    agent_configured: true,
+    credential_source: "sponsored",
+  })).read();
+  assert.equal(health.agentConfigured, false);
+  assert.equal(health.credentialSource, null);
+});

--- a/js/account/src/deploymentHealth.ts
+++ b/js/account/src/deploymentHealth.ts
@@ -1,9 +1,10 @@
-export type DeploymentCredentialSource = "brokered" | "user" | null;
+export type DeploymentCredentialSource = "brokered" | "sponsored" | null;
 
 export type DeploymentHealth = Readonly<{
   agentConfigured: boolean;
   credentialSource: DeploymentCredentialSource;
   deploymentSha: string | undefined;
+  freePromptsRemaining: number | null;
   voiceEnabled: boolean;
 }>;
 
@@ -11,6 +12,7 @@ type HealthPayload = {
   agent_configured?: unknown;
   credential_source?: unknown;
   deployment_sha?: unknown;
+  free_prompts_remaining?: unknown;
   voice_enabled?: unknown;
 };
 
@@ -33,18 +35,26 @@ export function createDeploymentHealthResource(
         throw new Error(`Could not check the agent session (HTTP ${response.status})`);
       }
       const payload = await response.json() as HealthPayload;
+      const sponsoredRemaining = Number.isSafeInteger(payload.free_prompts_remaining)
+        && (payload.free_prompts_remaining as number) >= 0
+        && (payload.free_prompts_remaining as number) <= 3
+        ? payload.free_prompts_remaining as number
+        : null;
       const credentialSource = payload.agent_configured !== true
         ? null
         : payload.credential_source === "brokered" || payload.credential_source === "subscription"
           ? "brokered"
-          : payload.credential_source === "user" ? "user" : null;
+          : payload.credential_source === "sponsored" && sponsoredRemaining !== null
+            ? "sponsored"
+            : payload.credential_source === "user" ? "brokered" : null;
       return Object.freeze({
         agentConfigured: credentialSource !== null,
         credentialSource,
         deploymentSha: typeof payload.deployment_sha === "string"
           ? payload.deployment_sha
           : undefined,
-        voiceEnabled: credentialSource === "brokered" && payload.voice_enabled === true,
+        freePromptsRemaining: credentialSource === "sponsored" ? sponsoredRemaining : null,
+        voiceEnabled: credentialSource !== "sponsored" && payload.voice_enabled === true,
       });
     });
     inFlight = current;

--- a/js/account/src/local-development.d.ts
+++ b/js/account/src/local-development.d.ts
@@ -1,0 +1,1 @@
+declare const __NANOCODEX_LOCAL_SPONSORED_TRIAL_RESET__: boolean;

--- a/js/account/src/modelSession.tsx
+++ b/js/account/src/modelSession.tsx
@@ -6,10 +6,10 @@ import { clientFailureMessage } from "./clientFailure";
 import { deploymentHealth } from "./deploymentHealth";
 import { invalidateModelHealthForAccountTransition } from "./modelHealthAccount";
 
-export type CredentialSource = "brokered" | "user" | null;
+export type CredentialSource = "brokered" | "sponsored" | null;
 export type ModelSessionStatus =
   | { state: "signed_out" }
-  | { state: "ready"; ready: boolean; voiceEnabled: boolean }
+  | { state: "ready"; freePromptsRemaining: number | null; ready: boolean; voiceEnabled: boolean }
   | { state: "error"; error: string };
 
 export type SessionPresentation = {
@@ -20,6 +20,8 @@ export type SessionPresentation = {
   runtime?: "browser" | "managed";
   source: CredentialSource | undefined;
 };
+
+const ACCOUNT_TRANSITION_RETRY_DELAYS_MS = [300, 900, 1_800] as const;
 
 export function inactiveTerminalMessage({
   agentError,
@@ -34,8 +36,14 @@ export function inactiveTerminalMessage({
   if (agentStatus === "error" && source) return agentStartFailure(agentError);
   if (source === undefined || authStatus === undefined) return "";
   const agent = runtime === "managed" ? "managed agent" : "browser agent";
-  if (authStatus.state === "signed_out") return `Sign in by SMS to start the ${agent}.`;
+  if (authStatus.state === "signed_out") return `Verify your phone by SMS to start the ${agent}.`;
   if (authStatus.state === "error") return "Could not check your model connection. Use Retry above.";
+  if (runtime === "managed" && source === "sponsored") {
+    return "The included model is limited to the ephemeral homepage demo. Connect ChatGPT or an OpenAI API key to use durable agents.";
+  }
+  if (runtime === "browser" && source === "sponsored" && authStatus.freePromptsRemaining === 0) {
+    return "Your three free prompts are used. Connect ChatGPT or an OpenAI API key to continue.";
+  }
   if (!authStatus.ready) {
     return `Connect ChatGPT or an OpenAI API key from the account menu to start the ${agent}.`;
   }
@@ -74,7 +82,7 @@ export function AgentSessionBar({
     onSourceChange,
   });
   const ready = agentStatus === "ready";
-  const hasCredential = source === "brokered";
+  const hasCredential = source === "brokered" || source === "sponsored";
   const label = sessionLabel({ agentStatus, authStatus: status, capabilityError, source });
   const compactReady = ready
     && hasCredential
@@ -109,7 +117,7 @@ export function AgentSessionBar({
         </p>
       ) : null}
       {status?.state === "signed_out" ? (
-        <p className="agent-session-note" role="status">Sign in by SMS from the account menu.</p>
+        <p className="agent-session-note" role="status">Verify your phone by SMS from the account menu.</p>
       ) : null}
       {agentError ? (
         <p className="agent-byok-error" role="alert">
@@ -133,7 +141,9 @@ export function useModelSession({
   const [busy, setBusy] = useState(false);
   const generation = useRef(0);
   const observedAccountId = useRef<string | undefined>(undefined);
-  const requests = useRef(new GenerationRequestOwner<void>());
+  const requests = useRef(new GenerationRequestOwner<
+    Awaited<ReturnType<typeof deploymentHealth.read>> | undefined
+  >());
   const publish = useCallback((next: ModelSessionStatus, source: CredentialSource) => {
     setStatus(next);
     onStatusChange(next);
@@ -154,9 +164,11 @@ export function useModelSession({
         if (generation.current !== current) return;
         publish({
           state: "ready",
+          freePromptsRemaining: health.freePromptsRemaining,
           ready: health.agentConfigured,
           voiceEnabled: health.voiceEnabled,
         }, health.credentialSource);
+        return health;
       } catch (cause) {
         if (generation.current !== current) return;
         publish({
@@ -185,7 +197,23 @@ export function useModelSession({
       publish({ state: "signed_out" }, null);
       return;
     }
-    void readStatus(accountChanged);
+    let cancelled = false;
+    let retry: number | undefined;
+    const retryWhileStarting = (
+      health: Awaited<ReturnType<typeof deploymentHealth.read>> | undefined,
+      attempt = 0,
+    ) => {
+      if (cancelled || health?.agentConfigured !== false
+        || attempt >= ACCOUNT_TRANSITION_RETRY_DELAYS_MS.length) return;
+      retry = window.setTimeout(() => {
+        void readStatus(true).then((next) => retryWhileStarting(next, attempt + 1));
+      }, ACCOUNT_TRANSITION_RETRY_DELAYS_MS[attempt]);
+    };
+    void readStatus(accountChanged).then((health) => retryWhileStarting(health));
+    return () => {
+      cancelled = true;
+      if (retry !== undefined) window.clearTimeout(retry);
+    };
   }, [account, accountSession.status, publish, readStatus]);
   useEffect(() => {
     let inactive = false;
@@ -233,7 +261,7 @@ function sessionLabel({
   source,
 }: SessionPresentation): string {
   if (capabilityError) return "browser unsupported";
-  if (agentStatus === "starting" && source === "brokered") return "agent starting";
+  if (agentStatus === "starting" && source) return "agent starting";
   if (agentStatus === "ready") return "agent ready";
   if (agentStatus === "error" && source) return "agent unavailable";
   if (authStatus?.state === "signed_out") return "account required";

--- a/js/account/src/useWalletFunding.ts
+++ b/js/account/src/useWalletFunding.ts
@@ -1,0 +1,169 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { responseFailure, useAccountSession } from "./AccountSession";
+import { clientFailureMessage } from "./clientFailure";
+import {
+  decodeFundingAttempt,
+  decodeMachineUsdConfig,
+  defaultFundingAmountCents,
+  type MachineUsdConfig,
+} from "./walletFunding";
+
+type WalletFundingOperation = "prepare" | "payment";
+
+type WalletFundingRun = Readonly<{
+  accountId: string;
+  controller: AbortController;
+}>;
+
+export function useWalletFunding(enabled: boolean) {
+  const session = useAccountSession();
+  const accountId = session.account?.id;
+  const address = session.account?.address;
+  const refreshSession = session.refresh;
+  const [config, setConfig] = useState<MachineUsdConfig | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [operation, setOperation] = useState<WalletFundingOperation | null>(null);
+  const cachedAccountId = useRef<string | undefined>(undefined);
+  const configRequest = useRef<Promise<void> | undefined>(undefined);
+  const fundingRun = useRef<WalletFundingRun | undefined>(undefined);
+
+  const cancel = useCallback(() => {
+    const run = fundingRun.current;
+    fundingRun.current = undefined;
+    run?.controller.abort();
+  }, []);
+
+  const loadConfig = useCallback((): Promise<void> => {
+    if (!accountId || config) return Promise.resolve();
+    if (configRequest.current) return configRequest.current;
+    setError(null);
+    let current!: Promise<void>;
+    current = (async () => {
+      try {
+        const response = await apiRequest("/v1/machine-usd/config");
+        if (response.status === 401) {
+          await response.body?.cancel();
+          await refreshSession();
+          return;
+        }
+        if (!response.ok) throw await responseFailure(response, "Couldn’t load Wallet funding.");
+        const next = decodeMachineUsdConfig(await response.json());
+        if (cachedAccountId.current === accountId) setConfig(next);
+      } catch (cause) {
+        if (cachedAccountId.current === accountId) {
+          setError(clientFailureMessage(cause, "Couldn’t load Wallet funding."));
+        }
+      }
+    })().finally(() => {
+      if (configRequest.current === current) configRequest.current = undefined;
+    });
+    configRequest.current = current;
+    return current;
+  }, [accountId, config, refreshSession]);
+
+  useEffect(() => {
+    if (!enabled) {
+      cancel();
+      setOperation(null);
+      return;
+    }
+    if (!accountId) {
+      cancel();
+      cachedAccountId.current = undefined;
+      configRequest.current = undefined;
+      setConfig(null);
+      setError(null);
+      setOperation(null);
+      return;
+    }
+    if (cachedAccountId.current !== accountId) {
+      cancel();
+      cachedAccountId.current = accountId;
+      configRequest.current = undefined;
+      setConfig(null);
+      setError(null);
+      setOperation(null);
+    }
+    void loadConfig();
+  }, [accountId, cancel, enabled, loadConfig]);
+
+  useEffect(() => cancel, [cancel]);
+
+  const fund = useCallback(() => {
+    if (!accountId || !address || !config || !config.onrampEnabled || operation) return;
+    const controller = new AbortController();
+    const run: WalletFundingRun = { accountId, controller };
+    cancel();
+    fundingRun.current = run;
+    setOperation("prepare");
+    setError(null);
+    void (async () => {
+      try {
+        const orderToken = randomOrderToken();
+        const response = await apiRequest("/v1/machine-usd/orders", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "idempotency-key": crypto.randomUUID(),
+          },
+          body: JSON.stringify({
+            order_token: orderToken,
+            payment_mode: "hosted_checkout",
+            usd_amount_cents: defaultFundingAmountCents(config),
+            wallet_address: address,
+          }),
+          signal: controller.signal,
+        });
+        if (response.status === 401) {
+          await response.body?.cancel();
+          await refreshSession();
+          return;
+        }
+        if (!response.ok) {
+          throw await responseFailure(response, "Couldn’t create the Wallet funding order.");
+        }
+        const attempt = decodeFundingAttempt(await response.json(), orderToken);
+        if (fundingRun.current !== run) return;
+        setOperation("payment");
+        window.location.assign(attempt.checkoutUrl);
+      } catch (cause) {
+        if (!controller.signal.aborted && fundingRun.current === run) {
+          setError(clientFailureMessage(cause, "Wallet funding did not complete."));
+        }
+      } finally {
+        if (fundingRun.current === run) {
+          fundingRun.current = undefined;
+          setOperation(null);
+        }
+      }
+    })();
+  }, [accountId, address, cancel, config, operation, refreshSession]);
+
+  return {
+    amountCents: config ? defaultFundingAmountCents(config) : 500,
+    available: config?.onrampEnabled === true,
+    error,
+    fund,
+    loading: enabled && config === null && error === null,
+    operation,
+  } as const;
+}
+
+function randomOrderToken(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
+
+async function apiRequest(path: string, init: RequestInit = {}): Promise<Response> {
+  return fetch(path, {
+    ...init,
+    cache: "no-store",
+    credentials: "same-origin",
+    headers: {
+      accept: "application/json",
+      ...Object.fromEntries(new Headers(init.headers)),
+    },
+  });
+}

--- a/js/account/src/walletFunding.test.ts
+++ b/js/account/src/walletFunding.test.ts
@@ -22,9 +22,9 @@ test("decodes and formats the canonical MACH balance", () => {
     token: "0x20c000000000000000000000f37de3740ADec032",
   }, account.toUpperCase());
   assert.equal(balance.atomics, 12_345_678n);
-  assert.equal(formatWalletBalance(balance), "12.345678 MACH");
-  assert.equal(formatWalletBalance({ ...balance, atomics: 0n }), "0.00 MACH");
-  assert.equal(formatWalletBalance({ ...balance, atomics: 1_200_000n }), "1.2 MACH");
+  assert.equal(formatWalletBalance(balance), "$12.345678");
+  assert.equal(formatWalletBalance({ ...balance, atomics: 0n }), "$0.00");
+  assert.equal(formatWalletBalance({ ...balance, atomics: 1_200_000n }), "$1.20");
   assert.throws(() => decodeWalletBalance({
     account,
     balance: "-1",

--- a/js/account/src/walletFunding.ts
+++ b/js/account/src/walletFunding.ts
@@ -47,12 +47,12 @@ export function decodeWalletBalance(value: unknown, expectedAccount: string): Wa
 export function formatWalletBalance(balance: WalletBalance): string {
   const scale = 1_000_000n;
   const whole = balance.atomics / scale;
-  const fractional = (balance.atomics % scale).toString().padStart(6, "0").replace(/0+$/, "");
-  return `${whole.toLocaleString("en-US")}.${fractional || "00"} MACH`;
+  const fractional = (balance.atomics % scale).toString().padStart(6, "0").replace(/0+$/, "").padEnd(2, "0");
+  return `$${whole.toLocaleString("en-US")}.${fractional || "00"}`;
 }
 
 export function decodeMachineUsdConfig(value: unknown): MachineUsdConfig {
-  const record = object(value, "MACH config");
+  const record = object(value, "wallet funding config");
   const min = record.min_usd_amount_cents;
   const max = record.max_usd_amount_cents;
   const enabled = record.onramp_enabled ?? true;
@@ -63,7 +63,7 @@ export function decodeMachineUsdConfig(value: unknown): MachineUsdConfig {
     || typeof record.token_address !== "string"
     || record.token_address.toLowerCase() !== MACHINE_USD
     || typeof record.stripe_publishable_key !== "string") {
-    throw new Error("The MACH onramp configuration is invalid.");
+    throw new Error("The Wallet funding configuration is invalid.");
   }
   return {
     minUsdAmountCents: min as number,
@@ -80,26 +80,26 @@ export function decodeFundingAttempt(
   value: unknown,
   orderToken: string,
 ): FundingAttempt {
-  const record = object(value, "MACH order");
-  const order = object(record.order, "MACH order");
-  const payment = object(record.payment, "MACH payment");
+  const record = object(value, "wallet funding order");
+  const order = object(record.order, "wallet funding order");
+  const payment = object(record.payment, "wallet funding payment");
   if (typeof order.id !== "string" || !order.id || typeof payment.checkout_url !== "string") {
-    throw new Error("The MACH order response is invalid.");
+    throw new Error("The Wallet funding order response is invalid.");
   }
   let checkout: URL;
   try {
     checkout = new URL(payment.checkout_url);
   } catch {
-    throw new Error("The MACH checkout URL is invalid.");
+    throw new Error("The Wallet checkout URL is invalid.");
   }
   if (checkout.origin !== "https://checkout.stripe.com" || checkout.username || checkout.password) {
-    throw new Error("The MACH checkout URL is invalid.");
+    throw new Error("The Wallet checkout URL is invalid.");
   }
   return { checkoutUrl: checkout.href, id: order.id, orderToken };
 }
 
 export function classifyFundingOrder(value: unknown): "complete" | "failed" | "pending" {
-  const record = object(value, "MACH order");
+  const record = object(value, "wallet funding order");
   if (record.status === "complete"
     && typeof record.issuance_transaction_hash === "string"
     && TRANSACTION_HASH.test(record.issuance_transaction_hash)) {
@@ -109,7 +109,7 @@ export function classifyFundingOrder(value: unknown): "complete" | "failed" | "p
   if (record.status === "requires_payment" || record.status === "processing" || record.status === "issuing") {
     return "pending";
   }
-  throw new Error("The MACH order response is invalid.");
+  throw new Error("The Wallet funding order response is invalid.");
 }
 
 export function formatDollars(cents: number): string {

--- a/js/account/vite.config.ts
+++ b/js/account/vite.config.ts
@@ -169,7 +169,6 @@ export default defineConfig({
   server: {
     allowedHosts: [".nanocodex.localhost"],
     host: process.env.HOST,
-    origin: process.env.PORTLESS_URL,
     port: localServerPort,
     // The Connect playground calls the paired application origin with its
     // account cookie, while the live artifact frame has an opaque `null`

--- a/js/account/worker/index.ts
+++ b/js/account/worker/index.ts
@@ -53,6 +53,7 @@ import {
   managedModelStatus,
   openManagedResponsesWebSocket,
   openManagedRealtimeSideband,
+  resetManagedSponsoredTrial,
   type ManagedModelAccess,
 } from "./managedModel.ts";
 
@@ -96,6 +97,8 @@ const SECURE_BYOK_COOKIE = "__Secure-nanocodex_byok_v2";
 const CHATGPT_COOKIE = "nanocodex_chatgpt_v2";
 const SECURE_CHATGPT_COOKIE = "__Secure-nanocodex_chatgpt_v2";
 const GIT_SHA_PATTERN = /^[0-9a-f]{40}$/;
+const LOCAL_SPONSORED_TRIAL_RESET = typeof __NANOCODEX_LOCAL_SPONSORED_TRIAL_RESET__ !== "undefined"
+  && __NANOCODEX_LOCAL_SPONSORED_TRIAL_RESET__;
 
 type WorkerEnv = GitStorageEnv & ThreadGitStorageEnv & EvalStorageEnv & ChatGptEgressEnv
   & AccountFundingProxyEnv
@@ -177,7 +180,12 @@ export default {
         const model = await managedModelStatus(managed);
         return json({
           agent_configured: model.ready,
-          credential_source: model.ready ? "brokered" : null,
+          credential_source: model.source === "sponsored"
+            ? "sponsored"
+            : model.ready ? "brokered" : null,
+          ...(model.source === "sponsored"
+            ? { free_prompts_remaining: model.freePromptsRemaining }
+            : {}),
           voice_enabled: model.voiceEnabled,
           deployment_sha: GIT_SHA_PATTERN.test(env.DEPLOYMENT_SHA ?? "")
             ? env.DEPLOYMENT_SHA
@@ -205,6 +213,27 @@ export default {
         runtime: "cloudflare-workers",
         status: "ok",
       });
+    }
+
+    if (LOCAL_SPONSORED_TRIAL_RESET && url.pathname === "/api/dev/sponsored-trial/reset") {
+      const environment = env.ENVIRONMENT?.trim().toLowerCase();
+      if (environment !== "development" && environment !== "local") {
+        return json({ error: "not_found" }, { status: 404 });
+      }
+      if (request.method !== "POST") {
+        return json({ error: "method_not_allowed" }, { status: 405 });
+      }
+      const managed = managedAccess(request, env);
+      if (managed instanceof Response) return managed;
+      if (!managed) return json({ error: "managed model access unavailable" }, { status: 503 });
+      const reset = await resetManagedSponsoredTrial(managed);
+      if (!reset.ok) {
+        const status = reset.status >= 400 && reset.status < 500 ? reset.status : 503;
+        await reset.body?.cancel();
+        return json({ error: "sponsored_trial_reset_failed" }, { status });
+      }
+      await reset.body?.cancel();
+      return json({ free_prompts_remaining: 3 });
     }
 
     if (url.pathname === "/api/auth/chatgpt" && request.method === "POST") {

--- a/js/account/worker/managedModel.test.ts
+++ b/js/account/worker/managedModel.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  managedModelStatus,
+  resetManagedSponsoredTrial,
+  type ManagedModelAccess,
+} from "./managedModel.ts";
+
+test("preserves the sponsored source while disabling shared-account voice", async () => {
+  const sponsoredAccess = access({
+    ready: true,
+    active: "chatgpt",
+    free_prompts_remaining: 3,
+    source: "sponsored",
+  });
+  const sponsored = await managedModelStatus(sponsoredAccess.access);
+  assert.equal(sponsoredAccess.requestedUrl(), "https://broker.internal/.well-known/nanocodex/model-status");
+  assert.deepEqual(sponsored, {
+    freePromptsRemaining: 3,
+    ready: true,
+    source: "sponsored",
+    voiceEnabled: false,
+  });
+
+  const user = await managedModelStatus(access({
+    ready: true,
+    active: "chatgpt",
+    source: "user",
+  }).access);
+  assert.deepEqual(user, {
+    freePromptsRemaining: null,
+    ready: true,
+    source: "brokered",
+    voiceEnabled: true,
+  });
+});
+
+test("fails closed when the credential source is absent or malformed", async () => {
+  for (const value of [
+    { ready: true, active: "chatgpt" },
+    { ready: true, active: "openai", source: "sponsored-owner-id" },
+  ]) {
+    assert.deepEqual(await managedModelStatus(access(value).access), {
+      freePromptsRemaining: null,
+      ready: false,
+      source: null,
+      voiceEnabled: false,
+    });
+  }
+});
+
+test("uses the private local-only trial reset boundary", async () => {
+  const target = access({ free_prompts_remaining: 3 });
+  const response = await resetManagedSponsoredTrial(target.access);
+  assert.equal(response.status, 200);
+  assert.equal(target.requestedUrl(), "https://broker.internal/.well-known/nanocodex/sponsored-trial-reset");
+  assert.equal(target.requestedMethod(), "POST");
+});
+
+function access(body: unknown): Readonly<{
+  access: ManagedModelAccess;
+  requestedMethod(): string | undefined;
+  requestedUrl(): string | undefined;
+}> {
+  let requestedMethod: string | undefined;
+  let requestedUrl: string | undefined;
+  return {
+    access: {
+    binding: {
+      fetch: async (request: RequestInfo | URL) => {
+        const received = new Request(request);
+        requestedMethod = received.method;
+        requestedUrl = received.url;
+        return Response.json(body, {
+          headers: { "cache-control": "no-store" },
+        });
+      },
+    } as unknown as Fetcher,
+    },
+    requestedMethod: () => requestedMethod,
+    requestedUrl: () => requestedUrl,
+  };
+}

--- a/js/account/worker/managedModel.ts
+++ b/js/account/worker/managedModel.ts
@@ -9,7 +9,9 @@ export type ManagedModelAccess = Readonly<{
 }>;
 
 export type ManagedModelStatus = Readonly<{
+  freePromptsRemaining: number | null;
   ready: boolean;
+  source: "brokered" | "sponsored" | null;
   voiceEnabled: boolean;
 }>;
 
@@ -28,7 +30,8 @@ const HTTP_OPERATIONS = Object.freeze({
   search: "https://nanocodex.internal/v1/search",
 });
 
-const CREDENTIAL_STATUS_URL = "https://managed.internal/v1/credentials";
+const CREDENTIAL_STATUS_URL = "https://broker.internal/.well-known/nanocodex/model-status";
+const SPONSORED_TRIAL_RESET_URL = "https://broker.internal/.well-known/nanocodex/sponsored-trial-reset";
 
 /** Resolves the deployment-owned model boundary without reading a provider credential. */
 export function managedModelAccess(
@@ -65,19 +68,39 @@ export async function managedModelStatus(access: ManagedModelAccess): Promise<Ma
       || response.headers.get("cache-control") !== "no-store"
       || !response.headers.get("content-type")?.toLowerCase().startsWith("application/json")) {
       await response.body?.cancel();
-      return { ready: false, voiceEnabled: false };
+      return { freePromptsRemaining: null, ready: false, source: null, voiceEnabled: false };
     }
     const encoded = await response.text();
-    if (encoded.length > 1_024) return { ready: false, voiceEnabled: false };
+    if (encoded.length > 1_024) {
+      return { freePromptsRemaining: null, ready: false, source: null, voiceEnabled: false };
+    }
     const value = JSON.parse(encoded) as Record<string, unknown>;
     const ready = value !== null
       && !Array.isArray(value)
       && value.ready === true
       && (value.active === "chatgpt" || value.active === "openai");
-    return { ready, voiceEnabled: ready && value.active === "chatgpt" };
+    const sponsoredRemaining = Number.isSafeInteger(value.free_prompts_remaining)
+      && (value.free_prompts_remaining as number) >= 0
+      && (value.free_prompts_remaining as number) <= 3
+      ? value.free_prompts_remaining as number
+      : null;
+    const source = ready && value.source === "sponsored" && sponsoredRemaining !== null
+      ? "sponsored"
+      : ready && value.source === "user" ? "brokered" : null;
+    return {
+      freePromptsRemaining: source === "sponsored" ? sponsoredRemaining : null,
+      ready: source !== null,
+      source,
+      voiceEnabled: source === "brokered" && value.active === "chatgpt",
+    };
   } catch {
-    return { ready: false, voiceEnabled: false };
+    return { freePromptsRemaining: null, ready: false, source: null, voiceEnabled: false };
   }
+}
+
+/** Resets only the current development account's sponsored homepage allowance. */
+export function resetManagedSponsoredTrial(access: ManagedModelAccess): Promise<Response> {
+  return access.binding.fetch(new Request(SPONSORED_TRIAL_RESET_URL, { method: "POST" }));
 }
 
 /** Opens the exact placeholder-only Responses WebSocket through the private broker. */

--- a/js/egress/README.md
+++ b/js/egress/README.md
@@ -9,8 +9,8 @@ production evidence live in [../../AGENTS.md](../../AGENTS.md).
 - `wrangler.broker.jsonc` deploys `src/egress.ts` as `nanocodex-egress`.
   It has `workers_dev = false` and no public routes; managed services reach it
   only through a Service Binding. Its named `ChiefOfStaffEgress` RPC can only
-  idempotently install the operator-funded model credential for a managed,
-  server-generated Chief user ID.
+  idempotently install the separately configured Chief credential for a
+  managed, server-generated Chief user ID.
 - `wrangler.agent.jsonc` deploys `src/agent.ts` as the public
   `nanocodex-egress-agent-example`. Its `EGRESS` binding demonstrates the
   private call shape; it is not the broker or a production control surface.
@@ -31,6 +31,28 @@ before storage. Production requires
 Chief of Staff deployments also require `CHIEF_OF_STAFF_OPENAI_API_KEY` on
 this broker. The named RPC copies it directly into the generated user's
 encrypted credential vault; the value is never returned to managed or Chief.
+
+The optional homepage demo sponsor is an ordinary Nanocodex account whose
+ChatGPT connection remains in its own encrypted broker. After connecting that
+account through the Account UI, configure its stable account ID on egress:
+
+```sh
+pnpm --filter nanocodex-egress-service exec wrangler secret put NANOCODEX_SPONSORED_CHATGPT_USER_ID --config wrangler.broker.jsonc
+```
+
+Egress uses that ChatGPT credential only when the requesting account has no
+credential and the model subject is the exact 43-character browser identity.
+The 64-character identity used by durable managed agents cannot fall back to
+the sponsor. User-connected ChatGPT or OpenAI credentials always take
+precedence, and no sponsor token or account identifier is returned to callers.
+Each SMS account may reserve exactly three sponsored root prompt IDs. The
+per-account Durable Object serializes reservations, owns a heartbeat-renewed
+attempt lease, permits at most one retry for an interrupted or orphaned root,
+rejects completed replays, retains
+single-use provider-issued tool and tool-search continuations across SDK
+full-history reconnects, and rejects a fourth prompt before its generation
+frame reaches OpenAI. Egress also forces sponsored frames to Luna, no thinking,
+and standard service.
 
 Credentials and encryption keys never enter browser code, managed Workers,
 agent configuration, tool output, or status/control responses. The managed

--- a/js/egress/src/broker.ts
+++ b/js/egress/src/broker.ts
@@ -62,14 +62,28 @@ const PRODUCTION_CONNECT_API_ORIGIN = "https://nanocodex-connect-api.gakonst.wor
 const MAX_WALLET_RESOURCES = 64;
 const MAX_WALLET_RESOURCE_BYTES = 512;
 const MAX_WALLET_RESOURCE_TOTAL_BYTES = 8 * 1024;
+const SPONSORED_PROMPT_STATE_KEY = "sponsored-prompt-state-v1";
+const SPONSORED_CONNECTION_STATE_KEY = "sponsored-connection-state-v1";
+const SPONSORED_PROMPT_LIMIT = 3;
+const SPONSORED_CONNECTION_LIMIT = 3;
+const SPONSORED_PROMPT_MAX_ATTEMPTS = 2;
+const SPONSORED_PROMPT_LEASE_MS = 15_000;
+const TEST_SPONSORED_PROMPT_LEASE_MS = 250;
+const SPONSORED_PROMPT_ID = /^[A-Za-z][A-Za-z0-9_-]{1,127}$/;
+const SPONSORED_PROMPT_HASH = /^[A-Za-z0-9_-]{43}$/;
+const SPONSORED_CONNECTION_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const SPONSORED_RESPONSE_ID = /^[A-Za-z][A-Za-z0-9._:-]{1,199}$/;
+const SPONSORED_CALL_ID = /^[A-Za-z][A-Za-z0-9._:-]{1,199}$/;
+const MAX_SPONSORED_CALL_IDS = 64;
 
 export interface BrokerEnv extends CredentialVaultEnv {
   AGENT_SUBJECTS: DurableObjectNamespace<AgentSubjectDirectory>;
   CHIEF_OF_STAFF_OPENAI_API_KEY?: string;
+  NANOCODEX_SPONSORED_CHATGPT_USER_ID?: string;
   CHATGPT_ISSUER?: string;
   ALLOW_LOCAL_CREDENTIAL_CLAIM?: string;
+  NANOCODEX_LOCAL_SPONSORED_TRIAL_RESET?: string;
   LOCAL_CHATGPT_BOOTSTRAP?: string;
-  NANOCODEX_LOCAL_CHATGPT_AUTO_CLAIM?: string;
 }
 
 export type UserCredentialSnapshot = Readonly<{
@@ -79,6 +93,7 @@ export type UserCredentialSnapshot = Readonly<{
   fedramp?: boolean;
   expiresAt?: number;
   revision: number;
+  provenance?: "user" | "sponsor";
 }>;
 
 type ApiKeyCredential = { secret: string; createdAt: number; revision: number };
@@ -89,6 +104,7 @@ type ChatGptCredential = {
   fedramp: boolean;
   expiresAt: number;
   revision: number;
+  provenance?: "user" | "sponsor";
   refreshState: "ready" | "in_flight";
   refreshAfter?: number;
   refreshAttempts?: number;
@@ -158,6 +174,27 @@ type CredentialState = {
   browserCookieJars?: Record<string, BrowserCookieJarMetadata>;
 };
 type StoredRow = { envelope: EncryptedEnvelope };
+type SponsoredPrompt = Readonly<{
+  id: string;
+  hash: string;
+  phase: "in_flight" | "retryable" | "continuation" | "terminal";
+  attempts: number;
+  leaseExpiresAt?: number;
+  continuation?: Readonly<{
+    responseId: string;
+    callIds: readonly string[];
+  }>;
+}>;
+type SponsoredPromptState = Readonly<{
+  prompts: readonly SponsoredPrompt[];
+}>;
+type SponsoredConnection = Readonly<{
+  id: string;
+  leaseExpiresAt: number;
+}>;
+type SponsoredConnectionState = Readonly<{
+  connections: readonly SponsoredConnection[];
+}>;
 
 export type ChatGptCredentialImport = Readonly<{
   access_token: string;
@@ -323,12 +360,7 @@ export class UserCredentialBroker extends DurableObject<BrokerEnv> {
 
   async #initialize(): Promise<void> {
     const row = await this.#state.storage.get<StoredRow>(STATE_KEY);
-    if (!row) {
-      if (localCredentialAutoClaimEnabled(this.#env)) {
-        await this.#claimLocalBootstrap();
-      }
-      return;
-    }
+    if (!row) return;
     const opened = await this.#vault.open<CredentialState>(row.envelope);
     const installed = this.#installRestoredState(opened.value);
     if (installed.legacy.length) {
@@ -347,6 +379,99 @@ export class UserCredentialBroker extends DurableObject<BrokerEnv> {
       }
       if (request.method === "GET" && url.pathname === "/v1/status") {
         return json(this.#publicStatus(), 200);
+      }
+      if (url.pathname === "/v1/sponsored-prompts") {
+        if (request.method === "GET") {
+          return json(await this.#sponsoredPromptStatus(), 200);
+        }
+        if (request.method === "POST") {
+          if (!isJsonContentType(request.headers.get("content-type"))) {
+            return jsonError(415, "invalid_content_type");
+          }
+          const body = await readJson(request, 1_024);
+          const promptId = stringField(body, "prompt_id");
+          const promptHash = stringField(body, "prompt_hash");
+          if (!promptId || !SPONSORED_PROMPT_ID.test(promptId)
+            || !promptHash || !SPONSORED_PROMPT_HASH.test(promptHash)) {
+            return jsonError(400, "invalid_sponsored_prompt");
+          }
+          return this.#reserveSponsoredPrompt(promptId, promptHash);
+        }
+        return jsonError(405, "method_not_allowed");
+      }
+      if (url.pathname === "/v1/sponsored-prompts/reset") {
+        if (!localSponsoredTrialResetEnabled(this.#env)) return jsonError(404, "not_found");
+        if (request.method !== "POST") return jsonError(405, "method_not_allowed");
+        if (await hasRequestPayload(request)) return jsonError(400, "invalid_request");
+        await this.#state.storage.delete(SPONSORED_PROMPT_STATE_KEY);
+        return json(sponsoredPromptStatus([]), 200);
+      }
+      if (url.pathname === "/v1/sponsored-connections") {
+        if (request.method !== "POST") return jsonError(405, "method_not_allowed");
+        if (!isJsonContentType(request.headers.get("content-type"))) {
+          return jsonError(415, "invalid_content_type");
+        }
+        const body = await readJson(request, 1_024);
+        const action = stringField(body, "action");
+        const connectionId = stringField(body, "connection_id");
+        if (!connectionId || !SPONSORED_CONNECTION_ID.test(connectionId)
+          || (action !== "acquire" && action !== "heartbeat" && action !== "release")) {
+          return jsonError(400, "invalid_sponsored_connection");
+        }
+        return this.#setSponsoredConnection(connectionId, action);
+      }
+      if (url.pathname === "/v1/sponsored-prompts/continuation") {
+        if (request.method !== "POST") return jsonError(405, "method_not_allowed");
+        if (!isJsonContentType(request.headers.get("content-type"))) {
+          return jsonError(415, "invalid_content_type");
+        }
+        const body = await readJson(request, 16 * 1024);
+        const action = stringField(body, "action");
+        const responseId = stringField(body, "response_id");
+        const callIds = sponsoredCallIds(isRecord(body) ? body.call_ids : undefined);
+        if ((responseId !== undefined && !SPONSORED_RESPONSE_ID.test(responseId)) || !callIds) {
+          return jsonError(400, "invalid_sponsored_continuation");
+        }
+        if (action === "grant") {
+          const promptId = stringField(body, "prompt_id");
+          const attempt = numberField(body, "attempt");
+          if (!promptId || !SPONSORED_PROMPT_ID.test(promptId) || !responseId
+            || !attempt || attempt > SPONSORED_PROMPT_MAX_ATTEMPTS) {
+            return jsonError(400, "invalid_sponsored_continuation");
+          }
+          return this.#grantSponsoredContinuation(promptId, attempt, responseId, callIds);
+        }
+        if (action === "consume") {
+          const promptId = stringField(body, "prompt_id");
+          const promptHash = stringField(body, "prompt_hash");
+          if ((promptId !== undefined && !SPONSORED_PROMPT_ID.test(promptId))
+            || (promptHash !== undefined && !SPONSORED_PROMPT_HASH.test(promptHash))) {
+            return jsonError(400, "invalid_sponsored_continuation");
+          }
+          return this.#consumeSponsoredContinuation(
+            responseId,
+            callIds,
+            promptId,
+            promptHash,
+          );
+        }
+        return jsonError(400, "invalid_sponsored_continuation");
+      }
+      if (url.pathname === "/v1/sponsored-prompts/lifecycle") {
+        if (request.method !== "POST") return jsonError(405, "method_not_allowed");
+        if (!isJsonContentType(request.headers.get("content-type"))) {
+          return jsonError(415, "invalid_content_type");
+        }
+        const body = await readJson(request, 1_024);
+        const action = stringField(body, "action");
+        const promptId = stringField(body, "prompt_id");
+        const attempt = numberField(body, "attempt");
+        if (!promptId || !SPONSORED_PROMPT_ID.test(promptId)
+          || !attempt || attempt > SPONSORED_PROMPT_MAX_ATTEMPTS
+          || (action !== "terminal" && action !== "interrupted" && action !== "heartbeat")) {
+          return jsonError(400, "invalid_sponsored_prompt_lifecycle");
+        }
+        return this.#setSponsoredPromptLifecycle(promptId, attempt, action);
       }
       if (url.pathname === "/v1/wallet") {
         if (request.method === "GET") {
@@ -725,7 +850,11 @@ export class UserCredentialBroker extends DurableObject<BrokerEnv> {
       if (request.method === "POST" && url.pathname === "/v1/chatgpt/local-claim") {
         if (!localCredentialClaimEnabled(this.#env)) throw new BrokerFailure(404, "not_found");
         if (await hasRequestPayload(request)) return jsonError(400, "invalid_request");
-        await this.#claimLocalBootstrap();
+        const provenance = request.headers.get("x-nanocodex-credential-provenance");
+        if (provenance !== "user" && provenance !== "sponsor") {
+          return jsonError(400, "invalid_request");
+        }
+        await this.#claimLocalBootstrap(provenance);
         return json(this.#publicStatus(), 200);
       }
       if (request.method === "PUT" && url.pathname === "/v1/chatgpt") {
@@ -779,6 +908,245 @@ export class UserCredentialBroker extends DurableObject<BrokerEnv> {
     };
   }
 
+  async #sponsoredPromptStatus(): Promise<Readonly<{
+    limit: number;
+    used: number;
+    remaining: number;
+  }>> {
+    const stored = await this.#state.storage.get<unknown>(SPONSORED_PROMPT_STATE_KEY);
+    const prompts = sponsoredPrompts(stored);
+    return sponsoredPromptStatus(prompts);
+  }
+
+  async #reserveSponsoredPrompt(promptId: string, promptHash: string): Promise<Response> {
+    const stored = await this.#state.storage.get<unknown>(SPONSORED_PROMPT_STATE_KEY);
+    const prompts = sponsoredPrompts(stored);
+    const status = sponsoredPromptStatus(prompts);
+    const existing = prompts.find(({ id }) => id === promptId);
+    if (existing?.hash === promptHash) {
+      const now = Date.now();
+      if ((existing.phase === "retryable"
+          || (existing.phase === "in_flight" && existing.leaseExpiresAt! <= now))
+        && existing.attempts < SPONSORED_PROMPT_MAX_ATTEMPTS) {
+        const next = prompts.map((prompt) => prompt.id === promptId
+          ? {
+            id: prompt.id,
+            hash: prompt.hash,
+            phase: "in_flight" as const,
+            attempts: prompt.attempts + 1,
+            leaseExpiresAt: now + sponsoredPromptLeaseMs(this.#env),
+          }
+          : prompt);
+        await this.#state.storage.put(SPONSORED_PROMPT_STATE_KEY, {
+          prompts: next,
+        } satisfies SponsoredPromptState);
+        return json({
+          ...status,
+          reserved: false,
+          dispatch: true,
+          attempt: existing.attempts + 1,
+        }, 200);
+      }
+      return json({
+        ...status,
+        reserved: false,
+        dispatch: false,
+        pending: existing.phase === "in_flight",
+        attempt: existing.attempts,
+        ...(existing.phase === "in_flight"
+          ? { retry_after_ms: Math.max(0, existing.leaseExpiresAt! - now) }
+          : {}),
+      }, 200);
+    }
+    if (existing) return jsonError(409, "sponsored_prompt_conflict");
+    if (prompts.length >= SPONSORED_PROMPT_LIMIT) {
+      return json({
+        error: "sponsored_prompt_limit_reached",
+        ...status,
+      }, 402);
+    }
+    const next = [...prompts, {
+      id: promptId,
+      hash: promptHash,
+      phase: "in_flight" as const,
+      attempts: 1,
+      leaseExpiresAt: Date.now() + sponsoredPromptLeaseMs(this.#env),
+    }];
+    await this.#state.storage.put(SPONSORED_PROMPT_STATE_KEY, {
+      prompts: next,
+    } satisfies SponsoredPromptState);
+    return json({
+      limit: SPONSORED_PROMPT_LIMIT,
+      used: next.length,
+      remaining: SPONSORED_PROMPT_LIMIT - next.length,
+      reserved: true,
+      dispatch: true,
+      attempt: 1,
+    }, 200);
+  }
+
+  async #grantSponsoredContinuation(
+    promptId: string,
+    attempt: number,
+    responseId: string,
+    callIds: readonly string[],
+  ): Promise<Response> {
+    const stored = await this.#state.storage.get<unknown>(SPONSORED_PROMPT_STATE_KEY);
+    const prompts = sponsoredPrompts(stored);
+    const index = prompts.findIndex(({ id }) => id === promptId);
+    if (index < 0 || prompts[index]!.attempts !== attempt) {
+      return jsonError(409, "sponsored_prompt_not_admitted");
+    }
+    const current = prompts[index]!;
+    if (current.phase !== "in_flight" || current.leaseExpiresAt! <= Date.now()) {
+      return jsonError(409, "sponsored_prompt_attempt_stale");
+    }
+    const next = [...prompts];
+    const { leaseExpiresAt: _leaseExpiresAt, ...retained } = current;
+    next[index] = {
+      ...retained,
+      phase: "continuation",
+      continuation: { responseId, callIds },
+    };
+    await this.#state.storage.put(SPONSORED_PROMPT_STATE_KEY, {
+      prompts: next,
+    } satisfies SponsoredPromptState);
+    return json({ granted: true }, 200);
+  }
+
+  async #consumeSponsoredContinuation(
+    responseId: string | undefined,
+    callIds: readonly string[],
+    promptId?: string,
+    promptHash?: string,
+  ): Promise<Response> {
+    const stored = await this.#state.storage.get<unknown>(SPONSORED_PROMPT_STATE_KEY);
+    const prompts = sponsoredPrompts(stored);
+    const candidates = prompts.map((prompt, index) => ({ prompt, index }))
+      .filter(({ prompt }) => prompt.phase === "continuation"
+        && prompt.continuation
+        && (!responseId || prompt.continuation.responseId === responseId)
+        && (!promptId || prompt.id === promptId)
+        && (!promptHash || prompt.hash === promptHash)
+        && isStringSubset(prompt.continuation.callIds, callIds));
+    const index = candidates.length === 1 ? candidates[0]!.index : -1;
+    if (index < 0) return jsonError(409, "sponsored_continuation_unavailable");
+    const current = prompts[index]!;
+    const next = [...prompts];
+    const { continuation: _continuation, ...retained } = current;
+    next[index] = {
+      ...retained,
+      phase: "in_flight",
+      leaseExpiresAt: Date.now() + sponsoredPromptLeaseMs(this.#env),
+    };
+    await this.#state.storage.put(SPONSORED_PROMPT_STATE_KEY, {
+      prompts: next,
+    } satisfies SponsoredPromptState);
+    return json({ prompt_id: current.id, attempt: current.attempts }, 200);
+  }
+
+  async #setSponsoredPromptLifecycle(
+    promptId: string,
+    attempt: number,
+    action: "terminal" | "interrupted" | "heartbeat",
+  ): Promise<Response> {
+    const stored = await this.#state.storage.get<unknown>(SPONSORED_PROMPT_STATE_KEY);
+    const prompts = sponsoredPrompts(stored);
+    const index = prompts.findIndex(({ id }) => id === promptId);
+    if (index < 0) return jsonError(409, "sponsored_prompt_not_admitted");
+    const current = prompts[index]!;
+    if (current.attempts !== attempt) return json({ updated: false }, 200);
+    if (action === "heartbeat") {
+      if (current.phase === "continuation" || current.phase === "terminal") {
+        return json({ updated: false, settled: true }, 200);
+      }
+      if (current.phase !== "in_flight" || current.leaseExpiresAt! <= Date.now()) {
+        return json({ updated: false }, 200);
+      }
+      const next = [...prompts];
+      next[index] = {
+        ...current,
+        leaseExpiresAt: Date.now() + sponsoredPromptLeaseMs(this.#env),
+      };
+      await this.#state.storage.put(SPONSORED_PROMPT_STATE_KEY, {
+        prompts: next,
+      } satisfies SponsoredPromptState);
+      return json({ updated: true }, 200);
+    }
+    if (current.phase !== "in_flight"
+      || (action === "terminal" && current.leaseExpiresAt! <= Date.now())) {
+      return json({ updated: false }, 200);
+    }
+    const {
+      continuation: _continuation,
+      leaseExpiresAt: _leaseExpiresAt,
+      ...retained
+    } = current;
+    const next = [...prompts];
+    next[index] = {
+      ...retained,
+      phase: action === "terminal" ? "terminal" : "retryable",
+    };
+    await this.#state.storage.put(SPONSORED_PROMPT_STATE_KEY, {
+      prompts: next,
+    } satisfies SponsoredPromptState);
+    return json({ updated: true }, 200);
+  }
+
+  async #setSponsoredConnection(
+    connectionId: string,
+    action: "acquire" | "heartbeat" | "release",
+  ): Promise<Response> {
+    const now = Date.now();
+    const stored = await this.#state.storage.get<unknown>(SPONSORED_CONNECTION_STATE_KEY);
+    const current = sponsoredConnections(stored).filter(({ leaseExpiresAt }) => (
+      leaseExpiresAt > now
+    ));
+    const index = current.findIndex(({ id }) => id === connectionId);
+    if (action === "release") {
+      if (index < 0) return json({ updated: false }, 200);
+      const next = current.filter(({ id }) => id !== connectionId);
+      await this.#persistSponsoredConnections(next);
+      return json({ updated: true }, 200);
+    }
+    if (action === "heartbeat") {
+      if (index < 0) return json({ updated: false }, 200);
+      const next = [...current];
+      next[index] = {
+        id: connectionId,
+        leaseExpiresAt: now + sponsoredPromptLeaseMs(this.#env),
+      };
+      await this.#persistSponsoredConnections(next);
+      return json({ updated: true }, 200);
+    }
+    const promptStored = await this.#state.storage.get<unknown>(SPONSORED_PROMPT_STATE_KEY);
+    const status = sponsoredPromptStatus(sponsoredPrompts(promptStored));
+    if (status.remaining === 0) {
+      await this.#persistSponsoredConnections(current);
+      return json({ error: "sponsored_prompt_limit_reached", ...status }, 402);
+    }
+    if (index >= 0) return jsonError(409, "sponsored_connection_conflict");
+    if (current.length >= SPONSORED_CONNECTION_LIMIT) {
+      return jsonError(429, "sponsored_connection_limit_reached");
+    }
+    const next = [...current, {
+      id: connectionId,
+      leaseExpiresAt: now + sponsoredPromptLeaseMs(this.#env),
+    }];
+    await this.#persistSponsoredConnections(next);
+    return json({ acquired: true }, 200);
+  }
+
+  async #persistSponsoredConnections(connections: readonly SponsoredConnection[]): Promise<void> {
+    if (connections.length === 0) {
+      await this.#state.storage.delete(SPONSORED_CONNECTION_STATE_KEY);
+      return;
+    }
+    await this.#state.storage.put(SPONSORED_CONNECTION_STATE_KEY, {
+      connections,
+    } satisfies SponsoredConnectionState);
+  }
+
   async #ensureRootWallet(): Promise<RootWallet> {
     const current = this.#credentials.wallet;
     if (current) return current;
@@ -816,6 +1184,7 @@ export class UserCredentialBroker extends DurableObject<BrokerEnv> {
         fedramp: current.fedramp,
         expiresAt: current.expiresAt,
         revision: current.revision,
+        ...(current.provenance ? { provenance: current.provenance } : {}),
       };
     }
     let credential = current;
@@ -840,6 +1209,7 @@ export class UserCredentialBroker extends DurableObject<BrokerEnv> {
       fedramp: credential.fedramp,
       expiresAt: credential.expiresAt,
       revision: credential.revision,
+      ...(credential.provenance ? { provenance: credential.provenance } : {}),
     };
   }
 
@@ -912,7 +1282,7 @@ export class UserCredentialBroker extends DurableObject<BrokerEnv> {
       throw new BrokerFailure(503, "invalid_chatgpt_login_response");
     }
     const tokens = await exchangeAuthorizationCode(issuer, authorizationCode, codeVerifier);
-    this.#credentials.chatgpt = credentialFromTokens(tokens, undefined, 0);
+    this.#credentials.chatgpt = credentialFromTokens(tokens, undefined, 0, "user");
     this.#credentials.active = "chatgpt";
     delete this.#credentials.login;
     await this.#persist();
@@ -920,11 +1290,10 @@ export class UserCredentialBroker extends DurableObject<BrokerEnv> {
     return { state: "authenticated", account_id: this.#credentials.chatgpt.accountId };
   }
 
-  async #claimLocalBootstrap(): Promise<void> {
+  async #claimLocalBootstrap(provenance: "user" | "sponsor"): Promise<void> {
     if (!localCredentialClaimEnabled(this.#env)) {
       throw new BrokerFailure(404, "not_found");
     }
-    if (this.#credentials.chatgpt && !this.#credentials.chatgpt.deadReason) return;
     const raw = this.#env.LOCAL_CHATGPT_BOOTSTRAP?.trim();
     if (!raw) throw new BrokerFailure(503, "local_chatgpt_bootstrap_unavailable");
     let parsed: unknown;
@@ -936,13 +1305,22 @@ export class UserCredentialBroker extends DurableObject<BrokerEnv> {
     if (!accessToken || !accountId || !expiresAt || expiresAt <= Date.now()) {
       throw new BrokerFailure(503, "invalid_local_chatgpt_bootstrap");
     }
+    const current = this.#credentials.chatgpt;
+    if (current && !current.deadReason) {
+      if (current.accessToken !== accessToken || current.accountId !== accountId) return;
+      if (current.provenance === provenance) return;
+      this.#credentials.chatgpt = { ...current, provenance };
+      await this.#persist();
+      return;
+    }
     this.#credentials.chatgpt = {
       accessToken,
       refreshToken: stringField(parsed, "refresh_token") ?? "",
       accountId,
       fedramp: parsed.fedramp === true,
       expiresAt,
-      revision: (this.#credentials.chatgpt?.revision ?? -1) + 1,
+      revision: (current?.revision ?? -1) + 1,
+      provenance,
       refreshState: "ready",
       deadReason: null,
     };
@@ -957,6 +1335,10 @@ export class UserCredentialBroker extends DurableObject<BrokerEnv> {
     if (current && !current.deadReason) {
       if (current.accountId !== imported.account_id) {
         throw new BrokerFailure(409, "chatgpt_account_conflict");
+      }
+      if (current.provenance !== "user") {
+        this.#credentials.chatgpt = { ...current, provenance: "user" };
+        await this.#persist();
       }
       return;
     }
@@ -973,6 +1355,7 @@ export class UserCredentialBroker extends DurableObject<BrokerEnv> {
         fedramp: imported.fedramp,
         expiresAt: imported.expires_at,
         revision: (current?.revision ?? -1) + 1,
+        provenance: "user",
         refreshState: "ready",
         deadReason: null,
       },
@@ -1482,6 +1865,7 @@ function credentialFromTokens(
   tokens: Record<string, unknown>,
   previous: ChatGptCredential | undefined,
   revision: number,
+  provenance: ChatGptCredential["provenance"] = previous?.provenance,
 ): ChatGptCredential {
   const accessToken = stringField(tokens, "access_token");
   const claims = idTokenClaims(stringField(tokens, "id_token"));
@@ -1498,6 +1882,7 @@ function credentialFromTokens(
     fedramp: claims.fedramp ?? previous?.fedramp ?? false,
     expiresAt,
     revision,
+    ...(provenance ? { provenance } : {}),
     refreshState: "ready",
     deadReason: null,
   };
@@ -1894,10 +2279,9 @@ function localCredentialClaimEnabled(env: BrokerEnv): boolean {
     && (environment === "development" || environment === "local" || environment === "test");
 }
 
-function localCredentialAutoClaimEnabled(env: BrokerEnv): boolean {
+function localSponsoredTrialResetEnabled(env: BrokerEnv): boolean {
   return localCredentialClaimEnabled(env)
-    && env.NANOCODEX_LOCAL_CHATGPT_AUTO_CLAIM === "true"
-    && Boolean(env.LOCAL_CHATGPT_BOOTSTRAP?.trim());
+    && env.NANOCODEX_LOCAL_SPONSORED_TRIAL_RESET === "true";
 }
 
 function parseExpiry(value: unknown): number | undefined {
@@ -1970,6 +2354,89 @@ function positiveNumber(value: unknown): number | undefined {
 function positiveNumberString(value: unknown): number | undefined {
   if (typeof value !== "string" || !/^[1-9][0-9]*$/.test(value)) return undefined;
   return positiveNumber(Number(value));
+}
+function sponsoredConnections(value: unknown): readonly SponsoredConnection[] {
+  if (value === undefined) return [];
+  if (!isRecord(value)
+    || Object.keys(value).length !== 1
+    || !Array.isArray(value.connections)
+    || value.connections.length > SPONSORED_CONNECTION_LIMIT
+    || value.connections.some((connection) => !isRecord(connection)
+      || Object.keys(connection).length !== 2
+      || typeof connection.id !== "string"
+      || !SPONSORED_CONNECTION_ID.test(connection.id)
+      || !Number.isSafeInteger(connection.leaseExpiresAt)
+      || (connection.leaseExpiresAt as number) <= 0)
+    || new Set(value.connections.map((connection) => (
+      (connection as Record<string, unknown>).id
+    ))).size !== value.connections.length) {
+    throw new BrokerFailure(503, "sponsored_connection_state_invalid");
+  }
+  return value.connections as readonly SponsoredConnection[];
+}
+function sponsoredPrompts(
+  value: unknown,
+): readonly SponsoredPrompt[] {
+  if (value === undefined) return [];
+  if (!isRecord(value)
+    || Object.keys(value).length !== 1
+    || !Array.isArray(value.prompts)
+    || value.prompts.length > SPONSORED_PROMPT_LIMIT
+    || value.prompts.some((prompt) => !isRecord(prompt)
+      || Object.keys(prompt).some((key) => ![
+        "id", "hash", "phase", "attempts", "leaseExpiresAt", "continuation",
+      ].includes(key))
+      || Object.keys(prompt).length < 4
+      || typeof prompt.id !== "string"
+      || !SPONSORED_PROMPT_ID.test(prompt.id)
+      || typeof prompt.hash !== "string"
+      || !SPONSORED_PROMPT_HASH.test(prompt.hash)
+      || (prompt.phase !== "in_flight" && prompt.phase !== "retryable"
+        && prompt.phase !== "continuation" && prompt.phase !== "terminal")
+      || !Number.isSafeInteger(prompt.attempts)
+      || (prompt.attempts as number) < 1
+      || (prompt.attempts as number) > SPONSORED_PROMPT_MAX_ATTEMPTS
+      || (prompt.phase === "in_flight") !== (Number.isSafeInteger(prompt.leaseExpiresAt)
+        && (prompt.leaseExpiresAt as number) > 0)
+      || (prompt.phase !== "in_flight" && prompt.leaseExpiresAt !== undefined)
+      || (prompt.phase === "continuation") !== validSponsoredContinuation(prompt.continuation)
+      || (prompt.phase !== "continuation" && prompt.continuation !== undefined))
+    || new Set(value.prompts.map((prompt) => (prompt as Record<string, unknown>).id)).size
+      !== value.prompts.length) {
+    throw new BrokerFailure(503, "sponsored_prompt_state_invalid");
+  }
+  return value.prompts as readonly SponsoredPrompt[];
+}
+function validSponsoredContinuation(value: unknown): boolean {
+  return isRecord(value)
+    && Object.keys(value).length === 2
+    && typeof value.responseId === "string"
+    && SPONSORED_RESPONSE_ID.test(value.responseId)
+    && sponsoredCallIds(value.callIds) !== undefined;
+}
+function sponsoredCallIds(value: unknown): readonly string[] | undefined {
+  if (!Array.isArray(value) || value.length === 0 || value.length > MAX_SPONSORED_CALL_IDS
+    || value.some((callId) => typeof callId !== "string" || !SPONSORED_CALL_ID.test(callId))) {
+    return undefined;
+  }
+  const unique = [...new Set(value as string[])].sort();
+  return unique.length === value.length ? unique : undefined;
+}
+function isStringSubset(required: readonly string[], supplied: readonly string[]): boolean {
+  const values = new Set(supplied);
+  return required.every((value) => values.has(value));
+}
+function sponsoredPromptStatus(prompts: readonly unknown[]) {
+  return {
+    limit: SPONSORED_PROMPT_LIMIT,
+    used: prompts.length,
+    remaining: SPONSORED_PROMPT_LIMIT - prompts.length,
+  };
+}
+function sponsoredPromptLeaseMs(env: BrokerEnv): number {
+  return env.ENVIRONMENT?.trim().toLowerCase() === "test"
+    ? TEST_SPONSORED_PROMPT_LEASE_MS
+    : SPONSORED_PROMPT_LEASE_MS;
 }
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);

--- a/js/egress/src/egress.ts
+++ b/js/egress/src/egress.ts
@@ -42,11 +42,19 @@ export { McpConnectionDirectory } from "./mcp-connection-owner";
 const SUBJECT_DIRECTORY_PREFIX = "agent-subject-v1:";
 const READINESS_SUBJECT_DIRECTORY_NAME = "agent-subject-readiness-v1";
 const SUBJECT = /^[A-Za-z0-9_-]{43,128}$/;
+const EPHEMERAL_BROWSER_MODEL_SUBJECT = /^[A-Za-z0-9_-]{43}$/;
+const SPONSORED_PROMPT_ID = /^[A-Za-z][A-Za-z0-9_-]{1,127}$/;
+const SPONSORED_RESPONSE_ID = /^[A-Za-z][A-Za-z0-9._:-]{1,199}$/;
+const SPONSORED_CALL_ID = /^[A-Za-z][A-Za-z0-9._:-]{1,199}$/;
+const MAX_SPONSORED_CALL_IDS = 64;
+const MAX_SPONSORED_RESPONSES_FRAME_CHARS = 16 * 1024 * 1024;
 const USER_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const CHIEF_USER_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const SUBJECT_HEADER = "x-nanocodex-subject";
+const CREDENTIAL_PROVENANCE_HEADER = "x-nanocodex-credential-provenance";
 const PROVIDER_PLACEHOLDER = "Bearer NANOCODEX_PROVIDER_CREDENTIAL";
 const MODEL_STATUS_PATH = "/.well-known/nanocodex/model-status";
+const SPONSORED_TRIAL_RESET_PATH = "/.well-known/nanocodex/sponsored-trial-reset";
 const BROKER_READINESS_PATH = "/.well-known/nanocodex/broker-readiness";
 const MAX_CONTROL_BODY_BYTES = 16 * 1024;
 const MAX_CHATGPT_IMPORT_BODY_BYTES = 64 * 1024;
@@ -284,7 +292,7 @@ export default {
 export async function handleEgress(
   request: Request,
   env: EgressEnv,
-  _ctx?: Pick<ExecutionContext, "waitUntil">,
+  ctx?: Pick<ExecutionContext, "waitUntil">,
   upstreamFetch: typeof fetch = fetch,
   diagnostics?: Readonly<{ upstreamException(error: Readonly<{ name: string }>): void }>,
 ): Promise<Response> {
@@ -318,6 +326,9 @@ export async function handleEgress(
   }
   if (url.pathname === BROKER_READINESS_PATH) return handleReadiness(request, env);
   if (url.pathname === MODEL_STATUS_PATH) return handleModelStatus(request, env);
+  if (url.pathname === SPONSORED_TRIAL_RESET_PATH) {
+    return handleSponsoredTrialReset(request, env);
+  }
 
   const operation = OPERATIONS.find((candidate) => (
     candidate.method === request.method && candidate.path === url.pathname
@@ -352,33 +363,21 @@ export async function handleEgress(
   let userId: string | undefined;
   try {
     userId = await resolveSubject(env, subject);
-    let credential = await resolveCredential(env, userId, false);
+    const sponsoredDemo = EPHEMERAL_BROWSER_MODEL_SUBJECT.test(subject)
+      && operation.id === "responses";
+    let credential = await resolveCredential(env, userId, false, undefined, sponsoredDemo);
     if (operation.chatGptOnly && credential.kind !== "chatgpt") {
       return auditedError(409, "chatgpt_credential_required", request, url, operation.id, started, {
         user_id: userId,
         deployment_sha: env.DEPLOYMENT_SHA,
       });
     }
-    const body = await replayableBody(request, operation);
-    let upstream = await fetchUpstream(
-      env,
-      userId,
-      credential,
-      operation,
-      buildUpstreamRequest(request, env, operation, credential, body),
-      upstreamFetch,
-    );
-    let recovered = false;
-    if (upstream.status === 401 && credential.kind === "chatgpt") {
-      await cancelResponseBody(upstream);
-      credential = await resolveCredential(env, userId, true, credential.revision);
-      if (operation.chatGptOnly && credential.kind !== "chatgpt") {
-        return auditedError(409, "chatgpt_credential_required", request, url, operation.id, started, {
-          user_id: userId,
-          deployment_sha: env.DEPLOYMENT_SHA,
-        });
-      }
-      upstream = await fetchUpstream(
+    let sponsoredConnectionId = credential.source === "sponsored" && operation.id === "responses"
+      ? await acquireSponsoredConnection(env, userId)
+      : undefined;
+    try {
+      const body = await replayableBody(request, operation);
+      let upstream = await fetchUpstream(
         env,
         userId,
         credential,
@@ -386,39 +385,84 @@ export async function handleEgress(
         buildUpstreamRequest(request, env, operation, credential, body),
         upstreamFetch,
       );
-      recovered = true;
-    }
-    if (REDIRECT_STATUS.has(upstream.status)) {
-      await cancelResponseBody(upstream);
-      return auditedError(502, "upstream_redirect_blocked", request, url, operation.id, started, {
+      let recovered = false;
+      if (upstream.status === 401 && credential.kind === "chatgpt") {
+        await cancelResponseBody(upstream);
+        credential = await resolveCredential(
+          env,
+          userId,
+          true,
+          credential.revision,
+          sponsoredDemo,
+        );
+        if (operation.chatGptOnly && credential.kind !== "chatgpt") {
+          return auditedError(409, "chatgpt_credential_required", request, url, operation.id, started, {
+            user_id: userId,
+            deployment_sha: env.DEPLOYMENT_SHA,
+          });
+        }
+        upstream = await fetchUpstream(
+          env,
+          userId,
+          credential,
+          operation,
+          buildUpstreamRequest(request, env, operation, credential, body),
+          upstreamFetch,
+        );
+        recovered = true;
+      }
+      if (REDIRECT_STATUS.has(upstream.status)) {
+        await cancelResponseBody(upstream);
+        return auditedError(502, "upstream_redirect_blocked", request, url, operation.id, started, {
+          user_id: userId,
+          deployment_sha: env.DEPLOYMENT_SHA,
+        });
+      }
+      if (upstream.status >= 400) {
+        const upstreamStatus = upstream.status;
+        await cancelResponseBody(upstream);
+        return auditedError(
+          upstreamStatus === 429 ? 503 : 502,
+          "upstream_rejected",
+          request,
+          url,
+          operation.id,
+          started,
+          {
+            upstream_status: upstreamStatus,
+            user_id: userId,
+            deployment_sha: env.DEPLOYMENT_SHA,
+          },
+        );
+      }
+      audit("allow", request, url, operation.id, started, {
+        status: upstream.status,
+        recovered,
+        model_source: credential.source,
         user_id: userId,
         deployment_sha: env.DEPLOYMENT_SHA,
       });
+      if (credential.source === "sponsored" && operation.id === "responses") {
+        if (!sponsoredConnectionId) {
+          throw new EgressFailure(503, "sponsored_connection_lease_unavailable");
+        }
+        const response = sponsoredResponsesWebSocket(
+          upstream,
+          env,
+          userId,
+          sponsoredConnectionId,
+          ctx,
+        );
+        sponsoredConnectionId = undefined;
+        return response;
+      }
+      return sanitizeUpstreamResponse(upstream);
+    } finally {
+      if (sponsoredConnectionId) {
+        await updateSponsoredConnection(env, userId, sponsoredConnectionId, "release")
+          .catch(logSponsoredConnectionReleaseFailure);
+      }
     }
-    if (upstream.status >= 400) {
-      const upstreamStatus = upstream.status;
-      await cancelResponseBody(upstream);
-      return auditedError(
-        upstreamStatus === 429 ? 503 : 502,
-        "upstream_rejected",
-        request,
-        url,
-        operation.id,
-        started,
-        {
-          upstream_status: upstreamStatus,
-          user_id: userId,
-          deployment_sha: env.DEPLOYMENT_SHA,
-        },
-      );
-    }
-    audit("allow", request, url, operation.id, started, {
-      status: upstream.status,
-      recovered,
-      user_id: userId,
-      deployment_sha: env.DEPLOYMENT_SHA,
-    });
-    return sanitizeUpstreamResponse(upstream);
   } catch (error) {
     const problem = egressFailure(error);
     if (!(error instanceof EgressFailure)) {
@@ -877,7 +921,16 @@ function sanitizeUpstreamResponse(upstream: Response): Response {
   // An upgraded socket must be returned intact. Its peer is the explicitly
   // trusted provider/relay selected by the fixed rule, never caller input.
   if (upstream.webSocket) return upstream;
-  const headers = new Headers(upstream.headers);
+  const headers = sanitizedUpstreamHeaders(upstream.headers);
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers,
+  });
+}
+
+function sanitizedUpstreamHeaders(source: Headers): Headers {
+  const headers = new Headers(source);
   for (const name of [
     "authorization",
     "chatgpt-account-id",
@@ -886,11 +939,677 @@ function sanitizeUpstreamResponse(upstream: Response): Response {
     "set-cookie",
     "x-openai-fedramp",
   ]) headers.delete(name);
-  return new Response(upstream.body, {
-    status: upstream.status,
-    statusText: upstream.statusText,
-    headers,
+  return headers;
+}
+
+type SponsoredPromptStatus = Readonly<{
+  limit: number;
+  used: number;
+  remaining: number;
+}>;
+
+async function acquireSponsoredConnection(env: EgressEnv, userId: string): Promise<string> {
+  const connectionId = crypto.randomUUID();
+  const response = await userBroker(env, userId).fetch(
+    "https://credentials.internal/v1/sponsored-connections",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ action: "acquire", connection_id: connectionId }),
+    },
+  );
+  if (response.status === 402) {
+    await cancelResponseBody(response);
+    throw new EgressFailure(402, "sponsored_prompt_limit_reached");
+  }
+  if (response.status === 429) {
+    await cancelResponseBody(response);
+    throw new EgressFailure(429, "sponsored_connection_limit_reached");
+  }
+  if (response.status !== 200) {
+    await cancelResponseBody(response);
+    throw new EgressFailure(503, "sponsored_connection_lease_unavailable");
+  }
+  let value: unknown;
+  try { value = JSON.parse(await readBoundedText(response, 1_024)); }
+  catch { throw new EgressFailure(503, "invalid_sponsored_connection_lease"); }
+  if (!isRecord(value) || value.acquired !== true) {
+    throw new EgressFailure(503, "invalid_sponsored_connection_lease");
+  }
+  return connectionId;
+}
+
+async function updateSponsoredConnection(
+  env: EgressEnv,
+  userId: string,
+  connectionId: string,
+  action: "heartbeat" | "release",
+): Promise<boolean> {
+  const response = await userBroker(env, userId).fetch(
+    "https://credentials.internal/v1/sponsored-connections",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ action, connection_id: connectionId }),
+    },
+  );
+  if (response.status !== 200) {
+    await cancelResponseBody(response);
+    throw new EgressFailure(503, "sponsored_connection_lease_unavailable");
+  }
+  let value: unknown;
+  try { value = JSON.parse(await readBoundedText(response, 1_024)); }
+  catch { throw new EgressFailure(503, "invalid_sponsored_connection_lease"); }
+  if (!isRecord(value) || typeof value.updated !== "boolean") {
+    throw new EgressFailure(503, "invalid_sponsored_connection_lease");
+  }
+  return value.updated;
+}
+
+function logSponsoredConnectionReleaseFailure(error: unknown): void {
+  console.error({
+    type: "sponsored_connection.release_failed",
+    error_kind: error instanceof Error ? error.name : typeof error,
   });
+}
+
+async function sponsoredPromptStatus(
+  env: EgressEnv,
+  userId: string,
+): Promise<SponsoredPromptStatus> {
+  const response = await userBroker(env, userId).fetch(
+    "https://credentials.internal/v1/sponsored-prompts",
+  );
+  if (response.status !== 200) {
+    await cancelResponseBody(response);
+    throw new EgressFailure(503, "sponsored_prompt_status_unavailable");
+  }
+  return parseSponsoredPromptStatus(response);
+}
+
+async function reserveSponsoredPrompt(
+  env: EgressEnv,
+  userId: string,
+  promptId: string,
+  promptHash: string,
+  cancelled: () => boolean = () => false,
+): Promise<{
+  allowed: boolean;
+  attempt?: number;
+  dispatch: boolean;
+  status: SponsoredPromptStatus;
+}> {
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    if (cancelled()) throw new EgressFailure(409, "sponsored_prompt_socket_closed");
+    const response = await userBroker(env, userId).fetch(
+      "https://credentials.internal/v1/sponsored-prompts",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ prompt_id: promptId, prompt_hash: promptHash }),
+      },
+    );
+    if (response.status !== 200 && response.status !== 402) {
+      await cancelResponseBody(response);
+      throw new EgressFailure(503, "sponsored_prompt_reservation_unavailable");
+    }
+    let value: unknown;
+    try { value = JSON.parse(await readBoundedText(response, 1_024)); }
+    catch { throw new EgressFailure(503, "invalid_sponsored_prompt_status"); }
+    const pending = response.status === 200 && isRecord(value) && value.pending === true;
+    if (pending && attempt < 3) {
+      const retryAfterMs = isRecord(value) && Number.isSafeInteger(value.retry_after_ms)
+        ? value.retry_after_ms as number
+        : -1;
+      if (retryAfterMs < 0 || retryAfterMs > 15_000) {
+        throw new EgressFailure(503, "invalid_sponsored_prompt_retry_lease");
+      }
+      await new Promise((resolve) => setTimeout(resolve, retryAfterMs + 5));
+      if (cancelled()) throw new EgressFailure(409, "sponsored_prompt_socket_closed");
+      continue;
+    }
+    return {
+      allowed: response.status === 200,
+      ...(response.status === 200 && isRecord(value)
+        && Number.isSafeInteger(value.attempt)
+        && (value.attempt as number) >= 1
+        && (value.attempt as number) <= 2
+        ? { attempt: value.attempt as number }
+        : {}),
+      dispatch: response.status === 200 && isRecord(value) && value.dispatch === true,
+      status: parseSponsoredPromptStatusValue(value),
+    };
+  }
+  throw new EgressFailure(503, "sponsored_prompt_reservation_unavailable");
+}
+
+async function parseSponsoredPromptStatus(response: Response): Promise<SponsoredPromptStatus> {
+  let value: unknown;
+  try {
+    value = JSON.parse(await readBoundedText(response, 1_024));
+  } catch {
+    throw new EgressFailure(503, "invalid_sponsored_prompt_status");
+  }
+  return parseSponsoredPromptStatusValue(value);
+}
+
+function parseSponsoredPromptStatusValue(value: unknown): SponsoredPromptStatus {
+  if (!isRecord(value)
+    || value.limit !== 3
+    || !Number.isSafeInteger(value.used)
+    || !Number.isSafeInteger(value.remaining)
+    || (value.used as number) < 0
+    || (value.remaining as number) < 0
+    || (value.used as number) + (value.remaining as number) !== 3) {
+    throw new EgressFailure(503, "invalid_sponsored_prompt_status");
+  }
+  return {
+    limit: 3,
+    used: value.used as number,
+    remaining: value.remaining as number,
+  };
+}
+
+async function grantSponsoredContinuation(
+  env: EgressEnv,
+  userId: string,
+  promptId: string,
+  attempt: number,
+  responseId: string,
+  callIds: readonly string[],
+): Promise<void> {
+  const response = await userBroker(env, userId).fetch(
+    "https://credentials.internal/v1/sponsored-prompts/continuation",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        action: "grant",
+        prompt_id: promptId,
+        attempt,
+        response_id: responseId,
+        call_ids: callIds,
+      }),
+    },
+  );
+  if (response.status !== 200) {
+    await cancelResponseBody(response);
+    throw new EgressFailure(503, "sponsored_continuation_grant_unavailable");
+  }
+  await cancelResponseBody(response);
+}
+
+async function consumeSponsoredContinuation(
+  env: EgressEnv,
+  userId: string,
+  callIds: readonly string[],
+  options?: Readonly<{
+    responseId?: string;
+    promptId?: string;
+    promptHash?: string;
+  }>,
+): Promise<Readonly<{ promptId: string; attempt: number }> | undefined> {
+  const response = await userBroker(env, userId).fetch(
+    "https://credentials.internal/v1/sponsored-prompts/continuation",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        action: "consume",
+        ...(options?.responseId ? { response_id: options.responseId } : {}),
+        ...(options?.promptId ? { prompt_id: options.promptId } : {}),
+        ...(options?.promptHash ? { prompt_hash: options.promptHash } : {}),
+        call_ids: callIds,
+      }),
+    },
+  );
+  if (response.status === 409) {
+    await cancelResponseBody(response);
+    return undefined;
+  }
+  if (response.status !== 200) {
+    await cancelResponseBody(response);
+    throw new EgressFailure(409, "sponsored_continuation_unavailable");
+  }
+  let value: unknown;
+  try { value = JSON.parse(await readBoundedText(response, 1_024)); }
+  catch { throw new EgressFailure(503, "invalid_sponsored_continuation"); }
+  const promptId = stringField(value, "prompt_id");
+  const attempt = isRecord(value) && Number.isSafeInteger(value.attempt)
+    ? value.attempt as number
+    : undefined;
+  if (!promptId || !SPONSORED_PROMPT_ID.test(promptId)
+    || !attempt || attempt > 2) {
+    throw new EgressFailure(503, "invalid_sponsored_continuation");
+  }
+  return { promptId, attempt };
+}
+
+async function setSponsoredPromptLifecycle(
+  env: EgressEnv,
+  userId: string,
+  promptId: string,
+  attempt: number,
+  action: "terminal" | "interrupted" | "heartbeat",
+): Promise<"updated" | "settled"> {
+  const response = await userBroker(env, userId).fetch(
+    "https://credentials.internal/v1/sponsored-prompts/lifecycle",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ action, prompt_id: promptId, attempt }),
+    },
+  );
+  if (response.status !== 200) {
+    await cancelResponseBody(response);
+    throw new EgressFailure(503, "sponsored_prompt_lifecycle_unavailable");
+  }
+  let value: unknown;
+  try { value = JSON.parse(await readBoundedText(response, 1_024)); }
+  catch { throw new EgressFailure(503, "invalid_sponsored_prompt_lifecycle"); }
+  if (isRecord(value) && value.updated === true) return "updated";
+  if (action === "heartbeat" && isRecord(value)
+    && value.updated === false && value.settled === true) return "settled";
+  throw new EgressFailure(409, "sponsored_prompt_attempt_stale");
+}
+
+async function publishSponsoredInterruption(
+  env: EgressEnv,
+  userId: string,
+  promptId: string,
+  attempt: number,
+): Promise<void> {
+  let failure: unknown;
+  for (let retry = 0; retry < 3; retry += 1) {
+    try {
+      await setSponsoredPromptLifecycle(env, userId, promptId, attempt, "interrupted");
+      return;
+    } catch (error) {
+      failure = error;
+    }
+  }
+  throw failure;
+}
+
+function sponsoredResponsesWebSocket(
+  upstreamResponse: Response,
+  env: EgressEnv,
+  userId: string,
+  connectionId: string,
+  ctx?: Pick<ExecutionContext, "waitUntil">,
+): Response {
+  const upstream = upstreamResponse.webSocket;
+  if (!upstream) throw new EgressFailure(502, "sponsored_responses_upgrade_missing");
+  const pair = new WebSocketPair();
+  const [client, server] = Object.values(pair);
+  upstream.accept();
+  server.accept();
+  let closed = false;
+  let activePromptId: string | undefined;
+  let activeAttempt: number | undefined;
+  let generationInFlight = false;
+  let clientTail = Promise.resolve();
+  let upstreamTail = Promise.resolve();
+  let heartbeat: ReturnType<typeof setInterval> | undefined;
+  let heartbeatRunning = false;
+  let connectionHeartbeat: ReturnType<typeof setInterval> | undefined;
+  let connectionHeartbeatRunning = false;
+  let connectionReleased = false;
+
+  const retain = (promise: Promise<void>) => {
+    if (ctx) ctx.waitUntil(promise);
+    else void promise;
+  };
+
+  const interruptActiveGeneration = () => {
+    if (!generationInFlight || !activePromptId || !activeAttempt) return;
+    generationInFlight = false;
+    const publication = publishSponsoredInterruption(
+      env,
+      userId,
+      activePromptId,
+      activeAttempt,
+    ).catch((error) => {
+      console.error({
+        type: "sponsored_prompt.interruption_failed",
+        error_kind: error instanceof Error ? error.name : typeof error,
+      });
+    });
+    retain(publication);
+  };
+
+  const releaseConnection = () => {
+    if (connectionReleased) return;
+    connectionReleased = true;
+    retain(updateSponsoredConnection(env, userId, connectionId, "release")
+      .then(() => undefined)
+      .catch(logSponsoredConnectionReleaseFailure));
+  };
+
+  const close = (code: number, reason: string, retryActive = false) => {
+    if (closed) return;
+    if (retryActive) interruptActiveGeneration();
+    closed = true;
+    if (heartbeat !== undefined) clearInterval(heartbeat);
+    if (connectionHeartbeat !== undefined) clearInterval(connectionHeartbeat);
+    releaseConnection();
+    closeSponsoredSocket(server, code, reason);
+    closeSponsoredSocket(upstream, code, reason);
+  };
+
+  const heartbeatMs = env.ENVIRONMENT?.trim().toLowerCase() === "test" ? 75 : 5_000;
+  heartbeat = setInterval(() => {
+    if (closed || !generationInFlight || !activePromptId || !activeAttempt || heartbeatRunning) return;
+    heartbeatRunning = true;
+    const renewal = setSponsoredPromptLifecycle(
+      env,
+      userId,
+      activePromptId,
+      activeAttempt,
+      "heartbeat",
+    ).then(() => undefined)
+      .catch(() => close(1011, "sponsored prompt heartbeat failed", true))
+      .finally(() => { heartbeatRunning = false; });
+    retain(renewal);
+  }, heartbeatMs);
+  connectionHeartbeat = setInterval(() => {
+    if (closed || connectionHeartbeatRunning) return;
+    connectionHeartbeatRunning = true;
+    const renewal = updateSponsoredConnection(env, userId, connectionId, "heartbeat")
+      .then((updated) => {
+        if (!updated) close(1011, "sponsored connection lease lost", true);
+      })
+      .catch(() => close(1011, "sponsored connection heartbeat failed", true))
+      .finally(() => { connectionHeartbeatRunning = false; });
+    retain(renewal);
+  }, heartbeatMs);
+
+  server.addEventListener("message", (event) => {
+    clientTail = clientTail.then(async () => {
+      if (closed) return;
+      if (typeof event.data !== "string"
+        || event.data.length > MAX_SPONSORED_RESPONSES_FRAME_CHARS) {
+        close(4002, "invalid sponsored prompt frame");
+        return;
+      }
+      const frame = sponsoredResponsesFrame(event.data);
+      if (!frame.valid) {
+        close(4002, "invalid sponsored prompt frame");
+        return;
+      }
+      if (frame.generation) {
+        if (generationInFlight) {
+          close(4002, "sponsored generation already in flight");
+          return;
+        }
+        let continuationClaim: Readonly<{ promptId: string; attempt: number }> | undefined;
+        if (frame.continuation
+          && (frame.continuation.responseId || (frame.promptId && frame.prompt))) {
+          const promptHash = frame.prompt ? await sponsoredPromptHash(frame.prompt) : undefined;
+          continuationClaim = await consumeSponsoredContinuation(
+            env,
+            userId,
+            frame.continuation.callIds,
+            {
+              ...(frame.continuation.responseId
+                ? { responseId: frame.continuation.responseId }
+                : {}),
+              ...(frame.promptId ? { promptId: frame.promptId } : {}),
+              ...(promptHash ? { promptHash } : {}),
+            },
+          );
+        }
+        if (continuationClaim) {
+          activePromptId = continuationClaim.promptId;
+          activeAttempt = continuationClaim.attempt;
+        } else if (frame.promptId) {
+          const promptHash = await sponsoredPromptHash(frame.prompt);
+          const reservation = await reserveSponsoredPrompt(
+            env,
+            userId,
+            frame.promptId,
+            promptHash,
+            () => closed
+              || server.readyState !== WebSocket.OPEN
+              || upstream.readyState !== WebSocket.OPEN,
+          );
+          if (!reservation.allowed) {
+            sendSponsoredPromptError(server);
+            close(4003, "three free prompts used");
+            return;
+          }
+          if (!reservation.dispatch) {
+            sendSponsoredProtocolError(
+              server,
+              "sponsored_prompt_replay",
+              "This free prompt was already dispatched.",
+            );
+            close(4002, "sponsored prompt already dispatched");
+            return;
+          }
+          if (!reservation.attempt) {
+            close(1011, "sponsored prompt attempt unavailable");
+            return;
+          }
+          activePromptId = frame.promptId;
+          activeAttempt = reservation.attempt;
+        } else {
+          close(4002, "sponsored prompt identity required");
+          return;
+        }
+        generationInFlight = true;
+      }
+      if (upstream.readyState === WebSocket.OPEN) upstream.send(frame.encoded);
+    }).catch(() => close(1011, "sponsored prompt check failed"));
+  });
+  upstream.addEventListener("message", (event) => {
+    upstreamTail = upstreamTail.then(async () => {
+      if (closed) return;
+      if (typeof event.data === "string") {
+        const providerFrame = sponsoredProviderFrame(event.data);
+        if (providerFrame.grant) {
+          if (!activePromptId || !activeAttempt) {
+            throw new EgressFailure(503, "sponsored_prompt_identity_unavailable");
+          }
+          await grantSponsoredContinuation(
+            env,
+            userId,
+            activePromptId,
+            activeAttempt,
+            providerFrame.grant.responseId,
+            providerFrame.grant.callIds,
+          );
+        } else if (providerFrame.terminal && activePromptId && activeAttempt) {
+          await setSponsoredPromptLifecycle(
+            env,
+            userId,
+            activePromptId,
+            activeAttempt,
+            "terminal",
+          );
+        }
+        if (providerFrame.terminal) generationInFlight = false;
+      }
+      if (server.readyState === WebSocket.OPEN) server.send(event.data);
+    }).catch(() => close(1011, "sponsored continuation check failed"));
+  });
+  server.addEventListener("close", (event) => {
+    close(event.code, event.reason || "client closed", true);
+  });
+  server.addEventListener("error", () => close(1011, "client WebSocket failed", true));
+  upstream.addEventListener("close", (event) => {
+    close(event.code, event.reason || "provider closed", true);
+  });
+  upstream.addEventListener("error", () => close(1011, "provider WebSocket failed", true));
+
+  return new Response(null, {
+    status: 101,
+    headers: sanitizedUpstreamHeaders(upstreamResponse.headers),
+    webSocket: client,
+  });
+}
+
+export function sponsoredResponsesFrame(encoded: string): Readonly<{
+  valid: boolean;
+  generation: boolean;
+  encoded: string;
+  promptId?: string;
+  prompt?: Readonly<Record<string, unknown>>;
+  continuation?: Readonly<{ responseId?: string; callIds: readonly string[] }>;
+}> {
+  let value: unknown;
+  try { value = JSON.parse(encoded); } catch {
+    return { valid: false, generation: false, encoded };
+  }
+  if (!isRecord(value)) return { valid: false, generation: false, encoded };
+  if (value.type !== "response.create") {
+    return { valid: true, generation: false, encoded };
+  }
+  const canonical = canonicalSponsoredResponseCreate(value);
+  if (value.generate === false) {
+    return { valid: true, generation: false, encoded: JSON.stringify(canonical) };
+  }
+  const input = Array.isArray(value.input) ? value.input : [];
+  const continuation = sponsoredContinuation(value, input);
+  for (let index = input.length - 1; index >= 0; index -= 1) {
+    const item = input[index];
+    if (!isRecord(item) || item.type !== "message" || item.role !== "user") continue;
+    return typeof item.id === "string" && SPONSORED_PROMPT_ID.test(item.id)
+      ? {
+        valid: true,
+        generation: true,
+        encoded: JSON.stringify(canonical),
+        promptId: item.id,
+        prompt: item,
+        ...(continuation ? { continuation } : {}),
+      }
+      : {
+        valid: true,
+        generation: true,
+        encoded: JSON.stringify(canonical),
+        ...(continuation ? { continuation } : {}),
+      };
+  }
+  return {
+    valid: true,
+    generation: true,
+    encoded: JSON.stringify(canonical),
+    ...(continuation ? { continuation } : {}),
+  };
+}
+
+function canonicalSponsoredResponseCreate(
+  value: Readonly<Record<string, unknown>>,
+): Record<string, unknown> {
+  const reasoning = isRecord(value.reasoning) ? value.reasoning : {};
+  const canonical: Record<string, unknown> = {
+    ...value,
+    model: "gpt-5.6-luna",
+    reasoning: { ...reasoning, effort: "none", mode: "standard" },
+  };
+  delete canonical.service_tier;
+  return canonical;
+}
+
+function sponsoredContinuation(
+  value: Readonly<Record<string, unknown>>,
+  input: readonly unknown[],
+): Readonly<{ responseId?: string; callIds: readonly string[] }> | undefined {
+  const responseId = typeof value.previous_response_id === "string"
+    && SPONSORED_RESPONSE_ID.test(value.previous_response_id)
+    ? value.previous_response_id
+    : undefined;
+  const callIds: string[] = [];
+  for (const item of input) {
+    if (!isRecord(item) || typeof item.type !== "string"
+      || !/^(?:(?:custom_tool|function|computer)_call_output|tool_search_output)$/.test(item.type)) {
+      continue;
+    }
+    if (item.call_id === undefined && item.type === "tool_search_output") continue;
+    if (typeof item.call_id !== "string" || !SPONSORED_CALL_ID.test(item.call_id)) {
+      return undefined;
+    }
+    callIds.push(item.call_id);
+  }
+  const unique = [...new Set(callIds)].sort();
+  return unique.length > 0 && unique.length === callIds.length
+    && unique.length <= MAX_SPONSORED_CALL_IDS
+    ? { ...(responseId ? { responseId } : {}), callIds: unique }
+    : undefined;
+}
+
+function sponsoredProviderFrame(encoded: string): Readonly<{
+  terminal: boolean;
+  grant?: Readonly<{ responseId: string; callIds: readonly string[] }>;
+}> {
+  let value: unknown;
+  try { value = JSON.parse(encoded); } catch { return { terminal: false }; }
+  if (!isRecord(value)) return { terminal: false };
+  const terminal = value.type === "response.completed"
+    || value.type === "response.failed"
+    || value.type === "response.incomplete"
+    || value.type === "response.cancelled";
+  if (value.type !== "response.completed" || !isRecord(value.response)
+    || typeof value.response.id !== "string"
+    || !SPONSORED_RESPONSE_ID.test(value.response.id)
+    || !Array.isArray(value.response.output)) return { terminal };
+  const callIds = value.response.output.flatMap((item) => isRecord(item)
+    && (item.type === "custom_tool_call"
+      || item.type === "function_call"
+      || item.type === "computer_call"
+      || item.type === "tool_search_call")
+    && typeof item.call_id === "string"
+    && SPONSORED_CALL_ID.test(item.call_id)
+    ? [item.call_id]
+    : []);
+  const unique = [...new Set(callIds)].sort();
+  return unique.length > 0 && unique.length <= MAX_SPONSORED_CALL_IDS
+    ? { terminal, grant: { responseId: value.response.id, callIds: unique } }
+    : { terminal };
+}
+
+async function sponsoredPromptHash(prompt: Readonly<Record<string, unknown>> | undefined) {
+  if (!prompt) throw new EgressFailure(400, "sponsored_prompt_identity_required");
+  const bytes = new Uint8Array(await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(JSON.stringify(prompt)),
+  ));
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function sendSponsoredPromptError(socket: WebSocket): void {
+  sendSponsoredProtocolError(
+    socket,
+    "sponsored_prompt_limit_reached",
+    "Your three free prompts are used. Connect ChatGPT to continue.",
+    "usage_limit_error",
+  );
+}
+
+function sendSponsoredProtocolError(
+  socket: WebSocket,
+  code: string,
+  message: string,
+  type = "invalid_request_error",
+): void {
+  if (socket.readyState !== WebSocket.OPEN) return;
+  socket.send(JSON.stringify({
+    type: "error",
+    error: {
+      type,
+      code,
+      message,
+      param: null,
+    },
+  }));
+}
+
+function closeSponsoredSocket(socket: WebSocket, code: number, reason: string): void {
+  if (socket.readyState !== WebSocket.CONNECTING && socket.readyState !== WebSocket.OPEN) return;
+  const safeCode = code === 1000 || (code >= 3000 && code <= 4999) ? code : 1011;
+  socket.close(safeCode, reason.slice(0, 120));
 }
 
 async function handleControl(request: Request, url: URL, env: EgressEnv): Promise<Response> {
@@ -1171,6 +1890,7 @@ async function handleControl(request: Request, url: URL, env: EgressEnv): Promis
     if (await hasRequestPayload(request)) return jsonError(400, "invalid_request");
     return userBroker(env, userId).fetch("https://credentials.internal/v1/chatgpt/local-claim", {
       method: "POST",
+      headers: { [CREDENTIAL_PROVENANCE_HEADER]: "user" },
     });
   }
 
@@ -1279,9 +1999,56 @@ async function handleModelStatus(request: Request, env: EgressEnv): Promise<Resp
   if (!subject || !SUBJECT.test(subject)) return jsonError(403, "agent_subject_required");
   try {
     const userId = await resolveSubject(env, subject);
-    await resolveCredential(env, userId, false);
-    return json({ ready: true }, 200);
+    const credential = await resolveCredential(
+      env,
+      userId,
+      false,
+      undefined,
+      EPHEMERAL_BROWSER_MODEL_SUBJECT.test(subject),
+    );
+    const sponsoredPrompts = credential.source === "sponsored"
+      ? await sponsoredPromptStatus(env, userId)
+      : undefined;
+    return json({
+      ready: true,
+      active: credential.kind,
+      source: credential.source,
+      ...(sponsoredPrompts
+        ? { free_prompts_remaining: sponsoredPrompts.remaining }
+        : {}),
+    }, 200);
   } catch { return jsonError(503, "broker_not_ready"); }
+}
+
+async function handleSponsoredTrialReset(request: Request, env: EgressEnv): Promise<Response> {
+  if (!localSponsoredTrialResetEnabled(env)
+    || request.method !== "POST") {
+    return jsonError(404, "not_found");
+  }
+  const subject = request.headers.get(SUBJECT_HEADER);
+  if (!subject || !EPHEMERAL_BROWSER_MODEL_SUBJECT.test(subject)) {
+    return jsonError(403, "agent_subject_required");
+  }
+  try {
+    const userId = await resolveSubject(env, subject);
+    const credential = await resolveCredential(env, userId, false, undefined, true);
+    if (credential.source !== "sponsored") return jsonError(409, "sponsored_trial_unavailable");
+    const reset = await userBroker(env, userId).fetch(
+      "https://credentials.internal/v1/sponsored-prompts/reset",
+      { method: "POST" },
+    );
+    if (!reset.ok) {
+      await cancelResponseBody(reset);
+      return jsonError(503, "sponsored_trial_reset_failed");
+    }
+    const value = await reset.json<Record<string, unknown>>();
+    if (value.remaining !== 3 || value.used !== 0 || value.limit !== 3) {
+      return jsonError(503, "sponsored_trial_reset_failed");
+    }
+    return json({ free_prompts_remaining: 3 }, 200);
+  } catch {
+    return jsonError(503, "sponsored_trial_reset_failed");
+  }
 }
 
 function buildUpstreamRequest(
@@ -1480,6 +2247,82 @@ async function resolveCredential(
   userId: string,
   recover: boolean,
   revision?: number,
+  allowSponsored = false,
+): Promise<ResolvedModelCredential> {
+  try {
+    const credential = await resolveUserCredential(env, userId, recover, revision);
+    if (!isLegacyLocalBootstrapCredential(env, userId, credential)) {
+      return { ...credential, source: "user" };
+    }
+  } catch (error) {
+    if (!(error instanceof EgressFailure) || error.status !== 409) throw error;
+  }
+  if (!allowSponsored) throw new EgressFailure(409, "user_credential_unavailable");
+  return { ...await resolveSponsoredChatGptCredential(env, recover, revision), source: "sponsored" };
+}
+
+type ResolvedModelCredential = UserCredentialSnapshot & Readonly<{
+  source: "sponsored" | "user";
+}>;
+
+async function resolveSponsoredChatGptCredential(
+  env: EgressEnv,
+  recover: boolean,
+  revision?: number,
+): Promise<UserCredentialSnapshot> {
+  const sponsorUserId = env.NANOCODEX_SPONSORED_CHATGPT_USER_ID?.trim();
+  if (!sponsorUserId || !USER_ID.test(sponsorUserId)) {
+    throw new EgressFailure(409, "sponsored_chatgpt_unavailable");
+  }
+  if (localClaimEnabled(env)) {
+    const claimed = await userBroker(env, sponsorUserId).fetch(
+      "https://credentials.internal/v1/chatgpt/local-claim",
+      {
+        method: "POST",
+        headers: { [CREDENTIAL_PROVENANCE_HEADER]: "sponsor" },
+      },
+    );
+    if (!claimed.ok) {
+      await cancelResponseBody(claimed);
+      throw new EgressFailure(409, "sponsored_chatgpt_unavailable");
+    }
+    await cancelResponseBody(claimed);
+  }
+  const credential = await resolveUserCredential(env, sponsorUserId, recover, revision);
+  if (credential.kind !== "chatgpt") {
+    throw new EgressFailure(409, "sponsored_chatgpt_unavailable");
+  }
+  return credential;
+}
+
+export function isLegacyLocalBootstrapCredential(
+  env: Pick<EgressEnv,
+    "ALLOW_LOCAL_CREDENTIAL_CLAIM" | "ENVIRONMENT" | "LOCAL_CHATGPT_BOOTSTRAP"
+    | "NANOCODEX_SPONSORED_CHATGPT_USER_ID">,
+  userId: string,
+  credential: UserCredentialSnapshot,
+): boolean {
+  if (!localClaimEnabled(env) || credential.kind !== "chatgpt" || credential.provenance
+    || userId === env.NANOCODEX_SPONSORED_CHATGPT_USER_ID?.trim()) {
+    return false;
+  }
+  const raw = env.LOCAL_CHATGPT_BOOTSTRAP?.trim();
+  if (!raw) return false;
+  try {
+    const bootstrap = JSON.parse(raw) as unknown;
+    if (!isRecord(bootstrap)) return false;
+    const accountId = stringField(bootstrap, "account_id");
+    return Boolean(accountId && credential.accountId === accountId);
+  } catch {
+    return false;
+  }
+}
+
+async function resolveUserCredential(
+  env: EgressEnv,
+  userId: string,
+  recover: boolean,
+  revision?: number,
 ): Promise<UserCredentialSnapshot> {
   const response = await userBroker(env, userId).fetch("https://credentials.internal/v1/credential", {
     method: "POST",
@@ -1566,10 +2409,19 @@ function connectorBroker(env: EgressEnv, userId: string): DurableObjectStub<User
 async function cancelResponseBody(response: Response): Promise<void> {
   try { await response.body?.cancel(); } catch { /* Response disposal is best-effort. */ }
 }
-function localClaimEnabled(env: EgressEnv): boolean {
+function localClaimEnabled(
+  env: Pick<EgressEnv, "ALLOW_LOCAL_CREDENTIAL_CLAIM" | "ENVIRONMENT">,
+): boolean {
   const environment = env.ENVIRONMENT?.trim().toLowerCase();
   return env.ALLOW_LOCAL_CREDENTIAL_CLAIM === "true"
     && (environment === "development" || environment === "local" || environment === "test");
+}
+function localSponsoredTrialResetEnabled(
+  env: Pick<EgressEnv,
+    "ALLOW_LOCAL_CREDENTIAL_CLAIM" | "ENVIRONMENT" | "NANOCODEX_LOCAL_SPONSORED_TRIAL_RESET">,
+): boolean {
+  return localClaimEnabled(env)
+    && env.NANOCODEX_LOCAL_SPONSORED_TRIAL_RESET === "true";
 }
 async function readJson(request: Request, limit: number): Promise<Record<string, unknown> | undefined> {
   try {

--- a/js/egress/test/chatgpt-import.test.ts
+++ b/js/egress/test/chatgpt-import.test.ts
@@ -237,6 +237,31 @@ describe("Service-Binding-only ChatGPT credential import", () => {
     expect(production.status).toBe(404);
     expect(await production.json()).toEqual({ error: "not_found" });
   });
+
+  it("marks local claims internally without exposing their provenance publicly", async () => {
+    const user = "local-user-provenance";
+    const claimed = await SELF.fetch(
+      `https://broker.internal/users/${user}/credentials/chatgpt/local-claim`,
+      { method: "POST" },
+    );
+    expect(claimed.status).toBe(200);
+    expect(await claimed.json()).not.toHaveProperty("provenance");
+    expect(await internalCredential(workerEnv.USER_CREDENTIALS.getByName(user)))
+      .toMatchObject({ status: 200, body: { provenance: "user" } });
+
+    const sponsor = workerEnv.USER_CREDENTIALS.getByName("local-sponsor-provenance");
+    const sponsored = await sponsor.fetch(
+      "https://credentials.internal/v1/chatgpt/local-claim",
+      {
+        method: "POST",
+        headers: { "x-nanocodex-credential-provenance": "sponsor" },
+      },
+    );
+    expect(sponsored.status).toBe(200);
+    expect(await sponsored.json()).not.toHaveProperty("provenance");
+    expect(await internalCredential(sponsor))
+      .toMatchObject({ status: 200, body: { provenance: "sponsor" } });
+  });
 });
 
 function importedCredential(

--- a/js/egress/test/sponsored-homepage.test.ts
+++ b/js/egress/test/sponsored-homepage.test.ts
@@ -1,0 +1,680 @@
+import { env } from "cloudflare:workers";
+import { SELF } from "cloudflare:test";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import {
+  handleEgress,
+  isLegacyLocalBootstrapCredential,
+  sponsoredResponsesFrame,
+  type EgressEnv,
+} from "../src/egress";
+
+const workerEnv = env as unknown as EgressEnv;
+const DEMO_USER_ID = "88888888-8888-4888-8888-888888888888";
+const QUOTA_USER_ID = "77777777-7777-4777-8777-777777777777";
+const SOCKET_USER_ID = "66666666-6666-4666-8666-666666666666";
+const REPLAY_USER_ID = "55555555-5555-4555-8555-555555555555";
+const TOOL_USER_ID = "44444444-4444-4444-8444-444444444444";
+const RETRY_USER_ID = "33333333-3333-4333-8333-333333333333";
+const LEASE_USER_ID = "22222222-2222-4222-8222-222222222222";
+const LEASE_FALLBACK_USER_ID = "11111111-1111-4111-8111-111111111111";
+const CANCEL_USER_ID = "00000000-0000-4000-8000-000000000000";
+const TAKEOVER_USER_ID = "abababab-abab-4bab-8bab-abababababab";
+const CONNECTION_USER_ID = "cdcdcdcd-cdcd-4dcd-8dcd-cdcdcdcdcdcd";
+const FENCE_USER_ID = "efefefef-efef-4fef-8fef-efefefefefef";
+const EPHEMERAL_SUBJECT = "e".repeat(43);
+const QUOTA_SUBJECT = "q".repeat(43);
+const SOCKET_SUBJECT = "s".repeat(43);
+const REPLAY_SUBJECT = "r".repeat(43);
+const TOOL_SUBJECT = "t".repeat(43);
+const RETRY_SUBJECT = "y".repeat(43);
+const LEASE_SUBJECT = "l".repeat(43);
+const CANCEL_SUBJECT = "c".repeat(43);
+const TAKEOVER_SUBJECT = "o".repeat(43);
+const CONNECTION_SUBJECT = "n".repeat(43);
+const FENCE_SUBJECT = "f".repeat(43);
+const DURABLE_SUBJECT = "d".repeat(64);
+
+beforeAll(async () => {
+  await Promise.all([
+    bindSubject(EPHEMERAL_SUBJECT, DEMO_USER_ID),
+    bindSubject(QUOTA_SUBJECT, QUOTA_USER_ID),
+    bindSubject(SOCKET_SUBJECT, SOCKET_USER_ID),
+    bindSubject(REPLAY_SUBJECT, REPLAY_USER_ID),
+    bindSubject(TOOL_SUBJECT, TOOL_USER_ID),
+    bindSubject(RETRY_SUBJECT, RETRY_USER_ID),
+    bindSubject(LEASE_SUBJECT, LEASE_USER_ID),
+    bindSubject(CANCEL_SUBJECT, CANCEL_USER_ID),
+    bindSubject(TAKEOVER_SUBJECT, TAKEOVER_USER_ID),
+    bindSubject(CONNECTION_SUBJECT, CONNECTION_USER_ID),
+    bindSubject(FENCE_SUBJECT, FENCE_USER_ID),
+    bindSubject(DURABLE_SUBJECT, DEMO_USER_ID),
+  ]);
+});
+
+describe("sponsored homepage model access", () => {
+  it("treats only an unmarked local bootstrap account as a legacy auto-claim", () => {
+    const legacy = {
+      kind: "chatgpt" as const,
+      secret: "legacy-local-access",
+      accountId: "legacy-local-account",
+      revision: 0,
+    };
+    const localEnv = {
+      ENVIRONMENT: "development",
+      ALLOW_LOCAL_CREDENTIAL_CLAIM: "true",
+      LOCAL_CHATGPT_BOOTSTRAP: JSON.stringify({
+        access_token: legacy.secret,
+        account_id: legacy.accountId,
+      }),
+      NANOCODEX_SPONSORED_CHATGPT_USER_ID: "local-sponsor",
+    };
+
+    expect(isLegacyLocalBootstrapCredential(localEnv, "sms-user", legacy)).toBe(true);
+    expect(isLegacyLocalBootstrapCredential(localEnv, "sms-user", {
+      ...legacy,
+      provenance: "user",
+    })).toBe(false);
+    expect(isLegacyLocalBootstrapCredential(localEnv, "local-sponsor", legacy)).toBe(false);
+    expect(isLegacyLocalBootstrapCredential({ ...localEnv, ENVIRONMENT: "production" },
+      "sms-user", legacy)).toBe(false);
+    expect(isLegacyLocalBootstrapCredential(localEnv, "sms-user", {
+      ...legacy,
+      secret: "rotated-legacy-access",
+    })).toBe(true);
+    expect(isLegacyLocalBootstrapCredential(localEnv, "sms-user", {
+      ...legacy,
+      accountId: "independently-connected-account",
+    })).toBe(false);
+  });
+
+  it("advertises the deployment owner's ChatGPT only for an ephemeral browser subject", async () => {
+    const status = await modelStatus(EPHEMERAL_SUBJECT);
+    expect(status.status).toBe(200);
+    expect(await status.json()).toEqual({
+      ready: true,
+      active: "chatgpt",
+      source: "sponsored",
+      free_prompts_remaining: 3,
+    });
+
+    const search = await handleEgress(new Request("https://nanocodex.internal/v1/search", {
+      method: "POST",
+      headers: {
+        authorization: "Bearer NANOCODEX_PROVIDER_CREDENTIAL",
+        "content-type": "application/json",
+        "x-nanocodex-subject": EPHEMERAL_SUBJECT,
+      },
+      body: "{}",
+    }), workerEnv);
+    expect(search.status).toBe(409);
+    expect(await search.json()).toEqual({ error: "user_credential_unavailable" });
+  });
+
+  it("allows three live Responses prompts, skips warmup, and blocks prompt four", async () => {
+    const response = await handleEgress(new Request("https://nanocodex.internal/v1/responses", {
+      headers: {
+        authorization: "Bearer NANOCODEX_PROVIDER_CREDENTIAL",
+        "openai-beta": "responses_websockets=2026-02-06",
+        upgrade: "websocket",
+        "x-nanocodex-subject": SOCKET_SUBJECT,
+      },
+    }), workerEnv);
+    expect(response.status).toBe(101);
+    const socket = response.webSocket!;
+    socket.accept();
+
+    socket.send(JSON.stringify({ type: "response.create", generate: false, input: [] }));
+    expect(await nextSocketMessage(socket)).toMatchObject({ type: "provider.received" });
+    expect(await nextSocketMessage(socket)).toMatchObject({ type: "response.completed" });
+
+    for (let index = 1; index <= 3; index += 1) {
+      socket.send(JSON.stringify({
+        type: "response.create",
+        model: "gpt-5.6-sol",
+        reasoning: { effort: "max", mode: "pro" },
+        service_tier: "priority",
+        input: [{
+          type: "message",
+          role: "user",
+          id: `msg_socket_${index}`,
+          content: [{ type: "input_text", text: `prompt ${index}` }],
+        }],
+      }));
+      const received = await nextSocketMessage(socket);
+      expect(received).toMatchObject({ type: "provider.received" });
+      const forwarded = JSON.parse(String(received.frame));
+      expect(forwarded).toMatchObject({
+        model: "gpt-5.6-luna",
+        reasoning: { effort: "none", mode: "standard" },
+      });
+      expect(forwarded).not.toHaveProperty("service_tier");
+      expect(await nextSocketMessage(socket)).toMatchObject({ type: "response.completed" });
+    }
+
+    socket.send(JSON.stringify({
+      type: "response.create",
+      input: [{
+        type: "message",
+        role: "user",
+        id: "msg_socket_four",
+        content: [{ type: "input_text", text: "prompt four" }],
+      }],
+    }));
+    expect(await nextSocketMessage(socket)).toMatchObject({
+      type: "error",
+      error: { code: "sponsored_prompt_limit_reached" },
+    });
+
+    const status = await modelStatus(SOCKET_SUBJECT);
+    expect(await status.json()).toMatchObject({ free_prompts_remaining: 0 });
+  });
+
+  it("caps pre-prompt sponsored sockets and rejects exhausted quota before upstream", async () => {
+    const providerPeers: WebSocket[] = [];
+    const upstream = vi.fn(async () => {
+      const pair = new WebSocketPair();
+      const [client, server] = Object.values(pair);
+      server.accept();
+      providerPeers.push(server);
+      return new Response(null, { status: 101, webSocket: client });
+    });
+    const { CHATGPT_EGRESS: _chatGptEgress, ...isolatedEnv } = workerEnv;
+    const request = () => new Request("https://nanocodex.internal/v1/responses", {
+      headers: {
+        authorization: "Bearer NANOCODEX_PROVIDER_CREDENTIAL",
+        "openai-beta": "responses_websockets=2026-02-06",
+        upgrade: "websocket",
+        "x-nanocodex-subject": CONNECTION_SUBJECT,
+      },
+    });
+    const opened = await Promise.all(Array.from({ length: 4 }, () => (
+      handleEgress(request(), isolatedEnv, undefined, upstream as typeof fetch)
+    )));
+    expect(opened.map(({ status }) => status).sort()).toEqual([101, 101, 101, 429]);
+    expect(upstream).toHaveBeenCalledTimes(3);
+
+    const broker = workerEnv.USER_CREDENTIALS.getByName(CONNECTION_USER_ID);
+    await Promise.all(["msg_cap_one", "msg_cap_two", "msg_cap_three"].map((promptId) => (
+      broker.fetch("https://credentials.internal/v1/sponsored-prompts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ prompt_id: promptId, prompt_hash: "c".repeat(43) }),
+      })
+    )));
+    const exhausted = await handleEgress(
+      request(), isolatedEnv, undefined, upstream as typeof fetch,
+    );
+    expect(exhausted.status).toBe(402);
+    expect(upstream).toHaveBeenCalledTimes(3);
+
+    for (const response of opened.filter(({ status }) => status === 101)) {
+      response.webSocket!.accept();
+      response.webSocket!.close(1000, "test complete");
+    }
+    for (const peer of providerPeers) peer.close(1000, "test complete");
+  });
+
+  it("settles heartbeat races and fences late provider results", async () => {
+    const broker = workerEnv.USER_CREDENTIALS.getByName(FENCE_USER_ID);
+    const reserve = (promptId: string) => broker.fetch(
+      "https://credentials.internal/v1/sponsored-prompts",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ prompt_id: promptId, prompt_hash: "f".repeat(43) }),
+      },
+    );
+    const lifecycle = (promptId: string, action: string, attempt = 1) => broker.fetch(
+      "https://credentials.internal/v1/sponsored-prompts/lifecycle",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ prompt_id: promptId, attempt, action }),
+      },
+    );
+    const grant = (promptId: string, attempt = 1) => broker.fetch(
+      "https://credentials.internal/v1/sponsored-prompts/continuation",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          action: "grant",
+          prompt_id: promptId,
+          attempt,
+          response_id: `resp_${promptId}`,
+          call_ids: [`call_${promptId}`],
+        }),
+      },
+    );
+
+    await reserve("msg_grant_race");
+    expect((await grant("msg_grant_race")).status).toBe(200);
+    expect(await (await lifecycle("msg_grant_race", "heartbeat")).json())
+      .toEqual({ updated: false, settled: true });
+
+    await reserve("msg_terminal_race");
+    expect(await (await lifecycle("msg_terminal_race", "terminal")).json())
+      .toEqual({ updated: true });
+    expect(await (await lifecycle("msg_terminal_race", "heartbeat")).json())
+      .toEqual({ updated: false, settled: true });
+
+    await reserve("msg_late_result");
+    expect(await (await lifecycle("msg_late_result", "interrupted")).json())
+      .toEqual({ updated: true });
+    expect((await grant("msg_late_result")).status).toBe(409);
+    expect(await (await lifecycle("msg_late_result", "terminal")).json())
+      .toEqual({ updated: false });
+    expect(await (await reserve("msg_late_result")).json())
+      .toMatchObject({ dispatch: true, attempt: 2 });
+    await new Promise((resolve) => setTimeout(resolve, 275));
+    expect((await grant("msg_late_result", 2)).status).toBe(409);
+    expect(await (await lifecycle("msg_late_result", "terminal", 2)).json())
+      .toEqual({ updated: false });
+  });
+
+  it("never redispatches an admitted prompt ID", async () => {
+    const socket = await openResponsesSocket(REPLAY_SUBJECT);
+    const frame = JSON.stringify({
+      type: "response.create",
+      input: [{
+        type: "message",
+        role: "user",
+        id: "msg_replay_once",
+        content: [{ type: "input_text", text: "only once" }],
+      }],
+    });
+    socket.send(frame);
+    expect(await nextSocketMessage(socket)).toMatchObject({ type: "provider.received" });
+    expect(await nextSocketMessage(socket)).toMatchObject({ type: "response.completed" });
+
+    socket.send(frame);
+    expect(await nextSocketMessage(socket)).toMatchObject({
+      type: "error",
+      error: { code: "sponsored_prompt_replay" },
+    });
+    expect(await (await modelStatus(REPLAY_SUBJECT)).json()).toMatchObject({
+      free_prompts_remaining: 2,
+    });
+  });
+
+  it("restores a full-history tool-search continuation after reconnect without another prompt", async () => {
+    const first = await openResponsesSocket(TOOL_SUBJECT);
+    first.send(JSON.stringify({
+      type: "response.create",
+      input: [{
+        type: "message",
+        role: "user",
+        id: "msg_tool_search_root",
+        content: [{ type: "input_text", text: "find a tool" }],
+      }],
+    }));
+    expect(await nextSocketMessage(first)).toMatchObject({ type: "provider.received" });
+    expect(await nextSocketMessage(first)).toMatchObject({
+      type: "response.completed",
+      response: { id: "resp_tool_search_root" },
+    });
+    first.close(1000, "test reconnect");
+
+    const second = await openResponsesSocket(TOOL_SUBJECT);
+    second.send(JSON.stringify({
+      type: "response.create",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          id: "msg_tool_search_root",
+          content: [{ type: "input_text", text: "find a tool" }],
+        },
+        {
+          type: "tool_search_call",
+          call_id: "call_tool_search_root",
+          execution: "client",
+          arguments: { query: "tools" },
+        },
+        {
+          type: "tool_search_output",
+          call_id: "call_tool_search_root",
+          execution: "client",
+          tools: [],
+        },
+      ],
+    }));
+    expect(await nextSocketMessage(second)).toMatchObject({ type: "provider.received" });
+    expect(await nextSocketMessage(second)).toMatchObject({ type: "response.completed" });
+    expect(await (await modelStatus(TOOL_SUBJECT)).json()).toMatchObject({
+      free_prompts_remaining: 2,
+    });
+  });
+
+  it("allows one bounded transport retry but not a completed or repeated replay", async () => {
+    const frame = JSON.stringify({
+      type: "response.create",
+      input: [{
+        type: "message",
+        role: "user",
+        id: "msg_retry_root",
+        content: [{ type: "input_text", text: "retry me" }],
+      }],
+    });
+    const first = await openResponsesSocket(RETRY_SUBJECT);
+    first.send(frame);
+    expect(await nextSocketMessage(first)).toMatchObject({ type: "provider.received" });
+    first.close(1000, "transport lost");
+
+    const second = await openResponsesSocket(RETRY_SUBJECT);
+    second.send(frame);
+    expect(await nextSocketMessage(second)).toMatchObject({ type: "provider.received" });
+    second.close(1000, "transport lost again");
+
+    let lifecycleState: unknown;
+    for (let check = 0; check < 5; check += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      const lifecycle = await workerEnv.USER_CREDENTIALS.getByName(RETRY_USER_ID).fetch(
+        "https://credentials.internal/v1/sponsored-prompts/lifecycle",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            action: "heartbeat",
+            prompt_id: "msg_retry_root",
+            attempt: 2,
+          }),
+        },
+      );
+      lifecycleState = await lifecycle.json();
+      if ((lifecycleState as { updated?: boolean }).updated === false) break;
+    }
+    expect(lifecycleState).toEqual({ updated: false });
+
+    const third = await openResponsesSocket(RETRY_SUBJECT);
+    third.send(frame);
+    expect(await nextSocketMessage(third)).toMatchObject({
+      type: "error",
+      error: { code: "sponsored_prompt_replay" },
+    });
+    expect(await (await modelStatus(RETRY_SUBJECT)).json()).toMatchObject({
+      free_prompts_remaining: 2,
+    });
+  });
+
+  it("renews the attempt lease while the original sponsored generation is live", async () => {
+    const frame = JSON.stringify({
+      type: "response.create",
+      input: [{
+        type: "message",
+        role: "user",
+        id: "msg_retry_root",
+        content: [{ type: "input_text", text: "lease recovery" }],
+      }],
+    });
+    const original = await openResponsesSocket(LEASE_SUBJECT);
+    original.send(frame);
+    expect(await nextSocketMessage(original)).toMatchObject({ type: "provider.received" });
+
+    const replacement = await openResponsesSocket(LEASE_SUBJECT);
+    replacement.send(frame);
+    expect(await nextSocketMessage(replacement)).toMatchObject({
+      type: "error",
+      error: { code: "sponsored_prompt_replay" },
+    });
+    expect(await (await modelStatus(LEASE_SUBJECT)).json()).toMatchObject({
+      free_prompts_remaining: 2,
+    });
+    original.close(1000, "test complete");
+    replacement.close(1000, "test complete");
+  });
+
+  it("closes a stale socket after another attempt takes over its prompt", async () => {
+    const frame = JSON.stringify({
+      type: "response.create",
+      input: [{
+        type: "message",
+        role: "user",
+        id: "msg_retry_root",
+        content: [{ type: "input_text", text: "take over" }],
+      }],
+    });
+    const original = await openResponsesSocket(TAKEOVER_SUBJECT);
+    const originalClosed = nextSocketClose(original);
+    original.send(frame);
+    expect(await nextSocketMessage(original)).toMatchObject({ type: "provider.received" });
+
+    const broker = workerEnv.USER_CREDENTIALS.getByName(TAKEOVER_USER_ID);
+    const interrupted = await broker.fetch(
+      "https://credentials.internal/v1/sponsored-prompts/lifecycle",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          action: "interrupted",
+          prompt_id: "msg_retry_root",
+          attempt: 1,
+        }),
+      },
+    );
+    expect(await interrupted.json()).toEqual({ updated: true });
+
+    const replacement = await openResponsesSocket(TAKEOVER_SUBJECT);
+    replacement.send(frame);
+    expect(await nextSocketMessage(replacement)).toMatchObject({ type: "provider.received" });
+    expect(await originalClosed).toMatchObject({
+      code: 1011,
+      reason: "sponsored prompt heartbeat failed",
+    });
+    replacement.close(1000, "test complete");
+  });
+
+  it("recovers one retry from the durable lease if an owner disappears without interruption", async () => {
+    const broker = workerEnv.USER_CREDENTIALS.getByName(LEASE_FALLBACK_USER_ID);
+    const request = () => broker.fetch("https://credentials.internal/v1/sponsored-prompts", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        prompt_id: "msg_lease_fallback",
+        prompt_hash: "f".repeat(43),
+      }),
+    });
+    expect(await (await request()).json()).toMatchObject({ dispatch: true, attempt: 1 });
+    await new Promise((resolve) => setTimeout(resolve, 275));
+    expect(await (await request()).json()).toMatchObject({
+      dispatch: true,
+      reserved: false,
+      attempt: 2,
+      remaining: 2,
+    });
+  });
+
+  it("does not consume the retry when a waiting replacement socket closes", async () => {
+    const frame = JSON.stringify({
+      type: "response.create",
+      input: [{
+        type: "message",
+        role: "user",
+        id: "msg_retry_root",
+        content: [{ type: "input_text", text: "cancel replacement" }],
+      }],
+    });
+    const original = await openResponsesSocket(CANCEL_SUBJECT);
+    original.send(frame);
+    expect(await nextSocketMessage(original)).toMatchObject({ type: "provider.received" });
+
+    const abandoned = await openResponsesSocket(CANCEL_SUBJECT);
+    abandoned.send(frame);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    abandoned.close(1000, "abandoned reconnect");
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    original.close(1000, "actual interruption");
+
+    const retry = await openResponsesSocket(CANCEL_SUBJECT);
+    retry.send(frame);
+    expect(await nextSocketMessage(retry)).toMatchObject({ type: "provider.received" });
+    retry.close(1000, "test complete");
+  });
+
+  it("refuses the shared credential to a durable agent subject", async () => {
+    const status = await modelStatus(DURABLE_SUBJECT);
+    expect(status.status).toBe(503);
+    expect(await status.json()).toEqual({ error: "broker_not_ready" });
+  });
+
+  it("reserves only three distinct prompt IDs atomically and preserves retries", async () => {
+    const broker = workerEnv.USER_CREDENTIALS.getByName(QUOTA_USER_ID);
+    const attempts = await Promise.all([
+      "msg_prompt_one",
+      "msg_prompt_two",
+      "msg_prompt_three",
+    ].map((promptId) => broker.fetch("https://credentials.internal/v1/sponsored-prompts", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompt_id: promptId, prompt_hash: "h".repeat(43) }),
+    })));
+    expect(attempts.map(({ status }) => status)).toEqual([200, 200, 200]);
+
+    const [retry, fourth] = await Promise.all([
+      broker.fetch("https://credentials.internal/v1/sponsored-prompts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ prompt_id: "msg_prompt_one", prompt_hash: "h".repeat(43) }),
+      }),
+      broker.fetch("https://credentials.internal/v1/sponsored-prompts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ prompt_id: "msg_prompt_four", prompt_hash: "h".repeat(43) }),
+      }),
+    ]);
+    expect(retry.status).toBe(200);
+    expect(fourth.status).toBe(402);
+    expect(await retry.json()).toMatchObject({
+      limit: 3,
+      used: 3,
+      remaining: 0,
+      reserved: false,
+      dispatch: false,
+      pending: true,
+    });
+
+    const conflict = await broker.fetch("https://credentials.internal/v1/sponsored-prompts", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ prompt_id: "msg_prompt_one", prompt_hash: "x".repeat(43) }),
+    });
+    expect(conflict.status).toBe(409);
+
+    const status = await broker.fetch("https://credentials.internal/v1/sponsored-prompts");
+    expect(await status.json()).toEqual({ limit: 3, used: 3, remaining: 0 });
+
+    const productionReset = await handleEgress(new Request(
+      "https://broker.internal/.well-known/nanocodex/sponsored-trial-reset",
+      { method: "POST", headers: { "x-nanocodex-subject": QUOTA_SUBJECT } },
+    ), {
+      ...workerEnv,
+      ALLOW_LOCAL_CREDENTIAL_CLAIM: "false",
+      NANOCODEX_LOCAL_SPONSORED_TRIAL_RESET: "false",
+      ENVIRONMENT: "production",
+    });
+    expect(productionReset.status).toBe(404);
+
+    const reset = await handleEgress(new Request(
+      "https://broker.internal/.well-known/nanocodex/sponsored-trial-reset",
+      { method: "POST", headers: { "x-nanocodex-subject": QUOTA_SUBJECT } },
+    ), workerEnv);
+    expect(reset.status).toBe(200);
+    expect(await reset.json()).toEqual({ free_prompts_remaining: 3 });
+    expect(await (await broker.fetch("https://credentials.internal/v1/sponsored-prompts")).json())
+      .toEqual({ limit: 3, used: 0, remaining: 3 });
+  });
+
+  it("identifies prompt generations without charging warmups or tool continuations", () => {
+    expect(sponsoredResponsesFrame(JSON.stringify({
+      type: "response.create",
+      generate: false,
+      input: [],
+    }))).toMatchObject({ valid: true, generation: false });
+    expect(sponsoredResponsesFrame(JSON.stringify({
+      type: "response.create",
+      input: [{ type: "function_call_output", call_id: "call_1", output: "done" }],
+    }))).toMatchObject({ valid: true, generation: true });
+    expect(sponsoredResponsesFrame(JSON.stringify({
+      type: "response.create",
+      input: [
+        { type: "message", role: "user", id: "msg_first", content: [] },
+        { type: "message", role: "user", id: "msg_second", content: [] },
+      ],
+    }))).toMatchObject({ valid: true, generation: true, promptId: "msg_second" });
+  });
+
+  it("prefers the user's connected credential and permits it for durable agents", async () => {
+    const connected = await SELF.fetch(
+      `https://broker.internal/users/${DEMO_USER_ID}/credentials/openai`,
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ api_key: "sk-user-owned-test-secret" }),
+      },
+    );
+    expect(connected.status).toBe(204);
+
+    for (const subject of [EPHEMERAL_SUBJECT, DURABLE_SUBJECT]) {
+      const status = await modelStatus(subject);
+      expect(status.status).toBe(200);
+      expect(await status.json()).toEqual({
+        ready: true,
+        active: "openai",
+        source: "user",
+      });
+    }
+  });
+});
+
+function modelStatus(subject: string): Promise<Response> {
+  return handleEgress(new Request(
+    "https://broker.internal/.well-known/nanocodex/model-status",
+    { headers: { "x-nanocodex-subject": subject } },
+  ), workerEnv);
+}
+
+async function openResponsesSocket(subject: string): Promise<WebSocket> {
+  const response = await handleEgress(new Request("https://nanocodex.internal/v1/responses", {
+    headers: {
+      authorization: "Bearer NANOCODEX_PROVIDER_CREDENTIAL",
+      "openai-beta": "responses_websockets=2026-02-06",
+      upgrade: "websocket",
+      "x-nanocodex-subject": subject,
+    },
+  }), workerEnv);
+  expect(response.status).toBe(101);
+  const socket = response.webSocket!;
+  socket.accept();
+  return socket;
+}
+
+async function bindSubject(subject: string, userId: string): Promise<void> {
+  const response = await SELF.fetch(`https://broker.internal/subjects/${subject}`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ user_id: userId }),
+  });
+  expect(response.status).toBe(200);
+  await response.body?.cancel();
+}
+
+function nextSocketMessage(socket: WebSocket): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    socket.addEventListener("message", (event) => {
+      try { resolve(JSON.parse(String(event.data)) as Record<string, unknown>); }
+      catch (error) { reject(error); }
+    }, { once: true });
+    socket.addEventListener("error", () => reject(new Error("WebSocket failed")), { once: true });
+  });
+}
+
+function nextSocketClose(socket: WebSocket): Promise<Readonly<{ code: number; reason: string }>> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("WebSocket did not close")), 1_000);
+    socket.addEventListener("close", (event) => {
+      clearTimeout(timeout);
+      resolve({ code: event.code, reason: event.reason });
+    }, { once: true });
+  });
+}

--- a/js/egress/vitest.config.ts
+++ b/js/egress/vitest.config.ts
@@ -9,6 +9,46 @@ export class ChatGptEgress {
   fetch(request) {
     const url = new URL(request.url);
     url.hostname = "chatgpt.com";
+    if (url.pathname.endsWith("/codex/responses")
+      && request.headers.get("upgrade")?.toLowerCase() === "websocket") {
+      const pair = new WebSocketPair();
+      const [client, server] = Object.values(pair);
+      server.accept();
+      server.addEventListener("message", (event) => {
+        const frame = JSON.parse(String(event.data));
+        server.send(JSON.stringify({ type: "provider.received", frame: event.data }));
+        const user = Array.isArray(frame.input)
+          ? frame.input.findLast((item) => item?.type === "message" && item?.role === "user")
+          : undefined;
+        const toolRoot = user?.id === "msg_tool_root";
+        const toolSearchRoot = user?.id === "msg_tool_search_root";
+        const interruptedRetry = user?.id === "msg_retry_root";
+        if (interruptedRetry) return;
+        server.send(JSON.stringify({
+          type: "response.completed",
+          response: {
+            id: toolRoot
+              ? "resp_tool_root"
+              : toolSearchRoot ? "resp_tool_search_root" : "resp_test_complete",
+            status: "completed",
+            output: toolRoot ? [{
+              type: "custom_tool_call",
+              call_id: "call_tool_root",
+              name: "exec",
+              input: "text('ok')",
+            }] : toolSearchRoot ? [{
+              type: "tool_search_call",
+              call_id: "call_tool_search_root",
+              status: "completed",
+              execution: "client",
+              arguments: { query: "tools" },
+            }] : [],
+            usage: null,
+          },
+        }));
+      });
+      return new Response(null, { status: 101, webSocket: client });
+    }
     return Response.json({
       url: url.href,
       credential: request.headers.get("authorization")?.startsWith("Bearer ")
@@ -31,7 +71,9 @@ export default defineConfig({
           ENVIRONMENT: "test",
           CREDENTIAL_ENCRYPTION_KEY: TEST_KEY,
           CHIEF_OF_STAFF_OPENAI_API_KEY: "sk-chief-of-staff-test-secret",
+          NANOCODEX_SPONSORED_CHATGPT_USER_ID: "99999999-9999-4999-8999-999999999999",
           ALLOW_LOCAL_CREDENTIAL_CLAIM: "true",
+          NANOCODEX_LOCAL_SPONSORED_TRIAL_RESET: "true",
           LOCAL_CHATGPT_BOOTSTRAP: JSON.stringify({
             access_token: jwt({ exp: 4_102_444_800, marker: "local-access" }),
             refresh_token: "local-refresh-secret",

--- a/js/managed/src/browser-model.ts
+++ b/js/managed/src/browser-model.ts
@@ -1,5 +1,5 @@
 import {
-  authenticate,
+  authenticatePersistentAccount,
   forwardPrincipalAssertions,
   type AccountAuthEnv,
   type Principal,
@@ -9,6 +9,7 @@ import { bindAgentCredential, browserModelSubject } from "./credentials";
 const MODEL_HOST = "nanocodex.internal";
 const STATUS_HOST = "broker.internal";
 const STATUS_PATH = "/.well-known/nanocodex/model-status";
+const SPONSORED_TRIAL_RESET_PATH = "/.well-known/nanocodex/sponsored-trial-reset";
 const MODEL_PATHS = new Set([
   "/v1/responses",
   "/v1/search",
@@ -40,14 +41,18 @@ export async function routeBrowserModel(
   const status = url.protocol === "https:" && url.hostname === STATUS_HOST
     && !url.port && !url.search && !url.hash && url.pathname === STATUS_PATH
     && request.method === "GET";
+  const resetSponsoredTrial = env.ENVIRONMENT?.trim().toLowerCase() === "development"
+    && url.protocol === "https:" && url.hostname === STATUS_HOST
+    && !url.port && !url.search && !url.hash && url.pathname === SPONSORED_TRIAL_RESET_PATH
+    && request.method === "POST";
   const model = url.protocol === "https:" && url.hostname === MODEL_HOST
     && !url.port && !url.search && !url.hash && MODEL_PATHS.has(url.pathname);
-  if (!status && !model) return undefined;
+  if (!status && !resetSponsoredTrial && !model) return undefined;
 
   const authenticationHeaders = new Headers(request.headers);
   authenticationHeaders.delete("authorization");
   authenticationHeaders.delete("x-nanocodex-subject");
-  const principal = await authenticate(
+  const principal = await authenticatePersistentAccount(
     new Request(request.url, {
       method: request.method,
       headers: authenticationHeaders,
@@ -72,7 +77,7 @@ export async function routeBrowserModel(
   headers.delete("x-nanocodex-agent-id");
   headers.set("x-nanocodex-subject", subject);
 
-  if (status) {
+  if (status || resetSponsoredTrial) {
     const bindingFailure = await bindBrowserModelSubject(env, subject, principal.userId);
     if (bindingFailure) return bindingFailure;
     return env.NANOCODEX.fetch(new Request(request, { headers }));

--- a/js/nanocodex-connect-ui/src/AccountChooser.tsx
+++ b/js/nanocodex-connect-ui/src/AccountChooser.tsx
@@ -1,4 +1,5 @@
 import { useId, useState, type ReactNode } from "react";
+import { normalizeSmsPhone } from "./smsPhone.js";
 
 export type StoredPasskey = Readonly<{
   address: `0x${string}`;
@@ -57,13 +58,14 @@ export function AccountChooser({
 
   async function sendCode() {
     if (operation) return;
-    const normalized = normalizedPhone(phone);
+    const normalized = normalizeSmsPhone(phone);
     if (!normalized) {
       setLocalFailure(/^\d{6}$/.test(phone.trim())
         ? "That looks like a verification code. First enter your mobile number; we’ll ask for the code next."
         : "Enter a valid mobile number with its country code, like +30 697 123 4567.");
       return;
     }
+    setPhone(normalized);
     setOperation("send");
     setLocalFailure(undefined);
     try {
@@ -255,11 +257,6 @@ export function orderedPasskeys(storedPasskeys: readonly StoredPasskey[]): reado
 function maskedPhone(value: string): string {
   const normalized = value.replace(/\D/g, "");
   return normalized.length > 4 ? `+••• ••${normalized.slice(-4)}` : "your phone";
-}
-
-function normalizedPhone(value: string): string | undefined {
-  const normalized = value.replace(/[\s()-]/g, "");
-  return /^\+[1-9]\d{7,14}$/.test(normalized) ? normalized : undefined;
 }
 
 function otpError(value: unknown, fallback: string): string {

--- a/js/nanocodex-connect-ui/src/smsPhone.ts
+++ b/js/nanocodex-connect-ui/src/smsPhone.ts
@@ -1,0 +1,18 @@
+const E164_DIGITS = /^[1-9]\d{7,14}$/;
+
+/** Normalizes an international mobile number without guessing a local country. */
+export function normalizeSmsPhone(value: string): string | undefined {
+  const compact = value.trim().replace(/[\s().-]/g, "");
+  if (compact.startsWith("+")) {
+    return E164_DIGITS.test(compact.slice(1)) ? compact : undefined;
+  }
+  if (compact.startsWith("00")) {
+    const digits = compact.slice(2);
+    return E164_DIGITS.test(digits) ? `+${digits}` : undefined;
+  }
+  // The North American country code plus its ten-digit national number is
+  // unambiguous. Other digit-only formats still need an explicit + or 00.
+  return /^1\d{10}$/.test(compact)
+    ? `+${compact}`
+    : undefined;
+}

--- a/js/nanocodex-connect-ui/test/smsPhone.test.mjs
+++ b/js/nanocodex-connect-ui/test/smsPhone.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { normalizeSmsPhone } from "../dist/smsPhone.js";
+
+test("normalizes common international phone input without guessing local numbers", () => {
+  assert.equal(normalizeSmsPhone("13417327405"), "+13417327405");
+  assert.equal(normalizeSmsPhone("1 (341) 732-7405"), "+13417327405");
+  assert.equal(normalizeSmsPhone("00 30 697 123 4567"), "+306971234567");
+  assert.equal(normalizeSmsPhone("+30 697 123 4567"), "+306971234567");
+
+  assert.equal(normalizeSmsPhone("3417327405"), undefined);
+  assert.equal(normalizeSmsPhone("01234567890"), undefined);
+  assert.equal(normalizeSmsPhone("5511987654321"), undefined);
+  assert.equal(normalizeSmsPhone("+1 341 CALL-NOW"), undefined);
+  assert.equal(normalizeSmsPhone("1234567890123456"), undefined);
+});

--- a/js/nanocodex-terminal/README.md
+++ b/js/nanocodex-terminal/README.md
@@ -20,7 +20,9 @@ its runtime, transport, credentials, or persistence policy. It forwards
 changing retained state. Set `voice` to render and own the standard microphone
 control; normalized managed and Connect sources retain their canonical voice
 handle, while a normal browser Agent works directly. `voiceOptions` is available
-for application policy such as a pre-turn authorization fence.
+for application policy such as a pre-turn authorization fence. Pass `composer`
+to replace the input surface without detaching the controller or clearing the
+visible transcript.
 
 ```tsx
 <AgentTerminalView agent={agent} voice {...terminalProps} />

--- a/js/nanocodex-terminal/src/AgentTerminalView.tsx
+++ b/js/nanocodex-terminal/src/AgentTerminalView.tsx
@@ -37,6 +37,7 @@ export function AgentTerminalView({
   accessory,
   agent,
   agentError,
+  composer,
   controls,
   inactiveMessage,
   maxEntries,
@@ -54,6 +55,8 @@ export function AgentTerminalView({
   accessory?(controls: AgentTerminalAccessory): ReactNode;
   agent: Agent | undefined;
   agentError: string | undefined;
+  /** Replaces the default composer without detaching the transcript controller. */
+  composer?: ReactNode;
   controls?(controls: Pick<AgentTerminalAccessory, "agentReady">): ReactNode;
   inactiveMessage?(state: Readonly<{
     agentError: string | undefined;
@@ -221,7 +224,7 @@ export function AgentTerminalView({
 
   const terminal = (
     <TerminalTranscriptSurface
-      composer={(
+      composer={composer === undefined ? (
         <TerminalComposer
           controls={(voice || controls) ? <>
             {voice ? <VoiceControl agentReady={agentStatus === "ready"} voice={voiceState} /> : null}
@@ -238,7 +241,7 @@ export function AgentTerminalView({
           }}
           onSubmit={submitTouchPrompt}
         />
-      )}
+      ) : composer}
       canLoadOlder={controller.canLoadOlder}
       entries={controller.entries}
       followTailRequest={followTailRequest}

--- a/js/nanocodex-terminal/test/components.test.mjs
+++ b/js/nanocodex-terminal/test/components.test.mjs
@@ -95,6 +95,36 @@ test("controller-backed terminal remains caller-owned when no Agent is attached"
   await act(async () => renderer.unmount());
 });
 
+test("caller can lock the composer without remounting the controller-backed terminal", async () => {
+  let renderer;
+  const props = {
+    agent: undefined,
+    agentError: undefined,
+    mode: "preview",
+    onConversationActivity() {},
+    onStateChange() {},
+    retryAgent() {},
+  };
+  await act(async () => {
+    renderer = TestRenderer.create(React.createElement(AgentTerminalView, props), {
+      createNodeMock(element) {
+        return element.type === "div"
+          ? { clientHeight: 300, firstElementChild: null, scrollHeight: 300, scrollTop: 0 }
+          : {};
+      },
+    });
+  });
+  assert.equal(renderer.root.findAllByType("form").length, 1);
+  await act(async () => renderer.update(React.createElement(AgentTerminalView, {
+    ...props,
+    composer: React.createElement("div", { "data-trial-exhausted": true }, "Connect or fund"),
+  })));
+  assert.equal(renderer.root.findAllByType("form").length, 0);
+  assert.equal(renderer.root.findByProps({ "data-trial-exhausted": true }).children.join(""), "Connect or fund");
+  assert.equal(renderer.root.findAllByProps({ role: "log" }).length, 1);
+  await act(async () => renderer.unmount());
+});
+
 function voiceSnapshot(overrides = {}) {
   return {
     error: undefined,

--- a/js/nanocodex-vite/plugin.mjs
+++ b/js/nanocodex-vite/plugin.mjs
@@ -12,6 +12,8 @@ import { defaultCodexAuthFile, readCodexSubscription } from "./codex-auth-file.m
 import { startChatGptWorkerEgress } from "./chatgpt-egress.mjs";
 import { startLocalOAuthRelay } from "./oauth-relay-server.mjs";
 
+const LOCAL_SPONSORED_CHATGPT_USER_ID = "00000000-0000-4000-8000-000000000001";
+
 const buildScript = fileURLToPath(new URL("./scripts/build-js-package.sh", import.meta.url));
 const repositoryRoot = fileURLToPath(new URL("../../", import.meta.url));
 const rustBuildFiles = new Set([
@@ -99,7 +101,7 @@ export function createNanocodexVitePlugin(options, integration) {
       ) {
         if (integration.target === "cloudflare") await cleanup();
         integration.setDevBindings?.(undefined);
-        return { worker: { plugins: nestedWorker } };
+        return nanocodexConfig(nestedWorker, false);
       }
 
       await cleanup();
@@ -115,7 +117,7 @@ export function createNanocodexVitePlugin(options, integration) {
       }
       if (chatGpt === false) {
         integration.setDevBindings(Object.freeze(oauthBindings));
-        return { worker: { plugins: nestedWorker } };
+        return nanocodexConfig(nestedWorker, false);
       }
       try {
         const configuredAuthFile = chatGpt.authFile === undefined
@@ -131,7 +133,8 @@ export function createNanocodexVitePlugin(options, integration) {
             ...oauthBindings,
             ALLOW_INSECURE_LOOPBACK_RELAY: "true",
             CODEX_RELAY_URL: egress.relayUrl,
-            NANOCODEX_LOCAL_CHATGPT_AUTO_CLAIM: "true",
+            NANOCODEX_LOCAL_SPONSORED_TRIAL_RESET: "true",
+            NANOCODEX_SPONSORED_CHATGPT_USER_ID: LOCAL_SPONSORED_CHATGPT_USER_ID,
             LOCAL_CHATGPT_BOOTSTRAP: JSON.stringify({
               access_token: workerAuth.accessToken,
               account_id: workerAuth.accountId,
@@ -157,7 +160,7 @@ export function createNanocodexVitePlugin(options, integration) {
           `Nanocodex local ChatGPT setup failed: ${errorMessage(error)}. Run \`codex login\` and retry.`,
         );
       }
-      return { worker: { plugins: nestedWorker } };
+      return nanocodexConfig(nestedWorker, Boolean(credentialBrokerWorker));
     },
     async configureServer(vite) {
       vite.httpServer?.once("close", () => {
@@ -193,6 +196,15 @@ export function createNanocodexVitePlugin(options, integration) {
     async closeBundle() {
       await Promise.all([cleanup(), cleanupOAuthRelay(), cleanupDevApplications()]);
     },
+  };
+}
+
+function nanocodexConfig(nestedWorker, localSponsoredTrialReset) {
+  return {
+    define: {
+      __NANOCODEX_LOCAL_SPONSORED_TRIAL_RESET__: JSON.stringify(localSponsoredTrialReset),
+    },
+    worker: { plugins: nestedWorker },
   };
 }
 

--- a/js/nanocodex-vite/test/vite.test.mjs
+++ b/js/nanocodex-vite/test/vite.test.mjs
@@ -141,6 +141,7 @@ test("one Vite plugin gives only the selected broker exact development bindings"
     const config = await plugin.config({
       worker: {},
     }, { command: "serve" });
+    assert.equal(config.define.__NANOCODEX_LOCAL_SPONSORED_TRIAL_RESET__, "true");
     const application = cloudflareOptions.config({ vars: { FROM_WRANGLER: "kept-too" } });
     assert.deepEqual(application.vars, { APPLICATION_VAR: "kept" });
     const broker = cloudflareOptions.auxiliaryWorkers[0].config({
@@ -151,7 +152,12 @@ test("one Vite plugin gives only the selected broker exact development bindings"
     assert.equal(broker.vars.ENVIRONMENT, "development");
     assert.equal(broker.vars.FROM_WRANGLER, "kept-too");
     assert.equal(broker.vars.ALLOW_INSECURE_LOOPBACK_RELAY, "true");
-    assert.equal(broker.vars.NANOCODEX_LOCAL_CHATGPT_AUTO_CLAIM, "true");
+    assert.equal(broker.vars.NANOCODEX_LOCAL_SPONSORED_TRIAL_RESET, "true");
+    assert.equal(
+      broker.vars.NANOCODEX_SPONSORED_CHATGPT_USER_ID,
+      "00000000-0000-4000-8000-000000000001",
+    );
+    assert.equal(Object.hasOwn(broker.vars, "NANOCODEX_LOCAL_CHATGPT_AUTO_CLAIM"), false);
     assert.equal(broker.vars.GITHUB_OAUTH_CLIENT_ID, "github-id");
     assert.equal(broker.vars.GITHUB_OAUTH_CLIENT_SECRET, "github-secret");
     assert.equal(broker.vars.SLACK_OAUTH_CLIENT_ID, "slack-id");
@@ -215,7 +221,11 @@ test("production builds neither read local auth nor start development egress", a
   }, { buildJsPackage: async (release) => packageBuildModes.push(release) });
   const config = await plugin.config({ plugins: [] }, { command: "build" });
   assert.deepEqual(packageBuildModes, [true]);
+  assert.equal(config.define.__NANOCODEX_LOCAL_SPONSORED_TRIAL_RESET__, "false");
   assert.equal(cloudflareOptions.config({ vars: { PRODUCTION: "yes" } }), undefined);
+  assert.equal(cloudflareOptions.config({
+    vars: { NANOCODEX_LOCAL_SPONSORED_TRIAL_RESET: "must-not-be-overridden" },
+  }), undefined);
   assert.equal(typeof config.worker.plugins, "function");
   await plugin.closeBundle();
 });


### PR DESCRIPTION
## Summary
- add SMS verification directly to the homepage terminal with three ephemeral Luna prompts
- fence sponsored ChatGPT access with durable per-account prompt and connection leases
- keep durable agents gated on user-funded or connected model access
- fund Wallet directly from the homepage and keep local-only trial reset out of production
- normalize explicit international and North American phone input and keep Vite workers same-origin

## Verification
- nanocodex-web: 66 tests, typecheck, production build
- nanocodex-egress-service: 68 tests, typecheck, agent and broker dry-runs
- nanocodex-managed-service: 235 tests, typecheck, Worker dry-run
- nanocodex-connect-ui: 22 tests and package typecheck
- nanocodex-terminal: 11 tests and pack check
- nanocodex-vite: 19 tests and package typecheck
- canonical browser: SMS OTP, three-prompt exhaustion, transcript retention, same-origin Worker, direct Wallet checkout, and post-fix leased real Luna prompt