### PR TITLE
feat(managed): add scoped VM hand factories

### DIFF
--- a/bin/nanocodex/nanocodex2/README.md
+++ b/bin/nanocodex/nanocodex2/README.md
@@ -38,6 +38,52 @@ The immutable attachment snapshot publishes the guest workspace plus `vm`,
 attachment generation under the existing lease/fencing rules. Ctrl-C drains
 admitted calls, syncs the guest filesystem, and stops the VM.
 
+## On-demand VM hosts
+
+`nanocodex2 host` advertises bounded capacity instead of attaching one VM. The
+command registers a named VM factory. The managed control plane asks that exact
+factory to create a private VM when an agent uses its name as the `/mount`
+provider, and releases that VM when the durable agent is deleted.
+Every allocation gets its own cloned root image, Hosted Tools attachment, and
+machine identity. One host process can run up to `--max-vms` allocations.
+
+```bash
+NANOCODEX_API_KEY=ncx_live_... \
+nanocodex2 host \
+  --scope user \
+  --factory-name garage-mac \
+  --vm-template /srv/nanocodex/template.ext4 \
+  --state-dir /srv/nanocodex/host-state \
+  --vm-guest-runtime target/x86_64-unknown-linux-musl/debug/nanocodex-vm-guest \
+  --max-vms 10 \
+  --vm-cpus 8 \
+  --vm-memory-mib 16384
+```
+
+The scope chooses who may consume the advertised capacity:
+
+- `--scope user` is the default. Any agent owned by the API-key account may
+  request a VM.
+- `--scope agent --agent AGENT_ID` reserves the host for one durable agent.
+- `--scope system` contributes capacity to the whole managed system. It uses
+  `NANOCODEX_SYSTEM_HOST_TOKEN`, not an account API key.
+
+Several factories may be connected at once. `--factory-name` is the exact
+lowercase portable selector agents pass to `/mount`; it is unique within its
+scope and remains bound to the persisted host identity. `cf_sandbox` names the
+built-in Cloudflare factory and cannot be registered by a device. If the same
+factory name is visible in several scopes, agent scope shadows user scope,
+which shadows system scope; an unavailable higher-priority factory is never
+silently replaced by a different lower-priority machine.
+
+Regardless of pool scope, an allocated VM and its tool connection are leased
+only to the durable agent that requested them. When multiple scopes have free
+capacity for the requested name, lookup prefers the exact-agent pool, then the
+user's pool, then the system pool. The host identity is generated once under `--state-dir`; that
+directory is process-locked and also retains allocation roots across host
+restarts. Graceful host shutdown stops VMs without deleting those roots so the
+next control lease can reconcile them.
+
 The command emits structured lifecycle and call traces to stderr by default.
 They include the machine ID, configured CPU/memory and root-image size,
 connection and catalog state, and each call's ID, tool name, outcome, and

--- a/bin/nanocodex/src/nanocodex2/main.rs
+++ b/bin/nanocodex/src/nanocodex2/main.rs
@@ -27,6 +27,8 @@ mod vm_hand;
 )))]
 #[path = "vm_hand_unsupported.rs"]
 mod vm_hand;
+mod vm_hand_config;
+mod vm_host;
 
 use std::{
     env,
@@ -36,13 +38,13 @@ use std::{
     time::Instant,
 };
 
-use clap::{Args, Parser, Subcommand, builder::NonEmptyStringValueParser};
+use clap::{Args, Parser, Subcommand, ValueEnum, builder::NonEmptyStringValueParser};
 use hand_observability::HandObservabilityArgs;
 use host::HostConfig;
 use nanocodex_agent::{AgentEvents, Nanocodex, NanocodexError, PromptRequest, Turn, TurnResult};
 use nanocodex_managed::{
     AgentSettings, AgentState, EventCursor, Managed, ManagedApiKey, ManagedClient, ManagedError,
-    ManagedEvent, PromptInput,
+    ManagedEvent, PromptInput, validate_vm_factory_name,
 };
 use nanocodex_tools::{
     Tools, WorkspaceTools,
@@ -55,6 +57,7 @@ use url::Url;
 const MANAGED_URL_ENV: &str = "NANOCODEX_MANAGED_URL";
 const API_KEY_ENV: &str = "NANOCODEX_API_KEY";
 const API_KEY_FALLBACK_ENV: &str = "NC_API_KEY";
+const SYSTEM_HOST_TOKEN_ENV: &str = "NANOCODEX_SYSTEM_HOST_TOKEN";
 const DEFAULT_MANAGED_ORIGIN: &str = "https://nanocodex.gakonst.workers.dev";
 
 #[derive(Parser)]
@@ -73,6 +76,8 @@ enum Command {
     Attach(Attach),
     /// Register one retained libkrun VM as a compute hand for the account.
     Hand(Hand),
+    /// Serve a bounded pool of on-demand libkrun VM hands.
+    Host(Host),
     /// Create a managed agent and print its receipt as JSON.
     New,
     /// List account-owned managed agents as JSON.
@@ -161,11 +166,110 @@ struct Hand {
     machine_name: String,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum HostScope {
+    User,
+    Agent,
+    System,
+}
+
+#[derive(Args)]
+struct Host {
+    #[command(flatten)]
+    observability: HandObservabilityArgs,
+
+    /// Authority scope that may provision VMs from this host.
+    #[arg(long, value_enum, default_value_t = HostScope::User)]
+    scope: HostScope,
+
+    /// Exact /mount provider selector, unique within the selected scope.
+    #[arg(long, value_name = "FACTORY_NAME")]
+    factory_name: String,
+
+    /// Managed agent ID. Required only with --scope agent.
+    #[arg(long, value_name = "AGENT_ID", required_if_eq("scope", "agent"))]
+    agent: Option<String>,
+
+    /// Immutable raw ext4 image cloned privately for every allocation.
+    #[arg(long, value_name = "ROOTFS")]
+    vm_template: PathBuf,
+
+    /// Durable private host state and per-allocation VM roots.
+    #[arg(long, value_name = "PATH")]
+    state_dir: PathBuf,
+
+    /// Maximum number of provisioning, live, or releasing VMs.
+    #[arg(long, value_name = "COUNT", default_value_t = 4, value_parser = clap::value_parser!(u16).range(1..=64))]
+    max_vms: u16,
+
+    /// Stable host UUID. Generated and persisted under --state-dir when omitted.
+    #[arg(long, value_name = "UUID")]
+    host_id: Option<uuid::Uuid>,
+
+    /// Statically linked Linux guest executable used with the raw ext4 roots.
+    #[arg(long, value_name = "ELF", env = "NANOCODEX_VM_GUEST_RUNTIME")]
+    vm_guest_runtime: PathBuf,
+
+    /// Cache for the prepared read-only guest runtime disk.
+    #[arg(long, value_name = "PATH", default_value = ".cache/vm")]
+    vm_cache: PathBuf,
+
+    /// Directory containing the platform libkrun firmware library.
+    #[arg(long, value_name = "PATH", env = "NANOCODEX_KRUNFW_DIR")]
+    vm_firmware: Option<PathBuf>,
+
+    /// Absolute working directory inside every provisioned VM.
+    #[arg(long, value_name = "PATH", default_value = "/app")]
+    vm_workspace: String,
+
+    /// Number of virtual CPUs assigned to each VM.
+    #[arg(long, value_name = "COUNT", default_value_t = 2, value_parser = clap::value_parser!(u8).range(1..=64))]
+    vm_cpus: u8,
+
+    /// Guest memory in mebibytes assigned to each VM.
+    #[arg(long, value_name = "MIB", default_value_t = 1_024, value_parser = clap::value_parser!(u32).range(128..=262_144))]
+    vm_memory_mib: u32,
+
+    /// Shell name described to the managed brain.
+    #[arg(long, value_name = "SHELL", default_value = "sh")]
+    vm_shell: String,
+
+    /// Disable guest internet socket proxying.
+    #[arg(long)]
+    vm_no_network: bool,
+}
+
 #[derive(Args)]
 struct VmRunConfig {
     /// Mode-0600 launch record prepared by nanocodex-vm.
     #[arg(long)]
     config: PathBuf,
+}
+
+impl Host {
+    fn validate(&self) -> Result<(), ManagedError> {
+        validate_vm_factory_name(&self.factory_name)?;
+        if self.host_id.is_some_and(|id| {
+            id.get_version_num() != 4 || id.get_variant() != uuid::Variant::RFC4122
+        }) {
+            return Err(ManagedError::Configuration(
+                "--host-id must be a UUID v4".to_owned(),
+            ));
+        }
+        match (self.scope, self.agent.as_deref()) {
+            (HostScope::Agent, Some(agent)) if valid_managed_agent_id(agent) => Ok(()),
+            (HostScope::Agent, Some(_)) => Err(ManagedError::Configuration(
+                "--agent must be a safe managed agent identifier".to_owned(),
+            )),
+            (HostScope::Agent, None) => Err(ManagedError::Configuration(
+                "--agent is required with --scope agent".to_owned(),
+            )),
+            (HostScope::User | HostScope::System, Some(_)) => Err(ManagedError::Configuration(
+                "--agent is only valid with --scope agent".to_owned(),
+            )),
+            (HostScope::User | HostScope::System, None) => Ok(()),
+        }
+    }
 }
 
 #[derive(Args)]
@@ -248,15 +352,23 @@ fn try_main() -> Result<(), ManagedError> {
 }
 
 async fn run(cli: Cli) -> Result<(), ManagedError> {
-    if let Some(Command::VmRunConfig(command)) = &cli.command {
-        return vm_hand::run_config(&command.config);
-    }
-    let managed_origin = match &cli.command {
+    let command = match cli.command {
+        Some(Command::VmRunConfig(command)) => return vm_hand::run_config(&command.config),
+        Some(Command::Host(command)) => {
+            let _observability = command
+                .observability
+                .install()
+                .map_err(|error| ManagedError::Configuration(error.to_string()))?;
+            return vm_host::serve(command).await;
+        }
+        command => command,
+    };
+    let managed_origin = match &command {
         Some(Command::Attach(Attach { agent: Some(agent) })) => agent.managed_origin.as_deref(),
         _ => None,
     };
     let client = client_from_environment(managed_origin)?;
-    match cli.command {
+    match command {
         Some(Command::Attach(command)) => {
             attach_tui(&client, command.agent.map(|agent| agent.agent_id)).await
         }
@@ -267,6 +379,7 @@ async fn run(cli: Cli) -> Result<(), ManagedError> {
                 .map_err(|error| ManagedError::Configuration(error.to_string()))?;
             serve_vm_hand(&client, command).await
         }
+        Some(Command::Host(_)) => unreachable!("handled before managed client setup"),
         Some(Command::New) => write_json(&client.create().await?),
         Some(Command::List) => write_json(&client.list().await?),
         Some(Command::State(command)) => write_json(&client.state(&command.agent_id).await?),
@@ -805,5 +918,83 @@ mod tests {
         ] {
             assert!(parse_agent_reference(value).is_err(), "{value}");
         }
+    }
+
+    #[test]
+    fn host_scope_requires_agent_exactly_for_agent_scope() {
+        let common = [
+            "--factory-name",
+            "garage-mac",
+            "--vm-template",
+            "/tmp/template.ext4",
+            "--state-dir",
+            "/tmp/host-state",
+            "--vm-guest-runtime",
+            "/tmp/guest",
+        ];
+        let user = Cli::try_parse_from(["nanocodex2", "host"].into_iter().chain(common)).unwrap();
+        let Some(Command::Host(user)) = user.command else {
+            panic!("host parsed into the wrong command")
+        };
+        assert_eq!(user.scope, HostScope::User);
+        assert_eq!(user.factory_name, "garage-mac");
+        user.validate().unwrap();
+
+        for invalid_name in ["host", "cloudflare", "cf_sandbox", "Garage-Mac", "bad/name"] {
+            let invalid = Cli::try_parse_from(
+                ["nanocodex2", "host", "--factory-name", invalid_name]
+                    .into_iter()
+                    .chain(common[2..].iter().copied()),
+            )
+            .unwrap();
+            let Some(Command::Host(invalid)) = invalid.command else {
+                panic!("invalid factory host parsed into the wrong command")
+            };
+            assert!(invalid.validate().is_err(), "accepted {invalid_name:?}");
+        }
+
+        assert!(
+            Cli::try_parse_from(
+                ["nanocodex2", "host", "--scope", "agent"]
+                    .into_iter()
+                    .chain(common),
+            )
+            .is_err()
+        );
+        let agent = Cli::try_parse_from(
+            [
+                "nanocodex2",
+                "host",
+                "--scope",
+                "agent",
+                "--agent",
+                "agent-1",
+            ]
+            .into_iter()
+            .chain(common),
+        )
+        .unwrap();
+        let Some(Command::Host(agent)) = agent.command else {
+            panic!("agent host parsed into the wrong command")
+        };
+        agent.validate().unwrap();
+
+        let system_with_agent = Cli::try_parse_from(
+            [
+                "nanocodex2",
+                "host",
+                "--scope",
+                "system",
+                "--agent",
+                "agent-1",
+            ]
+            .into_iter()
+            .chain(common),
+        )
+        .unwrap();
+        let Some(Command::Host(system_with_agent)) = system_with_agent.command else {
+            panic!("system host parsed into the wrong command")
+        };
+        assert!(system_with_agent.validate().is_err());
     }
 }

--- a/bin/nanocodex/src/nanocodex2/vm_hand.rs
+++ b/bin/nanocodex/src/nanocodex2/vm_hand.rs
@@ -15,6 +15,7 @@ use nanocodex_vm::{
 use tokio::time::sleep;
 
 use super::Hand;
+pub(crate) use super::vm_hand_config::VmHandConfig;
 
 const DEFAULT_KRUNFW_DIRECTORY: &str = ".cache/libkrunfw/libkrunfw";
 const CAPABILITY_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
@@ -29,6 +30,10 @@ pub(crate) struct VmHand {
 
 impl VmHand {
     pub(crate) async fn start(config: &Hand) -> Result<Self, ManagedError> {
+        Self::start_config(&VmHandConfig::from(config)).await
+    }
+
+    pub(crate) async fn start_config(config: &VmHandConfig) -> Result<Self, ManagedError> {
         if !Path::new(&config.vm_workspace).is_absolute() {
             return Err(configuration(format!(
                 "--vm-workspace must be an absolute guest path, got {:?}",
@@ -166,7 +171,7 @@ pub(crate) fn run_config(path: &Path) -> Result<(), ManagedError> {
         .map_err(|error| configuration(format!("VM process failed: {error}")))
 }
 
-fn firmware_directory(config: &Hand) -> Option<PathBuf> {
+fn firmware_directory(config: &VmHandConfig) -> Option<PathBuf> {
     if let Some(directory) = &config.vm_firmware {
         return Some(directory.clone());
     }

--- a/bin/nanocodex/src/nanocodex2/vm_hand.rs
+++ b/bin/nanocodex/src/nanocodex2/vm_hand.rs
@@ -34,33 +34,8 @@ impl VmHand {
     }
 
     pub(crate) async fn start_config(config: &VmHandConfig) -> Result<Self, ManagedError> {
-        if !Path::new(&config.vm_workspace).is_absolute() {
-            return Err(configuration(format!(
-                "--vm-workspace must be an absolute guest path, got {:?}",
-                config.vm_workspace
-            )));
-        }
-        let mut capabilities = vec![
-            "filesystem".to_owned(),
-            "linux".to_owned(),
-            "process".to_owned(),
-            "pty".to_owned(),
-            "shell".to_owned(),
-            "vm".to_owned(),
-            format!("cpu:{}", config.vm_cpus),
-            format!("memory-mib:{}", config.vm_memory_mib),
-        ];
-        if !config.vm_no_network {
-            capabilities.push("network".to_owned());
-        }
-        capabilities.sort_unstable();
-        let machine = AttachmentMachine::new(
-            &config.machine_id,
-            &config.machine_name,
-            &config.vm_workspace,
-            capabilities,
-        )
-        .map_err(|error| configuration(error.to_string()))?;
+        validate_common_config(config)?;
+        let machine = attachment_machine(config)?;
         let rootfs = config.rootfs.canonicalize().map_err(|error| {
             configuration(format!(
                 "failed to resolve VM rootfs {}: {error}",
@@ -85,17 +60,7 @@ impl VmHand {
             .cpus(config.vm_cpus)
             .memory_mib(config.vm_memory_mib);
         if ext4 {
-            let runtime = config.vm_guest_runtime.as_ref().ok_or_else(|| {
-                configuration(
-                    "raw ext4 VM roots require --vm-guest-runtime ELF; build it with `just build-vm-guest` or set NANOCODEX_VM_GUEST_RUNTIME",
-                )
-            })?;
-            let runtime =
-                GuestRuntimeDisk::prepare(runtime, &config.vm_cache).map_err(|error| {
-                    configuration(format!(
-                        "failed to prepare the read-only VM guest runtime disk: {error}"
-                    ))
-                })?;
+            let runtime = prepare_guest_runtime(config)?;
             builder = builder.guest_runtime_disk(runtime.path().to_path_buf());
         } else if config.vm_guest_runtime.is_some() {
             return Err(configuration(
@@ -133,6 +98,35 @@ impl VmHand {
         })
     }
 
+    /// Validates and prepares every host-wide input which does not depend on
+    /// an allocation root. Running this before the control lease is acquired
+    /// keeps deterministic guest/runtime failures out of the redrive loop.
+    pub(crate) fn preflight_host_config(config: &VmHandConfig) -> Result<(), ManagedError> {
+        validate_common_config(config)?;
+        attachment_machine(config)?;
+        prepare_guest_runtime(config)?;
+        if let Some(firmware) = &config.vm_firmware {
+            let firmware = firmware.canonicalize().map_err(|error| {
+                configuration(format!(
+                    "failed to resolve VM firmware directory {}: {error}",
+                    firmware.display()
+                ))
+            })?;
+            let library = if cfg!(target_os = "macos") {
+                firmware.join("libkrunfw.5.dylib")
+            } else {
+                firmware.join("libkrunfw.so.5")
+            };
+            if !library.is_file() {
+                return Err(configuration(format!(
+                    "VM firmware library is missing: {}",
+                    library.display()
+                )));
+            }
+        }
+        Ok(())
+    }
+
     pub(crate) const fn machine(&self) -> &AttachmentMachine {
         &self.machine
     }
@@ -161,6 +155,53 @@ impl VmHand {
             }
         }
     }
+}
+
+fn validate_common_config(config: &VmHandConfig) -> Result<(), ManagedError> {
+    if !Path::new(&config.vm_workspace).is_absolute() {
+        return Err(configuration(format!(
+            "--vm-workspace must be an absolute guest path, got {:?}",
+            config.vm_workspace
+        )));
+    }
+    Ok(())
+}
+
+fn attachment_machine(config: &VmHandConfig) -> Result<AttachmentMachine, ManagedError> {
+    let mut capabilities = vec![
+        "filesystem".to_owned(),
+        "linux".to_owned(),
+        "process".to_owned(),
+        "pty".to_owned(),
+        "shell".to_owned(),
+        "vm".to_owned(),
+        format!("cpu:{}", config.vm_cpus),
+        format!("memory-mib:{}", config.vm_memory_mib),
+    ];
+    if !config.vm_no_network {
+        capabilities.push("network".to_owned());
+    }
+    capabilities.sort_unstable();
+    AttachmentMachine::new(
+        &config.machine_id,
+        &config.machine_name,
+        &config.vm_workspace,
+        capabilities,
+    )
+    .map_err(|error| configuration(error.to_string()))
+}
+
+fn prepare_guest_runtime(config: &VmHandConfig) -> Result<GuestRuntimeDisk, ManagedError> {
+    let runtime = config.vm_guest_runtime.as_ref().ok_or_else(|| {
+        configuration(
+            "raw ext4 VM roots require --vm-guest-runtime ELF; build it with `just build-vm-guest` or set NANOCODEX_VM_GUEST_RUNTIME",
+        )
+    })?;
+    GuestRuntimeDisk::prepare(runtime, &config.vm_cache).map_err(|error| {
+        configuration(format!(
+            "failed to prepare the read-only VM guest runtime disk: {error}"
+        ))
+    })
 }
 
 pub(crate) fn run_config(path: &Path) -> Result<(), ManagedError> {

--- a/bin/nanocodex/src/nanocodex2/vm_hand_config.rs
+++ b/bin/nanocodex/src/nanocodex2/vm_hand_config.rs
@@ -1,0 +1,37 @@
+use std::path::PathBuf;
+
+use super::Hand;
+
+/// Complete single-VM launch recipe shared by every platform backend.
+#[derive(Clone, Debug)]
+pub(crate) struct VmHandConfig {
+    pub(crate) rootfs: PathBuf,
+    pub(crate) vm_guest_runtime: Option<PathBuf>,
+    pub(crate) vm_cache: PathBuf,
+    pub(crate) vm_firmware: Option<PathBuf>,
+    pub(crate) vm_workspace: String,
+    pub(crate) vm_cpus: u8,
+    pub(crate) vm_memory_mib: u32,
+    pub(crate) vm_shell: String,
+    pub(crate) vm_no_network: bool,
+    pub(crate) machine_id: String,
+    pub(crate) machine_name: String,
+}
+
+impl From<&Hand> for VmHandConfig {
+    fn from(config: &Hand) -> Self {
+        Self {
+            rootfs: config.rootfs.clone(),
+            vm_guest_runtime: config.vm_guest_runtime.clone(),
+            vm_cache: config.vm_cache.clone(),
+            vm_firmware: config.vm_firmware.clone(),
+            vm_workspace: config.vm_workspace.clone(),
+            vm_cpus: config.vm_cpus,
+            vm_memory_mib: config.vm_memory_mib,
+            vm_shell: config.vm_shell.clone(),
+            vm_no_network: config.vm_no_network,
+            machine_id: config.machine_id.clone(),
+            machine_name: config.machine_name.clone(),
+        }
+    }
+}

--- a/bin/nanocodex/src/nanocodex2/vm_hand_unsupported.rs
+++ b/bin/nanocodex/src/nanocodex2/vm_hand_unsupported.rs
@@ -4,11 +4,16 @@ use nanocodex_managed::ManagedError;
 use nanocodex_tools::{Tools, attachment::AttachmentMachine};
 
 use super::Hand;
+pub(crate) use super::vm_hand_config::VmHandConfig;
 
 pub(crate) struct VmHand;
 
 impl VmHand {
     pub(crate) async fn start(_config: &Hand) -> Result<Self, ManagedError> {
+        Err(unsupported())
+    }
+
+    pub(crate) async fn start_config(_config: &VmHandConfig) -> Result<Self, ManagedError> {
         Err(unsupported())
     }
 

--- a/bin/nanocodex/src/nanocodex2/vm_host.rs
+++ b/bin/nanocodex/src/nanocodex2/vm_host.rs
@@ -1697,10 +1697,12 @@ mod supported {
 
     fn locked_file_path(file: &File) -> PathBuf {
         #[cfg(target_os = "linux")]
-        let directory = "/proc/self/fd";
+        let directory = PathBuf::from("/proc")
+            .join(std::process::id().to_string())
+            .join("fd");
         #[cfg(target_os = "macos")]
-        let directory = "/dev/fd";
-        PathBuf::from(directory).join(file.as_raw_fd().to_string())
+        let directory = PathBuf::from("/dev/fd");
+        directory.join(file.as_raw_fd().to_string())
     }
 
     enum ControlAuth {

--- a/bin/nanocodex/src/nanocodex2/vm_host.rs
+++ b/bin/nanocodex/src/nanocodex2/vm_host.rs
@@ -15,6 +15,7 @@ mod supported {
         fs::{self, File, OpenOptions},
         future::Future,
         io::Write as _,
+        os::fd::AsRawFd as _,
         os::unix::fs::{MetadataExt as _, PermissionsExt as _},
         path::{Path, PathBuf},
         pin::Pin,
@@ -42,6 +43,9 @@ mod supported {
 
     type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
     const ATTACHMENT_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+    const INITIAL_RECONNECT_DELAY: Duration = Duration::from_millis(250);
+    const MAX_RECONNECT_DELAY: Duration = Duration::from_secs(5);
+    const HEALTHY_CONNECTION_DURATION: Duration = Duration::from_secs(20);
 
     /// Immutable control-plane identity for one VM allocation.
     #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -158,6 +162,7 @@ mod supported {
             let lock_path = directory.join("host.lock");
             let lock = OpenOptions::new()
                 .create(true)
+                .truncate(false)
                 .read(true)
                 .write(true)
                 .open(&lock_path)
@@ -376,6 +381,18 @@ mod supported {
             })?;
             sync_directory(&self.directory)?;
             Ok(())
+        }
+
+        fn remove(&self, allocation_id: Uuid) -> Result<(), VmHostError> {
+            let path = self.record_path(allocation_id);
+            match fs::remove_file(&path) {
+                Ok(()) => sync_directory(&self.directory),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Err(error) => Err(VmHostError::State(format!(
+                    "failed to remove acknowledged allocation record {}: {error}",
+                    path.display()
+                ))),
+            }
         }
 
         fn load(&self, capacity: u16) -> Result<LoadedAllocations, VmHostError> {
@@ -1147,6 +1164,28 @@ mod supported {
             first_error.map_or(Ok(()), Err)
         }
 
+        fn acknowledge_released(
+            &mut self,
+            identity: &VmAllocationIdentity,
+        ) -> Result<(), VmHostError> {
+            let retired = self.retired.get(&identity.allocation_id).ok_or_else(|| {
+                VmHostError::State(format!(
+                    "acknowledged allocation {} has no released journal record",
+                    identity.allocation_id
+                ))
+            })?;
+            if &retired.identity != identity || retired.release_pending {
+                return Err(VmHostError::ImmutableConflict {
+                    allocation_id: identity.allocation_id,
+                });
+            }
+            if let Some(store) = &self.store {
+                store.remove(identity.allocation_id)?;
+            }
+            self.retired.remove(&identity.allocation_id);
+            Ok(())
+        }
+
         fn reconcile(&self) -> Vec<VmAllocationIdentity> {
             self.active
                 .values()
@@ -1236,9 +1275,7 @@ mod supported {
                 config.machine_name = spec.identity.machine_id;
                 let hand = vm_hand::VmHand::start_config(&config)
                     .await
-                    .map_err(|error| {
-                        ProvisionFailure::unproven(VmHostError::Resource(error.to_string()))
-                    })?;
+                    .map_err(vm_hand_start_failure)?;
                 if cancellation.is_cancelled() {
                     let shutdown = hand
                         .shutdown()
@@ -1310,6 +1347,13 @@ mod supported {
                     .join(format!("{}.ext4", identity.allocation_id)),
             ))
         }
+    }
+
+    fn vm_hand_start_failure(error: ManagedError) -> ProvisionFailure {
+        // VmHand startup validates before spawning and VmWorkspace forcibly
+        // terminates a session on every bounded launch failure. No live VMM
+        // escapes an Err, so durable redrive may safely reuse the root.
+        ProvisionFailure::stopped(VmHostError::Resource(error.to_string()))
     }
 
     struct VmAllocation {
@@ -1572,6 +1616,7 @@ mod supported {
                     template_root.display()
                 ))
             })?;
+            let locked_template_root = locked_file_path(&template_lock);
             let hand_template = vm_hand::VmHandConfig {
                 rootfs: config.vm_template.clone(),
                 vm_guest_runtime: Some(config.vm_guest_runtime.clone()),
@@ -1585,8 +1630,13 @@ mod supported {
                 machine_id: "unprovisioned".to_owned(),
                 machine_name: "Unprovisioned VM".to_owned(),
             };
+            vm_hand::VmHand::preflight_host_config(&hand_template)
+                .map_err(|error| VmHostError::Configuration(error.to_string()))?;
             let factory = VmAllocationFactory {
-                template_root,
+                // Clone through the descriptor which owns the shared lock.
+                // Replacing the configured pathname cannot redirect a later
+                // allocation to a different inode.
+                template_root: locked_template_root,
                 allocation_directory: state.directory.join("allocations"),
                 hand_template,
             };
@@ -1629,6 +1679,13 @@ mod supported {
             self.supervisor.complete_startup_releases().await
         }
 
+        fn acknowledge_released(
+            &mut self,
+            identity: &VmAllocationIdentity,
+        ) -> Result<(), VmHostError> {
+            self.supervisor.acknowledge_released(identity)
+        }
+
         pub(crate) fn reconcile(&self) -> Vec<VmAllocationIdentity> {
             self.supervisor.reconcile()
         }
@@ -1636,6 +1693,14 @@ mod supported {
         pub(crate) async fn shutdown(&mut self) -> Result<(), VmHostError> {
             self.supervisor.shutdown().await
         }
+    }
+
+    fn locked_file_path(file: &File) -> PathBuf {
+        #[cfg(target_os = "linux")]
+        let directory = "/proc/self/fd";
+        #[cfg(target_os = "macos")]
+        let directory = "/dev/fd";
+        PathBuf::from(directory).join(file.as_raw_fd().to_string())
     }
 
     enum ControlAuth {
@@ -1679,8 +1744,94 @@ mod supported {
     }
 
     enum ConnectionOutcome {
-        Reconnect,
+        Reconnect { made_progress: bool },
         Shutdown,
+    }
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    enum PendingCommandKind {
+        Provision,
+        Release,
+    }
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    struct PendingCommandIdentity {
+        allocation_id: Uuid,
+        kind: PendingCommandKind,
+    }
+
+    trait PendingLifecycleCommand {
+        fn pending_identity(&self) -> PendingCommandIdentity;
+    }
+
+    impl PendingLifecycleCommand for VmHostCommand {
+        fn pending_identity(&self) -> PendingCommandIdentity {
+            match self {
+                Self::Provision(command) => PendingCommandIdentity {
+                    allocation_id: command.allocation_id(),
+                    kind: PendingCommandKind::Provision,
+                },
+                Self::Release(command) => PendingCommandIdentity {
+                    allocation_id: command.allocation_id(),
+                    kind: PendingCommandKind::Release,
+                },
+                Self::Fenced(_) => unreachable!("fencing is never queued"),
+            }
+        }
+    }
+
+    struct PendingCommandQueue<T> {
+        limit: usize,
+        commands: VecDeque<T>,
+    }
+
+    impl<T: PendingLifecycleCommand> PendingCommandQueue<T> {
+        fn new(max_vms: u16) -> Self {
+            Self {
+                // Reconciliation can release up to one old host snapshot while
+                // a disjoint desired snapshot is being provisioned.
+                limit: usize::from(max_vms).saturating_mul(2),
+                commands: VecDeque::new(),
+            }
+        }
+
+        fn push(&mut self, command: T, active: PendingCommandIdentity) -> Result<(), VmHostError> {
+            let incoming = command.pending_identity();
+            if incoming.allocation_id == active.allocation_id
+                && (active.kind == PendingCommandKind::Release || incoming.kind == active.kind)
+            {
+                return Ok(());
+            }
+            if let Some(position) = self.commands.iter().position(|queued| {
+                queued.pending_identity().allocation_id == incoming.allocation_id
+            }) {
+                let queued = self.commands[position].pending_identity();
+                if queued.kind == PendingCommandKind::Release || queued.kind == incoming.kind {
+                    return Ok(());
+                }
+                // A release supersedes the queued provision for the same
+                // allocation. The inverse is never allowed.
+                self.commands.remove(position);
+            }
+            if self.commands.len() >= self.limit {
+                return Err(VmHostError::State(format!(
+                    "pending VM host command queue exceeded its {}-allocation bound",
+                    self.limit
+                )));
+            }
+            self.commands.push_back(command);
+            Ok(())
+        }
+
+        fn pop(&mut self) -> Option<T> {
+            let release = self
+                .commands
+                .iter()
+                .position(|command| command.pending_identity().kind == PendingCommandKind::Release);
+            release
+                .and_then(|position| self.commands.remove(position))
+                .or_else(|| self.commands.pop_front())
+        }
     }
 
     enum ControlledOperationOutcome<T> {
@@ -1729,9 +1880,10 @@ mod supported {
     async fn drive_controlled_operation<O>(
         operation: O,
         cancellation: &OperationCancellation,
+        active: PendingCommandIdentity,
         connection: &mut VmHostConnection,
         heartbeat: &mut tokio::time::Interval,
-        pending: &mut VecDeque<VmHostCommand>,
+        pending: &mut PendingCommandQueue<VmHostCommand>,
     ) -> Result<ControlledOperationOutcome<O::Output>, ManagedError>
     where
         O: Future,
@@ -1777,7 +1929,14 @@ mod supported {
                 ControlledOperationEvent::Control(Ok(Some(
                     command @ (VmHostCommand::Provision(_) | VmHostCommand::Release(_)),
                 ))) => {
-                    pending.push_back(command);
+                    if let Err(error) = pending.push(command, active) {
+                        return Ok(finish_terminal_operation(
+                            operation.as_mut(),
+                            cancellation,
+                            DeferredControlOutcome::Error(error.into()),
+                        )
+                        .await);
+                    }
                 }
                 ControlledOperationEvent::Control(Ok(Some(command @ VmHostCommand::Fenced(_)))) => {
                     return Ok(finish_terminal_operation(
@@ -1838,6 +1997,7 @@ mod supported {
         operation: &'static str,
         result: Result<VmAllocationChange, VmHostError>,
         terminal: DeferredControlOutcome,
+        made_progress: bool,
     ) -> Result<ConnectionOutcome, ManagedError> {
         if let Err(error) = result {
             tracing::error!(
@@ -1848,7 +2008,7 @@ mod supported {
             );
         }
         match terminal {
-            DeferredControlOutcome::Reconnect => Ok(ConnectionOutcome::Reconnect),
+            DeferredControlOutcome::Reconnect => Ok(ConnectionOutcome::Reconnect { made_progress }),
             DeferredControlOutcome::Shutdown => {
                 host.shutdown().await?;
                 Ok(ConnectionOutcome::Shutdown)
@@ -1918,16 +2078,13 @@ mod supported {
             "VM host is ready for managed allocations"
         );
 
-        let mut retry = Duration::from_millis(250);
+        let mut retry = INITIAL_RECONNECT_DELAY;
         loop {
             let connection = auth
                 .connect(host.host_id(), &config.factory_name, host.capacity(), shape)
                 .await;
             let mut connection = match connection {
-                Ok(connection) => {
-                    retry = Duration::from_millis(250);
-                    connection
-                }
+                Ok(connection) => connection,
                 Err(error @ ManagedError::Configuration(_)) => return Err(error),
                 Err(error) => {
                     tracing::warn!(
@@ -1935,20 +2092,27 @@ mod supported {
                         error = %error,
                         "VM host control connection failed; retrying"
                     );
-                    if wait_to_reconnect_or_shutdown(host, retry).await? {
+                    let delay = next_reconnect_delay(&mut retry, false);
+                    if wait_to_reconnect_or_shutdown(host, delay).await? {
                         return Ok(());
                     }
-                    retry = retry.saturating_mul(2).min(Duration::from_secs(5));
                     continue;
                 }
             };
+            let connected_at = tokio::time::Instant::now();
             match serve_connection(host, &mut connection).await? {
                 ConnectionOutcome::Shutdown => return Ok(()),
-                ConnectionOutcome::Reconnect => {
+                ConnectionOutcome::Reconnect { made_progress } => {
                     tracing::warn!(
                         target: "nanocodex2",
                         "VM host control connection closed; reconciling on reconnect"
                     );
+                    let healthy =
+                        made_progress || connected_at.elapsed() >= HEALTHY_CONNECTION_DURATION;
+                    let delay = next_reconnect_delay(&mut retry, healthy);
+                    if wait_to_reconnect_or_shutdown(host, delay).await? {
+                        return Ok(());
+                    }
                 }
             }
         }
@@ -1971,15 +2135,18 @@ mod supported {
             .collect::<Result<Vec<_>, _>>()?;
         if let Err(error) = connection.reconcile(&allocations).await {
             tracing::warn!(target: "nanocodex2", error = %error, "VM host reconciliation failed");
-            return Ok(ConnectionOutcome::Reconnect);
+            return Ok(ConnectionOutcome::Reconnect {
+                made_progress: false,
+            });
         }
 
         let first_heartbeat = tokio::time::Instant::now() + Duration::from_secs(20);
         let mut heartbeat = tokio::time::interval_at(first_heartbeat, Duration::from_secs(20));
         heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        let mut pending_commands = VecDeque::new();
+        let mut pending_commands = PendingCommandQueue::new(host.capacity());
+        let mut made_progress = false;
         loop {
-            let command = if let Some(command) = pending_commands.pop_front() {
+            let command = if let Some(command) = pending_commands.pop() {
                 command
             } else {
                 tokio::select! {
@@ -1992,17 +2159,17 @@ mod supported {
                     }
                     command = connection.next() => match command {
                         Ok(Some(command)) => command,
-                        Ok(None) => return Ok(ConnectionOutcome::Reconnect),
+                        Ok(None) => return Ok(ConnectionOutcome::Reconnect { made_progress }),
                         Err(error @ ManagedError::Configuration(_)) => return Err(error),
                         Err(error) => {
                             tracing::warn!(target: "nanocodex2", error = %error, "VM host control receive failed");
-                            return Ok(ConnectionOutcome::Reconnect);
+                            return Ok(ConnectionOutcome::Reconnect { made_progress });
                         }
                     },
                     _ = heartbeat.tick() => {
                         if let Err(error) = connection.ping(None).await {
                             tracing::warn!(target: "nanocodex2", error = %error, "VM host heartbeat failed");
-                            return Ok(ConnectionOutcome::Reconnect);
+                            return Ok(ConnectionOutcome::Reconnect { made_progress });
                         }
                         continue;
                     }
@@ -2020,9 +2187,14 @@ mod supported {
                         provision.into_attachment(),
                     );
                     let cancellation = OperationCancellation::default();
+                    let active = PendingCommandIdentity {
+                        allocation_id: acknowledgement.allocation_id(),
+                        kind: PendingCommandKind::Provision,
+                    };
                     match drive_controlled_operation(
                         host.provision_controlled(spec, cancellation.clone()),
                         &cancellation,
+                        active,
                         connection,
                         &mut heartbeat,
                         &mut pending_commands,
@@ -2032,7 +2204,7 @@ mod supported {
                         ControlledOperationOutcome::Completed(Ok(_)) => {}
                         ControlledOperationOutcome::Completed(Err(error)) => {
                             tracing::error!(target: "nanocodex2", error = %error, "VM host provision failed; reconnecting for durable redrive");
-                            return Ok(ConnectionOutcome::Reconnect);
+                            return Ok(ConnectionOutcome::Reconnect { made_progress });
                         }
                         ControlledOperationOutcome::Terminal { result, terminal } => {
                             return finish_deferred_control_outcome(
@@ -2040,14 +2212,16 @@ mod supported {
                                 "provision",
                                 result,
                                 terminal,
+                                made_progress,
                             )
                             .await;
                         }
                     }
                     if let Err(error) = connection.provisioned(&acknowledgement).await {
                         tracing::warn!(target: "nanocodex2", error = %error, "VM host provision acknowledgement failed");
-                        return Ok(ConnectionOutcome::Reconnect);
+                        return Ok(ConnectionOutcome::Reconnect { made_progress });
                     }
+                    made_progress = true;
                 }
                 VmHostCommand::Release(release) => {
                     let identity = VmAllocationIdentity {
@@ -2056,9 +2230,14 @@ mod supported {
                         machine_id: release.machine_id().to_owned(),
                     };
                     let cancellation = OperationCancellation::default();
+                    let active = PendingCommandIdentity {
+                        allocation_id: identity.allocation_id,
+                        kind: PendingCommandKind::Release,
+                    };
                     match drive_controlled_operation(
                         host.release(&identity),
                         &cancellation,
+                        active,
                         connection,
                         &mut heartbeat,
                         &mut pending_commands,
@@ -2068,19 +2247,25 @@ mod supported {
                         ControlledOperationOutcome::Completed(Ok(_)) => {}
                         ControlledOperationOutcome::Completed(Err(error)) => {
                             tracing::error!(target: "nanocodex2", error = %error, "VM host release failed; reconnecting for durable redrive");
-                            return Ok(ConnectionOutcome::Reconnect);
+                            return Ok(ConnectionOutcome::Reconnect { made_progress });
                         }
                         ControlledOperationOutcome::Terminal { result, terminal } => {
                             return finish_deferred_control_outcome(
-                                host, "release", result, terminal,
+                                host,
+                                "release",
+                                result,
+                                terminal,
+                                made_progress,
                             )
                             .await;
                         }
                     }
                     if let Err(error) = connection.released(&release).await {
                         tracing::warn!(target: "nanocodex2", error = %error, "VM host release acknowledgement failed");
-                        return Ok(ConnectionOutcome::Reconnect);
+                        return Ok(ConnectionOutcome::Reconnect { made_progress });
                     }
+                    host.acknowledge_released(&identity)?;
+                    made_progress = true;
                 }
                 VmHostCommand::Fenced(fence) => {
                     return Err(ManagedError::VmHost(format!(
@@ -2109,6 +2294,15 @@ mod supported {
         }
     }
 
+    fn next_reconnect_delay(retry: &mut Duration, healthy: bool) -> Duration {
+        if healthy {
+            *retry = INITIAL_RECONNECT_DELAY;
+        }
+        let delay = *retry;
+        *retry = retry.saturating_mul(2).min(MAX_RECONNECT_DELAY);
+        delay
+    }
+
     fn system_host_token_from_environment() -> Result<String, ManagedError> {
         match env::var(SYSTEM_HOST_TOKEN_ENV) {
             Ok(value) if !value.trim().is_empty() => Ok(value),
@@ -2132,6 +2326,22 @@ mod supported {
         };
 
         use super::*;
+
+        #[derive(Debug, Eq, PartialEq)]
+        struct TestPendingCommand {
+            allocation_id: Uuid,
+            kind: PendingCommandKind,
+            sequence: u8,
+        }
+
+        impl PendingLifecycleCommand for TestPendingCommand {
+            fn pending_identity(&self) -> PendingCommandIdentity {
+                PendingCommandIdentity {
+                    allocation_id: self.allocation_id,
+                    kind: self.kind,
+                }
+            }
+        }
 
         #[derive(Clone)]
         struct FakeFactory {
@@ -2432,44 +2642,126 @@ mod supported {
             assert!(matches!(event, ControlledOperationEvent::Completed(7)));
         }
 
-        #[tokio::test]
-        async fn back_to_back_provisions_queue_fifo_while_operation_is_pending() {
-            #[derive(Debug, Eq, PartialEq)]
-            enum TestCommand {
-                Provision(u8),
+        #[test]
+        fn pending_commands_are_bounded_coalesced_and_release_first() {
+            let active_id = Uuid::new_v4();
+            let first = Uuid::new_v4();
+            let second = Uuid::new_v4();
+            let third = Uuid::new_v4();
+            let active = PendingCommandIdentity {
+                allocation_id: active_id,
+                kind: PendingCommandKind::Provision,
+            };
+            let mut queued = PendingCommandQueue::new(1);
+
+            for sequence in [1, 2] {
+                queued
+                    .push(
+                        TestPendingCommand {
+                            allocation_id: first,
+                            kind: PendingCommandKind::Provision,
+                            sequence,
+                        },
+                        active,
+                    )
+                    .unwrap();
             }
-
-            let (complete, operation) = tokio::sync::oneshot::channel::<()>();
-            let operation = async { operation.await.unwrap() };
-            tokio::pin!(operation);
-            let mut queued = VecDeque::new();
-
-            for slot in [0, 1] {
-                let event = next_controlled_operation_event(
-                    operation.as_mut(),
-                    pending::<()>(),
-                    pending::<()>(),
-                    ready(TestCommand::Provision(slot)),
+            assert_eq!(queued.commands.len(), 1, "duplicate provision coalesced");
+            queued
+                .push(
+                    TestPendingCommand {
+                        allocation_id: second,
+                        kind: PendingCommandKind::Provision,
+                        sequence: 3,
+                    },
+                    active,
                 )
-                .await;
-                match event {
-                    ControlledOperationEvent::Control(command) => queued.push_back(command),
-                    _ => panic!("pending operation must accept the queued provision"),
-                }
-            }
+                .unwrap();
+            assert!(
+                queued
+                    .push(
+                        TestPendingCommand {
+                            allocation_id: third,
+                            kind: PendingCommandKind::Provision,
+                            sequence: 4,
+                        },
+                        active,
+                    )
+                    .is_err(),
+                "a third unique identity exceeds twice max_vms"
+            );
+            queued
+                .push(
+                    TestPendingCommand {
+                        allocation_id: second,
+                        kind: PendingCommandKind::Release,
+                        sequence: 5,
+                    },
+                    active,
+                )
+                .unwrap();
 
-            complete.send(()).unwrap();
-            let event = next_controlled_operation_event(
-                operation.as_mut(),
-                pending::<()>(),
-                pending::<()>(),
-                pending::<()>(),
-            )
-            .await;
-            assert!(matches!(event, ControlledOperationEvent::Completed(())));
+            assert_eq!(queued.pop().unwrap().sequence, 5, "release has priority");
             assert_eq!(
-                queued.into_iter().collect::<Vec<_>>(),
-                [TestCommand::Provision(0), TestCommand::Provision(1)]
+                queued.pop().unwrap().sequence,
+                1,
+                "first provision retained"
+            );
+            assert!(queued.pop().is_none());
+
+            let active_release = PendingCommandIdentity {
+                allocation_id: active_id,
+                kind: PendingCommandKind::Release,
+            };
+            queued
+                .push(
+                    TestPendingCommand {
+                        allocation_id: active_id,
+                        kind: PendingCommandKind::Release,
+                        sequence: 6,
+                    },
+                    active_release,
+                )
+                .unwrap();
+            assert!(
+                queued.pop().is_none(),
+                "duplicate in-flight release coalesced"
+            );
+        }
+
+        #[test]
+        fn reconnect_backoff_resets_only_after_meaningful_health() {
+            let mut retry = INITIAL_RECONNECT_DELAY;
+            assert_eq!(
+                next_reconnect_delay(&mut retry, false),
+                Duration::from_millis(250)
+            );
+            assert_eq!(
+                next_reconnect_delay(&mut retry, false),
+                Duration::from_millis(500)
+            );
+            assert_eq!(
+                next_reconnect_delay(&mut retry, false),
+                Duration::from_secs(1)
+            );
+            assert_eq!(
+                next_reconnect_delay(&mut retry, true),
+                INITIAL_RECONNECT_DELAY
+            );
+            assert_eq!(retry, Duration::from_millis(500));
+        }
+
+        #[test]
+        fn vm_hand_start_failures_are_safe_for_same_process_redrive() {
+            let failure = vm_hand_start_failure(ManagedError::Configuration(
+                "pre-launch validation failed".to_owned(),
+            ));
+            assert!(failure.cleanup_safe);
+            assert!(
+                failure
+                    .error
+                    .to_string()
+                    .contains("pre-launch validation failed")
             );
         }
 
@@ -2499,6 +2791,25 @@ mod supported {
             clone_private_root_blocking(&template, &clone).unwrap();
             assert_eq!(fs::read(&template).unwrap(), b"template");
             assert_eq!(fs::read(&clone).unwrap(), b"private");
+        }
+
+        #[test]
+        fn locked_template_descriptor_survives_path_replacement() {
+            let directory = tempfile::tempdir().unwrap();
+            let template = directory.path().join("template.ext4");
+            let replacement = directory.path().join("replacement.ext4");
+            let clone = directory.path().join("allocations/allocation.ext4");
+            fs::write(&template, b"locked-template").unwrap();
+            let locked = File::open(&template).unwrap();
+            fs2::FileExt::try_lock_shared(&locked).unwrap();
+            let locked_path = locked_file_path(&locked);
+
+            fs::write(&replacement, b"replacement-template").unwrap();
+            fs::rename(&replacement, &template).unwrap();
+            clone_private_root_blocking(&locked_path, &clone).unwrap();
+
+            assert_eq!(fs::read(&template).unwrap(), b"replacement-template");
+            assert_eq!(fs::read(&clone).unwrap(), b"locked-template");
         }
 
         #[test]
@@ -2591,6 +2902,47 @@ mod supported {
                     format!("release-recovered:{}", request.identity.allocation_id),
                 ]
             );
+        }
+
+        #[tokio::test]
+        async fn acknowledged_release_compacts_tombstone_and_redrive_recreates_it_safely() {
+            let directory = tempfile::tempdir().unwrap();
+            let state = open_test_state(&directory);
+            let allocation_id = Uuid::new_v4();
+            let identity = VmAllocationIdentity {
+                allocation_id,
+                generation: 1,
+                machine_id: "machine-0".to_owned(),
+            };
+            let record = state
+                .directory
+                .join("allocations")
+                .join(format!("{allocation_id}.json"));
+            let mut supervisor = AllocationSupervisor::with_store(
+                1,
+                FakeFactory {
+                    events: Arc::new(Mutex::new(Vec::new())),
+                },
+                test_store(&state),
+                &state,
+            )
+            .unwrap();
+
+            supervisor.release(&identity).await.unwrap();
+            assert_eq!(
+                read_record(&state, allocation_id).state,
+                AllocationRecordState::Released
+            );
+            supervisor.acknowledge_released(&identity).unwrap();
+            assert!(!record.exists());
+            assert!(!supervisor.retired.contains_key(&allocation_id));
+
+            // If the process dies after the WebSocket send but before the
+            // service commits it, the repeated release is still idempotent.
+            supervisor.release(&identity).await.unwrap();
+            assert!(record.exists());
+            supervisor.acknowledge_released(&identity).unwrap();
+            assert!(!record.exists());
         }
 
         #[tokio::test]

--- a/bin/nanocodex/src/nanocodex2/vm_host.rs
+++ b/bin/nanocodex/src/nanocodex2/vm_host.rs
@@ -3145,17 +3145,18 @@ mod supported {
 
             recovered.complete_startup_releases().await.unwrap();
 
-            let startup_events = events.lock().unwrap();
-            assert_eq!(startup_events.len(), 2);
-            assert!(startup_events.contains(&format!(
-                "release-recovered:{}",
-                safe.identity.allocation_id
-            )));
-            assert!(startup_events.contains(&format!(
-                "release-recovered:{}",
-                unsafe_allocation.identity.allocation_id
-            )));
-            drop(startup_events);
+            {
+                let startup_events = events.lock().unwrap();
+                assert_eq!(startup_events.len(), 2);
+                assert!(startup_events.contains(&format!(
+                    "release-recovered:{}",
+                    safe.identity.allocation_id
+                )));
+                assert!(startup_events.contains(&format!(
+                    "release-recovered:{}",
+                    unsafe_allocation.identity.allocation_id
+                )));
+            }
             assert_eq!(
                 recovered.release(&safe.identity).await.unwrap(),
                 VmAllocationChange::Unchanged

--- a/bin/nanocodex/src/nanocodex2/vm_host.rs
+++ b/bin/nanocodex/src/nanocodex2/vm_host.rs
@@ -1,0 +1,3129 @@
+//! Bounded on-demand VM ownership behind the managed VM-host control plane.
+
+use nanocodex_managed::ManagedError;
+
+use super::Host;
+
+#[cfg(any(
+    all(target_os = "linux", not(target_env = "musl")),
+    all(target_os = "macos", target_arch = "aarch64")
+))]
+mod supported {
+    use std::{
+        collections::{BTreeMap, VecDeque},
+        env,
+        fs::{self, File, OpenOptions},
+        future::Future,
+        io::Write as _,
+        os::unix::fs::{MetadataExt as _, PermissionsExt as _},
+        path::{Path, PathBuf},
+        pin::Pin,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        time::Duration,
+    };
+
+    use fs2::FileExt as _;
+    use nanocodex_managed::{
+        ManagedClient, ManagedError, VmHostAllocationState, VmHostCommand, VmHostConnection,
+        VmHostScope, VmShape, connect_system_vm_host,
+    };
+    use nanocodex_tools::attachment::{Attachment, AttachmentMetadata, AttachmentTarget};
+    use serde::{Deserialize, Serialize};
+    use tempfile::NamedTempFile;
+    use uuid::Uuid;
+
+    use super::super::{
+        Host, HostScope, SYSTEM_HOST_TOKEN_ENV, client_from_environment,
+        managed_url_from_environment, vm_hand,
+    };
+
+    type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+    const ATTACHMENT_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
+    /// Immutable control-plane identity for one VM allocation.
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[serde(deny_unknown_fields)]
+    pub(crate) struct VmAllocationIdentity {
+        pub(crate) allocation_id: Uuid,
+        pub(crate) generation: u64,
+        pub(crate) machine_id: String,
+    }
+
+    /// Complete local provisioning request for one control-plane allocation.
+    #[derive(Clone, Debug)]
+    pub(crate) struct VmAllocationSpec {
+        pub(crate) identity: VmAllocationIdentity,
+        pub(crate) slot: u16,
+        pub(crate) attachment_target: AttachmentTarget,
+    }
+
+    impl VmAllocationSpec {
+        pub(crate) fn new(
+            allocation_id: Uuid,
+            slot: u16,
+            generation: u64,
+            machine_id: impl Into<String>,
+            attachment_target: AttachmentTarget,
+        ) -> Self {
+            Self {
+                identity: VmAllocationIdentity {
+                    allocation_id,
+                    generation,
+                    machine_id: machine_id.into(),
+                },
+                slot,
+                attachment_target,
+            }
+        }
+
+        fn immutable_key(&self) -> ImmutableAllocation {
+            ImmutableAllocation {
+                identity: self.identity.clone(),
+                slot: self.slot,
+                attachment_endpoint: self.attachment_target.endpoint().to_string(),
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[serde(deny_unknown_fields)]
+    struct ImmutableAllocation {
+        identity: VmAllocationIdentity,
+        slot: u16,
+        attachment_endpoint: String,
+    }
+
+    /// Result of an idempotent provision or release request.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub(crate) enum VmAllocationChange {
+        Changed,
+        Unchanged,
+    }
+
+    /// Local VM-host policy or resource failure.
+    #[derive(Debug, thiserror::Error)]
+    pub(crate) enum VmHostError {
+        #[error("invalid VM host configuration: {0}")]
+        Configuration(String),
+        #[error("VM host state failed: {0}")]
+        State(String),
+        #[error("VM host capacity {capacity} is exhausted")]
+        Capacity { capacity: u16 },
+        #[error("allocation {allocation_id} changed immutable fields")]
+        ImmutableConflict { allocation_id: Uuid },
+        #[error("VM allocation resource failed: {0}")]
+        Resource(String),
+        #[error("VM allocation operation cancelled after the control connection became terminal")]
+        Cancelled,
+    }
+
+    impl From<VmHostError> for ManagedError {
+        fn from(error: VmHostError) -> Self {
+            Self::Configuration(error.to_string())
+        }
+    }
+
+    /// Process-exclusive durable state for one stable host identity.
+    struct VmHostState {
+        directory: PathBuf,
+        host_id: Uuid,
+        _lock: File,
+    }
+
+    impl VmHostState {
+        fn open(directory: &Path, explicit_host_id: Option<Uuid>) -> Result<Self, VmHostError> {
+            fs::create_dir_all(directory).map_err(|error| {
+                VmHostError::State(format!(
+                    "failed to create host state directory {}: {error}",
+                    directory.display()
+                ))
+            })?;
+            let directory = directory.canonicalize().map_err(|error| {
+                VmHostError::State(format!(
+                    "failed to resolve host state directory {}: {error}",
+                    directory.display()
+                ))
+            })?;
+            fs::set_permissions(&directory, fs::Permissions::from_mode(0o700)).map_err(
+                |error| {
+                    VmHostError::State(format!(
+                        "failed to secure host state directory {}: {error}",
+                        directory.display()
+                    ))
+                },
+            )?;
+            let lock_path = directory.join("host.lock");
+            let lock = OpenOptions::new()
+                .create(true)
+                .read(true)
+                .write(true)
+                .open(&lock_path)
+                .map_err(|error| {
+                    VmHostError::State(format!(
+                        "failed to open host state lock {}: {error}",
+                        lock_path.display()
+                    ))
+                })?;
+            lock.try_lock_exclusive().map_err(|error| {
+                VmHostError::State(format!(
+                    "host state is already in use ({}): {error}",
+                    directory.display()
+                ))
+            })?;
+
+            let identity_path = directory.join("host-id");
+            let persisted = match fs::read_to_string(&identity_path) {
+                Ok(value) => {
+                    let parsed = Uuid::parse_str(value.trim()).map_err(|error| {
+                        VmHostError::State(format!(
+                            "host identity {} is invalid: {error}",
+                            identity_path.display()
+                        ))
+                    })?;
+                    if parsed.get_version_num() != 4
+                        || parsed.get_variant() != uuid::Variant::RFC4122
+                    {
+                        return Err(VmHostError::State(format!(
+                            "host identity {} must be a UUID v4",
+                            identity_path.display()
+                        )));
+                    }
+                    Some(parsed)
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+                Err(error) => {
+                    return Err(VmHostError::State(format!(
+                        "failed to read host identity {}: {error}",
+                        identity_path.display()
+                    )));
+                }
+            };
+            let host_id = match (persisted, explicit_host_id) {
+                (Some(persisted), Some(explicit)) if persisted != explicit => {
+                    return Err(VmHostError::Configuration(format!(
+                        "--host-id {explicit} does not match the persisted host identity {persisted}"
+                    )));
+                }
+                (Some(persisted), _) => persisted,
+                (None, explicit) => {
+                    let host_id = explicit.unwrap_or_else(Uuid::new_v4);
+                    persist_host_id(&directory, &identity_path, host_id)?;
+                    host_id
+                }
+            };
+            let allocations = directory.join("allocations");
+            fs::create_dir_all(&allocations).map_err(|error| {
+                VmHostError::State(format!("failed to create allocation state: {error}"))
+            })?;
+            let allocation_metadata = fs::symlink_metadata(&allocations).map_err(|error| {
+                VmHostError::State(format!("failed to inspect allocation state: {error}"))
+            })?;
+            if allocation_metadata.file_type().is_symlink() || !allocation_metadata.is_dir() {
+                return Err(VmHostError::State(
+                    "allocation state must be a real directory".to_owned(),
+                ));
+            }
+            let canonical_allocations = allocations.canonicalize().map_err(|error| {
+                VmHostError::State(format!("failed to resolve allocation state: {error}"))
+            })?;
+            if canonical_allocations.parent() != Some(directory.as_path()) {
+                return Err(VmHostError::State(
+                    "allocation state escapes the host state directory".to_owned(),
+                ));
+            }
+            fs::set_permissions(&allocations, fs::Permissions::from_mode(0o700)).map_err(
+                |error| VmHostError::State(format!("failed to secure allocation state: {error}")),
+            )?;
+            Ok(Self {
+                directory,
+                host_id,
+                _lock: lock,
+            })
+        }
+    }
+
+    fn persist_host_id(
+        directory: &Path,
+        identity_path: &Path,
+        host_id: Uuid,
+    ) -> Result<(), VmHostError> {
+        let mut temporary = NamedTempFile::new_in(directory).map_err(|error| {
+            VmHostError::State(format!("failed to create temporary host identity: {error}"))
+        })?;
+        writeln!(temporary, "{host_id}").map_err(|error| {
+            VmHostError::State(format!("failed to write host identity: {error}"))
+        })?;
+        temporary.as_file().sync_all().map_err(|error| {
+            VmHostError::State(format!("failed to sync host identity: {error}"))
+        })?;
+        temporary
+            .persist_noclobber(identity_path)
+            .map_err(|error| {
+                VmHostError::State(format!("failed to persist host identity: {}", error.error))
+            })?;
+        sync_directory(directory)?;
+        Ok(())
+    }
+
+    const ALLOCATION_RECORD_VERSION: u8 = 1;
+
+    #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[serde(rename_all = "snake_case")]
+    enum AllocationRecordState {
+        Provisioning,
+        Ready,
+        Stopped,
+        Releasing,
+        ReleasingStopped,
+        Released,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[serde(deny_unknown_fields)]
+    struct AllocationRecord {
+        version: u8,
+        state: AllocationRecordState,
+        identity: VmAllocationIdentity,
+        slot: Option<u16>,
+        attachment_endpoint: Option<String>,
+    }
+
+    impl AllocationRecord {
+        fn tracked(state: AllocationRecordState, immutable: &ImmutableAllocation) -> Self {
+            Self {
+                version: ALLOCATION_RECORD_VERSION,
+                state,
+                identity: immutable.identity.clone(),
+                slot: Some(immutable.slot),
+                attachment_endpoint: Some(immutable.attachment_endpoint.clone()),
+            }
+        }
+
+        fn release(
+            state: AllocationRecordState,
+            identity: &VmAllocationIdentity,
+            immutable: Option<&ImmutableAllocation>,
+        ) -> Self {
+            Self {
+                version: ALLOCATION_RECORD_VERSION,
+                state,
+                identity: identity.clone(),
+                slot: immutable.map(|value| value.slot),
+                attachment_endpoint: immutable.map(|value| value.attachment_endpoint.clone()),
+            }
+        }
+
+        fn immutable(&self) -> Result<Option<ImmutableAllocation>, VmHostError> {
+            match (&self.slot, &self.attachment_endpoint) {
+                (Some(slot), Some(endpoint)) => Ok(Some(ImmutableAllocation {
+                    identity: self.identity.clone(),
+                    slot: *slot,
+                    attachment_endpoint: endpoint.clone(),
+                })),
+                (None, None) => Ok(None),
+                _ => Err(VmHostError::State(
+                    "allocation record has incomplete immutable fields".to_owned(),
+                )),
+            }
+        }
+    }
+
+    struct AllocationStore {
+        directory: PathBuf,
+    }
+
+    struct LoadedAllocations {
+        recovered: BTreeMap<Uuid, RecoveredAllocation>,
+        retired: BTreeMap<Uuid, RetiredAllocation>,
+    }
+
+    struct RecoveredAllocation {
+        immutable: ImmutableAllocation,
+        cleanup_safe: bool,
+    }
+
+    impl AllocationStore {
+        fn new(directory: PathBuf) -> Self {
+            Self { directory }
+        }
+
+        fn record_path(&self, allocation_id: Uuid) -> PathBuf {
+            self.directory.join(format!("{allocation_id}.json"))
+        }
+
+        fn put(&self, record: &AllocationRecord) -> Result<(), VmHostError> {
+            let encoded = serde_json::to_vec(record).map_err(|error| {
+                VmHostError::State(format!("failed to encode allocation record: {error}"))
+            })?;
+            let destination = self.record_path(record.identity.allocation_id);
+            let mut temporary = NamedTempFile::new_in(&self.directory).map_err(|error| {
+                VmHostError::State(format!("failed to create allocation record: {error}"))
+            })?;
+            temporary.write_all(&encoded).map_err(|error| {
+                VmHostError::State(format!("failed to write allocation record: {error}"))
+            })?;
+            temporary.as_file().sync_all().map_err(|error| {
+                VmHostError::State(format!("failed to sync allocation record: {error}"))
+            })?;
+            temporary.persist(&destination).map_err(|error| {
+                VmHostError::State(format!(
+                    "failed to persist allocation record: {}",
+                    error.error
+                ))
+            })?;
+            sync_directory(&self.directory)?;
+            Ok(())
+        }
+
+        fn load(&self, capacity: u16) -> Result<LoadedAllocations, VmHostError> {
+            let mut recovered = BTreeMap::new();
+            let mut retired = BTreeMap::new();
+            let mut slots = BTreeMap::new();
+            let mut machines = BTreeMap::new();
+            for entry in fs::read_dir(&self.directory).map_err(|error| {
+                VmHostError::State(format!("failed to read allocation state: {error}"))
+            })? {
+                let entry = entry.map_err(|error| {
+                    VmHostError::State(format!("failed to inspect allocation state: {error}"))
+                })?;
+                let path = entry.path();
+                if path.extension().and_then(|value| value.to_str()) != Some("json") {
+                    continue;
+                }
+                let file_type = entry.file_type().map_err(|error| {
+                    VmHostError::State(format!(
+                        "failed to inspect allocation record {}: {error}",
+                        path.display()
+                    ))
+                })?;
+                if file_type.is_symlink() || !file_type.is_file() {
+                    return Err(VmHostError::State(format!(
+                        "allocation record must be a real file: {}",
+                        path.display()
+                    )));
+                }
+                let filename_id = path
+                    .file_stem()
+                    .and_then(|value| value.to_str())
+                    .and_then(|value| Uuid::parse_str(value).ok())
+                    .ok_or_else(|| {
+                        VmHostError::State(format!(
+                            "allocation record has invalid filename: {}",
+                            path.display()
+                        ))
+                    })?;
+                let record: AllocationRecord =
+                    serde_json::from_slice(&fs::read(&path).map_err(|error| {
+                        VmHostError::State(format!(
+                            "failed to read allocation record {}: {error}",
+                            path.display()
+                        ))
+                    })?)
+                    .map_err(|error| {
+                        VmHostError::State(format!(
+                            "allocation record {} is invalid: {error}",
+                            path.display()
+                        ))
+                    })?;
+                validate_record(&record, filename_id, capacity)?;
+                match record.state {
+                    AllocationRecordState::Provisioning
+                    | AllocationRecordState::Ready
+                    | AllocationRecordState::Stopped => {
+                        let immutable = record.immutable()?.ok_or_else(|| {
+                            VmHostError::State(
+                                "tracked allocation record lacks immutable fields".to_owned(),
+                            )
+                        })?;
+                        if slots.insert(immutable.slot, filename_id).is_some()
+                            || machines
+                                .insert(immutable.identity.machine_id.clone(), filename_id)
+                                .is_some()
+                        {
+                            return Err(VmHostError::State(
+                                "allocation records reuse a live slot or machine ID".to_owned(),
+                            ));
+                        }
+                        recovered.insert(
+                            filename_id,
+                            RecoveredAllocation {
+                                immutable,
+                                cleanup_safe: record.state == AllocationRecordState::Stopped,
+                            },
+                        );
+                    }
+                    AllocationRecordState::Releasing
+                    | AllocationRecordState::ReleasingStopped
+                    | AllocationRecordState::Released => {
+                        let immutable = record.immutable()?;
+                        if record.state != AllocationRecordState::Released {
+                            let immutable = immutable.as_ref().ok_or_else(|| {
+                                VmHostError::State(
+                                    "pending release record lacks immutable fields".to_owned(),
+                                )
+                            })?;
+                            if slots.insert(immutable.slot, filename_id).is_some()
+                                || machines
+                                    .insert(immutable.identity.machine_id.clone(), filename_id)
+                                    .is_some()
+                            {
+                                return Err(VmHostError::State(
+                                    "allocation records reuse a reserved slot or machine ID"
+                                        .to_owned(),
+                                ));
+                            }
+                        }
+                        retired.insert(
+                            filename_id,
+                            RetiredAllocation {
+                                identity: record.identity,
+                                immutable,
+                                release_pending: record.state != AllocationRecordState::Released,
+                                cleanup_safe: record.state
+                                    == AllocationRecordState::ReleasingStopped,
+                            },
+                        );
+                    }
+                }
+            }
+            Ok(LoadedAllocations { recovered, retired })
+        }
+
+        /// Converts every phase which could have owned a libkrun VM in the
+        /// predecessor into a durable stopped phase. This is only valid after
+        /// `VmHostState` has acquired the process-exclusive state lock: libkrun
+        /// VMs are process-owned, so acquiring that lock proves the predecessor
+        /// (and all of its VM execution) has ended.
+        fn fence_predecessor_orphans(
+            &self,
+            state: &VmHostState,
+            capacity: u16,
+        ) -> Result<LoadedAllocations, VmHostError> {
+            if self.directory != state.directory.join("allocations") {
+                return Err(VmHostError::State(
+                    "allocation store does not belong to the locked host state".to_owned(),
+                ));
+            }
+            let mut loaded = self.load(capacity)?;
+            for recovered in loaded.recovered.values_mut() {
+                if !recovered.cleanup_safe {
+                    self.put(&AllocationRecord::tracked(
+                        AllocationRecordState::Stopped,
+                        &recovered.immutable,
+                    ))?;
+                    recovered.cleanup_safe = true;
+                }
+            }
+            for retired in loaded.retired.values_mut() {
+                if retired.release_pending && !retired.cleanup_safe {
+                    let immutable = retired.immutable.as_ref().ok_or_else(|| {
+                        VmHostError::State(
+                            "pending release record lacks immutable fields".to_owned(),
+                        )
+                    })?;
+                    self.put(&AllocationRecord::release(
+                        AllocationRecordState::ReleasingStopped,
+                        &retired.identity,
+                        Some(immutable),
+                    ))?;
+                    retired.cleanup_safe = true;
+                }
+            }
+            Ok(loaded)
+        }
+    }
+
+    fn validate_record(
+        record: &AllocationRecord,
+        filename_id: Uuid,
+        capacity: u16,
+    ) -> Result<(), VmHostError> {
+        if record.version != ALLOCATION_RECORD_VERSION
+            || record.identity.allocation_id != filename_id
+            || record.identity.allocation_id.get_version_num() != 4
+            || record.identity.allocation_id.get_variant() != uuid::Variant::RFC4122
+            || record.identity.generation == 0
+            || record.identity.generation > 9_007_199_254_740_991
+            || !valid_persisted_machine_id(&record.identity.machine_id)
+        {
+            return Err(VmHostError::State(
+                "allocation record has invalid identity or version".to_owned(),
+            ));
+        }
+        if let Some(slot) = record.slot
+            && slot >= capacity
+        {
+            return Err(VmHostError::State(
+                "allocation record slot is outside host capacity".to_owned(),
+            ));
+        }
+        if let Some(endpoint) = &record.attachment_endpoint {
+            AttachmentTarget::new(endpoint.clone(), "record-validation-bearer").map_err(|_| {
+                VmHostError::State(
+                    "allocation record has an invalid attachment endpoint".to_owned(),
+                )
+            })?;
+        }
+        match record.state {
+            AllocationRecordState::Provisioning
+            | AllocationRecordState::Ready
+            | AllocationRecordState::Stopped
+            | AllocationRecordState::Releasing
+            | AllocationRecordState::ReleasingStopped
+                if record.slot.is_none() || record.attachment_endpoint.is_none() =>
+            {
+                Err(VmHostError::State(
+                    "tracked allocation record lacks immutable fields".to_owned(),
+                ))
+            }
+            AllocationRecordState::Released
+                if record.slot.is_some() || record.attachment_endpoint.is_some() =>
+            {
+                Err(VmHostError::State(
+                    "released allocation record retains immutable fields".to_owned(),
+                ))
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn valid_persisted_machine_id(value: &str) -> bool {
+        let bytes = value.as_bytes();
+        !bytes.is_empty()
+            && bytes.len() <= 123
+            && bytes[0].is_ascii_alphanumeric()
+            && bytes
+                .iter()
+                .all(|byte| byte.is_ascii_alphanumeric() || b"._:-".contains(byte))
+    }
+
+    fn sync_directory(directory: &Path) -> Result<(), VmHostError> {
+        File::open(directory)
+            .and_then(|handle| handle.sync_all())
+            .map_err(|error| {
+                VmHostError::State(format!("failed to sync allocation state: {error}"))
+            })
+    }
+
+    #[derive(Clone, Default)]
+    struct OperationCancellation {
+        cancelled: Arc<AtomicBool>,
+    }
+
+    impl OperationCancellation {
+        fn cancel(&self) {
+            self.cancelled.store(true, Ordering::Release);
+        }
+
+        fn is_cancelled(&self) -> bool {
+            self.cancelled.load(Ordering::Acquire)
+        }
+
+        fn check(&self) -> Result<(), VmHostError> {
+            if self.is_cancelled() {
+                Err(VmHostError::Cancelled)
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    struct ProvisionFailure {
+        error: VmHostError,
+        cleanup_safe: bool,
+    }
+
+    impl ProvisionFailure {
+        const fn stopped(error: VmHostError) -> Self {
+            Self {
+                error,
+                cleanup_safe: true,
+            }
+        }
+
+        const fn unproven(error: VmHostError) -> Self {
+            Self {
+                error,
+                cleanup_safe: false,
+            }
+        }
+    }
+
+    struct StopOutcome {
+        attachment: Result<(), VmHostError>,
+        shutdown: Result<(), VmHostError>,
+    }
+
+    impl StopOutcome {
+        #[cfg(test)]
+        const fn stopped() -> Self {
+            Self {
+                attachment: Ok(()),
+                shutdown: Ok(()),
+            }
+        }
+
+        fn shutdown_succeeded(&self) -> bool {
+            self.shutdown.is_ok()
+        }
+
+        fn into_result(self) -> Result<(), VmHostError> {
+            combine_failures([self.attachment, self.shutdown])
+        }
+    }
+
+    trait AllocationFactory {
+        type Allocation: Send;
+
+        fn provision<'a>(
+            &'a self,
+            spec: VmAllocationSpec,
+            cancellation: OperationCancellation,
+        ) -> BoxFuture<'a, Result<Self::Allocation, ProvisionFailure>>;
+
+        fn refresh_attachment<'a>(
+            &'a self,
+            allocation: &'a mut Self::Allocation,
+            target: AttachmentTarget,
+            cancellation: OperationCancellation,
+        ) -> BoxFuture<'a, Result<(), VmHostError>>;
+
+        fn stop<'a>(&'a self, allocation: Self::Allocation) -> BoxFuture<'a, StopOutcome>;
+
+        fn release_recovered<'a>(
+            &'a self,
+            identity: &'a VmAllocationIdentity,
+        ) -> BoxFuture<'a, Result<(), VmHostError>>;
+    }
+
+    enum ActiveAllocation<A> {
+        Live {
+            immutable: ImmutableAllocation,
+            allocation: A,
+            attachment_target: AttachmentTarget,
+        },
+        Recovered {
+            immutable: ImmutableAllocation,
+            cleanup_safe: bool,
+        },
+    }
+
+    impl<A> ActiveAllocation<A> {
+        const fn immutable(&self) -> &ImmutableAllocation {
+            match self {
+                Self::Live { immutable, .. } | Self::Recovered { immutable, .. } => immutable,
+            }
+        }
+    }
+
+    struct RetiredAllocation {
+        identity: VmAllocationIdentity,
+        immutable: Option<ImmutableAllocation>,
+        release_pending: bool,
+        cleanup_safe: bool,
+    }
+
+    struct AllocationSupervisor<F: AllocationFactory> {
+        capacity: u16,
+        factory: F,
+        store: Option<AllocationStore>,
+        active: BTreeMap<Uuid, ActiveAllocation<F::Allocation>>,
+        retired: BTreeMap<Uuid, RetiredAllocation>,
+    }
+
+    impl<F: AllocationFactory> AllocationSupervisor<F> {
+        #[cfg(test)]
+        fn new(capacity: u16, factory: F) -> Result<Self, VmHostError> {
+            if capacity == 0 {
+                return Err(VmHostError::Configuration(
+                    "VM host capacity must be positive".to_owned(),
+                ));
+            }
+            Ok(Self {
+                capacity,
+                factory,
+                store: None,
+                active: BTreeMap::new(),
+                retired: BTreeMap::new(),
+            })
+        }
+
+        fn with_store(
+            capacity: u16,
+            factory: F,
+            store: AllocationStore,
+            state: &VmHostState,
+        ) -> Result<Self, VmHostError> {
+            let loaded = store.fence_predecessor_orphans(state, capacity)?;
+            Ok(Self {
+                capacity,
+                factory,
+                store: Some(store),
+                active: loaded
+                    .recovered
+                    .into_iter()
+                    .map(|(id, recovered)| {
+                        (
+                            id,
+                            ActiveAllocation::Recovered {
+                                immutable: recovered.immutable,
+                                cleanup_safe: recovered.cleanup_safe,
+                            },
+                        )
+                    })
+                    .collect(),
+                retired: loaded.retired,
+            })
+        }
+
+        fn persist(&self, record: &AllocationRecord) -> Result<(), VmHostError> {
+            self.store
+                .as_ref()
+                .map_or(Ok(()), |store| store.put(record))
+        }
+
+        #[cfg(test)]
+        async fn provision(
+            &mut self,
+            spec: VmAllocationSpec,
+        ) -> Result<VmAllocationChange, VmHostError> {
+            self.provision_controlled(spec, OperationCancellation::default())
+                .await
+        }
+
+        async fn provision_controlled(
+            &mut self,
+            spec: VmAllocationSpec,
+            cancellation: OperationCancellation,
+        ) -> Result<VmAllocationChange, VmHostError> {
+            cancellation.check()?;
+            if spec.identity.generation == 0 {
+                return Err(VmHostError::Configuration(
+                    "allocation generation must be positive".to_owned(),
+                ));
+            }
+            let immutable = spec.immutable_key();
+            if self.retired.contains_key(&spec.identity.allocation_id) {
+                return Err(VmHostError::ImmutableConflict {
+                    allocation_id: spec.identity.allocation_id,
+                });
+            }
+            if let Some(existing) = self.active.get(&spec.identity.allocation_id) {
+                if existing.immutable() != &immutable {
+                    return Err(VmHostError::ImmutableConflict {
+                        allocation_id: spec.identity.allocation_id,
+                    });
+                }
+                if matches!(
+                    existing,
+                    ActiveAllocation::Recovered {
+                        cleanup_safe: false,
+                        ..
+                    }
+                ) {
+                    return Err(VmHostError::State(format!(
+                        "allocation {} cannot be reprovisioned because its recovered VM was not proven stopped",
+                        spec.identity.allocation_id
+                    )));
+                }
+            }
+            if let Some(ActiveAllocation::Live {
+                allocation,
+                attachment_target,
+                ..
+            }) = self.active.get_mut(&spec.identity.allocation_id)
+            {
+                if attachment_target == &spec.attachment_target {
+                    return Ok(VmAllocationChange::Unchanged);
+                }
+                let target = spec.attachment_target;
+                self.factory
+                    .refresh_attachment(allocation, target.clone(), cancellation.clone())
+                    .await?;
+                cancellation.check()?;
+                *attachment_target = target;
+                return Ok(VmAllocationChange::Unchanged);
+            }
+            if self.active.values().any(|allocation| {
+                allocation.immutable().identity.allocation_id != spec.identity.allocation_id
+                    && (allocation.immutable().slot == spec.slot
+                        || allocation.immutable().identity.machine_id == spec.identity.machine_id)
+            }) || self.retired.values().any(|allocation| {
+                allocation.release_pending
+                    && allocation.immutable.as_ref().is_some_and(|immutable| {
+                        immutable.slot == spec.slot
+                            || immutable.identity.machine_id == spec.identity.machine_id
+                    })
+            }) {
+                return Err(VmHostError::ImmutableConflict {
+                    allocation_id: spec.identity.allocation_id,
+                });
+            }
+            let reserved = self.active.len()
+                + self
+                    .retired
+                    .values()
+                    .filter(|allocation| allocation.release_pending)
+                    .count();
+            if spec.slot >= self.capacity
+                || (!self.active.contains_key(&spec.identity.allocation_id)
+                    && reserved >= usize::from(self.capacity))
+            {
+                return Err(VmHostError::Capacity {
+                    capacity: self.capacity,
+                });
+            }
+            self.persist(&AllocationRecord::tracked(
+                AllocationRecordState::Provisioning,
+                &immutable,
+            ))?;
+            self.active.insert(
+                immutable.identity.allocation_id,
+                ActiveAllocation::Recovered {
+                    immutable: immutable.clone(),
+                    cleanup_safe: false,
+                },
+            );
+            let attachment_target = spec.attachment_target.clone();
+            let allocation = match self.factory.provision(spec, cancellation.clone()).await {
+                Ok(allocation) => allocation,
+                Err(failure) => {
+                    let mut outcome = Err(failure.error);
+                    if failure.cleanup_safe {
+                        let stopped = self.persist(&AllocationRecord::tracked(
+                            AllocationRecordState::Stopped,
+                            &immutable,
+                        ));
+                        self.active.insert(
+                            immutable.identity.allocation_id,
+                            ActiveAllocation::Recovered {
+                                immutable,
+                                cleanup_safe: true,
+                            },
+                        );
+                        outcome = combine_pair(outcome, stopped);
+                    }
+                    return outcome.map(|()| VmAllocationChange::Changed);
+                }
+            };
+            if cancellation.is_cancelled() {
+                let stopped = self.factory.stop(allocation).await;
+                return self
+                    .record_cancelled_provision(&immutable, stopped)
+                    .map(|()| VmAllocationChange::Changed);
+            }
+            if let Err(error) = self.persist(&AllocationRecord::tracked(
+                AllocationRecordState::Ready,
+                &immutable,
+            )) {
+                let stopped = self.factory.stop(allocation).await;
+                return self
+                    .record_failed_ready_publish(&immutable, error, stopped)
+                    .map(|()| VmAllocationChange::Changed);
+            }
+            self.active.insert(
+                immutable.identity.allocation_id,
+                ActiveAllocation::Live {
+                    immutable,
+                    allocation,
+                    attachment_target,
+                },
+            );
+            Ok(VmAllocationChange::Changed)
+        }
+
+        fn record_cancelled_provision(
+            &mut self,
+            immutable: &ImmutableAllocation,
+            stopped: StopOutcome,
+        ) -> Result<(), VmHostError> {
+            let shutdown_succeeded = stopped.shutdown_succeeded();
+            let mut outcome = combine_pair(Err(VmHostError::Cancelled), stopped.into_result());
+            if shutdown_succeeded {
+                let persisted = self.persist(&AllocationRecord::tracked(
+                    AllocationRecordState::Stopped,
+                    immutable,
+                ));
+                self.active.insert(
+                    immutable.identity.allocation_id,
+                    ActiveAllocation::Recovered {
+                        immutable: immutable.clone(),
+                        cleanup_safe: true,
+                    },
+                );
+                outcome = combine_pair(outcome, persisted);
+            }
+            outcome
+        }
+
+        fn record_failed_ready_publish(
+            &mut self,
+            immutable: &ImmutableAllocation,
+            publish_error: VmHostError,
+            stopped: StopOutcome,
+        ) -> Result<(), VmHostError> {
+            let shutdown_succeeded = stopped.shutdown_succeeded();
+            let mut outcome = combine_pair(Err(publish_error), stopped.into_result());
+            if shutdown_succeeded {
+                let persisted = self.persist(&AllocationRecord::tracked(
+                    AllocationRecordState::Stopped,
+                    immutable,
+                ));
+                self.active.insert(
+                    immutable.identity.allocation_id,
+                    ActiveAllocation::Recovered {
+                        immutable: immutable.clone(),
+                        cleanup_safe: true,
+                    },
+                );
+                outcome = combine_pair(outcome, persisted);
+            }
+            outcome
+        }
+
+        async fn release(
+            &mut self,
+            identity: &VmAllocationIdentity,
+        ) -> Result<VmAllocationChange, VmHostError> {
+            if let Some(retired) = self.retired.get(&identity.allocation_id) {
+                if &retired.identity != identity {
+                    return Err(VmHostError::ImmutableConflict {
+                        allocation_id: identity.allocation_id,
+                    });
+                }
+                if !retired.release_pending {
+                    return Ok(VmAllocationChange::Unchanged);
+                }
+                if !retired.cleanup_safe {
+                    return Err(VmHostError::State(format!(
+                        "allocation {} release remains pending because its recovered VM was not proven stopped",
+                        identity.allocation_id
+                    )));
+                }
+                let immutable = retired.immutable.clone();
+                return self.finish_stopped_release(identity, immutable).await;
+            }
+            let existing = self.active.get(&identity.allocation_id);
+            if let Some(existing) = existing
+                && &existing.immutable().identity != identity
+            {
+                return Err(VmHostError::ImmutableConflict {
+                    allocation_id: identity.allocation_id,
+                });
+            }
+            let Some(existing) = existing else {
+                self.persist(&AllocationRecord::release(
+                    AllocationRecordState::Released,
+                    identity,
+                    None,
+                ))?;
+                self.retired.insert(
+                    identity.allocation_id,
+                    RetiredAllocation {
+                        identity: identity.clone(),
+                        immutable: None,
+                        release_pending: false,
+                        cleanup_safe: false,
+                    },
+                );
+                return Ok(VmAllocationChange::Changed);
+            };
+            let immutable = existing.immutable().clone();
+            let release_state = match existing {
+                ActiveAllocation::Live { .. } => AllocationRecordState::Releasing,
+                ActiveAllocation::Recovered {
+                    cleanup_safe: true, ..
+                } => AllocationRecordState::ReleasingStopped,
+                ActiveAllocation::Recovered {
+                    cleanup_safe: false,
+                    ..
+                } => AllocationRecordState::Releasing,
+            };
+            self.persist(&AllocationRecord::release(
+                release_state,
+                identity,
+                Some(&immutable),
+            ))?;
+            let active = self
+                .active
+                .remove(&identity.allocation_id)
+                .expect("active allocation was just observed");
+
+            let mut stop_result = Ok(());
+            let cleanup_safe = match active {
+                ActiveAllocation::Live { allocation, .. } => {
+                    let stopped = self.factory.stop(allocation).await;
+                    let shutdown_succeeded = stopped.shutdown_succeeded();
+                    stop_result = stopped.into_result();
+                    if !shutdown_succeeded {
+                        self.retired.insert(
+                            identity.allocation_id,
+                            RetiredAllocation {
+                                identity: identity.clone(),
+                                immutable: Some(immutable.clone()),
+                                release_pending: true,
+                                cleanup_safe: false,
+                            },
+                        );
+                        return stop_result.map(|()| VmAllocationChange::Changed);
+                    }
+                    true
+                }
+                ActiveAllocation::Recovered { cleanup_safe, .. } => cleanup_safe,
+            };
+
+            if !cleanup_safe {
+                let error = VmHostError::State(format!(
+                    "allocation {} release remains pending because its recovered VM was not proven stopped",
+                    identity.allocation_id
+                ));
+                self.retired.insert(
+                    identity.allocation_id,
+                    RetiredAllocation {
+                        identity: identity.clone(),
+                        immutable: Some(immutable.clone()),
+                        release_pending: true,
+                        cleanup_safe: false,
+                    },
+                );
+                return Err(error);
+            }
+
+            let stopped_record = self.persist(&AllocationRecord::release(
+                AllocationRecordState::ReleasingStopped,
+                identity,
+                Some(&immutable),
+            ));
+            let cleanup = self
+                .finish_stopped_release(identity, Some(immutable))
+                .await
+                .map(|_| ());
+            combine_failures([stop_result, stopped_record, cleanup])
+                .map(|()| VmAllocationChange::Changed)
+        }
+
+        async fn finish_stopped_release(
+            &mut self,
+            identity: &VmAllocationIdentity,
+            immutable: Option<ImmutableAllocation>,
+        ) -> Result<VmAllocationChange, VmHostError> {
+            let cleanup = self.factory.release_recovered(identity).await;
+            let outcome = match cleanup {
+                Ok(()) => self.persist(&AllocationRecord::release(
+                    AllocationRecordState::Released,
+                    identity,
+                    None,
+                )),
+                Err(error) => Err(error),
+            };
+            self.retired.insert(
+                identity.allocation_id,
+                RetiredAllocation {
+                    identity: identity.clone(),
+                    immutable: if outcome.is_err() { immutable } else { None },
+                    release_pending: outcome.is_err(),
+                    cleanup_safe: true,
+                },
+            );
+            outcome.map(|()| VmAllocationChange::Changed)
+        }
+
+        async fn complete_startup_releases(&mut self) -> Result<(), VmHostError> {
+            let pending = self
+                .retired
+                .values()
+                .filter(|allocation| allocation.release_pending && allocation.cleanup_safe)
+                .map(|allocation| allocation.identity.clone())
+                .collect::<Vec<_>>();
+            let mut first_error = None;
+            for identity in pending {
+                if let Err(error) = self.release(&identity).await {
+                    first_error.get_or_insert(error);
+                }
+            }
+            first_error.map_or(Ok(()), Err)
+        }
+
+        fn reconcile(&self) -> Vec<VmAllocationIdentity> {
+            self.active
+                .values()
+                .filter_map(|allocation| match allocation {
+                    ActiveAllocation::Live { immutable, .. } => Some(immutable.identity.clone()),
+                    ActiveAllocation::Recovered { .. } => None,
+                })
+                .collect()
+        }
+
+        async fn shutdown(&mut self) -> Result<(), VmHostError> {
+            let mut first_error = None;
+            let active = std::mem::take(&mut self.active);
+            for (allocation_id, active) in active {
+                let (immutable, stopped) = match active {
+                    ActiveAllocation::Live {
+                        immutable,
+                        allocation,
+                        ..
+                    } => (immutable, self.factory.stop(allocation).await),
+                    ActiveAllocation::Recovered {
+                        immutable,
+                        cleanup_safe,
+                    } => {
+                        self.active.insert(
+                            allocation_id,
+                            ActiveAllocation::Recovered {
+                                immutable,
+                                cleanup_safe,
+                            },
+                        );
+                        continue;
+                    }
+                };
+                let shutdown_succeeded = stopped.shutdown_succeeded();
+                if let Err(error) = stopped.into_result() {
+                    first_error.get_or_insert(error);
+                }
+                let cleanup_safe = if shutdown_succeeded {
+                    if let Err(error) = self.persist(&AllocationRecord::tracked(
+                        AllocationRecordState::Stopped,
+                        &immutable,
+                    )) {
+                        first_error.get_or_insert(error);
+                    }
+                    true
+                } else {
+                    false
+                };
+                self.active.insert(
+                    allocation_id,
+                    ActiveAllocation::Recovered {
+                        immutable,
+                        cleanup_safe,
+                    },
+                );
+            }
+            first_error.map_or(Ok(()), Err)
+        }
+    }
+
+    struct VmAllocationFactory {
+        template_root: PathBuf,
+        allocation_directory: PathBuf,
+        hand_template: vm_hand::VmHandConfig,
+    }
+
+    impl AllocationFactory for VmAllocationFactory {
+        type Allocation = VmAllocation;
+
+        fn provision<'a>(
+            &'a self,
+            spec: VmAllocationSpec,
+            cancellation: OperationCancellation,
+        ) -> BoxFuture<'a, Result<Self::Allocation, ProvisionFailure>> {
+            Box::pin(async move {
+                let private_root = self
+                    .allocation_directory
+                    .join(format!("{}.ext4", spec.identity.allocation_id));
+                clone_private_root(self.template_root.clone(), private_root.clone())
+                    .await
+                    .map_err(ProvisionFailure::stopped)?;
+                cancellation.check().map_err(ProvisionFailure::stopped)?;
+                let mut config = self.hand_template.clone();
+                config.rootfs = private_root.clone();
+                config.machine_id = spec.identity.machine_id.clone();
+                config.machine_name = spec.identity.machine_id;
+                let hand = vm_hand::VmHand::start_config(&config)
+                    .await
+                    .map_err(|error| {
+                        ProvisionFailure::unproven(VmHostError::Resource(error.to_string()))
+                    })?;
+                if cancellation.is_cancelled() {
+                    let shutdown = hand
+                        .shutdown()
+                        .await
+                        .map_err(|error| VmHostError::Resource(error.to_string()));
+                    let shutdown_succeeded = shutdown.is_ok();
+                    let error = combine_pair(Err(VmHostError::Cancelled), shutdown)
+                        .expect_err("cancellation is always an error");
+                    return Err(if shutdown_succeeded {
+                        ProvisionFailure::stopped(error)
+                    } else {
+                        ProvisionFailure::unproven(error)
+                    });
+                }
+                match connect_vm_attachment(&hand, spec.attachment_target).await {
+                    Ok(attachment) => {
+                        if cancellation.is_cancelled() {
+                            let stopped = VmAllocation { hand, attachment }.stop().await;
+                            let shutdown_succeeded = stopped.shutdown_succeeded();
+                            let error =
+                                combine_pair(Err(VmHostError::Cancelled), stopped.into_result())
+                                    .expect_err("cancellation is always an error");
+                            Err(if shutdown_succeeded {
+                                ProvisionFailure::stopped(error)
+                            } else {
+                                ProvisionFailure::unproven(error)
+                            })
+                        } else {
+                            Ok(VmAllocation { hand, attachment })
+                        }
+                    }
+                    Err(error) => {
+                        let shutdown = hand
+                            .shutdown()
+                            .await
+                            .map_err(|error| VmHostError::Resource(error.to_string()));
+                        let shutdown_succeeded = shutdown.is_ok();
+                        let error = combine_pair(Err(error), shutdown)
+                            .expect_err("attachment failure is always an error");
+                        Err(if shutdown_succeeded {
+                            ProvisionFailure::stopped(error)
+                        } else {
+                            ProvisionFailure::unproven(error)
+                        })
+                    }
+                }
+            })
+        }
+
+        fn refresh_attachment<'a>(
+            &'a self,
+            allocation: &'a mut Self::Allocation,
+            target: AttachmentTarget,
+            cancellation: OperationCancellation,
+        ) -> BoxFuture<'a, Result<(), VmHostError>> {
+            Box::pin(allocation.refresh_attachment(target, cancellation))
+        }
+
+        fn stop<'a>(&'a self, allocation: Self::Allocation) -> BoxFuture<'a, StopOutcome> {
+            Box::pin(allocation.stop())
+        }
+
+        fn release_recovered<'a>(
+            &'a self,
+            identity: &'a VmAllocationIdentity,
+        ) -> BoxFuture<'a, Result<(), VmHostError>> {
+            Box::pin(remove_private_root(
+                self.allocation_directory
+                    .join(format!("{}.ext4", identity.allocation_id)),
+            ))
+        }
+    }
+
+    struct VmAllocation {
+        hand: vm_hand::VmHand,
+        attachment: Attachment,
+    }
+
+    impl VmAllocation {
+        async fn refresh_attachment(
+            &mut self,
+            target: AttachmentTarget,
+            cancellation: OperationCancellation,
+        ) -> Result<(), VmHostError> {
+            let attachment = connect_vm_attachment(&self.hand, target).await?;
+            if cancellation.is_cancelled() {
+                let detached = attachment
+                    .detach()
+                    .await
+                    .map_err(|error| VmHostError::Resource(error.to_string()));
+                return combine_pair(Err(VmHostError::Cancelled), detached);
+            }
+            let previous = std::mem::replace(&mut self.attachment, attachment);
+            if let Err(error) = previous.detach().await {
+                tracing::warn!(
+                    target: "nanocodex2",
+                    error = %error,
+                    "previous VM attachment failed to detach after credential refresh"
+                );
+            }
+            Ok(())
+        }
+
+        async fn stop(self) -> StopOutcome {
+            let Self { hand, attachment } = self;
+            let (attachment, shutdown) = tokio::join!(attachment.detach(), hand.shutdown());
+            StopOutcome {
+                attachment: attachment.map_err(|error| VmHostError::Resource(error.to_string())),
+                shutdown: shutdown.map_err(|error| VmHostError::Resource(error.to_string())),
+            }
+        }
+    }
+
+    async fn connect_vm_attachment(
+        hand: &vm_hand::VmHand,
+        target: AttachmentTarget,
+    ) -> Result<Attachment, VmHostError> {
+        let connector = hand
+            .tools()
+            .attach(target)
+            .metadata(AttachmentMetadata::machine(hand.machine().clone()));
+        match tokio::time::timeout(ATTACHMENT_CONNECT_TIMEOUT, connector.connect()).await {
+            Ok(Ok((attachment, _events))) => Ok(attachment),
+            Ok(Err(error)) => Err(VmHostError::Resource(format!(
+                "failed to attach provisioned VM: {error}"
+            ))),
+            Err(_) => Err(VmHostError::Resource(format!(
+                "timed out after {}s attaching provisioned VM",
+                ATTACHMENT_CONNECT_TIMEOUT.as_secs()
+            ))),
+        }
+    }
+
+    fn combine_failures<const N: usize>(
+        results: [Result<(), VmHostError>; N],
+    ) -> Result<(), VmHostError> {
+        let failures = results
+            .into_iter()
+            .filter_map(Result::err)
+            .map(|error| error.to_string())
+            .collect::<Vec<_>>();
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(VmHostError::Resource(failures.join("; ")))
+        }
+    }
+
+    fn combine_pair(
+        first: Result<(), VmHostError>,
+        second: Result<(), VmHostError>,
+    ) -> Result<(), VmHostError> {
+        combine_failures([first, second])
+    }
+
+    async fn clone_private_root(
+        template: PathBuf,
+        destination: PathBuf,
+    ) -> Result<(), VmHostError> {
+        tokio::task::spawn_blocking(move || clone_private_root_blocking(&template, &destination))
+            .await
+            .map_err(|error| VmHostError::Resource(format!("VM root clone task failed: {error}")))?
+    }
+
+    fn clone_private_root_blocking(template: &Path, destination: &Path) -> Result<(), VmHostError> {
+        let metadata = fs::metadata(template).map_err(|error| {
+            VmHostError::Configuration(format!(
+                "failed to read VM template {}: {error}",
+                template.display()
+            ))
+        })?;
+        if !metadata.is_file() {
+            return Err(VmHostError::Configuration(format!(
+                "VM template must be a raw ext4 file: {}",
+                template.display()
+            )));
+        }
+        match fs::symlink_metadata(destination) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(VmHostError::State(format!(
+                    "allocation root must not be a symlink: {}",
+                    destination.display()
+                )));
+            }
+            Ok(metadata) if metadata.is_file() => {
+                if metadata.nlink() != 1 {
+                    return Err(VmHostError::State(format!(
+                        "allocation root must not have hard links: {}",
+                        destination.display()
+                    )));
+                }
+                return Ok(());
+            }
+            Ok(_) => {
+                return Err(VmHostError::State(format!(
+                    "allocation root is not a file: {}",
+                    destination.display()
+                )));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(VmHostError::State(format!(
+                    "failed to inspect allocation root {}: {error}",
+                    destination.display()
+                )));
+            }
+        }
+        let executable = std::env::current_exe().map_err(|error| {
+            VmHostError::State(format!("failed to resolve VM host executable: {error}"))
+        })?;
+        let parent = destination.parent().ok_or_else(|| {
+            VmHostError::State("allocation root has no parent directory".to_owned())
+        })?;
+        fs::create_dir_all(parent).map_err(|error| {
+            VmHostError::State(format!(
+                "failed to create allocation root directory: {error}"
+            ))
+        })?;
+        let temporary = NamedTempFile::new_in(parent).map_err(|error| {
+            VmHostError::State(format!("failed to reserve temporary VM root: {error}"))
+        })?;
+        let temporary = temporary.into_temp_path();
+        fs::remove_file(&temporary).map_err(|error| {
+            VmHostError::State(format!("failed to prepare temporary VM root: {error}"))
+        })?;
+        nanocodex_vm::VmWorkspaceBuilder::private_from(template, &temporary, executable).map_err(
+            |error| VmHostError::Resource(format!("failed to clone private VM root: {error}")),
+        )?;
+        fs::set_permissions(&temporary, fs::Permissions::from_mode(0o600)).map_err(|error| {
+            VmHostError::State(format!("failed to secure private VM root: {error}"))
+        })?;
+        File::open(&temporary)
+            .and_then(|file| file.sync_all())
+            .map_err(|error| {
+                VmHostError::State(format!("failed to sync private VM root: {error}"))
+            })?;
+        fs::rename(&temporary, destination).map_err(|error| {
+            VmHostError::State(format!("failed to publish private VM root: {error}"))
+        })?;
+        sync_directory(parent)
+    }
+
+    async fn remove_private_root(path: PathBuf) -> Result<(), VmHostError> {
+        tokio::task::spawn_blocking(move || {
+            let parent = path.parent().ok_or_else(|| {
+                VmHostError::State("allocation root has no parent directory".to_owned())
+            })?;
+            match fs::symlink_metadata(&path) {
+                Ok(metadata) if metadata.file_type().is_symlink() => {
+                    return Err(VmHostError::State(format!(
+                        "refusing to remove symlinked VM root {}",
+                        path.display()
+                    )));
+                }
+                Ok(metadata) if !metadata.is_file() => {
+                    return Err(VmHostError::State(format!(
+                        "VM root is not a file: {}",
+                        path.display()
+                    )));
+                }
+                Ok(metadata) => {
+                    if metadata.nlink() != 1 {
+                        return Err(VmHostError::State(format!(
+                            "refusing to remove multiply linked VM root {}",
+                            path.display()
+                        )));
+                    }
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+                Err(error) => {
+                    return Err(VmHostError::State(format!(
+                        "failed to inspect released VM root {}: {error}",
+                        path.display()
+                    )));
+                }
+            }
+            match fs::remove_file(&path) {
+                Ok(()) => sync_directory(parent),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Err(error) => Err(VmHostError::State(format!(
+                    "failed to remove released VM root {}: {error}",
+                    path.display()
+                ))),
+            }
+        })
+        .await
+        .map_err(|error| VmHostError::Resource(format!("VM root cleanup task failed: {error}")))?
+    }
+
+    /// Bounded owner of all locally ready VM allocations for one host lease.
+    pub(crate) struct VmHost {
+        state: VmHostState,
+        _template_lock: File,
+        supervisor: AllocationSupervisor<VmAllocationFactory>,
+    }
+
+    impl VmHost {
+        pub(crate) fn open(config: &Host) -> Result<Self, VmHostError> {
+            let state = VmHostState::open(&config.state_dir, config.host_id)?;
+            let template_root = config.vm_template.canonicalize().map_err(|error| {
+                VmHostError::Configuration(format!(
+                    "failed to resolve VM template {}: {error}",
+                    config.vm_template.display()
+                ))
+            })?;
+            let template_metadata = template_root.metadata().map_err(|error| {
+                VmHostError::Configuration(format!(
+                    "failed to inspect VM template {}: {error}",
+                    template_root.display()
+                ))
+            })?;
+            if !template_metadata.is_file() {
+                return Err(VmHostError::Configuration(format!(
+                    "VM template must be a raw ext4 file: {}",
+                    template_root.display()
+                )));
+            }
+            let template_lock =
+                OpenOptions::new()
+                    .read(true)
+                    .open(&template_root)
+                    .map_err(|error| {
+                        VmHostError::Configuration(format!(
+                            "failed to open VM template {}: {error}",
+                            template_root.display()
+                        ))
+                    })?;
+            fs2::FileExt::try_lock_shared(&template_lock).map_err(|error| {
+                VmHostError::Configuration(format!(
+                    "VM template is in use as a writable VM root ({}): {error}",
+                    template_root.display()
+                ))
+            })?;
+            let hand_template = vm_hand::VmHandConfig {
+                rootfs: config.vm_template.clone(),
+                vm_guest_runtime: Some(config.vm_guest_runtime.clone()),
+                vm_cache: config.vm_cache.clone(),
+                vm_firmware: config.vm_firmware.clone(),
+                vm_workspace: config.vm_workspace.clone(),
+                vm_cpus: config.vm_cpus,
+                vm_memory_mib: config.vm_memory_mib,
+                vm_shell: config.vm_shell.clone(),
+                vm_no_network: config.vm_no_network,
+                machine_id: "unprovisioned".to_owned(),
+                machine_name: "Unprovisioned VM".to_owned(),
+            };
+            let factory = VmAllocationFactory {
+                template_root,
+                allocation_directory: state.directory.join("allocations"),
+                hand_template,
+            };
+            let store = AllocationStore::new(state.directory.join("allocations"));
+            let supervisor =
+                AllocationSupervisor::with_store(config.max_vms, factory, store, &state)?;
+            Ok(Self {
+                state,
+                _template_lock: template_lock,
+                supervisor,
+            })
+        }
+
+        pub(crate) const fn host_id(&self) -> Uuid {
+            self.state.host_id
+        }
+
+        pub(crate) const fn capacity(&self) -> u16 {
+            self.supervisor.capacity
+        }
+
+        async fn provision_controlled(
+            &mut self,
+            spec: VmAllocationSpec,
+            cancellation: OperationCancellation,
+        ) -> Result<VmAllocationChange, VmHostError> {
+            self.supervisor
+                .provision_controlled(spec, cancellation)
+                .await
+        }
+
+        pub(crate) async fn release(
+            &mut self,
+            identity: &VmAllocationIdentity,
+        ) -> Result<VmAllocationChange, VmHostError> {
+            self.supervisor.release(identity).await
+        }
+
+        async fn complete_startup_releases(&mut self) -> Result<(), VmHostError> {
+            self.supervisor.complete_startup_releases().await
+        }
+
+        pub(crate) fn reconcile(&self) -> Vec<VmAllocationIdentity> {
+            self.supervisor.reconcile()
+        }
+
+        pub(crate) async fn shutdown(&mut self) -> Result<(), VmHostError> {
+            self.supervisor.shutdown().await
+        }
+    }
+
+    enum ControlAuth {
+        Account {
+            client: ManagedClient,
+            scope: VmHostScope,
+        },
+        System {
+            origin: String,
+            token: String,
+        },
+    }
+
+    impl ControlAuth {
+        async fn connect(
+            &self,
+            host_id: Uuid,
+            factory_name: &str,
+            max_vms: u16,
+            shape: VmShape,
+        ) -> Result<VmHostConnection, ManagedError> {
+            match self {
+                Self::Account { client, scope } => {
+                    client
+                        .connect_vm_host(scope.clone(), host_id, factory_name, max_vms, shape)
+                        .await
+                }
+                Self::System { origin, token } => {
+                    connect_system_vm_host(
+                        origin,
+                        token.clone(),
+                        host_id,
+                        factory_name,
+                        max_vms,
+                        shape,
+                    )
+                    .await
+                }
+            }
+        }
+    }
+
+    enum ConnectionOutcome {
+        Reconnect,
+        Shutdown,
+    }
+
+    enum ControlledOperationOutcome<T> {
+        Completed(T),
+        Terminal {
+            result: T,
+            terminal: DeferredControlOutcome,
+        },
+    }
+
+    enum DeferredControlOutcome {
+        Reconnect,
+        Shutdown,
+        Error(ManagedError),
+        Fenced(VmHostCommand),
+    }
+
+    enum ControlledOperationEvent<T, H, S, C> {
+        Completed(T),
+        Heartbeat(H),
+        Shutdown(S),
+        Control(C),
+    }
+
+    async fn next_controlled_operation_event<O, H, S, C>(
+        operation: Pin<&mut O>,
+        heartbeat: H,
+        shutdown: S,
+        control: C,
+    ) -> ControlledOperationEvent<O::Output, H::Output, S::Output, C::Output>
+    where
+        O: Future + ?Sized,
+        H: Future,
+        S: Future,
+        C: Future,
+    {
+        tokio::select! {
+            biased;
+            signal = shutdown => ControlledOperationEvent::Shutdown(signal),
+            control = control => ControlledOperationEvent::Control(control),
+            heartbeat = heartbeat => ControlledOperationEvent::Heartbeat(heartbeat),
+            result = operation => ControlledOperationEvent::Completed(result),
+        }
+    }
+
+    async fn drive_controlled_operation<O>(
+        operation: O,
+        cancellation: &OperationCancellation,
+        connection: &mut VmHostConnection,
+        heartbeat: &mut tokio::time::Interval,
+        pending: &mut VecDeque<VmHostCommand>,
+    ) -> Result<ControlledOperationOutcome<O::Output>, ManagedError>
+    where
+        O: Future,
+    {
+        tokio::pin!(operation);
+        loop {
+            match next_controlled_operation_event(
+                operation.as_mut(),
+                heartbeat.tick(),
+                tokio::signal::ctrl_c(),
+                connection.next(),
+            )
+            .await
+            {
+                ControlledOperationEvent::Completed(result) => {
+                    return Ok(ControlledOperationOutcome::Completed(result));
+                }
+                ControlledOperationEvent::Heartbeat(_) => {
+                    if let Err(error) = connection.ping(None).await {
+                        tracing::warn!(target: "nanocodex2", error = %error, "VM host heartbeat failed during allocation operation");
+                        return Ok(finish_terminal_operation(
+                            operation.as_mut(),
+                            cancellation,
+                            DeferredControlOutcome::Reconnect,
+                        )
+                        .await);
+                    }
+                }
+                ControlledOperationEvent::Shutdown(signal) => {
+                    let terminal = match signal {
+                        Ok(()) => DeferredControlOutcome::Shutdown,
+                        Err(error) => DeferredControlOutcome::Error(ManagedError::Configuration(
+                            format!("failed to listen for Ctrl-C: {error}"),
+                        )),
+                    };
+                    return Ok(finish_terminal_operation(
+                        operation.as_mut(),
+                        cancellation,
+                        terminal,
+                    )
+                    .await);
+                }
+                ControlledOperationEvent::Control(Ok(Some(
+                    command @ (VmHostCommand::Provision(_) | VmHostCommand::Release(_)),
+                ))) => {
+                    pending.push_back(command);
+                }
+                ControlledOperationEvent::Control(Ok(Some(command @ VmHostCommand::Fenced(_)))) => {
+                    return Ok(finish_terminal_operation(
+                        operation.as_mut(),
+                        cancellation,
+                        DeferredControlOutcome::Fenced(command),
+                    )
+                    .await);
+                }
+                ControlledOperationEvent::Control(Ok(None)) => {
+                    return Ok(finish_terminal_operation(
+                        operation.as_mut(),
+                        cancellation,
+                        DeferredControlOutcome::Reconnect,
+                    )
+                    .await);
+                }
+                ControlledOperationEvent::Control(Err(error @ ManagedError::Configuration(_))) => {
+                    return Ok(finish_terminal_operation(
+                        operation.as_mut(),
+                        cancellation,
+                        DeferredControlOutcome::Error(error),
+                    )
+                    .await);
+                }
+                ControlledOperationEvent::Control(Err(error)) => {
+                    tracing::warn!(target: "nanocodex2", error = %error, "VM host control receive failed during allocation operation");
+                    return Ok(finish_terminal_operation(
+                        operation.as_mut(),
+                        cancellation,
+                        DeferredControlOutcome::Reconnect,
+                    )
+                    .await);
+                }
+            }
+        }
+    }
+
+    async fn finish_terminal_operation<O>(
+        operation: Pin<&mut O>,
+        cancellation: &OperationCancellation,
+        terminal: DeferredControlOutcome,
+    ) -> ControlledOperationOutcome<O::Output>
+    where
+        O: Future + ?Sized,
+    {
+        cancellation.cancel();
+        tracing::info!(
+            target: "nanocodex2",
+            "VM host entered terminal control mode; retaining lifecycle operation until cleanup completes"
+        );
+        let result = operation.await;
+        ControlledOperationOutcome::Terminal { result, terminal }
+    }
+
+    async fn finish_deferred_control_outcome(
+        host: &mut VmHost,
+        operation: &'static str,
+        result: Result<VmAllocationChange, VmHostError>,
+        terminal: DeferredControlOutcome,
+    ) -> Result<ConnectionOutcome, ManagedError> {
+        if let Err(error) = result {
+            tracing::error!(
+                target: "nanocodex2",
+                error = %error,
+                operation,
+                "VM host allocation operation failed after a terminal control outcome"
+            );
+        }
+        match terminal {
+            DeferredControlOutcome::Reconnect => Ok(ConnectionOutcome::Reconnect),
+            DeferredControlOutcome::Shutdown => {
+                host.shutdown().await?;
+                Ok(ConnectionOutcome::Shutdown)
+            }
+            DeferredControlOutcome::Error(error) => Err(error),
+            DeferredControlOutcome::Fenced(VmHostCommand::Fenced(fence)) => {
+                Err(ManagedError::VmHost(format!(
+                    "host lease fenced at epoch {}: {}",
+                    fence.epoch(),
+                    fence.reason()
+                )))
+            }
+            DeferredControlOutcome::Fenced(_) => {
+                unreachable!("only fenced commands are deferred as fencing outcomes")
+            }
+        }
+    }
+
+    pub(super) async fn run(config: Host) -> Result<(), ManagedError> {
+        config.validate()?;
+        let shape = VmShape::new(config.vm_cpus, config.vm_memory_mib)?;
+        // Select authority before opening durable state. In particular, system
+        // hosts never construct a ManagedClient or read an account API key.
+        let auth = match config.scope {
+            HostScope::User => ControlAuth::Account {
+                client: client_from_environment(None)?,
+                scope: VmHostScope::User,
+            },
+            HostScope::Agent => ControlAuth::Account {
+                client: client_from_environment(None)?,
+                scope: VmHostScope::Agent(
+                    config
+                        .agent
+                        .clone()
+                        .expect("validated agent scope has an agent ID"),
+                ),
+            },
+            HostScope::System => ControlAuth::System {
+                origin: managed_url_from_environment(None)?,
+                token: system_host_token_from_environment()?,
+            },
+        };
+        let mut host = VmHost::open(&config)?;
+        let result = run_open_host(&config, shape, &auth, &mut host).await;
+        match result {
+            Ok(()) => Ok(()),
+            Err(error) => match host.shutdown().await {
+                Ok(()) => Err(error),
+                Err(shutdown) => Err(ManagedError::Configuration(format!(
+                    "{error}; VM host shutdown also failed: {shutdown}"
+                ))),
+            },
+        }
+    }
+
+    async fn run_open_host(
+        config: &Host,
+        shape: VmShape,
+        auth: &ControlAuth,
+        host: &mut VmHost,
+    ) -> Result<(), ManagedError> {
+        host.complete_startup_releases().await?;
+        tracing::info!(
+            target: "nanocodex2",
+            host_id = %host.host_id(),
+            vm_max = host.capacity(),
+            "VM host is ready for managed allocations"
+        );
+
+        let mut retry = Duration::from_millis(250);
+        loop {
+            let connection = auth
+                .connect(host.host_id(), &config.factory_name, host.capacity(), shape)
+                .await;
+            let mut connection = match connection {
+                Ok(connection) => {
+                    retry = Duration::from_millis(250);
+                    connection
+                }
+                Err(error @ ManagedError::Configuration(_)) => return Err(error),
+                Err(error) => {
+                    tracing::warn!(
+                        target: "nanocodex2",
+                        error = %error,
+                        "VM host control connection failed; retrying"
+                    );
+                    if wait_to_reconnect_or_shutdown(host, retry).await? {
+                        return Ok(());
+                    }
+                    retry = retry.saturating_mul(2).min(Duration::from_secs(5));
+                    continue;
+                }
+            };
+            match serve_connection(host, &mut connection).await? {
+                ConnectionOutcome::Shutdown => return Ok(()),
+                ConnectionOutcome::Reconnect => {
+                    tracing::warn!(
+                        target: "nanocodex2",
+                        "VM host control connection closed; reconciling on reconnect"
+                    );
+                }
+            }
+        }
+    }
+
+    async fn serve_connection(
+        host: &mut VmHost,
+        connection: &mut VmHostConnection,
+    ) -> Result<ConnectionOutcome, ManagedError> {
+        let allocations = host
+            .reconcile()
+            .into_iter()
+            .map(|allocation| {
+                VmHostAllocationState::ready(
+                    allocation.allocation_id,
+                    allocation.generation,
+                    allocation.machine_id,
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if let Err(error) = connection.reconcile(&allocations).await {
+            tracing::warn!(target: "nanocodex2", error = %error, "VM host reconciliation failed");
+            return Ok(ConnectionOutcome::Reconnect);
+        }
+
+        let first_heartbeat = tokio::time::Instant::now() + Duration::from_secs(20);
+        let mut heartbeat = tokio::time::interval_at(first_heartbeat, Duration::from_secs(20));
+        heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let mut pending_commands = VecDeque::new();
+        loop {
+            let command = if let Some(command) = pending_commands.pop_front() {
+                command
+            } else {
+                tokio::select! {
+                    signal = tokio::signal::ctrl_c() => {
+                        signal.map_err(|error| ManagedError::Configuration(
+                            format!("failed to listen for Ctrl-C: {error}")
+                        ))?;
+                        host.shutdown().await?;
+                        return Ok(ConnectionOutcome::Shutdown);
+                    }
+                    command = connection.next() => match command {
+                        Ok(Some(command)) => command,
+                        Ok(None) => return Ok(ConnectionOutcome::Reconnect),
+                        Err(error @ ManagedError::Configuration(_)) => return Err(error),
+                        Err(error) => {
+                            tracing::warn!(target: "nanocodex2", error = %error, "VM host control receive failed");
+                            return Ok(ConnectionOutcome::Reconnect);
+                        }
+                    },
+                    _ = heartbeat.tick() => {
+                        if let Err(error) = connection.ping(None).await {
+                            tracing::warn!(target: "nanocodex2", error = %error, "VM host heartbeat failed");
+                            return Ok(ConnectionOutcome::Reconnect);
+                        }
+                        continue;
+                    }
+                }
+            };
+            match command {
+                VmHostCommand::Provision(provision) => {
+                    let acknowledgement = provision.clone();
+                    let machine_id = provision.machine_id().to_owned();
+                    let spec = VmAllocationSpec::new(
+                        provision.allocation_id(),
+                        provision.slot(),
+                        provision.generation(),
+                        machine_id,
+                        provision.into_attachment(),
+                    );
+                    let cancellation = OperationCancellation::default();
+                    match drive_controlled_operation(
+                        host.provision_controlled(spec, cancellation.clone()),
+                        &cancellation,
+                        connection,
+                        &mut heartbeat,
+                        &mut pending_commands,
+                    )
+                    .await?
+                    {
+                        ControlledOperationOutcome::Completed(Ok(_)) => {}
+                        ControlledOperationOutcome::Completed(Err(error)) => {
+                            tracing::error!(target: "nanocodex2", error = %error, "VM host provision failed; reconnecting for durable redrive");
+                            return Ok(ConnectionOutcome::Reconnect);
+                        }
+                        ControlledOperationOutcome::Terminal { result, terminal } => {
+                            return finish_deferred_control_outcome(
+                                host,
+                                "provision",
+                                result,
+                                terminal,
+                            )
+                            .await;
+                        }
+                    }
+                    if let Err(error) = connection.provisioned(&acknowledgement).await {
+                        tracing::warn!(target: "nanocodex2", error = %error, "VM host provision acknowledgement failed");
+                        return Ok(ConnectionOutcome::Reconnect);
+                    }
+                }
+                VmHostCommand::Release(release) => {
+                    let identity = VmAllocationIdentity {
+                        allocation_id: release.allocation_id(),
+                        generation: release.generation(),
+                        machine_id: release.machine_id().to_owned(),
+                    };
+                    let cancellation = OperationCancellation::default();
+                    match drive_controlled_operation(
+                        host.release(&identity),
+                        &cancellation,
+                        connection,
+                        &mut heartbeat,
+                        &mut pending_commands,
+                    )
+                    .await?
+                    {
+                        ControlledOperationOutcome::Completed(Ok(_)) => {}
+                        ControlledOperationOutcome::Completed(Err(error)) => {
+                            tracing::error!(target: "nanocodex2", error = %error, "VM host release failed; reconnecting for durable redrive");
+                            return Ok(ConnectionOutcome::Reconnect);
+                        }
+                        ControlledOperationOutcome::Terminal { result, terminal } => {
+                            return finish_deferred_control_outcome(
+                                host, "release", result, terminal,
+                            )
+                            .await;
+                        }
+                    }
+                    if let Err(error) = connection.released(&release).await {
+                        tracing::warn!(target: "nanocodex2", error = %error, "VM host release acknowledgement failed");
+                        return Ok(ConnectionOutcome::Reconnect);
+                    }
+                }
+                VmHostCommand::Fenced(fence) => {
+                    return Err(ManagedError::VmHost(format!(
+                        "host lease fenced at epoch {}: {}",
+                        fence.epoch(),
+                        fence.reason()
+                    )));
+                }
+            }
+        }
+    }
+
+    async fn wait_to_reconnect_or_shutdown(
+        host: &mut VmHost,
+        delay: Duration,
+    ) -> Result<bool, ManagedError> {
+        tokio::select! {
+            signal = tokio::signal::ctrl_c() => {
+                signal.map_err(|error| ManagedError::Configuration(
+                    format!("failed to listen for Ctrl-C: {error}")
+                ))?;
+                host.shutdown().await?;
+                Ok(true)
+            }
+            () = tokio::time::sleep(delay) => Ok(false),
+        }
+    }
+
+    fn system_host_token_from_environment() -> Result<String, ManagedError> {
+        match env::var(SYSTEM_HOST_TOKEN_ENV) {
+            Ok(value) if !value.trim().is_empty() => Ok(value),
+            Ok(_) => Err(ManagedError::Configuration(format!(
+                "{SYSTEM_HOST_TOKEN_ENV} must not be empty"
+            ))),
+            Err(env::VarError::NotPresent) => Err(ManagedError::Configuration(format!(
+                "{SYSTEM_HOST_TOKEN_ENV} must be set for --scope system"
+            ))),
+            Err(env::VarError::NotUnicode(_)) => Err(ManagedError::Configuration(format!(
+                "{SYSTEM_HOST_TOKEN_ENV} must be valid Unicode"
+            ))),
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use std::{
+            future::{pending, ready},
+            sync::{Arc, Mutex},
+        };
+
+        use super::*;
+
+        #[derive(Clone)]
+        struct FakeFactory {
+            events: Arc<Mutex<Vec<String>>>,
+        }
+
+        impl AllocationFactory for FakeFactory {
+            type Allocation = VmAllocationIdentity;
+
+            fn provision<'a>(
+                &'a self,
+                spec: VmAllocationSpec,
+                _cancellation: OperationCancellation,
+            ) -> BoxFuture<'a, Result<Self::Allocation, ProvisionFailure>> {
+                Box::pin(async move {
+                    self.events
+                        .lock()
+                        .unwrap()
+                        .push(format!("provision:{}", spec.identity.allocation_id));
+                    Ok(spec.identity)
+                })
+            }
+
+            fn refresh_attachment<'a>(
+                &'a self,
+                allocation: &'a mut Self::Allocation,
+                _target: AttachmentTarget,
+                _cancellation: OperationCancellation,
+            ) -> BoxFuture<'a, Result<(), VmHostError>> {
+                Box::pin(async move {
+                    self.events
+                        .lock()
+                        .unwrap()
+                        .push(format!("refresh:{}", allocation.allocation_id));
+                    Ok(())
+                })
+            }
+
+            fn stop<'a>(&'a self, allocation: Self::Allocation) -> BoxFuture<'a, StopOutcome> {
+                Box::pin(async move {
+                    self.events
+                        .lock()
+                        .unwrap()
+                        .push(format!("stop:{}", allocation.allocation_id));
+                    StopOutcome::stopped()
+                })
+            }
+
+            fn release_recovered<'a>(
+                &'a self,
+                identity: &'a VmAllocationIdentity,
+            ) -> BoxFuture<'a, Result<(), VmHostError>> {
+                Box::pin(async move {
+                    self.events
+                        .lock()
+                        .unwrap()
+                        .push(format!("release-recovered:{}", identity.allocation_id));
+                    Ok(())
+                })
+            }
+        }
+
+        struct RootCleanupFactory {
+            allocation_directory: PathBuf,
+        }
+
+        impl AllocationFactory for RootCleanupFactory {
+            type Allocation = VmAllocationIdentity;
+
+            fn provision<'a>(
+                &'a self,
+                _spec: VmAllocationSpec,
+                _cancellation: OperationCancellation,
+            ) -> BoxFuture<'a, Result<Self::Allocation, ProvisionFailure>> {
+                Box::pin(async {
+                    Err(ProvisionFailure::stopped(VmHostError::Resource(
+                        "unexpected provision".to_owned(),
+                    )))
+                })
+            }
+
+            fn refresh_attachment<'a>(
+                &'a self,
+                _allocation: &'a mut Self::Allocation,
+                _target: AttachmentTarget,
+                _cancellation: OperationCancellation,
+            ) -> BoxFuture<'a, Result<(), VmHostError>> {
+                Box::pin(async {
+                    Err(VmHostError::Resource(
+                        "unexpected attachment refresh".to_owned(),
+                    ))
+                })
+            }
+
+            fn stop<'a>(&'a self, _allocation: Self::Allocation) -> BoxFuture<'a, StopOutcome> {
+                Box::pin(async { StopOutcome::stopped() })
+            }
+
+            fn release_recovered<'a>(
+                &'a self,
+                identity: &'a VmAllocationIdentity,
+            ) -> BoxFuture<'a, Result<(), VmHostError>> {
+                Box::pin(remove_private_root(
+                    self.allocation_directory
+                        .join(format!("{}.ext4", identity.allocation_id)),
+                ))
+            }
+        }
+
+        struct DetachFailingFactory {
+            events: Arc<Mutex<Vec<String>>>,
+            fail_cleanup_once: Arc<AtomicBool>,
+        }
+
+        impl AllocationFactory for DetachFailingFactory {
+            type Allocation = VmAllocationIdentity;
+
+            fn provision<'a>(
+                &'a self,
+                spec: VmAllocationSpec,
+                _cancellation: OperationCancellation,
+            ) -> BoxFuture<'a, Result<Self::Allocation, ProvisionFailure>> {
+                Box::pin(async move {
+                    self.events
+                        .lock()
+                        .unwrap()
+                        .push(format!("provision:{}", spec.identity.allocation_id));
+                    Ok(spec.identity)
+                })
+            }
+
+            fn refresh_attachment<'a>(
+                &'a self,
+                _allocation: &'a mut Self::Allocation,
+                _target: AttachmentTarget,
+                _cancellation: OperationCancellation,
+            ) -> BoxFuture<'a, Result<(), VmHostError>> {
+                Box::pin(async { Ok(()) })
+            }
+
+            fn stop<'a>(&'a self, allocation: Self::Allocation) -> BoxFuture<'a, StopOutcome> {
+                Box::pin(async move {
+                    self.events
+                        .lock()
+                        .unwrap()
+                        .push(format!("stop:{}", allocation.allocation_id));
+                    StopOutcome {
+                        attachment: Err(VmHostError::Resource("detach failed".to_owned())),
+                        shutdown: Ok(()),
+                    }
+                })
+            }
+
+            fn release_recovered<'a>(
+                &'a self,
+                identity: &'a VmAllocationIdentity,
+            ) -> BoxFuture<'a, Result<(), VmHostError>> {
+                Box::pin(async move {
+                    self.events
+                        .lock()
+                        .unwrap()
+                        .push(format!("release-recovered:{}", identity.allocation_id));
+                    if self.fail_cleanup_once.swap(false, Ordering::AcqRel) {
+                        Err(VmHostError::Resource("cleanup failed".to_owned()))
+                    } else {
+                        Ok(())
+                    }
+                })
+            }
+        }
+
+        struct BlockedFactory {
+            events: Arc<Mutex<Vec<String>>>,
+            started: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+            finish: Mutex<Option<tokio::sync::oneshot::Receiver<()>>>,
+        }
+
+        impl AllocationFactory for BlockedFactory {
+            type Allocation = VmAllocationIdentity;
+
+            fn provision<'a>(
+                &'a self,
+                spec: VmAllocationSpec,
+                _cancellation: OperationCancellation,
+            ) -> BoxFuture<'a, Result<Self::Allocation, ProvisionFailure>> {
+                let started = self.started.lock().unwrap().take().unwrap();
+                let finish = self.finish.lock().unwrap().take().unwrap();
+                Box::pin(async move {
+                    started.send(()).unwrap();
+                    finish.await.unwrap();
+                    self.events
+                        .lock()
+                        .unwrap()
+                        .push(format!("provision:{}", spec.identity.allocation_id));
+                    Ok(spec.identity)
+                })
+            }
+
+            fn refresh_attachment<'a>(
+                &'a self,
+                _allocation: &'a mut Self::Allocation,
+                _target: AttachmentTarget,
+                _cancellation: OperationCancellation,
+            ) -> BoxFuture<'a, Result<(), VmHostError>> {
+                Box::pin(async { Ok(()) })
+            }
+
+            fn stop<'a>(&'a self, allocation: Self::Allocation) -> BoxFuture<'a, StopOutcome> {
+                Box::pin(async move {
+                    self.events
+                        .lock()
+                        .unwrap()
+                        .push(format!("stop:{}", allocation.allocation_id));
+                    StopOutcome::stopped()
+                })
+            }
+
+            fn release_recovered<'a>(
+                &'a self,
+                identity: &'a VmAllocationIdentity,
+            ) -> BoxFuture<'a, Result<(), VmHostError>> {
+                Box::pin(async move {
+                    self.events
+                        .lock()
+                        .unwrap()
+                        .push(format!("release-recovered:{}", identity.allocation_id));
+                    Ok(())
+                })
+            }
+        }
+
+        fn spec(allocation_id: Uuid, slot: u16, machine_id: &str) -> VmAllocationSpec {
+            spec_with_bearer(allocation_id, slot, machine_id, "secret")
+        }
+
+        fn spec_with_bearer(
+            allocation_id: Uuid,
+            slot: u16,
+            machine_id: &str,
+            bearer: &str,
+        ) -> VmAllocationSpec {
+            VmAllocationSpec::new(
+                allocation_id,
+                slot,
+                1,
+                machine_id,
+                AttachmentTarget::new("ws://127.0.0.1:9/tool-host", bearer).unwrap(),
+            )
+        }
+
+        fn open_test_state(directory: &tempfile::TempDir) -> VmHostState {
+            VmHostState::open(directory.path(), None).unwrap()
+        }
+
+        fn test_store(state: &VmHostState) -> AllocationStore {
+            AllocationStore::new(state.directory.join("allocations"))
+        }
+
+        fn read_record(state: &VmHostState, allocation_id: Uuid) -> AllocationRecord {
+            serde_json::from_slice(
+                &fs::read(
+                    state
+                        .directory
+                        .join("allocations")
+                        .join(format!("{allocation_id}.json")),
+                )
+                .unwrap(),
+            )
+            .unwrap()
+        }
+
+        #[tokio::test]
+        async fn pending_operation_allows_heartbeat_progress() {
+            let (complete, operation) = tokio::sync::oneshot::channel::<u8>();
+            let operation = async { operation.await.unwrap() };
+            tokio::pin!(operation);
+
+            let event = next_controlled_operation_event(
+                operation.as_mut(),
+                ready("heartbeat"),
+                pending::<()>(),
+                pending::<()>(),
+            )
+            .await;
+            assert!(matches!(
+                event,
+                ControlledOperationEvent::Heartbeat("heartbeat")
+            ));
+
+            complete.send(7).unwrap();
+            let event = next_controlled_operation_event(
+                operation.as_mut(),
+                pending::<()>(),
+                pending::<()>(),
+                pending::<()>(),
+            )
+            .await;
+            assert!(matches!(event, ControlledOperationEvent::Completed(7)));
+        }
+
+        #[tokio::test]
+        async fn back_to_back_provisions_queue_fifo_while_operation_is_pending() {
+            #[derive(Debug, Eq, PartialEq)]
+            enum TestCommand {
+                Provision(u8),
+            }
+
+            let (complete, operation) = tokio::sync::oneshot::channel::<()>();
+            let operation = async { operation.await.unwrap() };
+            tokio::pin!(operation);
+            let mut queued = VecDeque::new();
+
+            for slot in [0, 1] {
+                let event = next_controlled_operation_event(
+                    operation.as_mut(),
+                    pending::<()>(),
+                    pending::<()>(),
+                    ready(TestCommand::Provision(slot)),
+                )
+                .await;
+                match event {
+                    ControlledOperationEvent::Control(command) => queued.push_back(command),
+                    _ => panic!("pending operation must accept the queued provision"),
+                }
+            }
+
+            complete.send(()).unwrap();
+            let event = next_controlled_operation_event(
+                operation.as_mut(),
+                pending::<()>(),
+                pending::<()>(),
+                pending::<()>(),
+            )
+            .await;
+            assert!(matches!(event, ControlledOperationEvent::Completed(())));
+            assert_eq!(
+                queued.into_iter().collect::<Vec<_>>(),
+                [TestCommand::Provision(0), TestCommand::Provision(1)]
+            );
+        }
+
+        #[test]
+        fn host_identity_is_persisted_explicit_and_exclusively_locked() {
+            let directory = tempfile::tempdir().unwrap();
+            let explicit = Uuid::new_v4();
+            let state = VmHostState::open(directory.path(), Some(explicit)).unwrap();
+            assert_eq!(state.host_id, explicit);
+            assert!(VmHostState::open(directory.path(), Some(explicit)).is_err());
+            drop(state);
+            assert_eq!(
+                VmHostState::open(directory.path(), None).unwrap().host_id,
+                explicit
+            );
+            assert!(VmHostState::open(directory.path(), Some(Uuid::new_v4())).is_err());
+        }
+
+        #[test]
+        fn private_root_clone_is_idempotent_and_not_linked_to_the_template() {
+            let directory = tempfile::tempdir().unwrap();
+            let template = directory.path().join("template.ext4");
+            let clone = directory.path().join("allocations/allocation.ext4");
+            fs::write(&template, b"template").unwrap();
+            clone_private_root_blocking(&template, &clone).unwrap();
+            fs::write(&clone, b"private").unwrap();
+            clone_private_root_blocking(&template, &clone).unwrap();
+            assert_eq!(fs::read(&template).unwrap(), b"template");
+            assert_eq!(fs::read(&clone).unwrap(), b"private");
+        }
+
+        #[test]
+        fn private_root_clone_rejects_an_existing_hard_link() {
+            let directory = tempfile::tempdir().unwrap();
+            let template = directory.path().join("template.ext4");
+            let allocations = directory.path().join("allocations");
+            let clone = allocations.join("allocation.ext4");
+            fs::write(&template, b"template").unwrap();
+            fs::create_dir(&allocations).unwrap();
+            fs::hard_link(&template, &clone).unwrap();
+
+            assert!(clone_private_root_blocking(&template, &clone).is_err());
+            assert_eq!(fs::read(&template).unwrap(), b"template");
+        }
+
+        #[tokio::test]
+        async fn matching_live_provision_refreshes_attachment_and_enforces_conflicts() {
+            let events = Arc::new(Mutex::new(Vec::new()));
+            let factory = FakeFactory {
+                events: Arc::clone(&events),
+            };
+            let mut supervisor = AllocationSupervisor::new(2, factory).unwrap();
+            let first = spec(Uuid::new_v4(), 0, "machine-0");
+            assert_eq!(
+                supervisor.provision(first.clone()).await.unwrap(),
+                VmAllocationChange::Changed
+            );
+            assert_eq!(
+                supervisor.provision(first.clone()).await.unwrap(),
+                VmAllocationChange::Unchanged
+            );
+            assert_eq!(events.lock().unwrap().len(), 1);
+            let rotated = spec_with_bearer(
+                first.identity.allocation_id,
+                first.slot,
+                &first.identity.machine_id,
+                "rotated-secret",
+            );
+            assert_eq!(
+                supervisor.provision(rotated).await.unwrap(),
+                VmAllocationChange::Unchanged
+            );
+            assert_eq!(
+                events.lock().unwrap().as_slice(),
+                [
+                    format!("provision:{}", first.identity.allocation_id),
+                    format!("refresh:{}", first.identity.allocation_id),
+                ]
+            );
+
+            let same_slot = spec(Uuid::new_v4(), 0, "machine-1");
+            assert!(matches!(
+                supervisor.provision(same_slot).await,
+                Err(VmHostError::ImmutableConflict { .. })
+            ));
+            let second = spec(Uuid::new_v4(), 1, "machine-1");
+            supervisor.provision(second).await.unwrap();
+            let over_cap = spec(Uuid::new_v4(), 2, "machine-2");
+            assert!(matches!(
+                supervisor.provision(over_cap).await,
+                Err(VmHostError::Capacity { capacity: 2 })
+            ));
+        }
+
+        #[tokio::test]
+        async fn reconcile_reports_only_ready_allocations_and_release_is_idempotent() {
+            let events = Arc::new(Mutex::new(Vec::new()));
+            let factory = FakeFactory {
+                events: Arc::clone(&events),
+            };
+            let mut supervisor = AllocationSupervisor::new(1, factory).unwrap();
+            let request = spec(Uuid::new_v4(), 0, "machine-0");
+            supervisor.provision(request.clone()).await.unwrap();
+            assert_eq!(supervisor.reconcile(), vec![request.identity.clone()]);
+            assert_eq!(
+                supervisor.release(&request.identity).await.unwrap(),
+                VmAllocationChange::Changed
+            );
+            assert_eq!(
+                supervisor.release(&request.identity).await.unwrap(),
+                VmAllocationChange::Unchanged
+            );
+            assert!(supervisor.reconcile().is_empty());
+            assert_eq!(
+                events.lock().unwrap().as_slice(),
+                [
+                    format!("provision:{}", request.identity.allocation_id),
+                    format!("stop:{}", request.identity.allocation_id),
+                    format!("release-recovered:{}", request.identity.allocation_id),
+                ]
+            );
+        }
+
+        #[tokio::test]
+        async fn successor_fences_ready_record_and_allows_safe_release() {
+            let directory = tempfile::tempdir().unwrap();
+            let state = open_test_state(&directory);
+            let allocations = state.directory.join("allocations");
+            let allocation_id = Uuid::new_v4();
+            let request = VmAllocationSpec::new(
+                allocation_id,
+                0,
+                1,
+                "machine-0",
+                AttachmentTarget::new(
+                    "ws://127.0.0.1:9/tool-host",
+                    "super-secret-allocation-bearer",
+                )
+                .unwrap(),
+            );
+            let events = Arc::new(Mutex::new(Vec::new()));
+            let mut first = AllocationSupervisor::with_store(
+                1,
+                FakeFactory {
+                    events: Arc::clone(&events),
+                },
+                AllocationStore::new(allocations.clone()),
+                &state,
+            )
+            .unwrap();
+            first.provision(request.clone()).await.unwrap();
+            assert_eq!(first.reconcile(), vec![request.identity.clone()]);
+            let journal =
+                fs::read_to_string(allocations.join(format!("{allocation_id}.json"))).unwrap();
+            assert!(!journal.contains("super-secret-allocation-bearer"));
+            drop(first);
+            drop(state);
+
+            let state = open_test_state(&directory);
+            let mut recovered = AllocationSupervisor::with_store(
+                1,
+                FakeFactory {
+                    events: Arc::clone(&events),
+                },
+                AllocationStore::new(allocations.clone()),
+                &state,
+            )
+            .unwrap();
+            assert!(recovered.reconcile().is_empty());
+            assert_eq!(
+                read_record(&state, allocation_id).state,
+                AllocationRecordState::Stopped
+            );
+            assert_eq!(
+                recovered.release(&request.identity).await.unwrap(),
+                VmAllocationChange::Changed
+            );
+            assert_eq!(
+                read_record(&state, allocation_id).state,
+                AllocationRecordState::Released
+            );
+        }
+
+        #[tokio::test]
+        async fn successor_fences_provisioning_record_and_allows_reprovision() {
+            let directory = tempfile::tempdir().unwrap();
+            let state = open_test_state(&directory);
+            let request = spec(Uuid::new_v4(), 0, "machine-0");
+            test_store(&state)
+                .put(&AllocationRecord::tracked(
+                    AllocationRecordState::Provisioning,
+                    &request.immutable_key(),
+                ))
+                .unwrap();
+            drop(state);
+
+            let state = open_test_state(&directory);
+            let events = Arc::new(Mutex::new(Vec::new()));
+            let mut recovered = AllocationSupervisor::with_store(
+                1,
+                FakeFactory {
+                    events: Arc::clone(&events),
+                },
+                test_store(&state),
+                &state,
+            )
+            .unwrap();
+            assert_eq!(
+                read_record(&state, request.identity.allocation_id).state,
+                AllocationRecordState::Stopped
+            );
+            assert_eq!(
+                recovered.provision(request.clone()).await.unwrap(),
+                VmAllocationChange::Changed
+            );
+            assert_eq!(recovered.reconcile(), vec![request.identity]);
+        }
+
+        #[test]
+        fn lock_acquisition_failure_does_not_rewrite_ready_record() {
+            let directory = tempfile::tempdir().unwrap();
+            let state = open_test_state(&directory);
+            let request = spec(Uuid::new_v4(), 0, "machine-0");
+            test_store(&state)
+                .put(&AllocationRecord::tracked(
+                    AllocationRecordState::Ready,
+                    &request.immutable_key(),
+                ))
+                .unwrap();
+
+            assert!(VmHostState::open(directory.path(), None).is_err());
+            assert_eq!(
+                read_record(&state, request.identity.allocation_id).state,
+                AllocationRecordState::Ready
+            );
+        }
+
+        #[tokio::test]
+        async fn stopped_recovered_release_is_durable_and_idempotent() {
+            let directory = tempfile::tempdir().unwrap();
+            let state = open_test_state(&directory);
+            let allocations = state.directory.join("allocations");
+            let request = spec(Uuid::new_v4(), 0, "machine-0");
+            let events = Arc::new(Mutex::new(Vec::new()));
+            let mut first = AllocationSupervisor::with_store(
+                1,
+                FakeFactory {
+                    events: Arc::clone(&events),
+                },
+                AllocationStore::new(allocations.clone()),
+                &state,
+            )
+            .unwrap();
+            first.provision(request.clone()).await.unwrap();
+            first.shutdown().await.unwrap();
+            drop(first);
+            drop(state);
+
+            let state = open_test_state(&directory);
+            let mut recovered = AllocationSupervisor::with_store(
+                1,
+                FakeFactory {
+                    events: Arc::clone(&events),
+                },
+                AllocationStore::new(allocations.clone()),
+                &state,
+            )
+            .unwrap();
+            assert_eq!(
+                recovered.release(&request.identity).await.unwrap(),
+                VmAllocationChange::Changed
+            );
+            assert_eq!(
+                recovered.release(&request.identity).await.unwrap(),
+                VmAllocationChange::Unchanged
+            );
+            let record: AllocationRecord = serde_json::from_slice(
+                &fs::read(allocations.join(format!("{}.json", request.identity.allocation_id)))
+                    .unwrap(),
+            )
+            .unwrap();
+            assert_eq!(record.state, AllocationRecordState::Released);
+            assert!(events.lock().unwrap().iter().any(|event| {
+                event == &format!("release-recovered:{}", request.identity.allocation_id)
+            }));
+        }
+
+        #[tokio::test]
+        async fn startup_fences_and_completes_all_predecessor_releases() {
+            let directory = tempfile::tempdir().unwrap();
+            let state = open_test_state(&directory);
+            let allocations = state.directory.join("allocations");
+            let safe = spec(Uuid::new_v4(), 0, "machine-0");
+            let unsafe_allocation = spec(Uuid::new_v4(), 1, "machine-1");
+            let store = AllocationStore::new(allocations.clone());
+            store
+                .put(&AllocationRecord::tracked(
+                    AllocationRecordState::ReleasingStopped,
+                    &safe.immutable_key(),
+                ))
+                .unwrap();
+            store
+                .put(&AllocationRecord::tracked(
+                    AllocationRecordState::Releasing,
+                    &unsafe_allocation.immutable_key(),
+                ))
+                .unwrap();
+            drop(state);
+
+            let state = open_test_state(&directory);
+            let events = Arc::new(Mutex::new(Vec::new()));
+            let mut recovered = AllocationSupervisor::with_store(
+                2,
+                FakeFactory {
+                    events: Arc::clone(&events),
+                },
+                store,
+                &state,
+            )
+            .unwrap();
+
+            recovered.complete_startup_releases().await.unwrap();
+
+            let startup_events = events.lock().unwrap();
+            assert_eq!(startup_events.len(), 2);
+            assert!(startup_events.contains(&format!(
+                "release-recovered:{}",
+                safe.identity.allocation_id
+            )));
+            assert!(startup_events.contains(&format!(
+                "release-recovered:{}",
+                unsafe_allocation.identity.allocation_id
+            )));
+            drop(startup_events);
+            assert_eq!(
+                recovered.release(&safe.identity).await.unwrap(),
+                VmAllocationChange::Unchanged
+            );
+            assert_eq!(
+                recovered
+                    .release(&unsafe_allocation.identity)
+                    .await
+                    .unwrap(),
+                VmAllocationChange::Unchanged
+            );
+            let unsafe_record: AllocationRecord = serde_json::from_slice(
+                &fs::read(
+                    allocations.join(format!("{}.json", unsafe_allocation.identity.allocation_id)),
+                )
+                .unwrap(),
+            )
+            .unwrap();
+            assert_eq!(unsafe_record.state, AllocationRecordState::Released);
+        }
+
+        #[test]
+        fn allocation_journal_fails_closed_on_corrupt_or_conflicting_state() {
+            let directory = tempfile::tempdir().unwrap();
+            let state = open_test_state(&directory);
+            let allocations = state.directory.join("allocations");
+            let allocation_id = Uuid::new_v4();
+            fs::write(
+                allocations.join(format!("{allocation_id}.json")),
+                b"{\"version\":1,\"state\":\"ready\"}",
+            )
+            .unwrap();
+            let events = Arc::new(Mutex::new(Vec::new()));
+            assert!(
+                AllocationSupervisor::with_store(
+                    1,
+                    FakeFactory { events },
+                    AllocationStore::new(allocations),
+                    &state,
+                )
+                .is_err()
+            );
+        }
+
+        #[tokio::test]
+        async fn host_shutdown_stops_allocations_without_release_cleanup() {
+            let directory = tempfile::tempdir().unwrap();
+            let state = open_test_state(&directory);
+            let allocations = state.directory.join("allocations");
+            let events = Arc::new(Mutex::new(Vec::new()));
+            let factory = FakeFactory {
+                events: Arc::clone(&events),
+            };
+            let mut supervisor = AllocationSupervisor::with_store(
+                1,
+                factory,
+                AllocationStore::new(allocations.clone()),
+                &state,
+            )
+            .unwrap();
+            let request = spec(Uuid::new_v4(), 0, "machine-0");
+            supervisor.provision(request.clone()).await.unwrap();
+
+            supervisor.shutdown().await.unwrap();
+
+            let events = events.lock().unwrap();
+            assert!(events.iter().any(|event| event.starts_with("stop:")));
+            assert!(
+                !events
+                    .iter()
+                    .any(|event| event.starts_with("release-recovered:"))
+            );
+            let record: AllocationRecord = serde_json::from_slice(
+                &fs::read(allocations.join(format!("{}.json", request.identity.allocation_id)))
+                    .unwrap(),
+            )
+            .unwrap();
+            assert_eq!(record.state, AllocationRecordState::Stopped);
+        }
+
+        #[tokio::test]
+        async fn stopped_allocation_can_be_reprovisioned_without_releasing_its_root() {
+            let directory = tempfile::tempdir().unwrap();
+            let state = open_test_state(&directory);
+            let events = Arc::new(Mutex::new(Vec::new()));
+            let mut supervisor = AllocationSupervisor::with_store(
+                1,
+                FakeFactory {
+                    events: Arc::clone(&events),
+                },
+                test_store(&state),
+                &state,
+            )
+            .unwrap();
+            let request = spec(Uuid::new_v4(), 0, "machine-0");
+            supervisor.provision(request.clone()).await.unwrap();
+            supervisor.shutdown().await.unwrap();
+
+            assert_eq!(
+                supervisor.provision(request.clone()).await.unwrap(),
+                VmAllocationChange::Changed
+            );
+            assert_eq!(supervisor.reconcile(), vec![request.identity.clone()]);
+            assert_eq!(
+                events.lock().unwrap().as_slice(),
+                [
+                    format!("provision:{}", request.identity.allocation_id),
+                    format!("stop:{}", request.identity.allocation_id),
+                    format!("provision:{}", request.identity.allocation_id),
+                ]
+            );
+        }
+
+        #[tokio::test]
+        async fn successor_recovery_never_removes_symlinked_or_hard_linked_roots() {
+            let directory = tempfile::tempdir().unwrap();
+            let state = open_test_state(&directory);
+            let allocations = state.directory.join("allocations");
+            let symlinked = spec(Uuid::new_v4(), 0, "machine-0");
+            let hard_linked = spec(Uuid::new_v4(), 1, "machine-1");
+            for request in [&symlinked, &hard_linked] {
+                test_store(&state)
+                    .put(&AllocationRecord::tracked(
+                        AllocationRecordState::Ready,
+                        &request.immutable_key(),
+                    ))
+                    .unwrap();
+            }
+            let symlink_target = directory.path().join("symlink-target.ext4");
+            let hard_link_target = directory.path().join("hard-link-target.ext4");
+            fs::write(&symlink_target, b"symlink target").unwrap();
+            fs::write(&hard_link_target, b"hard link target").unwrap();
+            let symlink_root =
+                allocations.join(format!("{}.ext4", symlinked.identity.allocation_id));
+            let hard_link_root =
+                allocations.join(format!("{}.ext4", hard_linked.identity.allocation_id));
+            std::os::unix::fs::symlink(&symlink_target, &symlink_root).unwrap();
+            fs::hard_link(&hard_link_target, &hard_link_root).unwrap();
+            drop(state);
+
+            let state = open_test_state(&directory);
+            let mut recovered = AllocationSupervisor::with_store(
+                2,
+                RootCleanupFactory {
+                    allocation_directory: allocations,
+                },
+                test_store(&state),
+                &state,
+            )
+            .unwrap();
+            assert_eq!(
+                read_record(&state, symlinked.identity.allocation_id).state,
+                AllocationRecordState::Stopped
+            );
+            assert_eq!(
+                read_record(&state, hard_linked.identity.allocation_id).state,
+                AllocationRecordState::Stopped
+            );
+
+            assert!(recovered.release(&symlinked.identity).await.is_err());
+            assert!(recovered.release(&hard_linked.identity).await.is_err());
+            assert_eq!(fs::read(&symlink_target).unwrap(), b"symlink target");
+            assert_eq!(fs::read(&hard_link_target).unwrap(), b"hard link target");
+            assert!(
+                fs::symlink_metadata(&symlink_root)
+                    .unwrap()
+                    .file_type()
+                    .is_symlink()
+            );
+            assert_eq!(fs::metadata(&hard_link_root).unwrap().nlink(), 2);
+        }
+
+        #[tokio::test]
+        async fn terminal_fence_cancels_blocked_provision_before_ready_publish() {
+            let directory = tempfile::tempdir().unwrap();
+            let state = open_test_state(&directory);
+            let events = Arc::new(Mutex::new(Vec::new()));
+            let (started_tx, mut started_rx) = tokio::sync::oneshot::channel();
+            let (finish_tx, finish_rx) = tokio::sync::oneshot::channel();
+            let factory = BlockedFactory {
+                events: Arc::clone(&events),
+                started: Mutex::new(Some(started_tx)),
+                finish: Mutex::new(Some(finish_rx)),
+            };
+            let mut supervisor =
+                AllocationSupervisor::with_store(1, factory, test_store(&state), &state).unwrap();
+            let request = spec(Uuid::new_v4(), 0, "machine-0");
+            let cancellation = OperationCancellation::default();
+            let observed = Arc::new(AtomicBool::new(false));
+            let outcome = {
+                let operation =
+                    supervisor.provision_controlled(request.clone(), cancellation.clone());
+                tokio::pin!(operation);
+                tokio::select! {
+                    started = &mut started_rx => started.unwrap(),
+                    result = operation.as_mut() => panic!("provision unexpectedly completed: {result:?}"),
+                }
+
+                let observed_in_task = Arc::clone(&observed);
+                let cancellation_in_task = cancellation.clone();
+                let observer = tokio::spawn(async move {
+                    while !cancellation_in_task.is_cancelled() {
+                        tokio::task::yield_now().await;
+                    }
+                    observed_in_task.store(true, Ordering::Release);
+                    finish_tx.send(()).unwrap();
+                });
+                let outcome = tokio::time::timeout(
+                    Duration::from_secs(1),
+                    finish_terminal_operation(
+                        operation.as_mut(),
+                        &cancellation,
+                        DeferredControlOutcome::Shutdown,
+                    ),
+                )
+                .await
+                .expect("terminal cancellation must be observed promptly");
+                observer.await.unwrap();
+                outcome
+            };
+            assert!(observed.load(Ordering::Acquire));
+            assert!(matches!(
+                outcome,
+                ControlledOperationOutcome::Terminal {
+                    result: Err(_),
+                    terminal: DeferredControlOutcome::Shutdown,
+                }
+            ));
+            assert!(supervisor.reconcile().is_empty());
+            assert_eq!(
+                read_record(&state, request.identity.allocation_id).state,
+                AllocationRecordState::Stopped
+            );
+            assert_eq!(
+                events.lock().unwrap().as_slice(),
+                [
+                    format!("provision:{}", request.identity.allocation_id),
+                    format!("stop:{}", request.identity.allocation_id),
+                ]
+            );
+        }
+
+        #[tokio::test]
+        async fn detach_failure_does_not_hide_stopped_phase_or_leak_slot() {
+            let directory = tempfile::tempdir().unwrap();
+            let state = open_test_state(&directory);
+            let events = Arc::new(Mutex::new(Vec::new()));
+            let mut supervisor = AllocationSupervisor::with_store(
+                1,
+                DetachFailingFactory {
+                    events: Arc::clone(&events),
+                    fail_cleanup_once: Arc::new(AtomicBool::new(true)),
+                },
+                test_store(&state),
+                &state,
+            )
+            .unwrap();
+            let request = spec(Uuid::new_v4(), 0, "machine-0");
+            supervisor.provision(request.clone()).await.unwrap();
+
+            let error = supervisor.release(&request.identity).await.unwrap_err();
+            assert!(error.to_string().contains("detach failed"));
+            assert!(error.to_string().contains("cleanup failed"));
+            assert_eq!(
+                read_record(&state, request.identity.allocation_id).state,
+                AllocationRecordState::ReleasingStopped
+            );
+            assert_eq!(
+                supervisor.release(&request.identity).await.unwrap(),
+                VmAllocationChange::Changed
+            );
+            assert_eq!(
+                read_record(&state, request.identity.allocation_id).state,
+                AllocationRecordState::Released
+            );
+            assert_eq!(
+                supervisor.release(&request.identity).await.unwrap(),
+                VmAllocationChange::Unchanged
+            );
+            let replacement = spec(Uuid::new_v4(), 0, "machine-1");
+            assert_eq!(
+                supervisor.provision(replacement).await.unwrap(),
+                VmAllocationChange::Changed
+            );
+            assert!(events.lock().unwrap().iter().any(|event| {
+                event == &format!("release-recovered:{}", request.identity.allocation_id)
+            }));
+        }
+
+        #[test]
+        fn release_combines_detach_shutdown_and_cleanup_failures_in_order() {
+            let result = combine_failures([
+                Err(VmHostError::Resource("detach".to_owned())),
+                Err(VmHostError::Resource("shutdown".to_owned())),
+                Err(VmHostError::Resource("cleanup".to_owned())),
+            ])
+            .unwrap_err()
+            .to_string();
+            assert!(result.find("detach").unwrap() < result.find("shutdown").unwrap());
+            assert!(result.find("shutdown").unwrap() < result.find("cleanup").unwrap());
+        }
+    }
+}
+
+/// Runs the managed VM-host control loop.
+///
+#[cfg(any(
+    all(target_os = "linux", not(target_env = "musl")),
+    all(target_os = "macos", target_arch = "aarch64")
+))]
+pub(crate) async fn serve(config: Host) -> Result<(), ManagedError> {
+    supported::run(config).await
+}
+
+#[cfg(not(any(
+    all(target_os = "linux", not(target_env = "musl")),
+    all(target_os = "macos", target_arch = "aarch64")
+)))]
+pub(crate) async fn serve(_config: Host) -> Result<(), ManagedError> {
+    Err(ManagedError::Configuration(
+        "VM hosts require glibc Linux with /dev/kvm or Apple Silicon macOS".to_owned(),
+    ))
+}

--- a/bin/nanocodex/tests/nanocodex2_managed.rs
+++ b/bin/nanocodex/tests/nanocodex2_managed.rs
@@ -60,6 +60,48 @@ async fn hand_help_exposes_the_vm_and_machine_contract() {
     }
 }
 
+#[tokio::test]
+async fn host_help_exposes_the_bounded_vm_pool_contract() {
+    let output = tokio::process::Command::new(env!("CARGO_BIN_EXE_nanocodex2"))
+        .args(["host", "--help"])
+        .output()
+        .await
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains(
+            "Usage: nanocodex2 host [OPTIONS] --factory-name <FACTORY_NAME> --vm-template <ROOTFS> --state-dir <PATH> --vm-guest-runtime <ELF>"
+        ),
+        "{stdout}"
+    );
+    for expected in [
+        "--scope <SCOPE>",
+        "--agent <AGENT_ID>",
+        "--factory-name <FACTORY_NAME>",
+        "--vm-template <ROOTFS>",
+        "--state-dir <PATH>",
+        "--max-vms <COUNT>",
+        "--host-id <UUID>",
+        "--vm-guest-runtime <ELF>",
+        "--vm-workspace <PATH>",
+        "--vm-cpus <COUNT>",
+        "--vm-memory-mib <MIB>",
+        "--log-filter <LOG_FILTER>",
+        "--otel-endpoint <OTEL_ENDPOINT>",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "missing {expected:?} in:\n{stdout}"
+        );
+    }
+    assert!(stdout.contains("[default: user]"), "{stdout}");
+    assert!(
+        stdout.contains("possible values: user, agent, system"),
+        "{stdout}"
+    );
+}
+
 #[cfg(any(
     all(target_os = "linux", not(target_env = "musl")),
     all(target_os = "macos", target_arch = "aarch64")

--- a/crates/nanocodex-agent/src/agent/driver/branch.rs
+++ b/crates/nanocodex-agent/src/agent/driver/branch.rs
@@ -11,6 +11,7 @@ pub(in crate::agent) struct BranchSpawner<S> {
     pub(in crate::agent) context_source: ContextSource,
     pub(in crate::agent) depth: u32,
     pub(in crate::agent) execution: ExecutionConfig,
+    pub(in crate::agent) host_context: Option<Arc<str>>,
     pub(in crate::agent) service_factory: ServiceFactory<S>,
 }
 
@@ -34,6 +35,7 @@ impl<S> BranchSpawner<S> {
             context_source: self.context_source.clone(),
             depth: self.depth,
             execution: self.execution.for_new_thread(operation)?,
+            host_context: self.host_context.as_ref().map(Arc::clone),
             service_factory: Arc::clone(&self.service_factory),
         })
     }
@@ -52,11 +54,13 @@ where
         model: Model,
         thinking: Thinking,
         fast_mode: bool,
+        host_context: Option<Arc<str>>,
     ) -> Result<(Nanocodex, AgentEvents)> {
         let session_id = SessionId::new();
         let workspace = Some(Arc::<str>::from(checkpoint.model().workspace()));
         let mut spawner = self.for_new_thread("fork")?;
         spawner.context_source = spawner.context_config.build();
+        spawner.host_context = host_context;
         let mut config = (*spawner.config).clone();
         config.model = model;
         config.thinking = thinking;
@@ -85,6 +89,7 @@ where
         model: Model,
         thinking: Thinking,
         fast_mode: bool,
+        host_context: Option<Arc<str>>,
     ) -> Result<(Nanocodex, AgentEvents)> {
         let session_id = SessionId::new();
         let session_id_text = session_id.to_string();
@@ -108,6 +113,7 @@ where
             context_source: self.context_config.build(),
             depth,
             execution: self.execution.for_new_thread("spawn")?,
+            host_context,
             service_factory: Arc::clone(&self.service_factory),
         };
         let service = (spawner.service_factory)(Arc::clone(&spawner.config));
@@ -132,6 +138,7 @@ where
         defaults: TurnDefaults,
         count: usize,
         observer: Option<&SpawnObserver>,
+        host_context: Option<Arc<str>>,
     ) -> Result<Vec<(Nanocodex, AgentEvents)>> {
         let mut children = Vec::with_capacity(count);
         for _ in 0..count {
@@ -141,6 +148,10 @@ where
                 defaults.model,
                 defaults.thinking,
                 defaults.fast_mode,
+                host_context
+                    .as_ref()
+                    .or(self.host_context.as_ref())
+                    .map(Arc::clone),
             )?;
             if let Some(observer) = observer {
                 observer(child.0.session_id());

--- a/crates/nanocodex-agent/src/agent/driver/control.rs
+++ b/crates/nanocodex-agent/src/agent/driver/control.rs
@@ -337,21 +337,34 @@ pub(super) fn handle_idle_command<S>(
                         defaults.model,
                         defaults.thinking,
                         defaults.fast_mode,
+                        spawner.host_context.as_ref().map(Arc::clone),
                     )
                 });
             drop(result.send(outcome));
         }
-        Command::Spawn { options, result } => {
+        Command::Spawn {
+            options,
+            host_context,
+            result,
+        } => {
             let model = options.model.unwrap_or(defaults.model);
             let thinking = options.thinking.unwrap_or(defaults.thinking);
             let outcome = validate_model_thinking(model, thinking).and_then(|()| {
-                spawner.spawn_clean(workspace, session_id, model, thinking, defaults.fast_mode)
+                spawner.spawn_clean(
+                    workspace,
+                    session_id,
+                    model,
+                    thinking,
+                    defaults.fast_mode,
+                    host_context.or_else(|| spawner.host_context.as_ref().map(Arc::clone)),
+                )
             });
             drop(result.send(outcome));
         }
         Command::SpawnBatch {
             count,
             observer,
+            host_context,
             result,
         } => {
             let outcome = spawner.spawn_clean_many(
@@ -360,6 +373,7 @@ pub(super) fn handle_idle_command<S>(
                 defaults,
                 count,
                 observer.as_deref(),
+                host_context,
             );
             drop(result.send(outcome));
         }

--- a/crates/nanocodex-agent/src/agent/driver/mod.rs
+++ b/crates/nanocodex-agent/src/agent/driver/mod.rs
@@ -68,6 +68,7 @@ where
                 self.tools.clone(),
                 prompt_cache.clone(),
                 initial,
+                self.spawner.host_context.as_ref().map(Arc::clone),
             )
         } else {
             ModelRun::new(
@@ -79,6 +80,7 @@ where
                 self.tools.clone(),
                 prompt_cache.clone(),
                 self.spawner.context_source.clone(),
+                self.spawner.host_context.as_ref().map(Arc::clone),
             )
         };
         let mut turn_index = 0_u64;
@@ -953,6 +955,13 @@ where
                 ));
                 continue;
             }
+            model.set_host_context(
+                self.spawner
+                    .host_context
+                    .as_ref()
+                    .map(Arc::clone)
+                    .or_else(|| execution_operation.as_deref().map(Arc::from)),
+            );
             turn_index += 1;
             logical_turn_index = logical_turn_index.saturating_add(1);
             let prompt_content = tracing::enabled!(
@@ -1696,6 +1705,7 @@ where
             tools.clone(),
             prompt_cache.clone(),
             prepared,
+            spawner.host_context.as_ref().map(Arc::clone),
         )
     } else {
         ModelRun::new(
@@ -1707,6 +1717,7 @@ where
             tools.clone(),
             prompt_cache.clone(),
             spawner.context_source.clone(),
+            spawner.host_context.as_ref().map(Arc::clone),
         )
     }
 }

--- a/crates/nanocodex-agent/src/agent/handle.rs
+++ b/crates/nanocodex-agent/src/agent/handle.rs
@@ -78,7 +78,18 @@ impl AgentHandle {
     /// Returns an error after the containing driver has stopped.
     pub async fn spawn_with(&self, options: SpawnOptions) -> Result<(Nanocodex, AgentEvents)> {
         let commands = self.commands()?;
-        request_spawn(&commands, &self.shutdown, options).await
+        request_spawn_with_host_context(&commands, &self.shutdown, options, None).await
+    }
+
+    /// Starts a clean child with embedding-owned context inherited by its tool invocations.
+    #[doc(hidden)]
+    pub async fn spawn_with_host_context(
+        &self,
+        options: SpawnOptions,
+        host_context: Option<Arc<str>>,
+    ) -> Result<(Nanocodex, AgentEvents)> {
+        let commands = self.commands()?;
+        request_spawn_with_host_context(&commands, &self.shutdown, options, host_context).await
     }
 
     /// Starts several clean agents in the order requested.
@@ -92,7 +103,7 @@ impl AgentHandle {
     /// Returns an error after the containing driver has stopped.
     pub async fn spawn_many(&self, count: usize) -> Result<Vec<(Nanocodex, AgentEvents)>> {
         let commands = self.commands()?;
-        request_spawn_many(&commands, &self.shutdown, count, None).await
+        request_spawn_many(&commands, &self.shutdown, count, None, None).await
     }
 
     /// Starts several clean agents and synchronously observes each child as it
@@ -108,7 +119,33 @@ impl AgentHandle {
         observer: impl Fn(&str) + Send + Sync + 'static,
     ) -> Result<Vec<(Nanocodex, AgentEvents)>> {
         let commands = self.commands()?;
-        request_spawn_many(&commands, &self.shutdown, count, Some(Arc::new(observer))).await
+        request_spawn_many(
+            &commands,
+            &self.shutdown,
+            count,
+            Some(Arc::new(observer)),
+            None,
+        )
+        .await
+    }
+
+    /// Observes a clean batch while privately inheriting embedding-owned context.
+    #[doc(hidden)]
+    pub async fn spawn_many_observed_with_host_context(
+        &self,
+        count: usize,
+        observer: impl Fn(&str) + Send + Sync + 'static,
+        host_context: Option<Arc<str>>,
+    ) -> Result<Vec<(Nanocodex, AgentEvents)>> {
+        let commands = self.commands()?;
+        request_spawn_many(
+            &commands,
+            &self.shutdown,
+            count,
+            Some(Arc::new(observer)),
+            host_context,
+        )
+        .await
     }
 
     /// Forks the containing agent's latest safe model boundary.
@@ -491,8 +528,19 @@ pub(super) async fn request_spawn(
     shutdown: &DriverShutdown,
     options: SpawnOptions,
 ) -> Result<(Nanocodex, AgentEvents)> {
+    request_spawn_with_host_context(commands, shutdown, options, None).await
+}
+
+#[cfg(feature = "openai")]
+async fn request_spawn_with_host_context(
+    commands: &mpsc::Sender<Command>,
+    shutdown: &DriverShutdown,
+    options: SpawnOptions,
+    host_context: Option<Arc<str>>,
+) -> Result<(Nanocodex, AgentEvents)> {
     request_command(commands, shutdown, |result| Command::Spawn {
         options,
+        host_context,
         result,
     })
     .await
@@ -504,10 +552,12 @@ async fn request_spawn_many(
     shutdown: &DriverShutdown,
     count: usize,
     observer: Option<Arc<SpawnObserver>>,
+    host_context: Option<Arc<str>>,
 ) -> Result<Vec<(Nanocodex, AgentEvents)>> {
     request_command(commands, shutdown, |result| Command::SpawnBatch {
         count,
         observer,
+        host_context,
         result,
     })
     .await

--- a/crates/nanocodex-agent/src/agent/spawn.rs
+++ b/crates/nanocodex-agent/src/agent/spawn.rs
@@ -115,6 +115,7 @@ where
             context_source,
             depth: 0,
             execution: codex.execution,
+            host_context: None,
             service_factory,
         },
         session_id,

--- a/crates/nanocodex-agent/src/agent/turn.rs
+++ b/crates/nanocodex-agent/src/agent/turn.rs
@@ -403,11 +403,13 @@ pub(super) enum Command {
     },
     Spawn {
         options: SpawnOptions,
+        host_context: Option<Arc<str>>,
         result: oneshot::Sender<Result<(Nanocodex, AgentEvents)>>,
     },
     SpawnBatch {
         count: usize,
         observer: Option<Arc<SpawnObserver>>,
+        host_context: Option<Arc<str>>,
         result: oneshot::Sender<Result<Vec<(Nanocodex, AgentEvents)>>>,
     },
     SetModel {

--- a/crates/nanocodex-agent/src/model/run/mod.rs
+++ b/crates/nanocodex-agent/src/model/run/mod.rs
@@ -263,6 +263,10 @@ impl<S> ModelRun<S> {
         }
     }
 
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "the private run owns each injected lifecycle component directly"
+    )]
     pub(crate) fn from_checkpoint(
         events: EventSink,
         config: Arc<ModelConfig>,

--- a/crates/nanocodex-agent/src/model/run/mod.rs
+++ b/crates/nanocodex-agent/src/model/run/mod.rs
@@ -89,6 +89,7 @@ pub(crate) struct ModelRun<S> {
     tools: Tools,
     prompt_cache: ModelPromptCache,
     context_source: ContextSource,
+    host_context: Option<Arc<str>>,
     global_instructions: Option<Arc<str>>,
     force_compaction: bool,
     pending_developer_messages: Vec<ResponseItem>,
@@ -229,6 +230,7 @@ impl<S> ModelRun<S> {
         tools: Tools,
         prompt_cache: ModelPromptCache,
         context_source: ContextSource,
+        host_context: Option<Arc<str>>,
     ) -> Self {
         let model = config.model;
         let thinking = config.thinking;
@@ -253,6 +255,7 @@ impl<S> ModelRun<S> {
             tools,
             prompt_cache,
             context_source,
+            host_context,
             global_instructions,
             force_compaction: false,
             pending_developer_messages: Vec::new(),
@@ -268,6 +271,7 @@ impl<S> ModelRun<S> {
         tools: Tools,
         prompt_cache: ModelPromptCache,
         prepared: PreparedCheckpoint,
+        host_context: Option<Arc<str>>,
     ) -> Self {
         let PreparedCheckpoint {
             checkpoint,
@@ -323,11 +327,16 @@ impl<S> ModelRun<S> {
             tools,
             prompt_cache,
             context_source,
+            host_context,
             global_instructions,
             force_compaction: false,
             pending_developer_messages: Vec::new(),
             execution_steps: None,
         }
+    }
+
+    pub(crate) fn set_host_context(&mut self, host_context: Option<Arc<str>>) {
+        self.host_context = host_context;
     }
 
     pub(crate) fn set_events(&mut self, events: EventSink) {

--- a/crates/nanocodex-agent/src/model/run/responses.rs
+++ b/crates/nanocodex-agent/src/model/run/responses.rs
@@ -328,6 +328,7 @@ pub(super) fn owned_code_context(
     history: Option<Arc<Vec<ResponseItem>>>,
     session_id: &str,
     model: Model,
+    host_context: Option<&str>,
 ) -> Result<Option<OwnedToolContext>> {
     if call.name != "exec" {
         return Ok(None);
@@ -335,13 +336,16 @@ pub(super) fn owned_code_context(
     let history = history.ok_or(NanocodexError::MalformedResponse {
         detail: "exec call did not have an owned history snapshot",
     })?;
-    Ok(Some(OwnedToolContext::new(
-        model.as_str(),
-        session_id,
-        &call.call_id,
-        history,
-        DEFAULT_TOOL_OUTPUT_TOKENS,
-    )))
+    Ok(Some(
+        OwnedToolContext::new(
+            model.as_str(),
+            session_id,
+            &call.call_id,
+            history,
+            DEFAULT_TOOL_OUTPUT_TOKENS,
+        )
+        .with_host_context(host_context.map(Arc::from)),
+    ))
 }
 
 pub(super) fn record_span_content(span: &tracing::Span, kind: &'static str, content: &str) {

--- a/crates/nanocodex-agent/src/model/run/tool_calls.rs
+++ b/crates/nanocodex-agent/src/model/run/tool_calls.rs
@@ -156,9 +156,7 @@ async fn execute_code_call(
     tools: &ToolRuntime,
     call: &CodeCall,
     owned_context: Option<OwnedToolContext>,
-    session_id: &str,
-    model: Model,
-    host_context: Option<&str>,
+    context: ToolContext<'_>,
     observer: &mut dyn CodeModeObserver,
     tool_span: &tracing::Span,
 ) -> CodeModeExecution {
@@ -168,14 +166,6 @@ async fn execute_code_call(
             .instrument(tool_span.clone())
             .await
     } else {
-        let context = ToolContext::new(
-            model.as_str(),
-            session_id,
-            &call.call_id,
-            &[],
-            DEFAULT_TOOL_OUTPUT_TOKENS,
-        )
-        .with_host_context(host_context);
         tools
             .wait_for_code_with_updates(&call.input, context, observer)
             .instrument(tool_span.clone())
@@ -677,6 +667,14 @@ where
             });
         }
         let owned_context = owned_code_context(&call, history, session_id, model, host_context)?;
+        let context = ToolContext::new(
+            model.as_str(),
+            session_id,
+            &call.call_id,
+            &[],
+            DEFAULT_TOOL_OUTPUT_TOKENS,
+        )
+        .with_host_context(host_context);
         let mut observer = NestedToolEventObserver {
             events,
             tool_call_indices,
@@ -689,9 +687,7 @@ where
             tools,
             &call,
             owned_context,
-            session_id,
-            model,
-            host_context,
+            context,
             &mut observer,
             tool_span,
         )

--- a/crates/nanocodex-agent/src/model/run/tool_calls.rs
+++ b/crates/nanocodex-agent/src/model/run/tool_calls.rs
@@ -158,6 +158,7 @@ async fn execute_code_call(
     owned_context: Option<OwnedToolContext>,
     session_id: &str,
     model: Model,
+    host_context: Option<&str>,
     observer: &mut dyn CodeModeObserver,
     tool_span: &tracing::Span,
 ) -> CodeModeExecution {
@@ -173,7 +174,8 @@ async fn execute_code_call(
             &call.call_id,
             &[],
             DEFAULT_TOOL_OUTPUT_TOKENS,
-        );
+        )
+        .with_host_context(host_context);
         tools
             .wait_for_code_with_updates(&call.input, context, observer)
             .instrument(tool_span.clone())
@@ -208,6 +210,7 @@ where
         let tool_call_indices = self.tool_call_indices.clone();
         let session_id = events.request_id().to_owned();
         let model = self.model;
+        let host_context = self.host_context.clone();
         let execution_steps = self.execution_steps.clone();
         let mut executions = prepared
             .into_iter()
@@ -217,6 +220,7 @@ where
                 let events = events.clone();
                 let tool_call_indices = tool_call_indices.clone();
                 let session_id = session_id.clone();
+                let host_context = host_context.clone();
                 let execution_steps = execution_steps.clone();
                 async move {
                     let started_at = active.started_at;
@@ -252,6 +256,7 @@ where
                                     history,
                                     &session_id,
                                     model,
+                                    host_context.as_deref(),
                                     started_at,
                                     &active.progress,
                                     &active.span,
@@ -273,6 +278,7 @@ where
                                     history,
                                     &session_id,
                                     model,
+                                    host_context.as_deref(),
                                     started_at,
                                     &active.progress,
                                     &active.span,
@@ -522,6 +528,7 @@ where
         history: Option<Arc<Vec<ResponseItem>>>,
         session_id: &str,
         model: Model,
+        host_context: Option<&str>,
         started_at: Instant,
         progress: &Mutex<ActiveToolProgress>,
         tool_span: &tracing::Span,
@@ -561,7 +568,8 @@ where
                 &call.call_id,
                 &[],
                 DEFAULT_TOOL_OUTPUT_TOKENS,
-            );
+            )
+            .with_host_context(host_context);
             let mut execution = match call.kind {
                 CodeCallKind::Function => match RawValue::from_string(call.input.clone()) {
                     Ok(input) => {
@@ -627,7 +635,8 @@ where
                 &call.call_id,
                 search_history,
                 DEFAULT_TOOL_OUTPUT_TOKENS,
-            );
+            )
+            .with_host_context(host_context);
             let execution = match RawValue::from_string(call.input.clone()) {
                 Ok(input) => {
                     tools
@@ -667,7 +676,7 @@ where
                 metadata: execution.metadata,
             });
         }
-        let owned_context = owned_code_context(&call, history, session_id, model)?;
+        let owned_context = owned_code_context(&call, history, session_id, model, host_context)?;
         let mut observer = NestedToolEventObserver {
             events,
             tool_call_indices,
@@ -682,6 +691,7 @@ where
             owned_context,
             session_id,
             model,
+            host_context,
             &mut observer,
             tool_span,
         )

--- a/crates/nanocodex-agent/tests/it/model/recovery/durable_provider.rs
+++ b/crates/nanocodex-agent/tests/it/model/recovery/durable_provider.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use nanocodex_agent::{
+    PromptRequest,
     execution::{
         ExecutionAdmission, ExecutionFuture, ExecutionOutput, ExecutionPolicy,
         ExecutionStepAdmission,
@@ -17,9 +18,12 @@ use nanocodex_agent::{
 use nanocodex_oai_api::{
     responses::{ContentItem, MessageRole, ResponseItem, ResponseItemId, WarmupResponse},
     tower::{
-        CompactionOutput, GenerationOutput, ResponsePipelineStats, ResponsesAttempt,
-        ResponsesAttemptKind, ResponsesOutput, ResponsesServiceResponse,
+        CodeCall, CodeCallKind, CompactionOutput, GenerationOutput, ResponsePipelineStats,
+        ResponsesAttempt, ResponsesAttemptKind, ResponsesOutput, ResponsesServiceResponse,
     },
+};
+use nanocodex_tools::{
+    Tool, ToolContext, ToolDefinition, ToolInput, ToolOutput, ToolResult, contract::async_trait,
 };
 use tower::Service;
 
@@ -81,6 +85,118 @@ impl Service<ResponsesAttempt> for ProviderProbe {
             _ => panic!("provider recovery probe received an unsupported attempt kind"),
         };
         ready(Ok(ResponsesServiceResponse::new(output)))
+    }
+}
+
+#[derive(Clone)]
+struct HostContextProvider {
+    generations: Arc<AtomicU32>,
+}
+
+impl Service<ResponsesAttempt> for HostContextProvider {
+    type Response = ResponsesServiceResponse;
+    type Error = ResponseError;
+    type Future = Ready<std::result::Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        _context: &mut Context<'_>,
+    ) -> Poll<std::result::Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: ResponsesAttempt) -> Self::Future {
+        let output = match request.kind() {
+            ResponsesAttemptKind::Warmup => ResponsesOutput::Warmup(WarmupResponse {
+                id: "resp-host-context-warmup".to_owned(),
+                usage: None,
+            }),
+            ResponsesAttemptKind::Generation
+                if self.generations.fetch_add(1, Ordering::Relaxed) == 0 =>
+            {
+                host_context_tool_generation()
+            }
+            ResponsesAttemptKind::Generation => {
+                assert!(request.input_items().any(|item| {
+                    serde_json::to_value(item).is_ok_and(|item| {
+                        item["type"] == "function_call_output"
+                            && item["call_id"] == "call-host-context"
+                    })
+                }));
+                ResponsesOutput::Generation(GenerationOutput {
+                    id: "resp-host-context-complete".to_owned(),
+                    status: "completed".to_owned(),
+                    end_turn: Some(true),
+                    final_message: Some("private context observed".to_owned()),
+                    output_items: vec![ResponseItem::message(
+                        MessageRole::Assistant,
+                        [ContentItem::output_text("private context observed")],
+                    )],
+                    code_calls: Vec::new(),
+                    usage: None,
+                    time_to_first_event_ns: 0,
+                    time_to_first_output_ns: None,
+                    pipeline_stats: ResponsePipelineStats::default(),
+                })
+            }
+            _ => panic!("host-context probe received an unsupported attempt kind"),
+        };
+        ready(Ok(ResponsesServiceResponse::new(output)))
+    }
+}
+
+fn host_context_tool_generation() -> ResponsesOutput {
+    let item = serde_json::from_value(json!({
+        "type": "function_call",
+        "call_id": "call-host-context",
+        "name": "host_context_probe",
+        "arguments": "{}"
+    }))
+    .expect("function call item decodes");
+    ResponsesOutput::Generation(GenerationOutput {
+        id: "resp-host-context-tool".to_owned(),
+        status: "completed".to_owned(),
+        end_turn: Some(false),
+        final_message: None,
+        output_items: vec![item],
+        code_calls: vec![CodeCall {
+            call_id: "call-host-context".to_owned(),
+            name: "host_context_probe".to_owned(),
+            namespace: None,
+            input: "{}".to_owned(),
+            kind: CodeCallKind::Function,
+        }],
+        usage: None,
+        time_to_first_event_ns: 0,
+        time_to_first_output_ns: None,
+        pipeline_stats: ResponsePipelineStats::default(),
+    })
+}
+
+struct HostContextProbe {
+    seen: Arc<Mutex<Vec<Option<String>>>>,
+}
+
+#[async_trait]
+impl Tool for HostContextProbe {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::function(
+            "host_context_probe",
+            "Records embedding-owned context without exposing it to the model.",
+            json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }),
+        )
+    }
+
+    async fn execute(&self, _input: ToolInput, context: ToolContext<'_>) -> ToolResult {
+        self.seen
+            .lock()
+            .unwrap()
+            .push(context.host_context().map(str::to_owned));
+        Ok(ToolOutput::text("observed"))
     }
 }
 
@@ -221,6 +337,41 @@ async fn assert_provider_step_executes(
 #[tokio::test]
 async fn model_call_admission_executes_the_provider() -> Result<()> {
     assert_provider_step_executes("model_call", ResponsesTransport::Https).await
+}
+
+#[tokio::test]
+async fn admitted_operation_id_reaches_tools_only_as_private_context() -> Result<()> {
+    const HOST_CONTEXT: &str = "opaque-managed-turn";
+
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let tools = Tools::builder()
+        .without_defaults()
+        .tool(HostContextProbe {
+            seen: Arc::clone(&seen),
+        })
+        .build()?;
+    let openai = OpenAi::builder("test-key")
+        .transport(ResponsesTransport::Https)
+        .service(|| HostContextProvider {
+            generations: Arc::new(AtomicU32::new(0)),
+        })
+        .build()?;
+    let workspace = tempfile::tempdir()?;
+    let (agent, events) = Nanocodex::builder(openai)
+        .workspace(workspace.path())
+        .execution_policy(Arc::new(ProviderSteps::new()))
+        .tools(tools)
+        .build()?;
+    drop(events);
+
+    let result = agent
+        .prompt(PromptRequest::new("inspect private context").request_id(HOST_CONTEXT))
+        .await?
+        .await?;
+    assert_eq!(result.final_message(), "private context observed");
+    assert_eq!(&*seen.lock().unwrap(), &[Some(HOST_CONTEXT.to_owned())]);
+    agent.shutdown().await?;
+    Ok(())
 }
 
 #[tokio::test]

--- a/crates/nanocodex-managed/src/client.rs
+++ b/crates/nanocodex-managed/src/client.rs
@@ -731,7 +731,7 @@ fn install_default_rustls_crypto_provider() {
     }
 }
 
-fn validate_origin(origin: &Url) -> Result<(), ManagedError> {
+pub(crate) fn validate_origin(origin: &Url) -> Result<(), ManagedError> {
     if !matches!(origin.scheme(), "http" | "https")
         || !origin.username().is_empty()
         || origin.password().is_some()

--- a/crates/nanocodex-managed/src/error.rs
+++ b/crates/nanocodex-managed/src/error.rs
@@ -26,6 +26,9 @@ pub enum ManagedError {
     /// A durable event-stream frame or envelope violated its protocol.
     #[error("managed event stream is malformed: {0}")]
     InvalidEvent(String),
+    /// A VM-host control connection or strict protocol frame was invalid.
+    #[error("managed VM host control failed: {0}")]
+    VmHost(String),
     /// A managed turn reached an unsuccessful terminal state.
     #[error("managed turn {turn_id} {state}: {message}")]
     Turn {

--- a/crates/nanocodex-managed/src/lib.rs
+++ b/crates/nanocodex-managed/src/lib.rs
@@ -15,6 +15,9 @@ mod types;
 mod websocket;
 
 #[cfg(feature = "tools")]
+mod vm_host;
+
+#[cfg(feature = "tools")]
 mod attachment;
 
 pub use auth::ManagedApiKey;
@@ -27,3 +30,10 @@ pub use sse::{
     EventCursor, ManagedEventFuture, ManagedEventSource, ManagedEventStream, ManagedEvents,
 };
 pub use types::*;
+
+#[cfg(feature = "tools")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tools")))]
+pub use vm_host::{
+    VmHostAllocationState, VmHostCommand, VmHostConnection, VmHostFence, VmHostProvision,
+    VmHostRelease, VmHostScope, VmShape, connect_system_vm_host, validate_vm_factory_name,
+};

--- a/crates/nanocodex-managed/src/vm_host.rs
+++ b/crates/nanocodex-managed/src/vm_host.rs
@@ -527,63 +527,83 @@ impl VmHostConnection {
             return Ok(None);
         }
         loop {
-            let Some(encoded) = read_text(&mut self.socket).await? else {
-                self.terminal = true;
-                return Ok(None);
+            let encoded = match read_text(&mut self.socket).await {
+                Ok(Some(encoded)) => encoded,
+                Ok(None) => {
+                    self.terminal = true;
+                    return Ok(None);
+                }
+                Err(error) => {
+                    self.terminal = true;
+                    return Err(error);
+                }
             };
-            let frame = decode_server_message(&encoded).map_err(|error| {
+            let frame = decode_server_message(&encoded).inspect_err(|_| {
                 self.terminal = true;
-                error
             })?;
-            match frame {
-                ServerMessage::Lease(_) => {
-                    return self.fail("VM host sent a second lease on one connection");
-                }
-                ServerMessage::Pong(pong) => {
-                    self.validate_pins(&pong.lease_id, pong.epoch)?;
-                    validate_timestamp(pong.expires_at)?;
-                    let expected = self
-                        .pending_ping
-                        .take()
-                        .ok_or_else(|| protocol("VM host sent an unsolicited pong"))?;
-                    if pong.nonce.as_deref().unwrap_or_default() != expected {
-                        return self.fail("VM host pong nonce does not match the outstanding ping");
-                    }
-                    self.expires_at = pong.expires_at;
-                }
-                ServerMessage::Provision(raw) => {
-                    self.require_reconciled()?;
-                    self.validate_pins(&raw.lease_id, raw.epoch)?;
-                    let provision = self.accept_provision(raw)?;
-                    return Ok(Some(VmHostCommand::Provision(provision)));
-                }
-                ServerMessage::Release(raw) => {
-                    self.require_reconciled()?;
-                    self.validate_pins(&raw.lease_id, raw.epoch)?;
-                    let release = self.accept_release(raw)?;
-                    return Ok(Some(VmHostCommand::Release(release)));
-                }
-                ServerMessage::Fenced(fenced) => {
-                    validate_generation(fenced.epoch)?;
-                    validate_bounded_text("fencing reason", &fenced.reason, MAX_REASON_BYTES)?;
-                    if fenced.epoch < self.epoch {
-                        return self.fail("VM host fencing epoch is stale");
-                    }
+            match self.accept_frame(frame) {
+                Ok(Some(command)) => return Ok(Some(command)),
+                Ok(None) => {}
+                Err(error) => {
                     self.terminal = true;
-                    return Ok(Some(VmHostCommand::Fenced(VmHostFence {
-                        epoch: fenced.epoch,
-                        reason: fenced.reason,
-                    })));
+                    return Err(error);
                 }
-                ServerMessage::Error(error) => {
-                    validate_machine_id_like("error code", &error.code)?;
-                    validate_bounded_text("error message", &error.message, MAX_REASON_BYTES)?;
-                    self.terminal = true;
-                    return Err(configuration(format!(
-                        "server rejected VM host control: {}: {}",
-                        error.code, error.message
-                    )));
+            }
+        }
+    }
+
+    fn accept_frame(
+        &mut self,
+        frame: ServerMessage,
+    ) -> Result<Option<VmHostCommand>, ManagedError> {
+        match frame {
+            ServerMessage::Lease(_) => self.fail("VM host sent a second lease on one connection"),
+            ServerMessage::Pong(pong) => {
+                self.validate_pins(&pong.lease_id, pong.epoch)?;
+                validate_timestamp(pong.expires_at)?;
+                let expected = self
+                    .pending_ping
+                    .as_deref()
+                    .ok_or_else(|| protocol("VM host sent an unsolicited pong"))?;
+                if pong.nonce.as_deref().unwrap_or_default() != expected {
+                    return self.fail("VM host pong nonce does not match the outstanding ping");
                 }
+                self.pending_ping = None;
+                self.expires_at = pong.expires_at;
+                Ok(None)
+            }
+            ServerMessage::Provision(raw) => {
+                self.require_reconciled()?;
+                self.validate_pins(&raw.lease_id, raw.epoch)?;
+                let provision = self.accept_provision(raw)?;
+                Ok(Some(VmHostCommand::Provision(provision)))
+            }
+            ServerMessage::Release(raw) => {
+                self.require_reconciled()?;
+                self.validate_pins(&raw.lease_id, raw.epoch)?;
+                let release = self.accept_release(raw)?;
+                Ok(Some(VmHostCommand::Release(release)))
+            }
+            ServerMessage::Fenced(fenced) => {
+                validate_generation(fenced.epoch)?;
+                validate_bounded_text("fencing reason", &fenced.reason, MAX_REASON_BYTES)?;
+                if fenced.epoch < self.epoch {
+                    return self.fail("VM host fencing epoch is stale");
+                }
+                self.terminal = true;
+                Ok(Some(VmHostCommand::Fenced(VmHostFence {
+                    epoch: fenced.epoch,
+                    reason: fenced.reason,
+                })))
+            }
+            ServerMessage::Error(error) => {
+                validate_machine_id_like("error code", &error.code)?;
+                validate_bounded_text("error message", &error.message, MAX_REASON_BYTES)?;
+                self.terminal = true;
+                Err(configuration(format!(
+                    "server rejected VM host control: {}: {}",
+                    error.code, error.message
+                )))
             }
         }
     }
@@ -595,6 +615,7 @@ impl VmHostConnection {
             return self.fail("VM host provision slot is outside max_vms");
         }
         validate_machine_id(&raw.machine_id)?;
+        let attachment = attachment_target(raw.tool_attachment.clone())?;
         let fingerprint = ProvisionFingerprint {
             generation: raw.generation,
             slot: raw.slot,
@@ -625,7 +646,6 @@ impl VmHostConnection {
                 },
             );
         }
-        let attachment = attachment_target(raw.tool_attachment)?;
         Ok(VmHostProvision {
             allocation_id,
             generation: raw.generation,
@@ -639,26 +659,28 @@ impl VmHostConnection {
         let allocation_id = parse_v4_uuid("allocation", &raw.allocation_id)?;
         validate_generation(raw.generation)?;
         validate_machine_id(&raw.machine_id)?;
-        if self.allocations.contains_key(&allocation_id) {
-            self.require_known(allocation_id, raw.generation, &raw.machine_id, false)?;
-            self.allocations
-                .get_mut(&allocation_id)
-                .expect("known allocation was just validated")
-                .releasing = true;
-        } else {
-            // A release may be replayed after its acknowledgement was lost, or
-            // after a replacement lease reconciled no ready copy. Keep the
-            // identity long enough for the local supervisor to apply its
-            // idempotent release/tombstone and acknowledge it again.
-            self.allocations.insert(
-                allocation_id,
-                KnownAllocation {
+        match self.allocations.entry(allocation_id) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                let existing = entry.get();
+                if existing.generation != raw.generation || existing.machine_id != raw.machine_id {
+                    return Err(protocol(
+                        "VM host release changed immutable allocation identity",
+                    ));
+                }
+                entry.get_mut().releasing = true;
+            }
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                // A release may be replayed after its acknowledgement was lost, or
+                // after a replacement lease reconciled no ready copy. Keep the
+                // identity long enough for the local supervisor to apply its
+                // idempotent release/tombstone and acknowledge it again.
+                entry.insert(KnownAllocation {
                     generation: raw.generation,
                     machine_id: raw.machine_id.clone(),
                     provision: None,
                     releasing: true,
-                },
-            );
+                });
+            }
         }
         Ok(VmHostRelease {
             allocation_id,
@@ -1298,6 +1320,37 @@ mod tests {
         }
     }
 
+    async fn connection_pair() -> (VmHostConnection, WebSocketStream<tokio::net::TcpStream>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            tokio_tungstenite::accept_async(stream).await.unwrap()
+        });
+        let (socket, _) = tokio_tungstenite::connect_async(format!("ws://{address}"))
+            .await
+            .unwrap();
+        let peer = server.await.unwrap();
+        let lease_id = parse_v4_uuid("lease", LEASE_ID).unwrap();
+        (
+            VmHostConnection {
+                socket,
+                scope: VmHostScope::User,
+                host_id: Uuid::new_v4(),
+                max_vms: 2,
+                vm: VmShape::new(2, 1_024).unwrap(),
+                lease_id,
+                epoch: 1,
+                expires_at: 10,
+                reconciled: true,
+                pending_ping: None,
+                allocations: HashMap::new(),
+                terminal: false,
+            },
+            peer,
+        )
+    }
+
     #[test]
     fn strict_frames_reject_unknown_fields_and_noncanonical_identities() {
         let valid = json!({
@@ -1449,6 +1502,64 @@ mod tests {
             matching,
         ));
         assert!(allocations[&allocation_id].provision.is_none());
+    }
+
+    #[tokio::test]
+    async fn duplicate_release_is_an_idempotent_redrive() {
+        let (mut connection, mut peer) = connection_pair().await;
+        let allocation_id = parse_v4_uuid("allocation", ALLOCATION_ID).unwrap();
+        connection
+            .allocations
+            .insert(allocation_id, reconciled_allocation("machine-1"));
+        let release = json!({
+            "type":"release", "lease_id":LEASE_ID, "epoch":1,
+            "allocation_id":ALLOCATION_ID, "generation":1,
+            "machine_id":"machine-1"
+        })
+        .to_string();
+
+        peer.send(Message::Text(release.clone().into()))
+            .await
+            .unwrap();
+        peer.send(Message::Text(release.into())).await.unwrap();
+
+        for _ in 0..2 {
+            let Some(VmHostCommand::Release(command)) = connection.next().await.unwrap() else {
+                panic!("expected an idempotent release command");
+            };
+            assert_eq!(command.allocation_id(), allocation_id);
+        }
+        assert!(connection.allocations[&allocation_id].releasing);
+        assert!(!connection.terminal);
+    }
+
+    #[tokio::test]
+    async fn invalid_provision_is_terminal_without_publishing_partial_state() {
+        let (mut connection, mut peer) = connection_pair().await;
+        let allocation_id = parse_v4_uuid("allocation", ALLOCATION_ID).unwrap();
+        connection
+            .allocations
+            .insert(allocation_id, reconciled_allocation("machine-1"));
+        peer.send(Message::Text(
+            json!({
+                "type":"provision", "lease_id":LEASE_ID, "epoch":1,
+                "allocation_id":ALLOCATION_ID, "generation":1, "slot":0,
+                "machine_id":"machine-1",
+                "tool_attachment":{
+                    "url":"wss://tools.example/attach",
+                    "bearer":"invalid"
+                }
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .unwrap();
+
+        assert!(connection.next().await.is_err());
+        assert!(connection.terminal);
+        assert!(connection.allocations[&allocation_id].provision.is_none());
+        assert!(connection.next().await.unwrap().is_none());
     }
 
     #[test]

--- a/crates/nanocodex-managed/src/vm_host.rs
+++ b/crates/nanocodex-managed/src/vm_host.rs
@@ -1,0 +1,1485 @@
+use std::{collections::HashMap, fmt, time::Duration};
+
+use futures_util::{SinkExt as _, StreamExt as _};
+use nanocodex_tools::attachment::AttachmentTarget;
+use serde::{Deserialize, Serialize};
+use tokio_tungstenite::{
+    MaybeTlsStream, WebSocketStream, connect_async_with_config,
+    tungstenite::{
+        Error as WebSocketError, Message, client::IntoClientRequest as _, protocol::WebSocketConfig,
+    },
+};
+use url::Url;
+use uuid::{Uuid, Variant, Version};
+use zeroize::Zeroize as _;
+
+use crate::{ManagedClient, ManagedError, client::validate_origin};
+
+const PROTOCOL_VERSION: u8 = 1;
+const MAX_MESSAGE_BYTES: usize = 256 * 1024;
+const MAX_VMS: u16 = 64;
+const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+const MAX_MACHINE_ID_BYTES: usize = 123;
+const MAX_FACTORY_NAME_BYTES: usize = 63;
+const MAX_NONCE_BYTES: usize = 128;
+const MAX_REASON_BYTES: usize = 1024;
+const ATTACHMENT_BEARER_BYTES: usize = 43;
+const MAX_ATTACHMENT_URL_BYTES: usize = 2048;
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+type Socket = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
+
+/// Authority scope used to lease allocations from a managed VM-host endpoint.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum VmHostScope {
+    /// Any hosted agent owned by the authenticated account may allocate a VM.
+    User,
+    /// Only the named account-owned agent may allocate a VM.
+    Agent(String),
+    /// System scheduling authority authenticated by a separate host token.
+    System,
+}
+
+/// Fixed resources assigned to every VM advertised by one host lease.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct VmShape {
+    cpus: u8,
+    memory_mib: u32,
+}
+
+impl VmShape {
+    /// Creates a protocol-valid fixed VM shape.
+    ///
+    /// # Errors
+    ///
+    /// Rejects CPU counts outside 1-64 and memory outside 128-262144 MiB.
+    pub fn new(cpus: u8, memory_mib: u32) -> Result<Self, ManagedError> {
+        let shape = Self { cpus, memory_mib };
+        shape.validate()?;
+        Ok(shape)
+    }
+
+    /// Returns the virtual CPU count assigned to every VM.
+    #[must_use]
+    pub const fn cpus(self) -> u8 {
+        self.cpus
+    }
+
+    /// Returns the memory assigned to every VM in mebibytes.
+    #[must_use]
+    pub const fn memory_mib(self) -> u32 {
+        self.memory_mib
+    }
+
+    fn validate(self) -> Result<(), ManagedError> {
+        if !(1..=64).contains(&self.cpus) {
+            return Err(configuration("VM host CPU count must be 1-64"));
+        }
+        if !(128..=262_144).contains(&self.memory_mib) {
+            return Err(configuration("VM host memory must be 128-262144 MiB"));
+        }
+        Ok(())
+    }
+}
+
+/// One live allocation reported while reconciling a replacement host lease.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VmHostAllocationState {
+    allocation_id: Uuid,
+    generation: u64,
+    machine_id: String,
+}
+
+impl VmHostAllocationState {
+    /// Creates one ready allocation reconciliation record.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a zero/unsafe generation or invalid machine identifier.
+    pub fn ready(
+        allocation_id: Uuid,
+        generation: u64,
+        machine_id: impl Into<String>,
+    ) -> Result<Self, ManagedError> {
+        require_v4_uuid("allocation", allocation_id)?;
+        validate_generation(generation)?;
+        let machine_id = machine_id.into();
+        validate_machine_id(&machine_id)?;
+        Ok(Self {
+            allocation_id,
+            generation,
+            machine_id,
+        })
+    }
+
+    /// Returns the durable allocation identifier.
+    #[must_use]
+    pub const fn allocation_id(&self) -> Uuid {
+        self.allocation_id
+    }
+
+    /// Returns the allocation generation.
+    #[must_use]
+    pub const fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    /// Returns the stable machine identifier.
+    #[must_use]
+    pub fn machine_id(&self) -> &str {
+        &self.machine_id
+    }
+}
+
+/// A managed request to create one private VM and attach its tools.
+#[derive(Clone)]
+pub struct VmHostProvision {
+    allocation_id: Uuid,
+    generation: u64,
+    slot: u16,
+    machine_id: String,
+    attachment: AttachmentTarget,
+}
+
+impl fmt::Debug for VmHostProvision {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("VmHostProvision")
+            .field("allocation_id", &self.allocation_id)
+            .field("generation", &self.generation)
+            .field("slot", &self.slot)
+            .field("machine_id", &self.machine_id)
+            .field("attachment", &self.attachment)
+            .finish()
+    }
+}
+
+impl VmHostProvision {
+    /// Returns the durable allocation identifier.
+    #[must_use]
+    pub const fn allocation_id(&self) -> Uuid {
+        self.allocation_id
+    }
+
+    /// Returns the allocation generation.
+    #[must_use]
+    pub const fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    /// Returns the host-local bounded slot.
+    #[must_use]
+    pub const fn slot(&self) -> u16 {
+        self.slot
+    }
+
+    /// Returns the stable machine identifier advertised by the leaf attachment.
+    #[must_use]
+    pub fn machine_id(&self) -> &str {
+        &self.machine_id
+    }
+
+    /// Returns the redacting leaf Hosted Tools attachment target.
+    #[must_use]
+    pub const fn attachment(&self) -> &AttachmentTarget {
+        &self.attachment
+    }
+
+    /// Consumes the command and returns its leaf Hosted Tools target.
+    #[must_use]
+    pub fn into_attachment(self) -> AttachmentTarget {
+        self.attachment
+    }
+}
+
+/// A managed request to drain and stop one allocated VM.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VmHostRelease {
+    allocation_id: Uuid,
+    generation: u64,
+    machine_id: String,
+}
+
+impl VmHostRelease {
+    /// Returns the durable allocation identifier.
+    #[must_use]
+    pub const fn allocation_id(&self) -> Uuid {
+        self.allocation_id
+    }
+
+    /// Returns the allocation generation.
+    #[must_use]
+    pub const fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    /// Returns the stable machine identifier.
+    #[must_use]
+    pub fn machine_id(&self) -> &str {
+        &self.machine_id
+    }
+}
+
+/// Terminal fencing notice for a superseded VM-host lease.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VmHostFence {
+    epoch: u64,
+    reason: String,
+}
+
+impl VmHostFence {
+    /// Returns the authoritative successor epoch.
+    #[must_use]
+    pub const fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    /// Returns the bounded non-secret fencing reason.
+    #[must_use]
+    pub fn reason(&self) -> &str {
+        &self.reason
+    }
+}
+
+/// One strict, identity-checked server command.
+#[derive(Clone, Debug)]
+pub enum VmHostCommand {
+    /// Provision one VM in the named host slot.
+    Provision(VmHostProvision),
+    /// Drain and release one VM.
+    Release(VmHostRelease),
+    /// Stop the host because its lease was superseded.
+    Fenced(VmHostFence),
+}
+
+/// One authenticated v1 VM-host control WebSocket.
+pub struct VmHostConnection {
+    socket: Socket,
+    scope: VmHostScope,
+    host_id: Uuid,
+    max_vms: u16,
+    vm: VmShape,
+    lease_id: Uuid,
+    epoch: u64,
+    expires_at: u64,
+    reconciled: bool,
+    pending_ping: Option<String>,
+    allocations: HashMap<Uuid, KnownAllocation>,
+    terminal: bool,
+}
+
+impl fmt::Debug for VmHostConnection {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("VmHostConnection")
+            .field("scope", &self.scope)
+            .field("host_id", &self.host_id)
+            .field("max_vms", &self.max_vms)
+            .field("vm", &self.vm)
+            .field("lease_id", &self.lease_id)
+            .field("epoch", &self.epoch)
+            .field("expires_at", &self.expires_at)
+            .field("reconciled", &self.reconciled)
+            .field("allocations", &self.allocations.len())
+            .field("terminal", &self.terminal)
+            .finish()
+    }
+}
+
+impl ManagedClient {
+    /// Connects an account- or agent-scoped VM host and acquires its first lease.
+    ///
+    /// System scope is deliberately rejected because it requires the separate
+    /// raw system host token accepted by [`connect_system_vm_host`].
+    ///
+    /// # Errors
+    ///
+    /// Returns configuration, WebSocket, or strict v1 protocol failures.
+    pub async fn connect_vm_host(
+        &self,
+        scope: VmHostScope,
+        host_id: Uuid,
+        factory_name: impl Into<String>,
+        max_vms: u16,
+        vm: VmShape,
+    ) -> Result<VmHostConnection, ManagedError> {
+        let path = match &scope {
+            VmHostScope::User => "/v1/account/vm-host".to_owned(),
+            VmHostScope::Agent(agent_id) => {
+                crate::client::validate_id("agent", agent_id)?;
+                format!("/v1/agents/{agent_id}/vm-host")
+            }
+            VmHostScope::System => {
+                return Err(configuration(
+                    "system VM hosts require connect_system_vm_host and a system host token",
+                ));
+            }
+        };
+        connect_vm_host(
+            self.base_url.clone(),
+            path,
+            self.bearer.to_string(),
+            scope,
+            host_id,
+            factory_name.into(),
+            max_vms,
+            vm,
+        )
+        .await
+    }
+}
+
+/// Connects a system-scoped VM host with its raw, separately issued host token.
+///
+/// The token is consumed, never parsed as an account API key, and never appears
+/// in debug output or returned errors.
+///
+/// # Errors
+///
+/// Returns origin, token-header, WebSocket, or strict v1 protocol failures.
+pub async fn connect_system_vm_host(
+    origin: impl AsRef<str>,
+    system_host_token: impl Into<String>,
+    host_id: Uuid,
+    factory_name: impl Into<String>,
+    max_vms: u16,
+    vm: VmShape,
+) -> Result<VmHostConnection, ManagedError> {
+    let origin =
+        Url::parse(origin.as_ref()).map_err(|_| configuration("managed origin must be a URL"))?;
+    validate_origin(&origin)?;
+    connect_vm_host(
+        origin,
+        "/v1/system/vm-host".to_owned(),
+        system_host_token.into(),
+        VmHostScope::System,
+        host_id,
+        factory_name.into(),
+        max_vms,
+        vm,
+    )
+    .await
+}
+
+impl VmHostConnection {
+    /// Returns the current lease identifier.
+    #[must_use]
+    pub const fn lease_id(&self) -> Uuid {
+        self.lease_id
+    }
+
+    /// Returns the current fencing epoch.
+    #[must_use]
+    pub const fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    /// Returns the current lease expiry as Unix epoch milliseconds.
+    #[must_use]
+    pub const fn expires_at(&self) -> u64 {
+        self.expires_at
+    }
+
+    /// Reconciles all ready allocations immediately after acquiring this lease.
+    ///
+    /// # Errors
+    ///
+    /// Rejects repeated reconciliation, over-capacity snapshots, duplicate
+    /// identities, or transport failure.
+    pub async fn reconcile(
+        &mut self,
+        allocations: &[VmHostAllocationState],
+    ) -> Result<(), ManagedError> {
+        if self.terminal {
+            return Err(protocol("VM host connection is terminal"));
+        }
+        if self.reconciled {
+            return Err(protocol("VM host lease was already reconciled"));
+        }
+        if allocations.len() > usize::from(self.max_vms) {
+            return Err(configuration("VM host reconciliation exceeds max_vms"));
+        }
+        let mut known = HashMap::with_capacity(allocations.len());
+        let mut machine_ids = HashMap::with_capacity(allocations.len());
+        let mut wire = Vec::with_capacity(allocations.len());
+        for allocation in allocations {
+            require_v4_uuid("allocation", allocation.allocation_id)?;
+            validate_generation(allocation.generation)?;
+            validate_machine_id(&allocation.machine_id)?;
+            if known
+                .insert(
+                    allocation.allocation_id,
+                    KnownAllocation {
+                        generation: allocation.generation,
+                        machine_id: allocation.machine_id.clone(),
+                        provision: None,
+                        releasing: false,
+                    },
+                )
+                .is_some()
+                || machine_ids
+                    .insert(allocation.machine_id.as_str(), ())
+                    .is_some()
+            {
+                return Err(configuration(
+                    "VM host reconciliation contains duplicate allocation or machine identity",
+                ));
+            }
+            wire.push(ReconcileAllocation {
+                allocation_id: allocation.allocation_id.to_string(),
+                generation: allocation.generation,
+                machine_id: &allocation.machine_id,
+                state: ReadyState::Ready,
+            });
+        }
+        self.send(&ClientMessage::Reconcile {
+            lease_id: self.lease_id.to_string(),
+            epoch: self.epoch,
+            allocations: wire,
+        })
+        .await?;
+        self.allocations = known;
+        self.reconciled = true;
+        Ok(())
+    }
+
+    /// Sends a lease heartbeat with an optional bounded nonce.
+    ///
+    /// # Errors
+    ///
+    /// Rejects invalid or overlapping nonces and transport failure.
+    pub async fn ping(&mut self, nonce: Option<&str>) -> Result<(), ManagedError> {
+        if self.terminal {
+            return Err(protocol("VM host connection is terminal"));
+        }
+        if self.pending_ping.is_some() {
+            return Err(protocol("VM host ping is already outstanding"));
+        }
+        if let Some(nonce) = nonce {
+            validate_bounded_text("ping nonce", nonce, MAX_NONCE_BYTES)?;
+        }
+        self.send(&ClientMessage::Ping {
+            lease_id: self.lease_id.to_string(),
+            epoch: self.epoch,
+            nonce,
+        })
+        .await?;
+        self.pending_ping = Some(nonce.unwrap_or_default().to_owned());
+        Ok(())
+    }
+
+    /// Reports that a provision command reached leaf attachment readiness.
+    ///
+    /// # Errors
+    ///
+    /// Rejects commands not owned by this live lease or transport failure.
+    pub async fn provisioned(&mut self, provision: &VmHostProvision) -> Result<(), ManagedError> {
+        self.require_known(
+            provision.allocation_id,
+            provision.generation,
+            &provision.machine_id,
+            false,
+        )?;
+        self.send(&ClientMessage::Provisioned {
+            lease_id: self.lease_id.to_string(),
+            epoch: self.epoch,
+            allocation_id: provision.allocation_id.to_string(),
+            generation: provision.generation,
+            machine_id: &provision.machine_id,
+        })
+        .await
+    }
+
+    /// Reports that a release command completed leaf drain and VM shutdown.
+    ///
+    /// # Errors
+    ///
+    /// Rejects commands not owned by this live lease or transport failure.
+    pub async fn released(&mut self, release: &VmHostRelease) -> Result<(), ManagedError> {
+        self.require_known(
+            release.allocation_id,
+            release.generation,
+            &release.machine_id,
+            true,
+        )?;
+        self.send(&ClientMessage::Released {
+            lease_id: self.lease_id.to_string(),
+            epoch: self.epoch,
+            allocation_id: release.allocation_id.to_string(),
+            generation: release.generation,
+            machine_id: &release.machine_id,
+        })
+        .await?;
+        self.allocations.remove(&release.allocation_id);
+        Ok(())
+    }
+
+    /// Waits for the next provision, release, or terminal fencing command.
+    ///
+    /// Valid pong heartbeats are consumed internally. Every application frame
+    /// is size-bounded, exact-key decoded, and pinned to this lease and epoch.
+    ///
+    /// # Errors
+    ///
+    /// Returns a transport or terminal strict-protocol failure.
+    pub async fn next(&mut self) -> Result<Option<VmHostCommand>, ManagedError> {
+        if self.terminal {
+            return Ok(None);
+        }
+        loop {
+            let Some(encoded) = read_text(&mut self.socket).await? else {
+                self.terminal = true;
+                return Ok(None);
+            };
+            let frame = decode_server_message(&encoded).map_err(|error| {
+                self.terminal = true;
+                error
+            })?;
+            match frame {
+                ServerMessage::Lease(_) => {
+                    return self.fail("VM host sent a second lease on one connection");
+                }
+                ServerMessage::Pong(pong) => {
+                    self.validate_pins(&pong.lease_id, pong.epoch)?;
+                    validate_timestamp(pong.expires_at)?;
+                    let expected = self
+                        .pending_ping
+                        .take()
+                        .ok_or_else(|| protocol("VM host sent an unsolicited pong"))?;
+                    if pong.nonce.as_deref().unwrap_or_default() != expected {
+                        return self.fail("VM host pong nonce does not match the outstanding ping");
+                    }
+                    self.expires_at = pong.expires_at;
+                }
+                ServerMessage::Provision(raw) => {
+                    self.require_reconciled()?;
+                    self.validate_pins(&raw.lease_id, raw.epoch)?;
+                    let provision = self.accept_provision(raw)?;
+                    return Ok(Some(VmHostCommand::Provision(provision)));
+                }
+                ServerMessage::Release(raw) => {
+                    self.require_reconciled()?;
+                    self.validate_pins(&raw.lease_id, raw.epoch)?;
+                    let release = self.accept_release(raw)?;
+                    return Ok(Some(VmHostCommand::Release(release)));
+                }
+                ServerMessage::Fenced(fenced) => {
+                    validate_generation(fenced.epoch)?;
+                    validate_bounded_text("fencing reason", &fenced.reason, MAX_REASON_BYTES)?;
+                    if fenced.epoch < self.epoch {
+                        return self.fail("VM host fencing epoch is stale");
+                    }
+                    self.terminal = true;
+                    return Ok(Some(VmHostCommand::Fenced(VmHostFence {
+                        epoch: fenced.epoch,
+                        reason: fenced.reason,
+                    })));
+                }
+                ServerMessage::Error(error) => {
+                    validate_machine_id_like("error code", &error.code)?;
+                    validate_bounded_text("error message", &error.message, MAX_REASON_BYTES)?;
+                    self.terminal = true;
+                    return Err(configuration(format!(
+                        "server rejected VM host control: {}: {}",
+                        error.code, error.message
+                    )));
+                }
+            }
+        }
+    }
+
+    fn accept_provision(&mut self, raw: ProvisionMessage) -> Result<VmHostProvision, ManagedError> {
+        let allocation_id = parse_v4_uuid("allocation", &raw.allocation_id)?;
+        validate_generation(raw.generation)?;
+        if raw.slot >= self.max_vms {
+            return self.fail("VM host provision slot is outside max_vms");
+        }
+        validate_machine_id(&raw.machine_id)?;
+        let fingerprint = ProvisionFingerprint {
+            generation: raw.generation,
+            slot: raw.slot,
+            machine_id: raw.machine_id.clone(),
+            url: raw.tool_attachment.url.clone(),
+            bearer: raw.tool_attachment.bearer.clone(),
+        };
+        if self.allocations.contains_key(&allocation_id) {
+            if !accept_existing_provision(&mut self.allocations, allocation_id, fingerprint) {
+                return self.fail("VM host changed immutable provision identity");
+            }
+        } else {
+            if self.allocations.len() >= usize::from(self.max_vms)
+                || self
+                    .allocations
+                    .values()
+                    .any(|entry| entry.machine_id == raw.machine_id)
+            {
+                return self.fail("VM host provision exceeds capacity or reuses a machine ID");
+            }
+            self.allocations.insert(
+                allocation_id,
+                KnownAllocation {
+                    generation: raw.generation,
+                    machine_id: raw.machine_id.clone(),
+                    provision: Some(fingerprint),
+                    releasing: false,
+                },
+            );
+        }
+        let attachment = attachment_target(raw.tool_attachment)?;
+        Ok(VmHostProvision {
+            allocation_id,
+            generation: raw.generation,
+            slot: raw.slot,
+            machine_id: raw.machine_id,
+            attachment,
+        })
+    }
+
+    fn accept_release(&mut self, raw: ReleaseMessage) -> Result<VmHostRelease, ManagedError> {
+        let allocation_id = parse_v4_uuid("allocation", &raw.allocation_id)?;
+        validate_generation(raw.generation)?;
+        validate_machine_id(&raw.machine_id)?;
+        if self.allocations.contains_key(&allocation_id) {
+            self.require_known(allocation_id, raw.generation, &raw.machine_id, false)?;
+            self.allocations
+                .get_mut(&allocation_id)
+                .expect("known allocation was just validated")
+                .releasing = true;
+        } else {
+            // A release may be replayed after its acknowledgement was lost, or
+            // after a replacement lease reconciled no ready copy. Keep the
+            // identity long enough for the local supervisor to apply its
+            // idempotent release/tombstone and acknowledge it again.
+            self.allocations.insert(
+                allocation_id,
+                KnownAllocation {
+                    generation: raw.generation,
+                    machine_id: raw.machine_id.clone(),
+                    provision: None,
+                    releasing: true,
+                },
+            );
+        }
+        Ok(VmHostRelease {
+            allocation_id,
+            generation: raw.generation,
+            machine_id: raw.machine_id,
+        })
+    }
+
+    fn require_known(
+        &mut self,
+        allocation_id: Uuid,
+        generation: u64,
+        machine_id: &str,
+        releasing: bool,
+    ) -> Result<(), ManagedError> {
+        if self.terminal {
+            return Err(protocol("VM host connection is terminal"));
+        }
+        let Some(known) = self.allocations.get(&allocation_id) else {
+            return self.fail("VM host acknowledgement has unknown allocation identity");
+        };
+        if known.generation != generation
+            || known.machine_id != machine_id
+            || known.releasing != releasing
+        {
+            return self.fail("VM host acknowledgement changed immutable allocation identity");
+        }
+        Ok(())
+    }
+
+    fn require_reconciled(&mut self) -> Result<(), ManagedError> {
+        if !self.reconciled {
+            return self.fail("VM host command arrived before lease reconciliation");
+        }
+        Ok(())
+    }
+
+    fn validate_pins(&mut self, lease_id: &str, epoch: u64) -> Result<(), ManagedError> {
+        let lease_id = parse_v4_uuid("lease", lease_id)?;
+        validate_generation(epoch)?;
+        if lease_id != self.lease_id || epoch != self.epoch {
+            return self.fail("VM host frame does not match the active lease and epoch");
+        }
+        Ok(())
+    }
+
+    fn fail<T>(&mut self, message: impl Into<String>) -> Result<T, ManagedError> {
+        self.terminal = true;
+        Err(protocol(message))
+    }
+
+    async fn send(&mut self, message: &ClientMessage<'_>) -> Result<(), ManagedError> {
+        let encoded = serde_json::to_string(message)
+            .map_err(|_| protocol("failed to encode VM host control frame"))?;
+        if encoded.len() > MAX_MESSAGE_BYTES {
+            return self.fail("outbound VM host frame exceeds 256 KiB");
+        }
+        self.socket
+            .send(Message::Text(encoded.into()))
+            .await
+            .map_err(|_| protocol("VM host WebSocket send failed"))
+    }
+}
+
+async fn connect_vm_host(
+    mut origin: Url,
+    path: String,
+    mut bearer: String,
+    scope: VmHostScope,
+    host_id: Uuid,
+    factory_name: String,
+    max_vms: u16,
+    vm: VmShape,
+) -> Result<VmHostConnection, ManagedError> {
+    require_v4_uuid("host", host_id)?;
+    validate_vm_factory_name(&factory_name)?;
+    validate_max_vms(max_vms)?;
+    vm.validate()?;
+    origin.set_path(&path);
+    origin.set_query(None);
+    origin.set_fragment(None);
+    origin
+        .set_scheme(match origin.scheme() {
+            "http" => "ws",
+            "https" => "wss",
+            _ => return Err(configuration("managed VM host origin is not HTTP(S)")),
+        })
+        .map_err(|_| configuration("failed to derive managed VM host endpoint"))?;
+    let mut request = origin
+        .as_str()
+        .into_client_request()
+        .map_err(|_| protocol("invalid VM host WebSocket request"))?;
+    let mut authorization = format!("Bearer {bearer}")
+        .parse::<tokio_tungstenite::tungstenite::http::HeaderValue>()
+        .map_err(|_| configuration("VM host credential cannot form authorization"))?;
+    bearer.zeroize();
+    authorization.set_sensitive(true);
+    request.headers_mut().insert(
+        tokio_tungstenite::tungstenite::http::header::AUTHORIZATION,
+        authorization,
+    );
+    let websocket = WebSocketConfig::default()
+        .max_message_size(Some(MAX_MESSAGE_BYTES))
+        .max_frame_size(Some(MAX_MESSAGE_BYTES));
+    let (mut socket, _) = tokio::time::timeout(
+        CONNECT_TIMEOUT,
+        connect_async_with_config(request, Some(websocket), false),
+    )
+    .await
+    .map_err(|_| protocol("VM host WebSocket handshake timed out"))?
+    .map_err(vm_host_handshake_error)?;
+    send_message(
+        &mut socket,
+        &ClientMessage::Attach {
+            protocol_version: PROTOCOL_VERSION,
+            host_id: host_id.to_string(),
+            factory_name: &factory_name,
+            max_vms,
+            vm,
+        },
+    )
+    .await?;
+    let encoded = tokio::time::timeout(CONNECT_TIMEOUT, read_text(&mut socket))
+        .await
+        .map_err(|_| protocol("VM host lease timed out"))??
+        .ok_or_else(|| protocol("VM host WebSocket closed before lease"))?;
+    let lease = match decode_server_message(&encoded)? {
+        ServerMessage::Lease(lease) => lease,
+        ServerMessage::Error(error) => {
+            validate_machine_id_like("error code", &error.code)?;
+            validate_bounded_text("error message", &error.message, MAX_REASON_BYTES)?;
+            return Err(configuration(format!(
+                "server rejected VM host control: {}: {}",
+                error.code, error.message
+            )));
+        }
+        _ => return Err(protocol("VM host connection did not begin with lease")),
+    };
+    if lease.protocol_version != PROTOCOL_VERSION {
+        return Err(protocol("VM host protocol version is not 1"));
+    }
+    let lease_id = parse_v4_uuid("lease", &lease.lease_id)?;
+    validate_generation(lease.epoch)?;
+    validate_timestamp(lease.expires_at)?;
+    validate_max_vms(lease.max_vms)?;
+    let leased_vm = lease.vm.validate()?;
+    if lease.max_vms != max_vms || leased_vm != vm {
+        return Err(protocol("VM host lease changed the advertised capacity"));
+    }
+    Ok(VmHostConnection {
+        socket,
+        scope,
+        host_id,
+        max_vms,
+        vm,
+        lease_id,
+        epoch: lease.epoch,
+        expires_at: lease.expires_at,
+        reconciled: false,
+        pending_ping: None,
+        allocations: HashMap::new(),
+        terminal: false,
+    })
+}
+
+fn vm_host_handshake_error(error: WebSocketError) -> ManagedError {
+    match error {
+        WebSocketError::Http(response) if matches!(response.status().as_u16(), 401 | 403) => {
+            configuration("VM host authentication was rejected")
+        }
+        _ => protocol("VM host WebSocket handshake failed"),
+    }
+}
+
+async fn send_message(
+    socket: &mut Socket,
+    message: &ClientMessage<'_>,
+) -> Result<(), ManagedError> {
+    let encoded = serde_json::to_string(message)
+        .map_err(|_| protocol("failed to encode VM host control frame"))?;
+    if encoded.len() > MAX_MESSAGE_BYTES {
+        return Err(protocol("outbound VM host frame exceeds 256 KiB"));
+    }
+    socket
+        .send(Message::Text(encoded.into()))
+        .await
+        .map_err(|_| protocol("VM host WebSocket send failed"))
+}
+
+async fn read_text(socket: &mut Socket) -> Result<Option<String>, ManagedError> {
+    loop {
+        match socket.next().await {
+            Some(Ok(Message::Text(encoded))) => {
+                if encoded.len() > MAX_MESSAGE_BYTES {
+                    return Err(protocol("VM host frame exceeds 256 KiB"));
+                }
+                return Ok(Some(encoded.to_string()));
+            }
+            Some(Ok(Message::Ping(payload))) => socket
+                .send(Message::Pong(payload))
+                .await
+                .map_err(|_| protocol("VM host WebSocket pong failed"))?,
+            Some(Ok(Message::Pong(_))) => {}
+            Some(Ok(Message::Close(_))) | None => return Ok(None),
+            Some(Ok(_)) => return Err(protocol("VM host control requires text JSON frames")),
+            Some(Err(_)) => return Err(protocol("VM host WebSocket receive failed")),
+        }
+    }
+}
+
+fn attachment_target(raw: ToolAttachment) -> Result<AttachmentTarget, ManagedError> {
+    if raw.bearer.len() != ATTACHMENT_BEARER_BYTES
+        || !raw
+            .bearer
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        return Err(protocol(
+            "VM host tool attachment bearer must be 43 base64url bytes",
+        ));
+    }
+    if raw.url.len() > MAX_ATTACHMENT_URL_BYTES {
+        return Err(protocol("VM host tool attachment URL exceeds 2048 bytes"));
+    }
+    let mut url =
+        Url::parse(&raw.url).map_err(|_| protocol("VM host tool attachment URL is malformed"))?;
+    if !matches!(url.scheme(), "https" | "wss")
+        || url.host().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(protocol(
+            "VM host tool attachment URL must be HTTPS/WSS without credentials or fragment",
+        ));
+    }
+    if url.scheme() == "https" {
+        url.set_scheme("wss")
+            .map_err(|_| protocol("VM host tool attachment URL cannot become WSS"))?;
+    }
+    AttachmentTarget::new(url.as_str(), raw.bearer)
+        .map_err(|_| protocol("VM host tool attachment target is invalid"))
+}
+
+fn decode_server_message(encoded: &str) -> Result<ServerMessage, ManagedError> {
+    if encoded.len() > MAX_MESSAGE_BYTES {
+        return Err(protocol("VM host frame exceeds 256 KiB"));
+    }
+    let value: serde_json::Value =
+        serde_json::from_str(encoded).map_err(|_| protocol("VM host frame is not valid JSON"))?;
+    let kind = value
+        .as_object()
+        .and_then(|object| object.get("type"))
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| protocol("VM host frame has no string type"))?;
+    macro_rules! decode {
+        ($ty:ty, $variant:ident) => {
+            serde_json::from_value::<$ty>(value)
+                .map(ServerMessage::$variant)
+                .map_err(|_| {
+                    protocol(concat!(
+                        "VM host ",
+                        stringify!($variant),
+                        " frame is malformed"
+                    ))
+                })
+        };
+    }
+    match kind {
+        "lease" => decode!(LeaseMessage, Lease),
+        "pong" => decode!(PongMessage, Pong),
+        "provision" => decode!(ProvisionMessage, Provision),
+        "release" => decode!(ReleaseMessage, Release),
+        "fenced" => decode!(FencedMessage, Fenced),
+        "error" => decode!(ErrorMessage, Error),
+        _ => Err(protocol("VM host frame type is unknown")),
+    }
+}
+
+fn validate_max_vms(max_vms: u16) -> Result<(), ManagedError> {
+    if !(1..=MAX_VMS).contains(&max_vms) {
+        return Err(configuration("VM host max_vms must be 1-64"));
+    }
+    Ok(())
+}
+
+fn validate_generation(value: u64) -> Result<(), ManagedError> {
+    if !(1..=MAX_SAFE_INTEGER).contains(&value) {
+        return Err(protocol(
+            "VM host epoch/generation is outside safe integer bounds",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_timestamp(value: u64) -> Result<(), ManagedError> {
+    if !(1..=MAX_SAFE_INTEGER).contains(&value) {
+        return Err(protocol("VM host expiry is outside safe integer bounds"));
+    }
+    Ok(())
+}
+
+fn require_v4_uuid(kind: &str, value: Uuid) -> Result<(), ManagedError> {
+    if value.get_version() != Some(Version::Random) || value.get_variant() != Variant::RFC4122 {
+        return Err(configuration(format!(
+            "VM host {kind} id must be a lowercase UUIDv4"
+        )));
+    }
+    Ok(())
+}
+
+fn parse_v4_uuid(kind: &str, value: &str) -> Result<Uuid, ManagedError> {
+    let parsed = Uuid::parse_str(value)
+        .map_err(|_| protocol(format!("VM host {kind} id is not a lowercase UUIDv4")))?;
+    if parsed.get_version() != Some(Version::Random)
+        || parsed.get_variant() != Variant::RFC4122
+        || parsed.to_string() != value
+    {
+        return Err(protocol(format!(
+            "VM host {kind} id is not a lowercase UUIDv4"
+        )));
+    }
+    Ok(parsed)
+}
+
+fn validate_machine_id(value: &str) -> Result<(), ManagedError> {
+    validate_machine_id_like("machine id", value)
+}
+
+/// Validates the canonical name used to select a connected VM factory in `/mount`.
+///
+/// # Errors
+///
+/// Rejects reserved providers and names outside the lowercase portable grammar.
+pub fn validate_vm_factory_name(value: &str) -> Result<(), ManagedError> {
+    let bytes = value.as_bytes();
+    let portable_edge = |byte: u8| byte.is_ascii_lowercase() || byte.is_ascii_digit();
+    if bytes.is_empty()
+        || bytes.len() > MAX_FACTORY_NAME_BYTES
+        || !portable_edge(bytes[0])
+        || !portable_edge(bytes[bytes.len() - 1])
+        || !bytes.iter().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'_' | b'-')
+        })
+        || matches!(value, "cf_sandbox" | "cloudflare" | "host")
+    {
+        return Err(configuration(
+            "VM host factory name must be a non-reserved lowercase portable identifier of 1-63 characters",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_machine_id_like(kind: &str, value: &str) -> Result<(), ManagedError> {
+    if value.is_empty()
+        || value.len() > MAX_MACHINE_ID_BYTES
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b':' | b'-'))
+    {
+        return Err(protocol(format!(
+            "VM host {kind} must be 1-123 safe ASCII characters"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_bounded_text(kind: &str, value: &str, max: usize) -> Result<(), ManagedError> {
+    if value.is_empty()
+        || value.len() > max
+        || value.contains('\0')
+        || value.chars().any(char::is_control)
+    {
+        return Err(protocol(format!("VM host {kind} is invalid")));
+    }
+    Ok(())
+}
+
+fn configuration(message: impl Into<String>) -> ManagedError {
+    ManagedError::Configuration(message.into())
+}
+
+fn protocol(message: impl Into<String>) -> ManagedError {
+    ManagedError::VmHost(message.into())
+}
+
+#[derive(Clone)]
+struct KnownAllocation {
+    generation: u64,
+    machine_id: String,
+    provision: Option<ProvisionFingerprint>,
+    releasing: bool,
+}
+
+#[derive(Clone, Eq, PartialEq)]
+struct ProvisionFingerprint {
+    generation: u64,
+    slot: u16,
+    machine_id: String,
+    url: String,
+    bearer: String,
+}
+
+fn accept_existing_provision(
+    allocations: &mut HashMap<Uuid, KnownAllocation>,
+    allocation_id: Uuid,
+    fingerprint: ProvisionFingerprint,
+) -> bool {
+    let Some(existing) = allocations.get(&allocation_id) else {
+        return false;
+    };
+    if existing.releasing
+        || existing.generation != fingerprint.generation
+        || existing.machine_id != fingerprint.machine_id
+    {
+        return false;
+    }
+    if let Some(provision) = &existing.provision {
+        return provision == &fingerprint;
+    }
+    // Reconciliation restores allocation identity without an attachment
+    // credential. Pin the first epoch-bound provision, then require exact
+    // fingerprint replays through the branch above.
+    if allocations.iter().any(|(known_id, known)| {
+        *known_id != allocation_id
+            && known
+                .provision
+                .as_ref()
+                .is_some_and(|provision| provision.slot == fingerprint.slot)
+    }) {
+        return false;
+    }
+    allocations
+        .get_mut(&allocation_id)
+        .expect("known allocation was just validated")
+        .provision = Some(fingerprint);
+    true
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ClientMessage<'a> {
+    Attach {
+        protocol_version: u8,
+        host_id: String,
+        factory_name: &'a str,
+        max_vms: u16,
+        vm: VmShape,
+    },
+    Ping {
+        lease_id: String,
+        epoch: u64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        nonce: Option<&'a str>,
+    },
+    Reconcile {
+        lease_id: String,
+        epoch: u64,
+        allocations: Vec<ReconcileAllocation<'a>>,
+    },
+    Provisioned {
+        lease_id: String,
+        epoch: u64,
+        allocation_id: String,
+        generation: u64,
+        machine_id: &'a str,
+    },
+    Released {
+        lease_id: String,
+        epoch: u64,
+        allocation_id: String,
+        generation: u64,
+        machine_id: &'a str,
+    },
+}
+
+#[derive(Serialize)]
+struct ReconcileAllocation<'a> {
+    allocation_id: String,
+    generation: u64,
+    machine_id: &'a str,
+    state: ReadyState,
+}
+
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum ReadyState {
+    Ready,
+}
+
+enum ServerMessage {
+    Lease(LeaseMessage),
+    Pong(PongMessage),
+    Provision(ProvisionMessage),
+    Release(ReleaseMessage),
+    Fenced(FencedMessage),
+    Error(ErrorMessage),
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LeaseMessage {
+    #[serde(rename = "type")]
+    _kind: LeaseKind,
+    protocol_version: u8,
+    lease_id: String,
+    epoch: u64,
+    expires_at: u64,
+    max_vms: u16,
+    vm: RawVmShape,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PongMessage {
+    #[serde(rename = "type")]
+    _kind: PongKind,
+    lease_id: String,
+    epoch: u64,
+    expires_at: u64,
+    #[serde(default)]
+    nonce: Option<String>,
+}
+
+#[derive(Clone, Deserialize, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct ProvisionMessage {
+    #[serde(rename = "type")]
+    _kind: ProvisionKind,
+    lease_id: String,
+    epoch: u64,
+    allocation_id: String,
+    generation: u64,
+    slot: u16,
+    machine_id: String,
+    tool_attachment: ToolAttachment,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReleaseMessage {
+    #[serde(rename = "type")]
+    _kind: ReleaseKind,
+    lease_id: String,
+    epoch: u64,
+    allocation_id: String,
+    generation: u64,
+    machine_id: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FencedMessage {
+    #[serde(rename = "type")]
+    _kind: FencedKind,
+    epoch: u64,
+    reason: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ErrorMessage {
+    #[serde(rename = "type")]
+    _kind: ErrorKind,
+    code: String,
+    message: String,
+}
+
+#[derive(Clone, Deserialize, Eq, PartialEq)]
+#[serde(deny_unknown_fields)]
+struct ToolAttachment {
+    url: String,
+    bearer: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawVmShape {
+    cpus: u8,
+    memory_mib: u32,
+}
+
+impl RawVmShape {
+    fn validate(self) -> Result<VmShape, ManagedError> {
+        VmShape::new(self.cpus, self.memory_mib)
+            .map_err(|_| protocol("VM host lease contains an invalid VM shape"))
+    }
+}
+
+macro_rules! message_kind {
+    ($name:ident, $value:literal) => {
+        #[derive(Clone, Copy, Deserialize, Eq, PartialEq)]
+        enum $name {
+            #[serde(rename = $value)]
+            Value,
+        }
+    };
+}
+
+message_kind!(LeaseKind, "lease");
+message_kind!(PongKind, "pong");
+message_kind!(ProvisionKind, "provision");
+message_kind!(ReleaseKind, "release");
+message_kind!(FencedKind, "fenced");
+message_kind!(ErrorKind, "error");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const LEASE_ID: &str = "550e8400-e29b-41d4-a716-446655440000";
+    const ALLOCATION_ID: &str = "6ba7b810-9dad-41d1-80b4-00c04fd430c8";
+    const OTHER_ALLOCATION_ID: &str = "8dc7cdb8-edf2-4bf4-8b15-0372a7b78b2f";
+
+    fn reconciled_allocation(machine_id: &str) -> KnownAllocation {
+        KnownAllocation {
+            generation: 1,
+            machine_id: machine_id.to_owned(),
+            provision: None,
+            releasing: false,
+        }
+    }
+
+    fn provision_fingerprint(
+        generation: u64,
+        slot: u16,
+        machine_id: &str,
+        bearer: char,
+    ) -> ProvisionFingerprint {
+        ProvisionFingerprint {
+            generation,
+            slot,
+            machine_id: machine_id.to_owned(),
+            url: "wss://tools.example/attach".to_owned(),
+            bearer: bearer.to_string().repeat(ATTACHMENT_BEARER_BYTES),
+        }
+    }
+
+    #[test]
+    fn strict_frames_reject_unknown_fields_and_noncanonical_identities() {
+        let valid = json!({
+            "type":"lease", "protocol_version":1, "lease_id":LEASE_ID,
+            "epoch":1, "expires_at":10, "max_vms":2,
+            "vm":{"cpus":2,"memory_mib":1024}
+        });
+        assert!(matches!(
+            decode_server_message(&valid.to_string()).unwrap(),
+            ServerMessage::Lease(_)
+        ));
+
+        let mut unknown = valid.clone();
+        unknown["extra"] = json!(true);
+        assert!(decode_server_message(&unknown.to_string()).is_err());
+
+        let mut uppercase = valid;
+        uppercase["lease_id"] = json!(LEASE_ID.to_uppercase());
+        let ServerMessage::Lease(lease) = decode_server_message(&uppercase.to_string()).unwrap()
+        else {
+            panic!("expected lease");
+        };
+        assert!(parse_v4_uuid("lease", &lease.lease_id).is_err());
+    }
+
+    #[test]
+    fn shape_capacity_generation_and_text_bounds_are_enforced() {
+        assert!(VmShape::new(1, 128).is_ok());
+        assert!(VmShape::new(64, 262_144).is_ok());
+        assert!(VmShape::new(0, 1024).is_err());
+        assert!(VmShape::new(1, 127).is_err());
+        assert!(validate_max_vms(0).is_err());
+        assert!(validate_max_vms(65).is_err());
+        assert!(validate_generation(0).is_err());
+        assert!(validate_generation(MAX_SAFE_INTEGER + 1).is_err());
+        assert!(validate_machine_id("safe.machine:1").is_ok());
+        assert!(validate_machine_id("unsafe/machine").is_err());
+        assert!(validate_vm_factory_name("garage-mac").is_ok());
+        assert!(validate_vm_factory_name("cf_sandbox").is_err());
+        assert!(validate_vm_factory_name("host").is_err());
+        assert!(validate_vm_factory_name("Uppercase").is_err());
+    }
+
+    #[test]
+    fn provision_converts_only_secure_opaque_attachment_targets() {
+        let target = attachment_target(ToolAttachment {
+            url: "https://tools.example/v1/attach?ticket=opaque".to_owned(),
+            bearer: "x".repeat(ATTACHMENT_BEARER_BYTES),
+        })
+        .unwrap();
+        assert_eq!(
+            target.endpoint().as_str(),
+            "wss://tools.example/v1/attach?ticket=opaque"
+        );
+        assert!(
+            attachment_target(ToolAttachment {
+                url: "http://tools.example/attach".to_owned(),
+                bearer: "x".repeat(ATTACHMENT_BEARER_BYTES),
+            })
+            .is_err()
+        );
+        assert!(
+            attachment_target(ToolAttachment {
+                url: "wss://tools.example/attach".to_owned(),
+                bearer: "secret".to_owned(),
+            })
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn reconciled_allocation_accepts_one_credential_refresh_and_pins_it() {
+        let allocation_id = parse_v4_uuid("allocation", ALLOCATION_ID).unwrap();
+        let mut allocations = HashMap::from([(allocation_id, reconciled_allocation("machine-1"))]);
+        let refreshed = provision_fingerprint(1, 0, "machine-1", 'a');
+
+        assert!(accept_existing_provision(
+            &mut allocations,
+            allocation_id,
+            refreshed.clone(),
+        ));
+        assert!(
+            allocations
+                .get(&allocation_id)
+                .and_then(|known| known.provision.as_ref())
+                == Some(&refreshed)
+        );
+        assert!(accept_existing_provision(
+            &mut allocations,
+            allocation_id,
+            refreshed.clone(),
+        ));
+        assert!(!accept_existing_provision(
+            &mut allocations,
+            allocation_id,
+            provision_fingerprint(1, 0, "machine-1", 'b'),
+        ));
+        assert!(!accept_existing_provision(
+            &mut allocations,
+            allocation_id,
+            provision_fingerprint(1, 1, "machine-1", 'a'),
+        ));
+        assert!(
+            allocations
+                .get(&allocation_id)
+                .and_then(|known| known.provision.as_ref())
+                == Some(&refreshed)
+        );
+    }
+
+    #[test]
+    fn reconciled_credential_refresh_preserves_identity_and_slot_conflicts() {
+        let allocation_id = parse_v4_uuid("allocation", ALLOCATION_ID).unwrap();
+        let other_id = parse_v4_uuid("allocation", OTHER_ALLOCATION_ID).unwrap();
+        let matching = provision_fingerprint(1, 0, "machine-1", 'a');
+
+        for conflicting in [
+            provision_fingerprint(2, 0, "machine-1", 'a'),
+            provision_fingerprint(1, 0, "machine-2", 'a'),
+        ] {
+            let mut allocations =
+                HashMap::from([(allocation_id, reconciled_allocation("machine-1"))]);
+            assert!(!accept_existing_provision(
+                &mut allocations,
+                allocation_id,
+                conflicting,
+            ));
+            assert!(allocations[&allocation_id].provision.is_none());
+        }
+
+        let mut releasing = reconciled_allocation("machine-1");
+        releasing.releasing = true;
+        let mut allocations = HashMap::from([(allocation_id, releasing)]);
+        assert!(!accept_existing_provision(
+            &mut allocations,
+            allocation_id,
+            matching.clone(),
+        ));
+
+        let mut occupied = reconciled_allocation("machine-2");
+        occupied.provision = Some(provision_fingerprint(1, 0, "machine-2", 'z'));
+        let mut allocations = HashMap::from([
+            (allocation_id, reconciled_allocation("machine-1")),
+            (other_id, occupied),
+        ]);
+        assert!(!accept_existing_provision(
+            &mut allocations,
+            allocation_id,
+            matching,
+        ));
+        assert!(allocations[&allocation_id].provision.is_none());
+    }
+
+    #[test]
+    fn decoded_provision_debug_never_contains_the_bearer() {
+        let bearer = "z".repeat(ATTACHMENT_BEARER_BYTES);
+        let encoded = json!({
+            "type":"provision", "lease_id":LEASE_ID, "epoch":1,
+            "allocation_id":ALLOCATION_ID, "generation":1, "slot":0,
+            "machine_id":"machine-1",
+            "tool_attachment":{"url":"wss://tools.example/attach","bearer":bearer}
+        });
+        let ServerMessage::Provision(raw) = decode_server_message(&encoded.to_string()).unwrap()
+        else {
+            panic!("expected provision");
+        };
+        let public = VmHostProvision {
+            allocation_id: parse_v4_uuid("allocation", &raw.allocation_id).unwrap(),
+            generation: raw.generation,
+            slot: raw.slot,
+            machine_id: raw.machine_id,
+            attachment: attachment_target(raw.tool_attachment).unwrap(),
+        };
+        assert!(!format!("{public:?}").contains(&bearer));
+    }
+
+    #[test]
+    fn oversized_and_nontext_protocol_inputs_are_rejected_before_decode() {
+        let oversized = format!(
+            "{{\"type\":\"error\",\"code\":\"x\",\"message\":\"{}\"}}",
+            "x".repeat(MAX_MESSAGE_BYTES)
+        );
+        assert!(decode_server_message(&oversized).is_err());
+    }
+}

--- a/crates/nanocodex-managed/src/vm_host.rs
+++ b/crates/nanocodex-managed/src/vm_host.rs
@@ -745,6 +745,10 @@ impl VmHostConnection {
     }
 }
 
+#[allow(
+    clippy::too_many_arguments,
+    reason = "the private connector keeps endpoint and lease boundary fields explicit"
+)]
 async fn connect_vm_host(
     mut origin: Url,
     path: String,

--- a/crates/nanocodex-oai-api/src/tools/mod.rs
+++ b/crates/nanocodex-oai-api/src/tools/mod.rs
@@ -323,6 +323,7 @@ pub struct ToolContext<'a> {
     call_id: &'a str,
     history: &'a [ResponseItem],
     output_token_budget: usize,
+    host_context: Option<&'a str>,
 }
 
 impl<'a> ToolContext<'a> {
@@ -341,7 +342,24 @@ impl<'a> ToolContext<'a> {
             call_id,
             history,
             output_token_budget,
+            host_context: None,
         }
+    }
+
+    /// Attaches embedding-owned invocation context without exposing it to tool
+    /// schemas or serialized model-visible values.
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn with_host_context(mut self, host_context: Option<&'a str>) -> Self {
+        self.host_context = host_context;
+        self
+    }
+
+    /// Returns embedding-owned invocation context, when one was supplied.
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn host_context(self) -> Option<&'a str> {
+        self.host_context
     }
 
     /// Returns the fixed model contract for this invocation.
@@ -491,7 +509,21 @@ pub trait Tool: Send + Sync + 'static {
 mod tests {
     use serde_json::json;
 
-    use super::ToolOutput;
+    use super::{ToolContext, ToolOutput};
+
+    #[test]
+    fn host_context_is_private_opt_in_invocation_state() {
+        let context = ToolContext::new("gpt-test", "session", "call", &[], 1_024);
+        assert_eq!(context.host_context(), None);
+
+        let context = context.with_host_context(Some("opaque-root-turn"));
+        assert_eq!(context.host_context(), Some("opaque-root-turn"));
+        assert_eq!(context.model(), "gpt-test");
+        assert_eq!(context.session_id(), "session");
+        assert_eq!(context.call_id(), "call");
+        assert!(context.history().is_empty());
+        assert_eq!(context.output_token_budget(), 1_024);
+    }
 
     #[test]
     fn structured_result_preserves_text_and_json_types() {

--- a/crates/nanocodex-subagents/src/runtime.rs
+++ b/crates/nanocodex-subagents/src/runtime.rs
@@ -33,6 +33,7 @@ use web_time::Instant;
 
 pub(super) struct ChildSession {
     pub(super) descriptor: AgentDescriptor,
+    pub(super) host_context: Option<Arc<str>>,
     pub(super) event_task: Option<Task<()>>,
     pub(super) harness: Option<HarnessHandle>,
     pub(super) harness_task: Option<Task<()>>,
@@ -478,7 +479,7 @@ impl RegistryState {
                     root_session_id.to_owned(),
                     descriptor.id,
                     descriptor.session_id.clone(),
-                    restored_tombstone(descriptor.clone()),
+                    restored_tombstone(descriptor.clone(), None),
                 )?;
                 ordered.push(descriptor);
             }
@@ -1027,11 +1028,26 @@ impl Registry {
         root_session_id: &str,
         descriptors: Vec<AgentDescriptor>,
     ) -> std::io::Result<()> {
-        let restored = self
-            .state
-            .lock()
+        self.restore_with_host_contexts(root_session_id, descriptors, HashMap::new())
             .await
-            .restore(root_session_id, descriptors)?;
+    }
+
+    /// Restores logical children with embedding-private invocation context.
+    #[doc(hidden)]
+    pub async fn restore_with_host_contexts(
+        &self,
+        root_session_id: &str,
+        descriptors: Vec<AgentDescriptor>,
+        mut host_contexts: HashMap<String, Arc<str>>,
+    ) -> std::io::Result<()> {
+        let mut state = self.state.lock().await;
+        let restored = state.restore(root_session_id, descriptors)?;
+        if let Some(scope) = state.scopes.get_mut(root_session_id) {
+            for session in scope.sessions.values_mut() {
+                session.host_context = host_contexts.remove(&session.descriptor.session_id);
+            }
+        }
+        drop(state);
         for descriptor in restored {
             let id = descriptor.id;
             self.send(root_session_id, AgentUpdate::Added(descriptor));
@@ -1045,6 +1061,32 @@ impl Registry {
         }
         self.changed();
         Ok(())
+    }
+
+    /// Returns embedding-private context for one retained child session.
+    #[doc(hidden)]
+    pub async fn host_context(&self, root_session_id: &str, id: AgentId) -> Option<Arc<str>> {
+        self.state
+            .lock()
+            .await
+            .scopes
+            .get(root_session_id)
+            .and_then(|scope| scope.sessions.get(&id))
+            .and_then(|session| session.host_context.as_ref().map(Arc::clone))
+    }
+
+    /// Returns embedding-private context inherited by a descendant session.
+    #[doc(hidden)]
+    pub async fn host_context_for_session(&self, session_id: &str) -> Option<Arc<str>> {
+        let state = self.state.lock().await;
+        let root_session_id = state.root_by_session.get(session_id)?;
+        state
+            .scopes
+            .get(root_session_id)?
+            .sessions
+            .values()
+            .find(|session| session.descriptor.session_id == session_id)
+            .and_then(|session| session.host_context.as_ref().map(Arc::clone))
     }
 
     pub(super) async fn reserve(&self, session_id: &str) -> std::io::Result<AgentReservation> {
@@ -1099,6 +1141,7 @@ impl Registry {
         self: &Arc<Self>,
         root_session_id: String,
         descriptor: AgentDescriptor,
+        host_context: Option<Arc<str>>,
         agent: Nanocodex,
         event_task: Task<()>,
         contract: OutputContract,
@@ -1120,6 +1163,7 @@ impl Registry {
             descriptor.session_id.clone(),
             ChildSession {
                 descriptor,
+                host_context,
                 event_task: Some(event_task),
                 harness: Some(harness),
                 harness_task: Some(harness_task),
@@ -1779,9 +1823,10 @@ fn complete_session(session: &mut ChildSession, output: Option<Value>) -> AgentS
     AgentStatus::Completed { output }
 }
 
-fn restored_tombstone(descriptor: AgentDescriptor) -> ChildSession {
+fn restored_tombstone(descriptor: AgentDescriptor, host_context: Option<Arc<str>>) -> ChildSession {
     ChildSession {
         descriptor,
+        host_context,
         event_task: None,
         harness: None,
         harness_task: None,
@@ -1931,6 +1976,7 @@ mod tests {
     };
     use serde_json::json;
     use std::{
+        collections::HashMap,
         future::{Pending, pending},
         result::Result as StdResult,
         sync::Arc,
@@ -2112,6 +2158,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn restored_host_contexts_remain_private_and_session_scoped() {
+        let (updates, _receiver) = mpsc::unbounded_channel();
+        let registry = Registry::new(updates, 3);
+        let first = AgentDescriptor {
+            id: AgentId::new(1),
+            session_id: "first-session".to_owned(),
+            role: "first".to_owned(),
+            task: "inspect".to_owned(),
+            parent: None,
+        };
+        let second = AgentDescriptor {
+            id: AgentId::new(2),
+            session_id: "second-session".to_owned(),
+            role: "second".to_owned(),
+            task: "review".to_owned(),
+            parent: None,
+        };
+
+        registry
+            .restore_with_host_contexts(
+                "root",
+                vec![first.clone(), second.clone()],
+                HashMap::from([
+                    (
+                        first.session_id.clone(),
+                        Arc::<str>::from("opaque-first-turn"),
+                    ),
+                    (
+                        second.session_id.clone(),
+                        Arc::<str>::from("opaque-second-turn"),
+                    ),
+                ]),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            registry.host_context("root", first.id).await.as_deref(),
+            Some("opaque-first-turn")
+        );
+        assert_eq!(
+            registry.host_context("root", second.id).await.as_deref(),
+            Some("opaque-second-turn")
+        );
+        assert_eq!(
+            registry
+                .host_context_for_session("first-session")
+                .await
+                .as_deref(),
+            Some("opaque-first-turn")
+        );
+        assert_eq!(registry.host_context("other-root", first.id).await, None);
+        assert_eq!(
+            registry.directory("root", true, false).await.len(),
+            2,
+            "private context must not change the public directory projection"
+        );
+    }
+
+    #[tokio::test]
     async fn invalid_restored_topologies_are_rejected_atomically() {
         let descriptor = |id: u64, session_id: &str, parent: Option<u64>| AgentDescriptor {
             id: AgentId::new(id),
@@ -2187,6 +2293,7 @@ mod tests {
                     task: "work".to_owned(),
                     parent: None,
                 },
+                None,
                 agent,
                 forward_events(
                     "root".to_owned(),
@@ -2265,6 +2372,7 @@ mod tests {
             .insert(
                 reservation.root_session_id.clone(),
                 descriptor,
+                None,
                 agent,
                 event_task,
                 test_contract(),
@@ -2333,6 +2441,7 @@ mod tests {
         };
         ChildSession {
             descriptor,
+            host_context: None,
             event_task: Some(platform::spawn(async {})),
             harness: None,
             harness_task: None,

--- a/crates/nanocodex-subagents/src/runtime.rs
+++ b/crates/nanocodex-subagents/src/runtime.rs
@@ -1038,7 +1038,7 @@ impl Registry {
         &self,
         root_session_id: &str,
         descriptors: Vec<AgentDescriptor>,
-        mut host_contexts: HashMap<String, Arc<str>>,
+        mut host_contexts: HashMap<String, Option<Arc<str>>>,
     ) -> std::io::Result<()> {
         if !host_contexts.is_empty()
             && (host_contexts.len() != descriptors.len()
@@ -1064,7 +1064,7 @@ impl Registry {
                 .sessions
                 .get_mut(&descriptor.id)
                 .expect("a restored descriptor has a retained session")
-                .host_context = host_contexts.remove(&descriptor.session_id);
+                .host_context = host_contexts.remove(&descriptor.session_id).flatten();
         }
         drop(state);
         for descriptor in restored {
@@ -2202,11 +2202,11 @@ mod tests {
                 HashMap::from([
                     (
                         first.session_id.clone(),
-                        Arc::<str>::from("opaque-first-turn"),
+                        Some(Arc::<str>::from("opaque-first-turn")),
                     ),
                     (
                         second.session_id.clone(),
-                        Arc::<str>::from("opaque-second-turn"),
+                        Some(Arc::<str>::from("opaque-second-turn")),
                     ),
                 ]),
             )
@@ -2265,11 +2265,23 @@ mod tests {
         };
 
         for host_contexts in [
-            HashMap::from([(first.session_id.clone(), Arc::<str>::from("opaque-turn"))]),
+            HashMap::from([(
+                first.session_id.clone(),
+                Some(Arc::<str>::from("opaque-turn")),
+            )]),
             HashMap::from([
-                (first.session_id.clone(), Arc::<str>::from("opaque-turn")),
-                (second.session_id.clone(), Arc::<str>::from("second-turn")),
-                ("unknown-session".to_owned(), Arc::<str>::from("other-turn")),
+                (
+                    first.session_id.clone(),
+                    Some(Arc::<str>::from("opaque-turn")),
+                ),
+                (
+                    second.session_id.clone(),
+                    Some(Arc::<str>::from("second-turn")),
+                ),
+                (
+                    "unknown-session".to_owned(),
+                    Some(Arc::<str>::from("other-turn")),
+                ),
             ]),
         ] {
             let (updates, _receiver) = mpsc::unbounded_channel();

--- a/crates/nanocodex-subagents/src/runtime.rs
+++ b/crates/nanocodex-subagents/src/runtime.rs
@@ -1040,12 +1040,31 @@ impl Registry {
         descriptors: Vec<AgentDescriptor>,
         mut host_contexts: HashMap<String, Arc<str>>,
     ) -> std::io::Result<()> {
+        if !host_contexts.is_empty()
+            && (host_contexts.len() != descriptors.len()
+                || descriptors
+                    .iter()
+                    .any(|descriptor| !host_contexts.contains_key(&descriptor.session_id)))
+        {
+            return Err(std::io::Error::other(
+                "restored subagent host contexts must exactly match restored sessions",
+            ));
+        }
         let mut state = self.state.lock().await;
         let restored = state.restore(root_session_id, descriptors)?;
-        if let Some(scope) = state.scopes.get_mut(root_session_id) {
-            for session in scope.sessions.values_mut() {
-                session.host_context = host_contexts.remove(&session.descriptor.session_id);
-            }
+        if restored.is_empty() {
+            return Ok(());
+        }
+        let scope = state
+            .scopes
+            .get_mut(root_session_id)
+            .expect("a non-empty successful restore creates its scope");
+        for descriptor in &restored {
+            scope
+                .sessions
+                .get_mut(&descriptor.id)
+                .expect("a restored descriptor has a retained session")
+                .host_context = host_contexts.remove(&descriptor.session_id);
         }
         drop(state);
         for descriptor in restored {
@@ -2215,6 +2234,61 @@ mod tests {
             2,
             "private context must not change the public directory projection"
         );
+
+        registry.restore("root", Vec::new()).await.unwrap();
+        assert_eq!(
+            registry.host_context("root", first.id).await.as_deref(),
+            Some("opaque-first-turn"),
+            "an empty compatibility restore must not clear a live context"
+        );
+        assert_eq!(
+            registry.host_context("root", second.id).await.as_deref(),
+            Some("opaque-second-turn")
+        );
+    }
+
+    #[tokio::test]
+    async fn restored_host_context_keys_are_validated_before_registry_mutation() {
+        let first = AgentDescriptor {
+            id: AgentId::new(1),
+            session_id: "first-session".to_owned(),
+            role: "worker".to_owned(),
+            task: "inspect".to_owned(),
+            parent: None,
+        };
+        let second = AgentDescriptor {
+            id: AgentId::new(2),
+            session_id: "second-session".to_owned(),
+            role: "reviewer".to_owned(),
+            task: "review".to_owned(),
+            parent: None,
+        };
+
+        for host_contexts in [
+            HashMap::from([(first.session_id.clone(), Arc::<str>::from("opaque-turn"))]),
+            HashMap::from([
+                (first.session_id.clone(), Arc::<str>::from("opaque-turn")),
+                (second.session_id.clone(), Arc::<str>::from("second-turn")),
+                ("unknown-session".to_owned(), Arc::<str>::from("other-turn")),
+            ]),
+        ] {
+            let (updates, _receiver) = mpsc::unbounded_channel();
+            let registry = Registry::new(updates, 3);
+            let error = registry
+                .restore_with_host_contexts(
+                    "root",
+                    vec![first.clone(), second.clone()],
+                    host_contexts,
+                )
+                .await
+                .unwrap_err();
+
+            assert!(error.to_string().contains("must exactly match"));
+            assert!(registry.directory("root", true, false).await.is_empty());
+            for descriptor in [&first, &second] {
+                assert!(registry.is_root_session(&descriptor.session_id).await);
+            }
+        }
     }
 
     #[tokio::test]

--- a/crates/nanocodex-subagents/src/tools.rs
+++ b/crates/nanocodex-subagents/src/tools.rs
@@ -179,8 +179,13 @@ pub async fn start_agents_observed(
     let mut startup = registry.batch_startup();
     let capacities = registry.reserve_turns(prepared.len())?;
     let reservations = registry.reserve_many(session_id, prepared.len()).await?;
+    let host_context = registry.host_context_for_session(session_id).await;
     let children = parent
-        .spawn_many_observed(prepared.len(), observe_session)
+        .spawn_many_observed_with_host_context(
+            prepared.len(),
+            observe_session,
+            host_context.as_ref().map(Arc::clone),
+        )
         .await?;
 
     let mut reports = Vec::with_capacity(prepared.len());
@@ -213,6 +218,7 @@ pub async fn start_agents_observed(
             .insert(
                 reservation.root_session_id.clone(),
                 descriptor.clone(),
+                host_context.as_ref().map(Arc::clone),
                 child,
                 event_task,
                 contract,
@@ -278,6 +284,18 @@ pub async fn start_agent_with(
     task: AgentTask,
     options: SpawnOptions,
 ) -> AgentToolResult<AgentStartReport> {
+    let host_context = registry.host_context_for_session(session_id).await;
+    start_agent_with_host_context(parent, registry, session_id, task, options, host_context).await
+}
+
+async fn start_agent_with_host_context(
+    parent: &AgentHandle,
+    registry: &Arc<Registry>,
+    session_id: &str,
+    task: AgentTask,
+    options: SpawnOptions,
+    host_context: Option<Arc<str>>,
+) -> AgentToolResult<AgentStartReport> {
     let AgentTask {
         role,
         task,
@@ -287,7 +305,13 @@ pub async fn start_agent_with(
     let capacity = registry.reserve_turn()?;
     let reservation = registry.reserve(session_id).await?;
     let id = reservation.id;
-    let (child, events) = parent.spawn_with(options).await?;
+    let host_context = match host_context {
+        Some(host_context) => Some(host_context),
+        None => registry.host_context_for_session(session_id).await,
+    };
+    let (child, events) = parent
+        .spawn_with_host_context(options, host_context.as_ref().map(Arc::clone))
+        .await?;
     let session_id = child.session_id().to_string();
     let descriptor = AgentDescriptor {
         id,
@@ -309,6 +333,7 @@ pub async fn start_agent_with(
         .insert(
             reservation.root_session_id.clone(),
             descriptor.clone(),
+            host_context,
             child,
             event_task,
             contract,
@@ -350,12 +375,20 @@ impl Tool for SpawnAgent {
 
     async fn execute(&self, input: ToolInput, context: ToolContext<'_>) -> ToolResult {
         let (task, options) = input.decode_json::<SpawnAgentTask>()?.into_parts();
+        let host_context = context.host_context().map(Arc::<str>::from);
         let registry = self
             .registry
             .upgrade()
             .ok_or_else(|| std::io::Error::other("subagent runtime is closed"))?;
-        let report =
-            start_agent_with(&self.parent, &registry, context.session_id(), task, options).await?;
+        let report = start_agent_with_host_context(
+            &self.parent,
+            &registry,
+            context.session_id(),
+            task,
+            options,
+            host_context,
+        )
+        .await?;
         json_output(&report)
     }
 }

--- a/crates/nanocodex-tools/src/attachment/mod.rs
+++ b/crates/nanocodex-tools/src/attachment/mod.rs
@@ -193,7 +193,7 @@ fn valid_capability(value: &str) -> bool {
 }
 
 /// Transport-only destination for an attached tool executor.
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct AttachmentTarget {
     endpoint: Url,
     bearer: Arc<str>,

--- a/crates/nanocodex-tools/src/embedded/types.rs
+++ b/crates/nanocodex-tools/src/embedded/types.rs
@@ -18,6 +18,7 @@ pub struct OwnedToolContext {
     pub(crate) call_id: String,
     pub(crate) history: Arc<Vec<ResponseItem>>,
     pub(crate) output_token_budget: usize,
+    pub(crate) host_context: Option<Arc<str>>,
 }
 
 impl OwnedToolContext {
@@ -36,6 +37,7 @@ impl OwnedToolContext {
             call_id: call_id.into(),
             history,
             output_token_budget,
+            host_context: None,
         }
     }
 
@@ -49,6 +51,7 @@ impl OwnedToolContext {
             Arc::new(context.history().to_vec()),
             context.output_token_budget(),
         )
+        .with_host_context(context.host_context().map(Arc::from))
     }
 
     /// Borrows this owned state as the standard tool invocation context.
@@ -61,6 +64,15 @@ impl OwnedToolContext {
             self.history.as_slice(),
             self.output_token_budget,
         )
+        .with_host_context(self.host_context.as_deref())
+    }
+
+    /// Attaches embedding-owned context to this owned invocation.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn with_host_context(mut self, host_context: Option<Arc<str>>) -> Self {
+        self.host_context = host_context;
+        self
     }
 
     #[cfg(not(target_family = "wasm"))]

--- a/js/account/worker/managedProxy.test.ts
+++ b/js/account/worker/managedProxy.test.ts
@@ -52,3 +52,23 @@ test("the account hand WebSocket stays on the managed service boundary", async (
   assert.equal(response?.status, 204);
   assert.equal(forwarded, request);
 });
+
+test("VM host WebSockets stay on their exact managed service boundaries", () => {
+  for (const path of [
+    "/v1/account/vm-host",
+    "/v1/agents/agent-1/vm-host",
+    "/v1/system/vm-host",
+    `/v1/vm-host-attachments/${"p".repeat(43)}/11111111-1111-4111-8111-111111111111/tool-host`,
+  ]) {
+    assert.equal(isManagedRoutePath(path), true, path);
+  }
+
+  for (const path of [
+    "/v1/account/vm-host/",
+    "/v1/system/vm-host/",
+    "/v1/system/vm-host/extra",
+    `/v1/vm-host-attachments/${"p".repeat(43)}/11111111-1111-4111-8111-111111111111/tool-host/extra`,
+  ]) {
+    assert.equal(isManagedRoutePath(path), false, path);
+  }
+});

--- a/js/account/worker/managedProxy.ts
+++ b/js/account/worker/managedProxy.ts
@@ -2,7 +2,7 @@ export type ManagedProxyEnv = {
   NANOCODEX_BACKEND?: Fetcher;
 };
 
-const MANAGED_ROUTE = /^(?:\/auth(?:\/.*)?|\/webauthn\/.*|\/sandbox-preview\/[^/]+(?:\/.*)?|\/v1\/(?:auth(?:\/.*)?|me|model-capabilities|account\/tool-host|wallet(?:\/(?:balance|connect|revoke-access-key))?|egress|api-keys(?:\/.*)?|credentials(?:\/.*)?|connect(?:\/.*)?|connectors(?:\/.*)?|agents(?:\/.*)?|rooms(?:\/.*)?|history(?:\/.*)?|memory(?:\/.*)?|organization(?:\/.*)?))$/;
+const MANAGED_ROUTE = /^(?:\/auth(?:\/.*)?|\/webauthn\/.*|\/sandbox-preview\/[^/]+(?:\/.*)?|\/v1\/(?:auth(?:\/.*)?|me|model-capabilities|account\/(?:tool-host|vm-host)|system\/vm-host|vm-host-attachments\/[A-Za-z0-9_-]{43}\/[0-9a-f-]{36}\/tool-host|wallet(?:\/(?:balance|connect|revoke-access-key))?|egress|api-keys(?:\/.*)?|credentials(?:\/.*)?|connect(?:\/.*)?|connectors(?:\/.*)?|agents(?:\/.*)?|rooms(?:\/.*)?|history(?:\/.*)?|memory(?:\/.*)?|organization(?:\/.*)?))$/;
 
 export function isManagedRoutePath(pathname: string): boolean {
   return MANAGED_ROUTE.test(pathname);

--- a/js/managed/README.md
+++ b/js/managed/README.md
@@ -30,8 +30,15 @@ storage ownership.
   cancel or steer work, delete an agent, and support explicit durability import
   and export. Stable `Idempotency-Key` values make create and turn retries safe.
 - Managed agents begin with no sandbox hand. The provider-neutral `mount` model
-  tool provisions and attaches named execution hands on demand; Cloudflare
-  Sandbox is the first provider, and repeated names resolve idempotently.
+  tool provisions and attaches named execution hands on demand. `cf_sandbox`
+  names the built-in Cloudflare Sandbox factory (`cloudflare` remains a legacy
+  input alias); any other provider value is the exact name of a connected VM
+  factory. Several agent-, account-, or system-scoped factories may coexist,
+  and repeated mount names resolve idempotently.
+- Code Mode routes each command from the root of its `cwd`: mounted roots may
+  live on different factories while remaining visible in one namespace.
+  Subagents inherit the spawning turn's exact namespace authorization, so a
+  long-lived child cannot borrow capabilities from a later root turn.
 - Agent events are a durable, ordered cursor stream. SSE resumes with `cursor`
   or `Last-Event-ID`; same-origin browser WebSockets carry the typed
   prompt/steer/cancel protocol. Realtime calls and sideband transport have

--- a/js/managed/src/account-hosted-tools.ts
+++ b/js/managed/src/account-hosted-tools.ts
@@ -73,6 +73,8 @@ type InvocationContext = Readonly<{
   subagent?: SubagentToolContext;
 }>;
 
+type AuthorizationContext = Pick<InvocationContext, "sessionId" | "subagent">;
+
 /** One account-owned reverse attachment shared by every managed agent in that account. */
 export class AccountHostedTools extends DurableObject<AccountHostedToolsEnv> {
   readonly #broker: HostedToolsBroker;
@@ -201,7 +203,7 @@ export class AccountHostedToolsProvider implements HostedToolsDynamicProvider {
   readonly sourceId = "account-hands";
   readonly #stub: DurableObjectStub<AccountHostedTools>;
   readonly #ownerId: string;
-  readonly #allowed: (context?: InvocationContext) => boolean;
+  readonly #allowed: (context?: AuthorizationContext) => boolean;
   #definitions: readonly HostedToolsCodeDefinition[] = [];
   #candidates: readonly HostedToolsCatalogCandidate[] = [];
   #machines: readonly HostedMachine[] = [];
@@ -214,7 +216,7 @@ export class AccountHostedToolsProvider implements HostedToolsDynamicProvider {
   constructor(
     namespace: DurableObjectNamespace<AccountHostedTools>,
     ownerId: string,
-    allowed: (context?: InvocationContext) => boolean,
+    allowed: (context?: AuthorizationContext) => boolean,
   ) {
     this.#stub = namespace.getByName(ownerId);
     this.#ownerId = ownerId;
@@ -229,12 +231,16 @@ export class AccountHostedToolsProvider implements HostedToolsDynamicProvider {
     return this.#allowed() ? this.#tools.get(name) : undefined;
   }
 
-  machines(): readonly HostedMachine[] {
-    return this.#allowed() ? this.#machines : [];
+  machines(context?: AuthorizationContext): readonly HostedMachine[] {
+    return this.#allowed(context) ? this.#machines : [];
   }
 
-  machineTool(machineId: string, name: HostedMachineToolName): HostedToolsCodeTool | undefined {
-    return this.#allowed() ? this.#machineTools.get(machineToolKey(machineId, name)) : undefined;
+  machineTool(
+    machineId: string,
+    name: HostedMachineToolName,
+    context?: AuthorizationContext,
+  ): HostedToolsCodeTool | undefined {
+    return this.#allowed(context) ? this.#machineTools.get(machineToolKey(machineId, name)) : undefined;
   }
 
   settled(): Promise<void> {

--- a/js/managed/src/account-hosted-tools.ts
+++ b/js/managed/src/account-hosted-tools.ts
@@ -10,6 +10,7 @@ import {
   type HostedToolsCodeTool,
   type HostedToolsDynamicProvider,
 } from "nanocodex-tools/hosted";
+import type { SubagentToolContext } from "nanocodex-tools";
 
 import { isUserId } from "./account-auth";
 import { HostedToolsBroker } from "./hosted-tools-broker";
@@ -62,6 +63,14 @@ type InvocationResult = Readonly<{
   metadata: unknown;
   value: unknown;
   pre_admission_unavailable?: true;
+}>;
+
+type InvocationContext = Readonly<{
+  sessionId: string;
+  callId: string;
+  model?: string;
+  signal?: AbortSignal;
+  subagent?: SubagentToolContext;
 }>;
 
 /** One account-owned reverse attachment shared by every managed agent in that account. */
@@ -192,7 +201,7 @@ export class AccountHostedToolsProvider implements HostedToolsDynamicProvider {
   readonly sourceId = "account-hands";
   readonly #stub: DurableObjectStub<AccountHostedTools>;
   readonly #ownerId: string;
-  readonly #allowed: () => boolean;
+  readonly #allowed: (context?: InvocationContext) => boolean;
   #definitions: readonly HostedToolsCodeDefinition[] = [];
   #candidates: readonly HostedToolsCatalogCandidate[] = [];
   #machines: readonly HostedMachine[] = [];
@@ -205,7 +214,7 @@ export class AccountHostedToolsProvider implements HostedToolsDynamicProvider {
   constructor(
     namespace: DurableObjectNamespace<AccountHostedTools>,
     ownerId: string,
-    allowed: () => boolean,
+    allowed: (context?: InvocationContext) => boolean,
   ) {
     this.#stub = namespace.getByName(ownerId);
     this.#ownerId = ownerId;
@@ -304,7 +313,7 @@ export class AccountHostedToolsProvider implements HostedToolsDynamicProvider {
         ...(entry.summary === undefined ? {} : { summary: entry.summary }),
         handler: (
           input: unknown,
-          context: { sessionId: string; callId: string; model?: string; signal?: AbortSignal },
+          context: InvocationContext,
         ) => this.#invoke(definition.name, entry.route_token, input, context),
       };
       tools.set(definition.name, Object.freeze(tool));
@@ -323,7 +332,7 @@ export class AccountHostedToolsProvider implements HostedToolsDynamicProvider {
           routeToken: route.route_token,
           handler: (
             input: unknown,
-            context: { sessionId: string; callId: string; model?: string; signal?: AbortSignal },
+            context: InvocationContext,
           ) => this.#invoke(route.name, route.route_token, input, context, entry.machine.id),
         }));
       }
@@ -337,10 +346,12 @@ export class AccountHostedToolsProvider implements HostedToolsDynamicProvider {
     name: string,
     routeToken: string,
     input: unknown,
-    context: { sessionId: string; callId: string; model?: string; signal?: AbortSignal },
+    context: InvocationContext,
     machineId?: string,
   ): Promise<unknown> {
-    if (!this.#allowed()) return failedToolResult("Account hand is outside the active grant", "unavailable", true);
+    if (!this.#allowed(context)) {
+      return failedToolResult("Account hand is outside the active grant", "unavailable", true);
+    }
     let response: Response;
     try {
       response = await this.#stub.fetch("https://account-tools.internal/invoke", {

--- a/js/managed/src/hosted-tools-broker.ts
+++ b/js/managed/src/hosted-tools-broker.ts
@@ -7,6 +7,7 @@ import {
   type HostedToolsBrokerPersistence,
   type HostedToolsCallRow,
   type HostedToolsCallState,
+  type HostedToolsLeasedAttachmentPolicy,
   type HostedToolsStateRow,
 } from "nanocodex-tools/hosted";
 
@@ -43,10 +44,18 @@ export class HostedToolsBroker extends HostedToolsBrokerCore {
     allowedMcpIds?: readonly string[],
     appToolCatalogDigest?: `0x${string}`,
     connectGrantId?: string,
+    leasedAttachment?: HostedToolsLeasedAttachmentPolicy,
   ): Response {
     const pair = new WebSocketPair();
     const [client, server] = Object.values(pair);
-    this.accept(server, sessionId, allowedMcpIds, appToolCatalogDigest, connectGrantId);
+    this.accept(
+      server,
+      sessionId,
+      allowedMcpIds,
+      appToolCatalogDigest,
+      connectGrantId,
+      leasedAttachment,
+    );
     return new Response(null, { status: 101, webSocket: client });
   }
 }

--- a/js/managed/src/index.ts
+++ b/js/managed/src/index.ts
@@ -48,11 +48,25 @@ import {
   managedAccountMcpServers,
   type ManagedAccountMcpConnection,
 } from "./default-mcp";
-import { HostedToolsBroker } from "./hosted-tools-broker";
+import {
+  HostedToolsBroker,
+  type HostedToolsLeasedAttachmentRenewal,
+} from "./hosted-tools-broker";
 import {
   AccountHostedTools,
   AccountHostedToolsProvider,
 } from "./account-hosted-tools";
+import { VmHostPool } from "./vm-host-pool";
+import { isVmFactoryName } from "./vm-factory-name";
+import {
+  VM_HOST_ATTACHMENT_ROUTE,
+  VM_HOST_DONOR,
+  VM_HOST_POOL_AGENT,
+  VM_HOST_POOL_LOCATOR,
+  VM_HOST_POOL_OWNER,
+  VM_HOST_POOL_SCOPE,
+  VM_HOST_PUBLIC_ORIGIN,
+} from "./vm-host-boundary";
 import {
   hostedToolCatalogEntryAllowed,
   isAppToolCatalogDigest,
@@ -186,6 +200,7 @@ import {
 } from "./account-info";
 import { accountConnectorsTool } from "./account-connectors-tool";
 import {
+  MANAGED_CLOUDFLARE_PROVIDER,
   managedMountProviderResourceId,
   managedMountRoot,
   managedMountTool,
@@ -248,6 +263,7 @@ import { memorySessionTools } from "./memory-session-tools";
 import { MemoryScope } from "./memory-scope";
 export { MemoryScope } from "./memory-scope";
 export { AccountHostedTools } from "./account-hosted-tools";
+export { VmHostPool } from "./vm-host-pool";
 export { ApiKeyRecord, NonceStorage, Organization, UserAccount } from "./account-auth";
 
 const MAX_CLIENT_MESSAGE_BYTES = 1024 * 1024;
@@ -302,13 +318,13 @@ const MEMORY_ORGANIZATION_ASSERTION = "x-nanocodex-organization-id";
 const MEMORY_TEAM_ASSERTION = "x-nanocodex-team-id";
 const MEMORY_SUBJECT_ASSERTION = "x-nanocodex-subject-id";
 const MEMORY_MUTATION_ASSERTION = "x-nanocodex-memory-mutation";
-
 export interface Env extends
   AccountAuthEnv,
   ChiefOfStaffPrincipalEnv,
   HostPrincipalEnv {
   NANOCODEX_SESSIONS: DurableObjectNamespace<DurableAgentSession>;
   NANOCODEX_ACCOUNT_TOOLS: DurableObjectNamespace<AccountHostedTools>;
+  NANOCODEX_VM_HOST_POOLS: DurableObjectNamespace<VmHostPool>;
   NANOCODEX_ROOMS: DurableObjectNamespace<MultiplayerRoom>;
   NANOCODEX_MULTIPLAYER_QUOTA: DurableObjectNamespace<MultiplayerQuota>;
   NANOCODEX_MEMORY: DurableObjectNamespace<MemoryScope>;
@@ -317,6 +333,7 @@ export interface Env extends
   NANOCODEX_HISTORY: R2Bucket;
   NANOCODEX_WORKSPACES: R2Bucket;
   NANOCODEX_ADMIN_TOKEN: string;
+  NANOCODEX_SYSTEM_HOST_TOKEN?: string;
   HISTORY_AI_SEARCH?: AiSearchInstance;
   BROWSER?: import("agents/browser").BrowserBinding;
   LOADER?: WorkerLoader;
@@ -438,8 +455,65 @@ type ManagedMountCallRow = {
 
 type ManagedMountConfiguration = Readonly<{
   namespace_slot?: number;
+  vm_factory_name?: string;
+  vm_pool_locator?: string;
+  vm_host?: Readonly<{
+    pool_locator: string;
+    allocation_id: string;
+    generation: number;
+    machine_id: string;
+    route_id?: string;
+  }>;
   [key: string]: unknown;
 }>;
+
+type VmHostPoolScope = "agent" | "account" | "system";
+
+type VmHostAllocation = Readonly<{
+  allocation_id: string;
+  generation: number;
+  factory_name: string;
+  machine_id: string;
+  host_id: string;
+  slot: number;
+  route_id: string;
+}>;
+
+type VmHostAttachmentGrant = Readonly<{
+  valid: true;
+  allocation_id: string;
+  generation: number;
+  agent_id: string;
+  owner_id: string;
+  organization_id: string;
+  team_id: string;
+  authorization_epoch: number;
+  public_origin: string;
+  machine_id: string;
+  lease_expires_at: number;
+  route_id: string;
+}>;
+
+type VmHostAttachmentRenewalClaim = Readonly<{
+  pool_locator: string;
+  allocation_id: string;
+  generation: number;
+  bearer: string;
+}>;
+
+function validVmHostAllocation(value: unknown): value is VmHostAllocation {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const allocation = value as Partial<VmHostAllocation>;
+  return typeof allocation.allocation_id === "string" && UUID.test(allocation.allocation_id)
+    && Number.isSafeInteger(allocation.generation) && Number(allocation.generation) >= 1
+    && typeof allocation.factory_name === "string"
+    && /^[a-z0-9](?:[a-z0-9._-]{0,61}[a-z0-9])?$/.test(allocation.factory_name)
+    && typeof allocation.machine_id === "string"
+    && /^[A-Za-z0-9][A-Za-z0-9._:-]{0,122}$/.test(allocation.machine_id)
+    && typeof allocation.host_id === "string" && UUID.test(allocation.host_id)
+    && Number.isSafeInteger(allocation.slot) && Number(allocation.slot) >= 0
+    && typeof allocation.route_id === "string" && VM_HOST_ATTACHMENT_ROUTE.test(allocation.route_id);
+}
 
 function managedMountConfiguration(encoded: string): ManagedMountConfiguration {
   const value = JSON.parse(encoded) as unknown;
@@ -447,6 +521,58 @@ function managedMountConfiguration(encoded: string): ManagedMountConfiguration {
     throw new Error("retained mount configuration is invalid");
   }
   return value as ManagedMountConfiguration;
+}
+
+function managedMountStorageProvider(provider: string): "cloudflare" | "host" {
+  return provider === MANAGED_CLOUDFLARE_PROVIDER ? "cloudflare" : "host";
+}
+
+function sameManagedMountProvider(left: string, right: string): boolean {
+  const normalized = (provider: string) => provider === "cloudflare"
+    ? MANAGED_CLOUDFLARE_PROVIDER
+    : provider;
+  return normalized(left) === normalized(right);
+}
+
+function vmHostFactoryName(
+  mount: Pick<ManagedMountRow, "configuration_json" | "provider">,
+): string | undefined {
+  if (mount.provider !== "host") return undefined;
+  const name = managedMountConfiguration(mount.configuration_json).vm_factory_name;
+  return isVmFactoryName(name) ? name : undefined;
+}
+
+function managedMountUsesProvider(mount: ManagedMountRow, provider: string): boolean {
+  return mount.provider === "cloudflare"
+    ? provider === MANAGED_CLOUDFLARE_PROVIDER
+    : mount.provider === "host" && vmHostFactoryName(mount) === provider;
+}
+
+function managedMountPublicProvider(mount: ManagedMountRow): string {
+  if (mount.provider === "cloudflare") return MANAGED_CLOUDFLARE_PROVIDER;
+  const factoryName = vmHostFactoryName(mount);
+  if (factoryName !== undefined) return factoryName;
+  throw new Error("retained VM host mount has no valid factory name");
+}
+
+function vmHostMountAllocation(
+  mount: Pick<ManagedMountRow, "configuration_json" | "provider">,
+): ManagedMountConfiguration["vm_host"] | undefined {
+  if (mount.provider !== "host") return undefined;
+  const allocation = managedMountConfiguration(mount.configuration_json).vm_host;
+  if (!allocation || typeof allocation !== "object"
+    || typeof allocation.pool_locator !== "string"
+    || !/^[A-Za-z0-9_-]{43}$/.test(allocation.pool_locator)
+    || typeof allocation.allocation_id !== "string" || !UUID.test(allocation.allocation_id)
+    || !Number.isSafeInteger(allocation.generation) || allocation.generation < 1
+    || typeof allocation.machine_id !== "string"
+    || !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,122}$/.test(allocation.machine_id)
+    || (allocation.route_id !== undefined
+      && (typeof allocation.route_id !== "string"
+        || !VM_HOST_ATTACHMENT_ROUTE.test(allocation.route_id)))) {
+    return undefined;
+  }
+  return allocation;
 }
 
 type ManagedTurnState =
@@ -526,6 +652,20 @@ type ManagedRealtimeRouteResult = Readonly<{
 type TurnAuthorization = Readonly<{
   capabilities: readonly OrganizationCapability[];
   connectGrant?: ConnectGrantSlice;
+}>;
+
+type ManagedSubagentDescriptor = Readonly<{
+  agentId: string;
+  parentAgentId: string | null;
+  sessionId: string;
+  role: string;
+  task: string;
+}>;
+
+type ManagedSubagentAuthorizationRow = ManagedSubagentDescriptor & Readonly<{
+  authorization_json: string;
+  host_context_ref: string;
+  root_session_id: string;
 }>;
 
 type SessionSocketAttachment = Readonly<{
@@ -733,6 +873,167 @@ function parseTurnAuthorization(encoded: string): TurnAuthorization {
   if (parsed.connectGrant === undefined) return { capabilities: parsed.capabilities };
   if (!isConnectGrantSlice(parsed.connectGrant)) throw new Error("invalid turn authorization");
   return { capabilities: parsed.capabilities, connectGrant: parsed.connectGrant };
+}
+
+function managedSubagentDescriptor(value: unknown): ManagedSubagentDescriptor {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("invalid managed subagent descriptor");
+  }
+  const descriptor = value as Record<string, unknown>;
+  if (Object.keys(descriptor).sort().join("\0")
+      !== ["agentId", "parentAgentId", "role", "sessionId", "task"].sort().join("\0")
+    || typeof descriptor.agentId !== "string" || !/^[A-Za-z0-9._:-]{1,128}$/u.test(descriptor.agentId)
+    || (descriptor.parentAgentId !== null
+      && (typeof descriptor.parentAgentId !== "string"
+        || !/^[A-Za-z0-9._:-]{1,128}$/u.test(descriptor.parentAgentId)))
+    || typeof descriptor.sessionId !== "string" || !SESSION_ID.test(descriptor.sessionId)
+    || typeof descriptor.role !== "string" || descriptor.role.length === 0
+    || descriptor.role.length > 1_024 || descriptor.role.includes("\0")
+    || typeof descriptor.task !== "string" || descriptor.task.length === 0
+    || descriptor.task.length > MAX_REQUEST_BODY_BYTES || descriptor.task.includes("\0")) {
+    throw new TypeError("invalid managed subagent descriptor");
+  }
+  return Object.freeze({
+    agentId: descriptor.agentId,
+    parentAgentId: descriptor.parentAgentId,
+    sessionId: descriptor.sessionId,
+    role: descriptor.role,
+    task: descriptor.task,
+  }) as ManagedSubagentDescriptor;
+}
+
+function sameManagedSubagentDescriptor(
+  row: ManagedSubagentAuthorizationRow,
+  descriptor: ManagedSubagentDescriptor,
+): boolean {
+  return row.agentId === descriptor.agentId
+    && row.parentAgentId === descriptor.parentAgentId
+    && row.sessionId === descriptor.sessionId
+    && row.role === descriptor.role
+    && row.task === descriptor.task;
+}
+
+/** Managed half of the private Cloudflare subagent lifecycle transaction. */
+export function applyManagedSubagentLifecycle(
+  storage: DurableObjectStorage,
+  value: unknown,
+): void {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("invalid managed subagent lifecycle event");
+  }
+  const event = value as Record<string, unknown>;
+  const type = event.type;
+  if ((type !== "bind" && type !== "reconstruct" && type !== "release")
+    || typeof event.rootSessionId !== "string" || !SESSION_ID.test(event.rootSessionId)
+    || typeof event.sessionId !== "string" || !SESSION_ID.test(event.sessionId)
+    || typeof event.hostContextRef !== "string" || !TURN_ID.test(event.hostContextRef)) {
+    throw new TypeError("invalid managed subagent lifecycle event");
+  }
+  const rootSessionId = event.rootSessionId;
+  const sessionId = event.sessionId;
+  const hostContextRef = event.hostContextRef;
+  const retained = storage.sql.exec<ManagedSubagentAuthorizationRow>(
+    `SELECT root_session_id, session_id AS sessionId, agent_id AS agentId,
+            parent_agent_id AS parentAgentId, role, task, host_context_ref, authorization_json
+     FROM managed_subagent_authorizations WHERE session_id = ?`,
+    sessionId,
+  ).toArray()[0];
+  if (type === "release") {
+    if (Object.keys(event).some((key) => !["type", "rootSessionId", "sessionId", "hostContextRef"].includes(key))
+      || retained === undefined
+      || retained.root_session_id !== rootSessionId
+      || retained.host_context_ref !== hostContextRef) {
+      throw new Error("managed subagent release does not match retained authorization");
+    }
+    storage.sql.exec(
+      `DELETE FROM managed_subagent_authorizations
+       WHERE session_id = ? AND root_session_id = ? AND host_context_ref = ?`,
+      sessionId,
+      rootSessionId,
+      hostContextRef,
+    );
+    return;
+  }
+  if (Object.keys(event).some((key) => ![
+    "type", "rootSessionId", "sessionId", "descriptor", "hostContextRef",
+  ].includes(key))) {
+    throw new TypeError("invalid managed subagent lifecycle event");
+  }
+  const descriptor = managedSubagentDescriptor(event.descriptor);
+  if (descriptor.sessionId !== sessionId) {
+    throw new Error("managed subagent session does not match its descriptor");
+  }
+  if (retained !== undefined) {
+    if (retained.root_session_id !== rootSessionId
+      || retained.host_context_ref !== hostContextRef
+      || !sameManagedSubagentDescriptor(retained, descriptor)) {
+      throw new Error("managed subagent binding conflicts with retained authorization");
+    }
+    return;
+  }
+  let authorizationJson: string;
+  if (descriptor.parentAgentId === null) {
+    const turn = storage.sql.exec<Pick<ManagedTurnRow, "authorization_json">>(
+      "SELECT authorization_json FROM managed_turns WHERE id = ?",
+      hostContextRef,
+    ).toArray()[0];
+    if (turn === undefined) throw new Error("managed subagent authorization turn is missing");
+    authorizationJson = JSON.stringify(parseTurnAuthorization(turn.authorization_json));
+  } else {
+    const parent = storage.sql.exec<ManagedSubagentAuthorizationRow>(
+      `SELECT authorization_json, host_context_ref
+       FROM managed_subagent_authorizations
+       WHERE root_session_id = ? AND agent_id = ?`,
+      rootSessionId,
+      descriptor.parentAgentId,
+    ).toArray()[0];
+    if (parent === undefined || parent.host_context_ref !== hostContextRef) {
+      throw new Error("managed nested subagent authorization parent is missing");
+    }
+    authorizationJson = JSON.stringify(parseTurnAuthorization(parent.authorization_json));
+  }
+  storage.sql.exec(
+    `INSERT INTO managed_subagent_authorizations
+       (session_id, root_session_id, agent_id, parent_agent_id, role, task,
+        host_context_ref, authorization_json, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    descriptor.sessionId,
+    rootSessionId,
+    descriptor.agentId,
+    descriptor.parentAgentId,
+    descriptor.role,
+    descriptor.task,
+    hostContextRef,
+    authorizationJson,
+    Date.now(),
+  );
+}
+
+export function managedAuthorizationForToolContext(
+  storage: DurableObjectStorage,
+  rootSessionId: string | undefined,
+  activeAuthorization: TurnAuthorization | undefined,
+  context: Pick<ToolContext, "sessionId" | "subagent">,
+): TurnAuthorization | undefined {
+  if (context.subagent === undefined) {
+    return rootSessionId !== undefined && context.sessionId === rootSessionId
+      ? activeAuthorization
+      : undefined;
+  }
+  let descriptor: ManagedSubagentDescriptor;
+  try { descriptor = managedSubagentDescriptor(context.subagent); }
+  catch { return undefined; }
+  if (descriptor.sessionId !== context.sessionId) return undefined;
+  const retained = storage.sql.exec<ManagedSubagentAuthorizationRow>(
+    `SELECT root_session_id, session_id AS sessionId, agent_id AS agentId,
+            parent_agent_id AS parentAgentId, role, task, host_context_ref, authorization_json
+     FROM managed_subagent_authorizations WHERE session_id = ?`,
+    context.sessionId,
+  ).toArray()[0];
+  if (retained === undefined || retained.root_session_id !== rootSessionId
+    || !sameManagedSubagentDescriptor(retained, descriptor)) return undefined;
+  try { return parseTurnAuthorization(retained.authorization_json); }
+  catch { return undefined; }
 }
 
 export function turnCanUseExecutionNamespace(
@@ -957,6 +1258,58 @@ async function managedFetch(
       } catch {
         return json({ astra_entitled: false });
       }
+    }
+    const leasedVmHost = url.pathname.match(
+      /^\/v1\/vm-host-attachments\/([A-Za-z0-9_-]{43})\/([0-9a-f-]{36})\/tool-host$/,
+    );
+    if (leasedVmHost) {
+      return routeVmHostToolAttachment(
+        request,
+        env,
+        url,
+        leasedVmHost[1]!,
+        leasedVmHost[2]!,
+      );
+    }
+    if (url.pathname === "/v1/system/vm-host") {
+      if (url.search !== "") return json({ error: "invalid_request" }, { status: 400 });
+      if (request.method !== "GET" || request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+        return new Response("Expected WebSocket upgrade", { status: 426 });
+      }
+      if (!await authorizedSystemVmHost(request, env.NANOCODEX_SYSTEM_HOST_TOKEN)) {
+        return json({ error: "unauthorized" }, { status: 401 });
+      }
+      const locator = await vmHostPoolLocator("system", "system");
+      return vmHostPoolUpgrade(request, env, {
+        scope: "system",
+        donor: "system",
+        locator,
+        publicOrigin: url.origin,
+      });
+    }
+    if (url.pathname === "/v1/account/vm-host") {
+      if (url.search !== "") return json({ error: "invalid_request" }, { status: 400 });
+      if (request.method !== "GET" || request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+        return new Response("Expected WebSocket upgrade", { status: 426 });
+      }
+      const principal = trustedAgentPrincipal ?? await authenticate(request, env, url);
+      if (!principal) return json({ error: "unauthorized" }, { status: 401 });
+      if (principal.connectGrant
+        || !principal.capabilities.includes("agents:write")
+        || !principal.capabilities.includes("tools:use")) {
+        return json({ error: "forbidden" }, { status: 403 });
+      }
+      if (principal.kind !== "api_key" && request.headers.get("origin") !== url.origin) {
+        return json({ error: "forbidden_origin" }, { status: 403 });
+      }
+      const locator = await vmHostPoolLocator("account", principal.userId);
+      return vmHostPoolUpgrade(request, env, {
+        scope: "account",
+        owner: principal.userId,
+        donor: principal.userId,
+        locator,
+        publicOrigin: url.origin,
+      });
     }
     if (url.pathname === "/v1/account/tool-host") {
       if (url.search !== "") return json({ error: "invalid_request" }, { status: 400 });
@@ -1439,8 +1792,40 @@ async function managedFetch(
       });
     }
     const sessionHeaders = new Headers(request.headers);
+    sessionHeaders.delete("x-nanocodex-vm-machine-id");
+    sessionHeaders.delete("x-nanocodex-vm-lease-expires-at");
+    sessionHeaders.delete("x-nanocodex-vm-route-id");
+    sessionHeaders.delete("x-nanocodex-vm-renewal");
     forwardPrincipalAssertions(sessionHeaders, principal);
     const publicOrigin = `public_origin=${encodeURIComponent(url.origin)}`;
+    if (resource === "vm-host") {
+      if (url.search !== "") return json({ error: "invalid_request" }, { status: 400 });
+      if (request.method !== "GET" || request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+        return new Response("Expected WebSocket upgrade", { status: 426 });
+      }
+      if (principal.connectGrant
+        || !principal.capabilities.includes("agents:write")
+        || !principal.capabilities.includes("tools:use")) {
+        return json({ error: "forbidden" }, { status: 403 });
+      }
+      if (principal.kind !== "api_key" && request.headers.get("origin") !== url.origin) {
+        return json({ error: "forbidden_origin" }, { status: 403 });
+      }
+      const existence = await stub.fetch("https://session.internal/vm-host-existence", {
+        headers: sessionHeaders,
+      });
+      if (!existence.ok) return existence;
+      await existence.body?.cancel();
+      const locator = await vmHostPoolLocator("agent", agentId);
+      return vmHostPoolUpgrade(request, env, {
+        scope: "agent",
+        owner: principal.userId,
+        agent: agentId,
+        donor: principal.userId,
+        locator,
+        publicOrigin: url.origin,
+      });
+    }
     if (resource === "ws" || resource === "tool-host" || resource === "device-host") {
       if (request.method !== "GET" || request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
         return new Response("Expected WebSocket upgrade", { status: 426 });
@@ -1669,6 +2054,150 @@ async function managedFetch(
     return json({ error: "method_not_allowed" }, { status: 405 });
 }
 
+async function routeVmHostToolAttachment(
+  request: Request,
+  env: Env,
+  url: URL,
+  poolLocator: string,
+  allocationId: string,
+): Promise<Response> {
+  if (url.search !== "" || request.method !== "GET"
+    || request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+    return new Response("Expected WebSocket upgrade", { status: 426 });
+  }
+  const bearer = request.headers.get("authorization")?.match(/^Bearer ([A-Za-z0-9_-]{43})$/)?.[1];
+  if (!bearer) return json({ error: "unauthorized" }, { status: 401 });
+  const pool = env.NANOCODEX_VM_HOST_POOLS.getByName(poolLocator);
+  let validated: Response;
+  try {
+    validated = await pool.fetch("https://vm-host-pool.internal/validate-attachment", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ allocation_id: allocationId, bearer }),
+    });
+  } catch {
+    return json({ error: "attachment_unavailable" }, { status: 503 });
+  }
+  if (!validated.ok) {
+    await validated.body?.cancel();
+    return json({ error: "not_found" }, { status: 404 });
+  }
+  let grant: VmHostAttachmentGrant;
+  try { grant = await validated.json<VmHostAttachmentGrant>(); }
+  catch { return json({ error: "attachment_unavailable" }, { status: 503 }); }
+  if (!validVmHostAttachmentGrant(grant) || grant.allocation_id !== allocationId) {
+    return json({ error: "attachment_unavailable" }, { status: 503 });
+  }
+  const headers = new Headers(request.headers);
+  headers.delete("authorization");
+  headers.delete("cookie");
+  headers.delete("origin");
+  headers.set(SESSION_OWNER_ASSERTION, grant.owner_id);
+  headers.set(SESSION_ORGANIZATION_ASSERTION, grant.organization_id);
+  headers.set(SESSION_TEAM_ASSERTION, grant.team_id);
+  headers.set(SESSION_AUTHORIZATION_EPOCH_ASSERTION, String(grant.authorization_epoch));
+  headers.set(SESSION_CAPABILITIES_ASSERTION, JSON.stringify(["agents:write", "tools:use"]));
+  headers.set("x-nanocodex-vm-machine-id", grant.machine_id);
+  headers.set("x-nanocodex-vm-lease-expires-at", String(grant.lease_expires_at));
+  headers.set("x-nanocodex-vm-route-id", grant.route_id);
+  headers.delete("x-nanocodex-vm-renewal");
+  headers.set("x-nanocodex-vm-renewal", JSON.stringify({
+    pool_locator: poolLocator,
+    allocation_id: allocationId,
+    generation: grant.generation,
+    bearer,
+  } satisfies VmHostAttachmentRenewalClaim));
+  return env.NANOCODEX_SESSIONS.getByName(grant.agent_id).fetch(
+    `https://session.internal/tool-host?public_origin=${encodeURIComponent(grant.public_origin)}`,
+    new Request(request, { headers }),
+  );
+}
+
+function validVmHostAttachmentGrant(value: unknown): value is VmHostAttachmentGrant {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const grant = value as Partial<VmHostAttachmentGrant>;
+  return grant.valid === true
+    && typeof grant.allocation_id === "string" && UUID.test(grant.allocation_id)
+    && typeof grant.agent_id === "string" && SESSION_ID.test(grant.agent_id)
+    && Number.isSafeInteger(grant.generation) && Number(grant.generation) >= 1
+    && isUserId(grant.owner_id)
+    && typeof grant.organization_id === "string" && UUID.test(grant.organization_id)
+    && typeof grant.team_id === "string" && UUID.test(grant.team_id)
+    && Number.isSafeInteger(grant.authorization_epoch) && Number(grant.authorization_epoch) >= 1
+    && typeof grant.public_origin === "string" && validPublicOrigin(grant.public_origin)
+    && typeof grant.machine_id === "string" && /^[A-Za-z0-9][A-Za-z0-9._:-]{0,122}$/.test(grant.machine_id)
+    && Number.isSafeInteger(grant.lease_expires_at)
+    && Number(grant.lease_expires_at) > Date.now()
+    && typeof grant.route_id === "string" && VM_HOST_ATTACHMENT_ROUTE.test(grant.route_id);
+}
+
+function vmHostAttachmentRenewalClaim(encoded: string): VmHostAttachmentRenewalClaim | undefined {
+  let value: unknown;
+  try { value = JSON.parse(encoded); }
+  catch { return undefined; }
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const claim = value as Partial<VmHostAttachmentRenewalClaim>;
+  return typeof claim.pool_locator === "string" && /^[A-Za-z0-9_-]{43}$/.test(claim.pool_locator)
+    && typeof claim.allocation_id === "string" && UUID.test(claim.allocation_id)
+    && Number.isSafeInteger(claim.generation) && Number(claim.generation) >= 1
+    && typeof claim.bearer === "string" && /^[A-Za-z0-9_-]{43}$/.test(claim.bearer)
+    ? claim as VmHostAttachmentRenewalClaim
+    : undefined;
+}
+
+function vmHostPoolUpgrade(
+  request: Request,
+  env: Env,
+  options: Readonly<{
+    scope: VmHostPoolScope;
+    owner?: string;
+    agent?: string;
+    donor: string;
+    locator: string;
+    publicOrigin: string;
+  }>,
+): Promise<Response> {
+  const headers = new Headers(request.headers);
+  headers.delete("authorization");
+  headers.delete("cookie");
+  headers.delete("origin");
+  headers.set(VM_HOST_POOL_SCOPE, options.scope);
+  if (options.owner === undefined) headers.delete(VM_HOST_POOL_OWNER);
+  else headers.set(VM_HOST_POOL_OWNER, options.owner);
+  if (options.agent === undefined) headers.delete(VM_HOST_POOL_AGENT);
+  else headers.set(VM_HOST_POOL_AGENT, options.agent);
+  headers.set(VM_HOST_DONOR, options.donor);
+  headers.set(VM_HOST_PUBLIC_ORIGIN, options.publicOrigin);
+  headers.set(VM_HOST_POOL_LOCATOR, options.locator);
+  return env.NANOCODEX_VM_HOST_POOLS.getByName(options.locator).fetch(
+    "https://vm-host-pool.internal/host",
+    new Request(request, { headers }),
+  );
+}
+
+async function vmHostPoolLocator(scope: VmHostPoolScope, identity: string): Promise<string> {
+  const digest = new Uint8Array(await crypto.subtle.digest(
+    "SHA-256",
+    encoder.encode(`nanocodex:vm-host-pool:v1\0${scope}\0${identity}`),
+  ));
+  let binary = "";
+  for (const byte of digest) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/u, "");
+}
+
+async function authorizedSystemVmHost(request: Request, expected: string | undefined): Promise<boolean> {
+  const supplied = request.headers.get("authorization")?.match(/^Bearer (\S{32,512})$/)?.[1];
+  if (!supplied || !expected) return false;
+  const [left, right] = await Promise.all([supplied, expected].map(async (value) => (
+    new Uint8Array(await crypto.subtle.digest("SHA-256", encoder.encode(value)))
+  )));
+  let difference = left.length ^ right.length;
+  for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
+    difference |= (left[index] ?? 0) ^ (right[index] ?? 0);
+  }
+  return difference === 0;
+}
+
 export async function routeSandboxPreviewRequest(
   request: Request,
   env: Pick<Env, "NANOCODEX_ADMIN_TOKEN" | "NANOCODEX_SANDBOXES">,
@@ -1695,37 +2224,85 @@ export async function routeSandboxPreviewRequest(
 }
 
 export function createManagedNamespaceTools(
-  canUseExecutionNamespace: () => boolean,
-  machines: () => readonly NamespaceMachine[] = () => [],
+  canUseExecutionNamespace: (context: ToolContext) => boolean,
+  machines: (context: ToolContext) => readonly NamespaceMachine[] = () => [],
   resolveMachineTool: MachineToolResolver = () => undefined,
+  prepareNamespace: (context: ToolContext) => Promise<void> = async () => {},
 ): NamedTool[] {
-  return createManagedNamespaceRuntime(canUseExecutionNamespace, machines, resolveMachineTool).tools;
+  return createManagedNamespaceRuntime(
+    canUseExecutionNamespace,
+    machines,
+    resolveMachineTool,
+    prepareNamespace,
+  ).tools;
 }
 
 function createManagedNamespaceRuntime(
-  canUseExecutionNamespace: () => boolean,
-  machines: () => readonly NamespaceMachine[] = () => [],
+  canUseExecutionNamespace: (context: ToolContext) => boolean,
+  machines: (context: ToolContext) => readonly NamespaceMachine[] = () => [],
   resolveMachineTool: MachineToolResolver = () => undefined,
-): Readonly<{ tools: NamedTool[]; capture(context: ToolContext): void }> {
+  prepareNamespace: (context: ToolContext) => Promise<void> = async () => {},
+): Readonly<{ tools: NamedTool[]; capture(context: ToolContext): Promise<void> }> {
   const runtime = createNamespaceExecutionRuntime(
     machines,
     resolveMachineTool,
   );
+  const captured = new Set<string>();
+  const preparations = new Map<string, Promise<void>>();
+  const cellKey = (context: ToolContext): string => (
+    `${context.sessionId}\u0000${context.parentCallId}`
+  );
+  const capture = async (context: ToolContext): Promise<void> => {
+    const key = cellKey(context);
+    if (captured.has(key)) return;
+    const pending = preparations.get(key);
+    if (pending !== undefined) return pending;
+    const preparation = (async () => {
+      await prepareNamespace(context);
+      runtime.capture(context);
+      captured.add(key);
+    })();
+    preparations.set(key, preparation);
+    try {
+      await preparation;
+    } finally {
+      if (preparations.get(key) === preparation) preparations.delete(key);
+    }
+  };
+  const releaseSession = (sessionId: string): void => {
+    const prefix = `${sessionId}\u0000`;
+    for (const key of captured) {
+      if (key.startsWith(prefix)) captured.delete(key);
+    }
+    for (const key of preparations.keys()) {
+      if (key.startsWith(prefix)) preparations.delete(key);
+    }
+  };
   const tools = Object.entries(runtime.tools).map(([name, tool]) => ({
     name,
     ...tool,
     handler: async (input, context) => {
-      if (!canUseExecutionNamespace()) {
+      if (!canUseExecutionNamespace(context)) {
         throw new ManagedRequestError(
           403,
           "namespace_forbidden",
           "the current authorization cannot use execution hands",
         );
       }
+      await capture(context);
       return tool.handler(input, context);
     },
+    releaseSession: (sessionId: string) => {
+      releaseSession(sessionId);
+      tool.releaseSession?.(sessionId);
+    },
+    dispose: () => {
+      captured.clear();
+      preparations.clear();
+      tool.dispose?.();
+    },
   } satisfies NamedTool));
-  return Object.freeze({ tools, capture: runtime.capture });
+  return Object.freeze({ tools, capture });
 }
 
 export class ChiefOfStaffBackend extends WorkerEntrypoint<Env> {
@@ -1861,6 +2438,7 @@ export class DurableAgentSession extends DurableComputerSession {
   readonly #realtimeOperations = new Map<string, Promise<unknown>>();
   #realtimeOperationTail: Promise<void> = Promise.resolve();
   readonly #inFlight = new Set<Promise<unknown>>();
+  readonly #namespaceMountRefreshTasks = new Map<string, Promise<void>>();
   #realtimeEventBuffer?: AgentEvent[];
   #realtimeRouteTail: Promise<void> = Promise.resolve();
   #settingsMutationTail: Promise<void> = Promise.resolve();
@@ -1949,6 +2527,18 @@ export class DurableAgentSession extends DurableComputerSession {
       );
       CREATE UNIQUE INDEX IF NOT EXISTS managed_turns_request_key
         ON managed_turns(request_key) WHERE request_key IS NOT NULL;
+      CREATE TABLE IF NOT EXISTS managed_subagent_authorizations (
+        session_id TEXT PRIMARY KEY,
+        root_session_id TEXT NOT NULL,
+        agent_id TEXT NOT NULL,
+        parent_agent_id TEXT,
+        role TEXT NOT NULL,
+        task TEXT NOT NULL,
+        host_context_ref TEXT NOT NULL,
+        authorization_json TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        UNIQUE (root_session_id, agent_id)
+      );
       CREATE TABLE IF NOT EXISTS managed_turn_cancel_intents (
         turn_id TEXT PRIMARY KEY,
         created_at INTEGER NOT NULL
@@ -2034,6 +2624,7 @@ export class DurableAgentSession extends DurableComputerSession {
       entryAllowed: (entry, connectGrantId, appToolCatalogDigest) => (
         this.#activeTurnHostedToolAllowed(entry, connectGrantId, appToolCatalogDigest)
       ),
+      renewLeasedAttachment: (renewal) => this.#renewVmHostAttachment(renewal),
     });
     this.#eventLog = new DurableEventLog<StreamMessage>(this.ctx.storage);
     this.#eventArchive = new ManagedEventArchive<StreamMessage>(
@@ -2130,6 +2721,12 @@ export class DurableAgentSession extends DurableComputerSession {
         return json({ error: "not_found" }, { status: 404 });
       }
       turnAuthorization = asserted.authorization;
+    }
+    if (request.method === "GET" && url.pathname === "/vm-host-existence") {
+      const session = this.#session();
+      return session?.runtime_profile === "managed" && !this.#deleting && !this.#deleted
+        ? new Response(null, { status: 204 })
+        : json({ error: "not_found" }, { status: 404 });
     }
     if (request.method === "PUT" && url.pathname === "/credential-binding") {
       if (this.#deleting || this.#deleted) return new Response(null, { status: 409 });
@@ -2395,6 +2992,16 @@ export class DurableAgentSession extends DurableComputerSession {
     }
     if (request.method === "GET" && url.pathname === "/socket")
       return this.#upgrade(turnAuthorization, url.searchParams.get("cursor"));
+    if (request.method === "POST" && url.pathname === "/vm-host-revoke") {
+      const routeId = request.headers.get("x-nanocodex-vm-route-id");
+      if (!routeId || !VM_HOST_ATTACHMENT_ROUTE.test(routeId)) {
+        return json({ error: "not_found" }, { status: 404 });
+      }
+      const reason = request.headers.get("x-nanocodex-vm-revoke-reason")
+        ?? "VM host control lease ended";
+      this.#hostedTools.revokeRoute(routeId, reason.slice(0, 256));
+      return new Response(null, { status: 204 });
+    }
     if (request.method === "GET" && url.pathname === "/tool-host") {
       if (ownerAssertion === null) return json({ error: "not_found" }, { status: 404 });
       if (this.#deleting) return new Response("Agent is being deleted", { status: 409 });
@@ -2415,11 +3022,35 @@ export class DurableAgentSession extends DurableComputerSession {
         console.error({ type: "managed.tool_router_startup_failed", error_kind: errorKind(error) });
         return json({ error: "tool_router_unavailable" }, { status: 503 });
       }
+      const expectedMachineId = request.headers.get("x-nanocodex-vm-machine-id") ?? undefined;
+      const maximumLeaseExpiresAt = Number(
+        request.headers.get("x-nanocodex-vm-lease-expires-at") ?? Number.MAX_SAFE_INTEGER,
+      );
+      const fixedRouteId = request.headers.get("x-nanocodex-vm-route-id") ?? undefined;
+      const renewalToken = request.headers.get("x-nanocodex-vm-renewal") ?? undefined;
+      if (expectedMachineId !== undefined
+        && !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,122}$/.test(expectedMachineId)) {
+        return json({ error: "not_found" }, { status: 404 });
+      }
+      if (!Number.isSafeInteger(maximumLeaseExpiresAt) || maximumLeaseExpiresAt <= Date.now()) {
+        return json({ error: "not_found" }, { status: 404 });
+      }
+      if ((expectedMachineId === undefined) !== (fixedRouteId === undefined)
+        || (fixedRouteId !== undefined && (!VM_HOST_ATTACHMENT_ROUTE.test(fixedRouteId)
+          || renewalToken === undefined || vmHostAttachmentRenewalClaim(renewalToken) === undefined))) {
+        return json({ error: "not_found" }, { status: 404 });
+      }
       return this.#hostedTools.upgrade(
         session.session_id,
         turnAuthorization.connectGrant?.mcpIds,
         turnAuthorization.connectGrant?.appToolCatalogDigest,
         turnAuthorization.connectGrant?.grantId,
+        expectedMachineId === undefined ? undefined : {
+          expectedAttachmentId: expectedMachineId,
+          maximumLeaseExpiresAt,
+          fixedRouteId: fixedRouteId!,
+          renewalToken: renewalToken!,
+        },
       );
     }
     if (request.method === "GET" && url.pathname === "/device-host")
@@ -4863,14 +5494,20 @@ export class DurableAgentSession extends DurableComputerSession {
       );
       if (!tombstoned.ok) throw new Error(`memory tombstone failed with HTTP ${tombstoned.status}`);
       const retainedMounts = this.#managedMounts();
-      const unsupportedMount = retainedMounts.find(({ provider }) => provider !== "cloudflare");
+      const unsupportedMount = retainedMounts.find(
+        ({ provider }) => provider !== "cloudflare" && provider !== "host",
+      );
       if (unsupportedMount !== undefined) {
         throw new Error(`unsupported retained mount provider: ${unsupportedMount.provider}`);
       }
+      await Promise.all(retainedMounts
+        .filter(({ provider }) => provider === "host")
+        .map((mount) => this.#releaseHostMount(mount, false)));
       const cloudflareResources = new Set([
         // Preserve cleanup for agents that used the pre-mount singleton sandbox.
         session.session_id,
         ...retainedMounts
+          .filter(({ provider }) => provider === "cloudflare")
           .map(({ provider_resource_id }) => provider_resource_id),
       ]);
       // Every Cloudflare hand mounts peer prefixes. Stop all possible writers
@@ -4939,6 +5576,7 @@ export class DurableAgentSession extends DurableComputerSession {
     CloudflareAgent.destroy(this);
     this.ctx.storage.transactionSync(() => {
       this.ctx.storage.sql.exec("DELETE FROM managed_turn_dispatch_chunks");
+      this.ctx.storage.sql.exec("DELETE FROM managed_subagent_authorizations");
       this.ctx.storage.sql.exec("DELETE FROM managed_turns");
       this.ctx.storage.sql.exec("DELETE FROM managed_turn_cancel_intents");
       this.ctx.storage.sql.exec("DELETE FROM history_projection_outbox");
@@ -5363,7 +6001,11 @@ export class DurableAgentSession extends DurableComputerSession {
     this.#accountHostedTools ??= new AccountHostedToolsProvider(
       this.env.NANOCODEX_ACCOUNT_TOOLS,
       session.owner_id,
-      () => this.#hasFullAccountAuthority(),
+      (context) => this.#hasFullAccountAuthority(
+        context === undefined
+          ? this.#activeTurnAuthorization()
+          : this.#authorizationForToolContext(context),
+      ),
     );
     await this.#accountHostedTools.refresh();
   }
@@ -5419,9 +6061,9 @@ export class DurableAgentSession extends DurableComputerSession {
       computer.filesystem,
     );
     const computerRuntimeMs = performance.now() - phaseStartedAt;
-    const currentAccountInfo = async (signal?: AbortSignal) => {
+    const currentAccountInfo = async (context: ToolContext) => {
       await this.#accountHostedTools?.refresh();
-      const authorization = this.#activeTurnAuthorization();
+      const authorization = this.#authorizationForToolContext(context);
       return await accountInfo(
         this.env.NANOCODEX,
         session.owner_id,
@@ -5434,7 +6076,7 @@ export class DurableAgentSession extends DurableComputerSession {
             : accountConnectionProjection(authorization),
           enabled: !multiplayer,
           machines: this.#accountMachines(authorization),
-          signal,
+          signal: context.signal,
         },
       );
     };
@@ -5449,6 +6091,10 @@ export class DurableAgentSession extends DurableComputerSession {
       codeEvaluator: await managedCodeEvaluator(),
       toolMode: "code" as const,
       toolProviders: hostedProviders,
+      subagentLifecycle: (event: unknown) => applyManagedSubagentLifecycle(
+        this.ctx.storage,
+        event,
+      ),
     };
     const codeEvaluatorMs = performance.now() - codeEvaluatorStartedAt;
     const accountMcpConnections = this.#accountMcpConnections ?? [];
@@ -5468,14 +6114,16 @@ export class DurableAgentSession extends DurableComputerSession {
           ),
     };
     const sandboxToolsByMount = new Map<string, ReturnType<typeof cloudflareSandboxTools>>();
-    const namespaceMachines = () => {
-      const authorization = this.#activeTurnAuthorization();
+    const namespaceMachines = (context: ToolContext) => {
+      const authorization = this.#authorizationForToolContext(context);
       if (!this.#canUseExecutionNamespace(authorization)) return [];
       return [
-        ...this.#managedMounts("mounted").map((mount) => ({
+        ...this.#availableManagedMounts().map((mount) => ({
           id: `sandbox:${mount.id}`,
           root: mount.root,
-          workspace: "/workspace",
+          workspace: mount.provider === "host"
+            ? this.#hostMachineForMount(mount)!.workspace
+            : "/workspace",
         })),
         ...(this.#hasFullAccountAuthority(authorization)
           ? this.#userHandMachines()
@@ -5486,13 +6134,24 @@ export class DurableAgentSession extends DurableComputerSession {
           })),
       ];
     };
-    const resolveNamespaceMachineTool: MachineToolResolver = (machineId, name) => {
-      const authorization = this.#activeTurnAuthorization();
+    const resolveNamespaceMachineTool: MachineToolResolver = (machineId, name, context) => {
+      const authorization = this.#authorizationForToolContext(context);
       if (!this.#canUseExecutionNamespace(authorization)) return undefined;
       if (machineId.startsWith("sandbox:")) {
         const mountId = machineId.slice("sandbox:".length);
         const mount = this.#managedMount(mountId);
-        if (mount?.state !== "mounted" || mount.provider !== "cloudflare") return undefined;
+        if (mount?.state !== "mounted") return undefined;
+        if (mount.provider === "host") {
+          const allocation = vmHostMountAllocation(mount);
+          return allocation?.route_id === undefined
+            ? undefined
+            : this.#hostedTools.machineToolOnRoute(
+              allocation.route_id,
+              allocation.machine_id,
+              name,
+            );
+        }
+        if (mount.provider !== "cloudflare") return undefined;
         let tools = sandboxToolsByMount.get(mount.id);
         if (tools === undefined) {
           tools = cloudflareSandboxTools(
@@ -5518,15 +6177,18 @@ export class DurableAgentSession extends DurableComputerSession {
         ?? this.#accountHostedTools?.machineTool(id, name);
     };
     const namespaceRuntime = multiplayer ? undefined : createManagedNamespaceRuntime(
-      () => this.#canUseExecutionNamespace(),
+      (context) => this.#canUseExecutionNamespace(this.#authorizationForToolContext(context)),
       namespaceMachines,
       resolveNamespaceMachineTool,
+      (context) => this.#refreshMountedHostMounts(
+        this.#authorizationForToolContext(context),
+      ),
     );
     const cloudTools: NamedTool[] = [
       ...(browserRuntime?.tools ?? []),
       ...(multiplayer ? [computer.tool] : []),
       ...(multiplayer ? [] : [managedMountTool(async (request, context) => {
-        if (!this.#canUseExecutionNamespace()) {
+        if (!this.#canUseExecutionNamespace(this.#authorizationForToolContext(context))) {
           throw new ManagedRequestError(
             403,
             "mount_forbidden",
@@ -5534,7 +6196,7 @@ export class DurableAgentSession extends DurableComputerSession {
           );
         }
         context.signal.throwIfAborted();
-        namespaceRuntime?.capture(context);
+        await namespaceRuntime?.capture(context);
         return this.#mount(request, context, session);
       })]),
       ...(namespaceRuntime?.tools ?? []),
@@ -5542,7 +6204,7 @@ export class DurableAgentSession extends DurableComputerSession {
         name: "accountInfo",
         description: "Report live machine hands, account authentication, safe Vault references, stablecoin balances, and app authorization boundaries. Vault references may show usernames, addresses, phone numbers, and card last four, but never passwords or complete card data.",
         parameters: { type: "object", additionalProperties: false },
-        handler: (_input: unknown, context: ToolContext) => currentAccountInfo(context.signal),
+        handler: (_input: unknown, context: ToolContext) => currentAccountInfo(context),
       }]),
       ...(multiplayer ? [] : [accountConnectorsTool({
         broker: this.env.NANOCODEX,
@@ -5588,7 +6250,7 @@ export class DurableAgentSession extends DurableComputerSession {
             default_cwd: "/brain",
             native_cross_mounts: false,
             cloudflare_native_cross_mounts: this.env.NANOCODEX_SANDBOX_LOCAL !== "true",
-            mounts: this.#accountMachines(this.#activeTurnAuthorization()).map(({ id, mount }) => ({
+            mounts: this.#accountMachines(this.#authorizationForToolContext(context)).map(({ id, mount }) => ({
               id,
               mount,
             })),
@@ -5605,7 +6267,7 @@ export class DurableAgentSession extends DurableComputerSession {
           pty: multiplayer ? computer.descriptor.pty : false,
           sessions: multiplayer ? computer.descriptor.sessions : false,
           sandbox_escalation: false,
-          account: await currentAccountInfo(context.signal),
+          account: await currentAccountInfo(context),
         }),
       },
       ...(multiplayer ? [] : memorySessionTools({
@@ -5665,7 +6327,7 @@ export class DurableAgentSession extends DurableComputerSession {
           ].join("\n\n")
           : [
             "You are the durable Nanocodex brain running on Cloudflare Workers. The brain does not execute shell commands. /brain is durable shared scratch mounted read-write in every Cloudflare hand; it never contains credentials or control-plane authority.",
-            "The agent starts without a sandbox hand. When a task such as cloning a repository, building code, or running tests needs native Linux execution, infer that need and call mount with provider cloudflare and a useful stable name. Do not ask the user to request a routine sandbox mount. mount provisions and attaches the hand before it returns.",
+            "The agent starts without a sandbox hand. When a task such as cloning a repository, building code, or running tests needs native Linux execution, infer that need and call mount with provider cf_sandbox and a useful stable name. Use another provider only when the user supplied its exact connected VM factory name. Do not ask the user to request a routine sandbox mount. mount provisions and attaches the hand before it returns.",
             "Hands appear as logical top-level paths returned by mount or listed in accountInfo().machines. exec_command has its standard shape: set workdir to the exact hand mount or a path beneath it; the root of that cwd selects where the process runs. The default /brain cwd is not executable. write_stdin remains pinned to the hand that created its session. There is no environment or host argument.",
             "A Code Mode cell captures its mount mapping. Commands in Promise.all may run concurrently on different cwd roots, and subagents use the same cwd rule independently. A disconnect or reconnect never retargets an admitted command or session.",
             "Cloudflare sandbox hands are separate retained workspaces mounted into each other's native filesystem namespaces. A process may write its executing hand through /workspace or that hand's logical mount path, read peer hand paths without mutating them, and read or write /brain using ordinary filesystem syscalls. The trees are mounted, never copied or synchronized. Connected user hands and future providers remain placement-only until their provider advertises a conforming native namespace adapter, so native_cross_mounts remains false globally while runtimeInfo.cloudflare_native_cross_mounts is true.",
@@ -5866,11 +6528,29 @@ export class DurableAgentSession extends DurableComputerSession {
     catch { return undefined; }
   }
 
+  #authorizationForToolContext(
+    context: Pick<ToolContext, "sessionId" | "subagent">,
+  ): TurnAuthorization | undefined {
+    let rootSessionId: string | undefined;
+    try {
+      rootSessionId = this.ctx.storage.sql.exec<{ session_id: string }>(
+        "SELECT session_id FROM nanocodex_cloudflare_agent WHERE singleton = 1",
+      ).toArray()[0]?.session_id;
+    } catch { /* The adapter creates the identity table during construction. */ }
+    return managedAuthorizationForToolContext(
+      this.ctx.storage,
+      rootSessionId,
+      this.#activeTurnAuthorization(),
+      context,
+    );
+  }
+
   async #mount(
     request: ManagedMountRequest,
     context: ToolContext,
     session: SessionRow,
   ): Promise<ManagedMountResult> {
+    const storageProvider = managedMountStorageProvider(request.provider);
     const replay = this.ctx.storage.sql.exec<ManagedMountCallRow>(
       `SELECT provider, name, mount_id, created
        FROM managed_mount_calls WHERE tool_session_id = ? AND tool_call_id = ?`,
@@ -5880,7 +6560,8 @@ export class DurableAgentSession extends DurableComputerSession {
     let mount: ManagedMountRow | undefined;
     let created = false;
     if (replay !== undefined) {
-      if (replay.provider !== request.provider || replay.name !== request.name) {
+      if (!sameManagedMountProvider(replay.provider, request.provider)
+        || replay.name !== request.name) {
         throw new ManagedRequestError(
           409,
           "mount_call_conflict",
@@ -5921,24 +6602,24 @@ export class DurableAgentSession extends DurableComputerSession {
       const now = Date.now();
       const providerCount = this.ctx.storage.sql.exec<{ count: number }>(
         "SELECT COUNT(*) AS count FROM managed_mounts WHERE provider = ?",
-        request.provider,
+        storageProvider,
       ).one().count;
       const providerResourceId = managedMountProviderResourceId(
         session.session_id,
         id,
-        providerCount,
+        storageProvider === "host" ? 1 : providerCount,
       );
       const root = managedMountRoot(request.name, id);
-      const configuration = request.provider === "cloudflare"
+      const configuration = storageProvider === "cloudflare"
         ? JSON.stringify({ namespace_slot: this.#nextCloudflareNamespaceSlot() })
-        : "{}";
+        : JSON.stringify({ vm_factory_name: request.provider });
       this.ctx.storage.sql.exec(
         `INSERT INTO managed_mounts (
            id, provider, name, root, provider_resource_id, configuration_json,
            state, created_at, updated_at
          ) VALUES (?, ?, ?, ?, ?, ?, 'mounting', ?, ?)`,
         id,
-        request.provider,
+        storageProvider,
         request.name,
         root,
         providerResourceId,
@@ -5950,11 +6631,11 @@ export class DurableAgentSession extends DurableComputerSession {
       if (retained === undefined) throw new Error("durable mount intent was not retained");
       mount = retained;
     }
-    if (mount.provider !== request.provider) {
+    if (!managedMountUsesProvider(mount, request.provider)) {
       throw new ManagedRequestError(
         409,
         "mount_name_conflict",
-        `mount ${request.name} already belongs to provider ${mount.provider}`,
+        `mount ${request.name} already belongs to provider ${managedMountPublicProvider(mount)}`,
       );
     }
     if (replay === undefined) {
@@ -5971,7 +6652,8 @@ export class DurableAgentSession extends DurableComputerSession {
         Date.now(),
       );
     }
-    if (mount.state !== "mounted") {
+    if (mount.state !== "mounted"
+      || (mount.provider === "host" && this.#hostMachineForMount(mount) === undefined)) {
       try {
         await this.#prepareManagedMount(mount);
         this.ctx.storage.sql.exec(
@@ -5991,7 +6673,7 @@ export class DurableAgentSession extends DurableComputerSession {
     return Object.freeze({
       id: mount.id,
       name: mount.name,
-      provider: mount.provider,
+      provider: managedMountPublicProvider(mount),
       mount: mount.root,
       status: "mounted" as const,
       created,
@@ -6012,9 +6694,303 @@ export class DurableAgentSession extends DurableComputerSession {
         );
         return;
       }
+      case "host": {
+        await this.#prepareHostMount(mount);
+        return;
+      }
       default:
         throw new Error(`unsupported retained mount provider: ${mount.provider}`);
     }
+  }
+
+  async #renewVmHostAttachment(
+    renewal: HostedToolsLeasedAttachmentRenewal,
+  ): Promise<number | undefined> {
+    const claim = vmHostAttachmentRenewalClaim(renewal.renewalToken);
+    const session = this.#session();
+    if (claim === undefined || session === undefined || this.#deleting || this.#deleted
+      || renewal.expectedAttachmentId.length === 0
+      || !renewal.fixedRouteId.startsWith(`vm-host:${claim.allocation_id}:`)) {
+      return undefined;
+    }
+    return fetchResponseWithDeadline(
+      this.env.NANOCODEX_VM_HOST_POOLS.getByName(claim.pool_locator),
+      "https://vm-host-pool.internal/validate-attachment",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ allocation_id: claim.allocation_id, bearer: claim.bearer }),
+      },
+      5_000,
+      "VM host attachment validation",
+      async (response) => {
+        if (response.status === 404) return undefined;
+        if (!response.ok) {
+          throw new Error(`VM host attachment validation failed with HTTP ${response.status}`);
+        }
+        const grant = await response.json<unknown>();
+        if (!validVmHostAttachmentGrant(grant)
+          || grant.allocation_id !== claim.allocation_id
+          || grant.generation !== claim.generation
+          || grant.agent_id !== session.session_id
+          || grant.owner_id !== session.owner_id
+          || grant.organization_id !== session.organization_id
+          || grant.team_id !== session.team_id
+          || grant.authorization_epoch !== session.authorization_epoch
+          || grant.machine_id !== renewal.expectedAttachmentId
+          || grant.route_id !== renewal.fixedRouteId) return undefined;
+        return grant.lease_expires_at;
+      },
+    );
+  }
+
+  async #refreshMountedHostMounts(
+    authorization: TurnAuthorization | undefined,
+  ): Promise<void> {
+    if (!this.#canUseExecutionNamespace(authorization)) {
+      throw new ManagedRequestError(
+        403,
+        "namespace_forbidden",
+        "the current authorization cannot use execution hands",
+      );
+    }
+    if (this.#deleting || this.#deleted) throw retryableError("agent is being deleted");
+    const deletionGeneration = this.#deletionGeneration;
+    const mounts = this.#managedMounts("mounted").filter((mount) => (
+      mount.provider === "host" && vmHostMountAllocation(mount) !== undefined
+    ));
+    await Promise.all(mounts.map((mount) => this.#refreshMountedHostMount(mount)));
+    if (this.#deleting || this.#deleted || this.#deletionGeneration !== deletionGeneration) {
+      throw retryableError("agent is being deleted");
+    }
+  }
+
+  #refreshMountedHostMount(mount: ManagedMountRow): Promise<void> {
+    const pending = this.#namespaceMountRefreshTasks.get(mount.id);
+    if (pending !== undefined) return pending;
+    const refresh = this.#prepareHostMount(mount);
+    this.#namespaceMountRefreshTasks.set(mount.id, refresh);
+    void refresh.finally(() => {
+      if (this.#namespaceMountRefreshTasks.get(mount.id) === refresh) {
+        this.#namespaceMountRefreshTasks.delete(mount.id);
+      }
+    }).catch(() => {});
+    return refresh;
+  }
+
+  async #prepareHostMount(mount: ManagedMountRow): Promise<void> {
+    const session = this.#session();
+    if (session === undefined) throw new Error("managed session is not initialized");
+    let configuration = managedMountConfiguration(mount.configuration_json);
+    const persistConfiguration = (next: ManagedMountConfiguration): void => {
+      configuration = next;
+      this.ctx.storage.sql.exec(
+        "UPDATE managed_mounts SET configuration_json = ?, updated_at = ? WHERE id = ?",
+        JSON.stringify(next), Date.now(), mount.id,
+      );
+    };
+    const factoryName = vmHostFactoryName(mount);
+    if (factoryName === undefined) {
+      throw new Error("retained VM host mount has no valid factory name");
+    }
+    let retained = vmHostMountAllocation(mount);
+    if (retained === undefined) {
+      const candidates: readonly [VmHostPoolScope, string][] = [
+        ["agent", session.session_id],
+        ["account", session.owner_id],
+        ["system", "system"],
+      ];
+      const located = await Promise.all(candidates.map(async ([scope, identity]) => ({
+        scope,
+        locator: await vmHostPoolLocator(scope, identity),
+      })));
+      const selection = configuration.vm_pool_locator;
+      if (selection !== undefined && (typeof selection !== "string"
+        || !/^[A-Za-z0-9_-]{43}$/.test(selection))) {
+        throw new Error("retained VM host mount has an invalid pool selection intent");
+      }
+      const selectedIndex = selection === undefined
+        ? 0
+        : located.findIndex(({ locator }) => locator === selection);
+      if (selectedIndex < 0) {
+        throw new Error("retained VM host mount pool selection is outside its visible scopes");
+      }
+      for (const { locator } of located.slice(selectedIndex)) {
+        if (configuration.vm_pool_locator !== locator) {
+          persistConfiguration({ ...configuration, vm_pool_locator: locator });
+        }
+        const response = await this.env.NANOCODEX_VM_HOST_POOLS.getByName(locator).fetch(
+          "https://vm-host-pool.internal/acquire",
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              factory_name: factoryName,
+              owner_id: session.owner_id,
+              organization_id: session.organization_id,
+              team_id: session.team_id,
+              authorization_epoch: session.authorization_epoch,
+              agent_id: session.session_id,
+              mount_id: mount.id,
+              pool_locator: locator,
+            }),
+          },
+        );
+        if (!response.ok) {
+          const failure = await response.json<{ error?: unknown }>().catch(() => undefined);
+          if (response.status === 404 && failure?.error === "factory_not_found") continue;
+          if (response.status === 409 && failure?.error === "factory_unavailable") {
+            throw new ManagedRequestError(
+              503,
+              "factory_unavailable",
+              `VM factory ${factoryName} has no available capacity`,
+            );
+          }
+          throw new Error(`VM host allocation failed with HTTP ${response.status}`);
+        }
+        const allocation = await response.json<unknown>();
+        if (!validVmHostAllocation(allocation) || allocation.factory_name !== factoryName) {
+          throw new Error("VM host pool returned an invalid allocation");
+        }
+        retained = {
+          pool_locator: locator,
+          allocation_id: allocation.allocation_id,
+          generation: allocation.generation,
+          machine_id: allocation.machine_id,
+          route_id: allocation.route_id,
+        };
+        const { vm_pool_locator: _selection, ...stableConfiguration } = configuration;
+        persistConfiguration({ ...stableConfiguration, vm_host: retained });
+        break;
+      }
+      if (retained === undefined) {
+        const { vm_pool_locator: _selection, ...stableConfiguration } = configuration;
+        persistConfiguration(stableConfiguration);
+        throw new ManagedRequestError(
+          404,
+          "factory_not_found",
+          `VM factory ${factoryName} is not connected in any visible scope`,
+        );
+      }
+    }
+    const identity = {
+      owner_id: session.owner_id,
+      agent_id: session.session_id,
+      mount_id: mount.id,
+      allocation_id: retained.allocation_id,
+      generation: retained.generation,
+      pool_locator: retained.pool_locator,
+    };
+    const pool = this.env.NANOCODEX_VM_HOST_POOLS.getByName(retained.pool_locator);
+    const deadline = Date.now() + 30_000;
+    while (Date.now() < deadline) {
+      const response = await pool.fetch("https://vm-host-pool.internal/ready", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(identity),
+      });
+      if (!response.ok) throw new Error(`VM host readiness failed with HTTP ${response.status}`);
+      const status = await response.json<unknown>();
+      if (!status || typeof status !== "object" || Array.isArray(status)) {
+        throw new Error("VM host pool returned an invalid readiness response");
+      }
+      const readiness = status as { ready?: unknown; state?: unknown };
+      if (validVmHostAllocation(status)
+        && status.factory_name === factoryName
+        && status.allocation_id === retained.allocation_id
+        && status.generation === retained.generation
+        && status.machine_id === retained.machine_id
+        && status.route_id !== retained.route_id) {
+        const refreshed = this.#persistRefreshedHostRoute(mount, retained, status.route_id);
+        if (refreshed === undefined) {
+          throw new Error("retained VM host mount changed while refreshing its route");
+        }
+        retained = refreshed;
+      }
+      const current = this.#managedMount(mount.id);
+      if (this.#deleting || this.#deleted || current === undefined || current.state === "failed") {
+        throw retryableError("retained VM host mount is no longer available");
+      }
+      if (readiness.ready === true && current.state === "mounted"
+        && this.#hostMachineForMount(current)) return;
+      if (readiness.ready === true && mount.state === "mounting"
+        && current.state === "mounting" && this.#hostMachineForMount(current)) return;
+      if (readiness.state === "releasing" || readiness.state === "released") {
+        throw new Error("VM host allocation was released before becoming ready");
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    }
+    throw new ManagedRequestError(503, "host_not_ready", "VM host did not publish its assigned machine route");
+  }
+
+  #persistRefreshedHostRoute(
+    mount: ManagedMountRow,
+    expected: NonNullable<ManagedMountConfiguration["vm_host"]>,
+    routeId: string,
+  ): ManagedMountConfiguration["vm_host"] | undefined {
+    return this.ctx.storage.transactionSync(() => {
+      const current = this.#managedMount(mount.id);
+      if (current === undefined || current.provider !== "host"
+        || (current.state !== mount.state
+          && !(mount.state === "mounting" && current.state === "mounted"))) return undefined;
+      const allocation = vmHostMountAllocation(current);
+      if (allocation === undefined
+        || allocation.pool_locator !== expected.pool_locator
+        || allocation.allocation_id !== expected.allocation_id
+        || allocation.generation !== expected.generation
+        || allocation.machine_id !== expected.machine_id) return undefined;
+      if (allocation.route_id === routeId) return allocation;
+      const configuration = managedMountConfiguration(current.configuration_json);
+      const refreshed = Object.freeze({ ...allocation, route_id: routeId });
+      this.ctx.storage.sql.exec(
+        "UPDATE managed_mounts SET configuration_json = ?, updated_at = ? WHERE id = ?",
+        JSON.stringify({ ...configuration, vm_host: refreshed }), Date.now(), mount.id,
+      );
+      return refreshed;
+    });
+  }
+
+  async #releaseHostMount(mount: ManagedMountRow, waitForHost = true): Promise<void> {
+    const session = this.#session();
+    const allocation = vmHostMountAllocation(mount);
+    if (session === undefined) return;
+    const configuration = managedMountConfiguration(mount.configuration_json);
+    const factoryName = vmHostFactoryName(mount);
+    const locator = allocation?.pool_locator ?? configuration.vm_pool_locator;
+    if (factoryName === undefined || typeof locator !== "string"
+      || !/^[A-Za-z0-9_-]{43}$/.test(locator)) return;
+    const pool = this.env.NANOCODEX_VM_HOST_POOLS.getByName(locator);
+    const identity = allocation === undefined ? {
+      factory_name: factoryName,
+      owner_id: session.owner_id,
+      organization_id: session.organization_id,
+      team_id: session.team_id,
+      authorization_epoch: session.authorization_epoch,
+      agent_id: session.session_id,
+      mount_id: mount.id,
+      pool_locator: locator,
+    } : {
+      owner_id: session.owner_id,
+      agent_id: session.session_id,
+      mount_id: mount.id,
+      allocation_id: allocation.allocation_id,
+      generation: allocation.generation,
+      pool_locator: locator,
+    };
+    const path = allocation === undefined ? "release-intent" : "release";
+    const deadline = Date.now() + 30_000;
+    while (Date.now() < deadline) {
+      const response = await pool.fetch(`https://vm-host-pool.internal/${path}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(identity),
+      });
+      if (!response.ok) throw new Error(`VM host release failed with HTTP ${response.status}`);
+      const status = await response.json<{ state?: unknown }>();
+      if (status.state === "released" || !waitForHost) return;
+      await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    }
+    throw new Error("VM host release acknowledgement timed out");
   }
 
   #managedMount(id: string): ManagedMountRow | undefined {
@@ -6034,6 +7010,20 @@ export class DurableAgentSession extends DurableComputerSession {
        ORDER BY created_at, id`,
       ...(state === undefined ? [] : [state]),
     ).toArray();
+  }
+
+  #availableManagedMounts(): readonly ManagedMountRow[] {
+    return this.#managedMounts("mounted").filter((mount) => (
+      mount.provider === "cloudflare"
+      || (vmHostFactoryName(mount) !== undefined && this.#hostMachineForMount(mount) !== undefined)
+    ));
+  }
+
+  #hostMachineForMount(mount: ManagedMountRow): HostedMachine | undefined {
+    if (mount.provider !== "host") return undefined;
+    const allocation = vmHostMountAllocation(mount);
+    if (allocation?.route_id === undefined) return undefined;
+    return this.#hostedTools.machineOnRoute(allocation.route_id, allocation.machine_id);
   }
 
   #cloudflareNamespaceMounts(
@@ -6110,15 +7100,18 @@ export class DurableAgentSession extends DurableComputerSession {
   #accountMachines(authorization: TurnAuthorization | undefined): readonly AccountMachine[] {
     if (!this.#canUseExecutionNamespace(authorization)) return [];
     return Object.freeze([
-      ...this.#managedMounts("mounted").map((mount) => Object.freeze({
-        id: `sandbox:${mount.id}`,
-        name: mount.name,
-        kind: "sandbox" as const,
-        provider: mount.provider,
-        mount: mount.root,
-        workspace: mount.root,
-        capabilities: SANDBOX_HAND_CAPABILITIES,
-      })),
+      ...this.#availableManagedMounts().map((mount) => {
+        const hostMachine = mount.provider === "host" ? this.#hostMachineForMount(mount) : undefined;
+        return Object.freeze({
+          id: `sandbox:${mount.id}`,
+          name: mount.name,
+          kind: "sandbox" as const,
+          provider: managedMountPublicProvider(mount),
+          mount: mount.root,
+          workspace: mount.root,
+          capabilities: hostMachine?.capabilities ?? SANDBOX_HAND_CAPABILITIES,
+        });
+      }),
       ...(this.#hasFullAccountAuthority(authorization)
         ? this.#userHandMachines()
         : []).map((machine) => {
@@ -6148,6 +7141,10 @@ export class DurableAgentSession extends DurableComputerSession {
   }
 
   #userHandMachines(): readonly HostedMachine[] {
+    const leasedMachineIds = new Set(this.#managedMounts().flatMap((mount) => {
+      const allocation = vmHostMountAllocation(mount);
+      return allocation === undefined ? [] : [allocation.machine_id];
+    }));
     const machines = [
       ...this.#hostedTools.machines(),
       ...(this.#accountHostedTools?.machines() ?? []),
@@ -6155,7 +7152,7 @@ export class DurableAgentSession extends DurableComputerSession {
     const counts = new Map<string, number>();
     for (const machine of machines) counts.set(machine.id, (counts.get(machine.id) ?? 0) + 1);
     return machines
-      .filter((machine) => counts.get(machine.id) === 1)
+      .filter((machine) => counts.get(machine.id) === 1 && !leasedMachineIds.has(machine.id))
       .sort((left, right) => left.id.localeCompare(right.id));
   }
 

--- a/js/managed/src/index.ts
+++ b/js/managed/src/index.ts
@@ -925,12 +925,39 @@ export function applyManagedSubagentLifecycle(
   const type = event.type;
   if ((type !== "bind" && type !== "reconstruct" && type !== "release")
     || typeof event.rootSessionId !== "string" || !SESSION_ID.test(event.rootSessionId)
-    || typeof event.sessionId !== "string" || !SESSION_ID.test(event.sessionId)
-    || typeof event.hostContextRef !== "string" || !TURN_ID.test(event.hostContextRef)) {
+    || typeof event.sessionId !== "string" || !SESSION_ID.test(event.sessionId)) {
     throw new TypeError("invalid managed subagent lifecycle event");
   }
   const rootSessionId = event.rootSessionId;
   const sessionId = event.sessionId;
+  if (event.hostContextRef === undefined && (type === "reconstruct" || type === "release")) {
+    const allowedKeys = type === "release"
+      ? ["type", "rootSessionId", "sessionId", "hostContextRef"]
+      : ["type", "rootSessionId", "sessionId", "descriptor", "hostContextRef"];
+    if (Object.keys(event).some((key) => !allowedKeys.includes(key))) {
+      throw new TypeError("invalid managed subagent lifecycle event");
+    }
+    if (type === "reconstruct") {
+      const descriptor = managedSubagentDescriptor(event.descriptor);
+      if (descriptor.sessionId !== sessionId) {
+        throw new Error("managed subagent session does not match its descriptor");
+      }
+    }
+    // Rows created before private host provenance cannot inherit authority.
+    // Revoke any divergent retained snapshot while allowing the Cloudflare
+    // adapter to reconstruct or release the child itself. This is idempotent,
+    // and the absent managed row makes every capability lookup fail closed.
+    storage.sql.exec(
+      `DELETE FROM managed_subagent_authorizations
+       WHERE session_id = ? AND root_session_id = ?`,
+      sessionId,
+      rootSessionId,
+    );
+    return;
+  }
+  if (typeof event.hostContextRef !== "string" || !TURN_ID.test(event.hostContextRef)) {
+    throw new TypeError("invalid managed subagent lifecycle event");
+  }
   const hostContextRef = event.hostContextRef;
   const retained = storage.sql.exec<ManagedSubagentAuthorizationRow>(
     `SELECT root_session_id, session_id AS sessionId, agent_id AS agentId,
@@ -2621,8 +2648,8 @@ export class DurableAgentSession extends DurableComputerSession {
       Date.now(),
     );
     this.#hostedTools = new HostedToolsBroker(this.ctx, {
-      entryAllowed: (entry, connectGrantId, appToolCatalogDigest) => (
-        this.#activeTurnHostedToolAllowed(entry, connectGrantId, appToolCatalogDigest)
+      entryAllowed: (entry, connectGrantId, appToolCatalogDigest, context) => (
+        this.#hostedToolAllowed(entry, connectGrantId, appToolCatalogDigest, context)
       ),
       renewLeasedAttachment: (renewal) => this.#renewVmHostAttachment(renewal),
     });
@@ -6075,7 +6102,7 @@ export class DurableAgentSession extends DurableComputerSession {
             ? {}
             : accountConnectionProjection(authorization),
           enabled: !multiplayer,
-          machines: this.#accountMachines(authorization),
+          machines: this.#accountMachines(authorization, context),
           signal: context.signal,
         },
       );
@@ -6126,7 +6153,7 @@ export class DurableAgentSession extends DurableComputerSession {
             : "/workspace",
         })),
         ...(this.#hasFullAccountAuthority(authorization)
-          ? this.#userHandMachines()
+          ? this.#userHandMachines(context)
           : []).map((machine) => ({
             id: `user:${machine.id}`,
             root: machineMountRoot(machine.id),
@@ -6149,6 +6176,7 @@ export class DurableAgentSession extends DurableComputerSession {
               allocation.route_id,
               allocation.machine_id,
               name,
+              context,
             );
         }
         if (mount.provider !== "cloudflare") return undefined;
@@ -6172,9 +6200,9 @@ export class DurableAgentSession extends DurableComputerSession {
         return undefined;
       }
       const id = machineId.slice("user:".length);
-      if (!this.#userHandMachines().some((machine) => machine.id === id)) return undefined;
-      return this.#hostedTools.machineTool(id, name)
-        ?? this.#accountHostedTools?.machineTool(id, name);
+      if (!this.#userHandMachines(context).some((machine) => machine.id === id)) return undefined;
+      return this.#hostedTools.machineTool(id, name, context)
+        ?? this.#accountHostedTools?.machineTool(id, name, context);
     };
     const namespaceRuntime = multiplayer ? undefined : createManagedNamespaceRuntime(
       (context) => this.#canUseExecutionNamespace(this.#authorizationForToolContext(context)),
@@ -6250,7 +6278,10 @@ export class DurableAgentSession extends DurableComputerSession {
             default_cwd: "/brain",
             native_cross_mounts: false,
             cloudflare_native_cross_mounts: this.env.NANOCODEX_SANDBOX_LOCAL !== "true",
-            mounts: this.#accountMachines(this.#authorizationForToolContext(context)).map(({ id, mount }) => ({
+            mounts: this.#accountMachines(
+              this.#authorizationForToolContext(context),
+              context,
+            ).map(({ id, mount }) => ({
               id,
               mount,
             })),
@@ -6591,7 +6622,7 @@ export class DurableAgentSession extends DurableComputerSession {
           `an agent may retain at most ${MAX_MANAGED_MOUNTS} mounts`,
         );
       }
-      if (count + this.#userHandMachines().length >= MAX_NAMESPACE_MOUNTS - 1) {
+      if (count + this.#userHandMachines(context).length >= MAX_NAMESPACE_MOUNTS - 1) {
         throw new ManagedRequestError(
           409,
           "namespace_mount_limit_reached",
@@ -7097,7 +7128,10 @@ export class DurableAgentSession extends DurableComputerSession {
     return slots;
   }
 
-  #accountMachines(authorization: TurnAuthorization | undefined): readonly AccountMachine[] {
+  #accountMachines(
+    authorization: TurnAuthorization | undefined,
+    context?: Pick<ToolContext, "sessionId" | "subagent">,
+  ): readonly AccountMachine[] {
     if (!this.#canUseExecutionNamespace(authorization)) return [];
     return Object.freeze([
       ...this.#availableManagedMounts().map((mount) => {
@@ -7113,7 +7147,7 @@ export class DurableAgentSession extends DurableComputerSession {
         });
       }),
       ...(this.#hasFullAccountAuthority(authorization)
-        ? this.#userHandMachines()
+        ? this.#userHandMachines(context)
         : []).map((machine) => {
           const mount = machineMountRoot(machine.id);
           return Object.freeze({
@@ -7140,14 +7174,16 @@ export class DurableAgentSession extends DurableComputerSession {
     return authorization !== undefined && authorization.connectGrant === undefined;
   }
 
-  #userHandMachines(): readonly HostedMachine[] {
+  #userHandMachines(
+    context?: Pick<ToolContext, "sessionId" | "subagent">,
+  ): readonly HostedMachine[] {
     const leasedMachineIds = new Set(this.#managedMounts().flatMap((mount) => {
       const allocation = vmHostMountAllocation(mount);
       return allocation === undefined ? [] : [allocation.machine_id];
     }));
     const machines = [
       ...this.#hostedTools.machines(),
-      ...(this.#accountHostedTools?.machines() ?? []),
+      ...(this.#accountHostedTools?.machines(context) ?? []),
     ];
     const counts = new Map<string, number>();
     for (const machine of machines) counts.set(machine.id, (counts.get(machine.id) ?? 0) + 1);
@@ -7183,12 +7219,15 @@ export class DurableAgentSession extends DurableComputerSession {
     return this.#hasFullAccountAuthority();
   }
 
-  #activeTurnHostedToolAllowed(
+  #hostedToolAllowed(
     entry: HostedToolCatalogEntry,
     hostConnectGrantId?: string,
     hostAppToolCatalogDigest?: string,
+    context?: Pick<ToolContext, "sessionId" | "subagent">,
   ): boolean {
-    const authorization = this.#activeTurnAuthorization();
+    const authorization = context === undefined
+      ? this.#activeTurnAuthorization()
+      : this.#authorizationForToolContext(context);
     if (!authorization) return false;
     return hostedToolCatalogEntryAllowed(
       authorization.connectGrant,

--- a/js/managed/src/mount-tool.ts
+++ b/js/managed/src/mount-tool.ts
@@ -1,10 +1,14 @@
 import type { NamedTool, ToolContext } from "nanocodex";
+import {
+  CF_SANDBOX_PROVIDER,
+  isVmFactoryName,
+} from "./vm-factory-name";
 
 const MOUNT_NAME = /^[a-z0-9](?:[a-z0-9._-]{0,61}[a-z0-9])?$/;
 
-export const MANAGED_MOUNT_PROVIDERS = Object.freeze(["cloudflare"] as const);
+export const MANAGED_CLOUDFLARE_PROVIDER = CF_SANDBOX_PROVIDER;
 
-export type ManagedMountProvider = (typeof MANAGED_MOUNT_PROVIDERS)[number];
+export type ManagedMountProvider = string;
 
 export type ManagedMountRequest = Readonly<{
   provider: ManagedMountProvider;
@@ -25,8 +29,8 @@ export const MANAGED_MOUNT_PARAMETERS = Object.freeze({
   properties: {
     provider: {
       type: "string",
-      enum: MANAGED_MOUNT_PROVIDERS,
-      description: "Sandbox provider to mount. Cloudflare is the built-in managed provider.",
+      pattern: MOUNT_NAME.source,
+      description: "Execution provider to mount: cf_sandbox or the exact name of a connected VM factory.",
     },
     name: {
       type: "string",
@@ -76,23 +80,37 @@ export function parseManagedMountRequest(input: unknown): ManagedMountRequest {
   const value = input as Record<string, unknown>;
   const unsupported = Object.keys(value).find((key) => key !== "provider" && key !== "name");
   if (unsupported !== undefined) throw new TypeError(`mount input contains unsupported field ${unsupported}`);
-  if (value.provider !== "cloudflare") {
-    throw new TypeError("mount provider must be cloudflare");
-  }
-  if (typeof value.name !== "string" || !MOUNT_NAME.test(value.name)) {
-    throw new TypeError(
-      "mount name must be a lowercase portable identifier of 1-63 characters",
-    );
-  }
-  return Object.freeze({ provider: value.provider, name: value.name });
+  const provider = managedMountProvider(value.provider);
+  const name = portableName(value.name, "mount name");
+  return Object.freeze({ provider, name });
 }
 
 export function managedMountRoot(name: string, id: string): string {
-  const parsed = parseManagedMountRequest({ provider: "cloudflare", name });
+  const parsedName = portableName(name, "mount name");
   if (!/^[a-f0-9-]{36}$/.test(id)) throw new TypeError("mount id must be a lowercase UUID");
   const suffix = id.replaceAll("-", "").slice(-8);
-  const stem = parsed.name.slice(0, 49).replace(/[._-]+$/, "") || "hand";
+  const stem = parsedName.slice(0, 49).replace(/[._-]+$/, "") || "hand";
   return `/mnt-${stem}-${suffix}`;
+}
+
+function managedMountProvider(value: unknown): ManagedMountProvider {
+  const provider = portableName(value, "mount provider");
+  if (provider === "cloudflare") return MANAGED_CLOUDFLARE_PROVIDER;
+  if (!isVmFactoryName(provider) && provider !== MANAGED_CLOUDFLARE_PROVIDER) {
+    throw new TypeError(
+      "mount provider must be cf_sandbox or an exact non-reserved VM factory name",
+    );
+  }
+  return provider;
+}
+
+function portableName(value: unknown, name: string): string {
+  if (typeof value !== "string" || !MOUNT_NAME.test(value)) {
+    throw new TypeError(
+      `${name} must be a lowercase portable identifier of 1-63 characters`,
+    );
+  }
+  return value;
 }
 
 export function managedMountProviderResourceId(

--- a/js/managed/src/namespace-tools.ts
+++ b/js/managed/src/namespace-tools.ts
@@ -30,6 +30,7 @@ export type NamespaceMachine = Readonly<{
 export type MachineToolResolver = (
   machineId: string,
   name: HostedMachineToolName,
+  context: ToolContext,
 ) => RoutedTool | undefined;
 
 type MountedHand = Readonly<{
@@ -64,7 +65,7 @@ export type NamespaceExecutionRuntime = Readonly<{
  * so a disconnect or reconnect cannot retarget an admitted command.
  */
 export function createNamespaceExecutionRuntime(
-  machines: () => readonly NamespaceMachine[],
+  machines: (context: ToolContext) => readonly NamespaceMachine[],
   resolveMachineTool: MachineToolResolver = () => undefined,
 ): NamespaceExecutionRuntime {
   const brain = Object.freeze({
@@ -79,7 +80,7 @@ export function createNamespaceExecutionRuntime(
     const key = `${context.sessionId}\u0000${context.parentCallId}`;
     const retained = cells.get(key);
     if (retained !== undefined) return retained;
-    const created = createCellBinding(brain, machines(), resolveMachineTool, key);
+    const created = createCellBinding(brain, machines(context), resolveMachineTool, context, key);
     cells.set(key, created);
     return created;
   };
@@ -205,7 +206,7 @@ export function createNamespaceExecutionRuntime(
 }
 
 export function createNamespaceExecutionTools(
-  machines: () => readonly NamespaceMachine[],
+  machines: (context: ToolContext) => readonly NamespaceMachine[],
   resolveMachineTool: MachineToolResolver = () => undefined,
 ): ToolMap {
   return createNamespaceExecutionRuntime(machines, resolveMachineTool).tools;
@@ -217,6 +218,7 @@ function createCellBinding(
   brain: MountedHand,
   sourceMachines: readonly NamespaceMachine[],
   resolveMachineTool: MachineToolResolver,
+  context: ToolContext,
   key: string,
 ): CellBinding {
   const hands: MountedHand[] = [brain];
@@ -231,9 +233,9 @@ function createCellBinding(
       machineId: machine.id,
       root,
       workspace: machine.workspace,
-      exec: resolveMachineTool(machine.id, "exec_command"),
-      writeStdin: resolveMachineTool(machine.id, "write_stdin"),
-      preview: resolveMachineTool(machine.id, "preview"),
+      exec: resolveMachineTool(machine.id, "exec_command", context),
+      writeStdin: resolveMachineTool(machine.id, "write_stdin", context),
+      preview: resolveMachineTool(machine.id, "preview", context),
     }));
   }
   const manifest = createNamespaceManifest({

--- a/js/managed/src/vm-factory-name.ts
+++ b/js/managed/src/vm-factory-name.ts
@@ -1,0 +1,15 @@
+export const CF_SANDBOX_PROVIDER = "cf_sandbox" as const;
+export const LEGACY_CF_SANDBOX_PROVIDER = "cloudflare" as const;
+export const VM_FACTORY_NAME_PATTERN = /^[a-z0-9](?:[a-z0-9._-]{0,61}[a-z0-9])?$/;
+
+const RESERVED_VM_FACTORY_NAMES = new Set<string>([
+  CF_SANDBOX_PROVIDER,
+  LEGACY_CF_SANDBOX_PROVIDER,
+  "host",
+]);
+
+export function isVmFactoryName(value: unknown): value is string {
+  return typeof value === "string"
+    && VM_FACTORY_NAME_PATTERN.test(value)
+    && !RESERVED_VM_FACTORY_NAMES.has(value);
+}

--- a/js/managed/src/vm-host-boundary.ts
+++ b/js/managed/src/vm-host-boundary.ts
@@ -1,0 +1,13 @@
+export const VM_HOST_POOL_SCOPE = "x-nanocodex-pool-scope";
+export const VM_HOST_POOL_OWNER = "x-nanocodex-pool-owner";
+export const VM_HOST_POOL_AGENT = "x-nanocodex-pool-agent";
+export const VM_HOST_DONOR = "x-nanocodex-donor-id";
+export const VM_HOST_PUBLIC_ORIGIN = "x-nanocodex-public-origin";
+export const VM_HOST_POOL_LOCATOR = "x-nanocodex-pool-locator";
+
+export const VM_HOST_ATTACHMENT_ROUTE =
+  /^vm-host:[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}:[1-9][0-9]{0,15}$/;
+
+export function vmHostAttachmentRouteId(allocationId: string, hostEpoch: number): string {
+  return `vm-host:${allocationId}:${hostEpoch}`;
+}

--- a/js/managed/src/vm-host-pool.ts
+++ b/js/managed/src/vm-host-pool.ts
@@ -1,0 +1,1207 @@
+import { DurableObject } from "cloudflare:workers";
+
+import { isUserId } from "./account-auth";
+import { isVmFactoryName } from "./vm-factory-name";
+import {
+  VM_HOST_DONOR as DONOR_ID,
+  VM_HOST_POOL_AGENT as POOL_AGENT,
+  VM_HOST_POOL_LOCATOR as POOL_LOCATOR,
+  VM_HOST_POOL_OWNER as POOL_OWNER,
+  VM_HOST_POOL_SCOPE as POOL_SCOPE,
+  VM_HOST_PUBLIC_ORIGIN as PUBLIC_ORIGIN,
+  vmHostAttachmentRouteId,
+} from "./vm-host-boundary";
+import {
+  VM_HOST_LEASE_MS,
+  VM_HOST_PROTOCOL_VERSION,
+  VmHostProtocolError,
+  matchesVmHostLease,
+  parseVmHostCommand,
+  type VmHostCommand,
+  type VmHostServerMessage,
+  type VmShape,
+} from "./vm-host-protocol";
+
+const OPAQUE = /^[A-Za-z0-9_-]{43}$/;
+const SAFE_ID = /^[A-Za-z0-9._:-]{1,128}$/;
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+type PoolScope = "agent" | "account" | "system";
+type AllocationState = "provisioning" | "ready" | "releasing" | "released";
+
+type PoolClaim = {
+  scope: PoolScope;
+  owner_id: string | null;
+  agent_id: string | null;
+  pool_locator: string;
+};
+
+type HostRow = {
+  host_id: string;
+  factory_name: string;
+  donor_id: string;
+  max_vms: number;
+  vm_cpus: number;
+  vm_memory_mib: number;
+  public_origin: string;
+  epoch: number;
+  lease_id: string | null;
+  lease_expires_at: number;
+};
+
+type AllocationRow = {
+  allocation_id: string;
+  generation: number;
+  factory_name: string;
+  owner_id: string;
+  organization_id: string;
+  team_id: string;
+  authorization_epoch: number;
+  agent_id: string;
+  mount_id: string;
+  public_origin: string;
+  pool_locator: string;
+  machine_id: string;
+  host_id: string;
+  lease_id: string | null;
+  host_epoch: number | null;
+  slot: number;
+  bearer: string;
+  state: AllocationState;
+  created_at: number;
+  updated_at: number;
+};
+
+type HostAttachment = {
+  kind: "vm-host";
+  donorId: string;
+  publicOrigin: string;
+  hostId?: string;
+  leaseId?: string;
+  epoch?: number;
+};
+
+type HostClaim = PoolClaim & { donorId: string; publicOrigin: string };
+
+type AcquireRequest = {
+  factory_name: string;
+  owner_id: string;
+  organization_id: string;
+  team_id: string;
+  authorization_epoch: number;
+  agent_id: string;
+  mount_id: string;
+  pool_locator: string;
+};
+
+type AllocationIdentity = {
+  owner_id: string;
+  agent_id: string;
+  mount_id: string;
+  allocation_id: string;
+  generation: number;
+  pool_locator: string;
+};
+
+type AllocationReleaseIntent = AcquireRequest;
+
+export type VmHostPoolEnv = {
+  NANOCODEX_SESSIONS: DurableObjectNamespace;
+};
+
+/** A scope-keyed, durable scheduler for independently connected VM hosts. */
+export class VmHostPool extends DurableObject<VmHostPoolEnv> {
+  readonly #env: VmHostPoolEnv;
+
+  constructor(ctx: DurableObjectState, env: VmHostPoolEnv) {
+    super(ctx, env);
+    this.#env = env;
+    this.ctx.storage.sql.exec(`
+      CREATE TABLE IF NOT EXISTS vm_pool_claim (
+        singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+        scope TEXT NOT NULL CHECK (scope IN ('agent', 'account', 'system')),
+        owner_id TEXT,
+        agent_id TEXT,
+        pool_locator TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS vm_hosts (
+        host_id TEXT PRIMARY KEY,
+        factory_name TEXT NOT NULL UNIQUE,
+        donor_id TEXT NOT NULL,
+        max_vms INTEGER NOT NULL CHECK (max_vms BETWEEN 1 AND 64),
+        vm_cpus INTEGER NOT NULL CHECK (vm_cpus BETWEEN 1 AND 64),
+        vm_memory_mib INTEGER NOT NULL CHECK (vm_memory_mib BETWEEN 128 AND 262144),
+        public_origin TEXT NOT NULL,
+        epoch INTEGER NOT NULL DEFAULT 0,
+        lease_id TEXT,
+        lease_expires_at INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE TABLE IF NOT EXISTS vm_allocations (
+        allocation_id TEXT PRIMARY KEY,
+        generation INTEGER NOT NULL CHECK (generation >= 1),
+        factory_name TEXT NOT NULL,
+        owner_id TEXT NOT NULL,
+        organization_id TEXT NOT NULL,
+        team_id TEXT NOT NULL,
+        authorization_epoch INTEGER NOT NULL CHECK (authorization_epoch >= 0),
+        agent_id TEXT NOT NULL,
+        mount_id TEXT NOT NULL,
+        public_origin TEXT NOT NULL,
+        pool_locator TEXT NOT NULL,
+        machine_id TEXT NOT NULL,
+        host_id TEXT NOT NULL,
+        lease_id TEXT,
+        host_epoch INTEGER,
+        slot INTEGER NOT NULL CHECK (slot >= 0),
+        bearer TEXT NOT NULL,
+        state TEXT NOT NULL CHECK (state IN ('provisioning', 'ready', 'releasing', 'released')),
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        UNIQUE(owner_id, agent_id, mount_id),
+        FOREIGN KEY(host_id) REFERENCES vm_hosts(host_id)
+      );
+      CREATE INDEX IF NOT EXISTS vm_allocations_host_state
+        ON vm_allocations(host_id, state, slot);
+      CREATE UNIQUE INDEX IF NOT EXISTS vm_allocations_live_slot
+        ON vm_allocations(host_id, slot)
+        WHERE state IN ('provisioning', 'ready', 'releasing');
+      CREATE TABLE IF NOT EXISTS vm_allocation_release_intents (
+        owner_id TEXT NOT NULL,
+        organization_id TEXT NOT NULL,
+        team_id TEXT NOT NULL,
+        authorization_epoch INTEGER NOT NULL,
+        agent_id TEXT NOT NULL,
+        mount_id TEXT NOT NULL,
+        pool_locator TEXT NOT NULL,
+        factory_name TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        PRIMARY KEY(owner_id, agent_id, mount_id)
+      );
+    `);
+    const hostColumns = new Set(this.ctx.storage.sql.exec<{ name: string }>(
+      "PRAGMA table_info(vm_hosts)",
+    ).toArray().map((column) => column.name));
+    if (!hostColumns.has("public_origin")) {
+      this.ctx.storage.sql.exec(
+        "ALTER TABLE vm_hosts ADD COLUMN public_origin TEXT NOT NULL DEFAULT ''",
+      );
+    }
+    const allocationColumns = new Set(this.ctx.storage.sql.exec<{ name: string }>(
+      "PRAGMA table_info(vm_allocations)",
+    ).toArray().map((column) => column.name));
+    if (!allocationColumns.has("public_origin")) {
+      this.ctx.storage.sql.exec(
+        "ALTER TABLE vm_allocations ADD COLUMN public_origin TEXT NOT NULL DEFAULT ''",
+      );
+    }
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (request.method === "GET" && url.pathname === "/host") {
+      if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+        return new Response("Expected WebSocket upgrade", { status: 426 });
+      }
+      const claim = hostClaim(request.headers);
+      if (!claim || !this.#claimPool(claim)) return notFound();
+      const pair = new WebSocketPair();
+      const [client, server] = Object.values(pair);
+      server.serializeAttachment({
+        kind: "vm-host",
+        donorId: claim.donorId,
+        publicOrigin: claim.publicOrigin,
+      } satisfies HostAttachment);
+      this.ctx.acceptWebSocket(server, ["vm-host"]);
+      return new Response(null, { status: 101, webSocket: client });
+    }
+    if (request.method === "POST" && url.pathname === "/acquire") {
+      const body = await readObject(request);
+      const acquire = body && acquireRequest(body);
+      if (!acquire) return notFound();
+      const claim = this.#poolClaim();
+      if (!claim) {
+        return Response.json({ error: "factory_not_found" }, { status: 404 });
+      }
+      if (!this.#allows(acquire)) return notFound();
+      return this.#acquire(acquire);
+    }
+    if (request.method === "POST" && url.pathname === "/release") {
+      const body = await readObject(request);
+      const identity = body && allocationIdentity(body);
+      if (!identity || !this.#allows(identity)) return notFound();
+      return this.#release(identity);
+    }
+    if (request.method === "POST" && url.pathname === "/release-intent") {
+      const body = await readObject(request);
+      const intent = body && acquireRequest(body);
+      if (!intent || !this.#allows(intent)) return notFound();
+      return this.#releaseIntent(intent);
+    }
+    if (request.method === "POST" && url.pathname === "/validate-attachment") {
+      const body = await readObject(request);
+      if (!body || !hasExactKeys(body, ["allocation_id", "bearer"])
+        || !uuidV4(body.allocation_id) || !opaque(body.bearer)) return notFound();
+      return this.#validateAttachment(body.allocation_id, body.bearer);
+    }
+    if (request.method === "POST" && url.pathname === "/ready") {
+      const body = await readObject(request);
+      const identity = body && allocationIdentity(body);
+      if (!identity || !this.#allows(identity)) return notFound();
+      return this.#ready(identity);
+    }
+    return notFound();
+  }
+
+  async alarm(): Promise<void> {
+    const now = Date.now();
+    const expired = this.ctx.storage.sql.exec<{
+      host_id: string;
+      lease_id: string;
+      epoch: number;
+    }>(
+      `SELECT host_id, lease_id, epoch FROM vm_hosts
+       WHERE lease_id IS NOT NULL AND lease_expires_at > 0 AND lease_expires_at <= ?`,
+      now,
+    ).toArray();
+    for (const { host_id: hostId, lease_id: leaseId, epoch } of expired) {
+      this.ctx.storage.sql.exec(
+        `UPDATE vm_hosts SET lease_expires_at = 0
+         WHERE host_id = ? AND lease_id = ? AND epoch = ? AND lease_expires_at <= ?`,
+        hostId, leaseId, epoch, now,
+      );
+      const connected = this.#socketForHostLease(hostId, leaseId, epoch);
+      if (connected) closeSocket(connected.socket, 1008, "VM host lease expired");
+      await this.#revokeHostAttachments(
+        hostId, leaseId, epoch, "VM host control lease expired",
+      );
+    }
+    await this.#scheduleLeaseAlarm();
+  }
+
+  async webSocketMessage(socket: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    const attachment = socket.deserializeAttachment() as HostAttachment | null;
+    if (attachment?.kind !== "vm-host") {
+      closeSocket(socket, 1008, "invalid VM host socket");
+      return;
+    }
+    let command: VmHostCommand;
+    try {
+      command = parseVmHostCommand(typeof message === "string"
+        ? message
+        : new TextDecoder().decode(message));
+    } catch (error) {
+      const protocol = error instanceof VmHostProtocolError
+        ? error
+        : new VmHostProtocolError("invalid_message", errorMessage(error));
+      this.#send(socket, { type: "error", code: protocol.code, message: protocol.message });
+      return;
+    }
+    try {
+      if (command.type === "attach") {
+      await this.#attachHost(socket, attachment, command);
+        return;
+      }
+      const host = this.#requireLease(socket, attachment, command.lease_id, command.epoch);
+      if (command.type === "ping") {
+        this.#renewLease(socket, host, command);
+      } else if (command.type === "reconcile") {
+        this.#reconcile(socket, host, command);
+      } else if (command.type === "provisioned") {
+        this.#provisioned(socket, host, command);
+      } else {
+        this.#released(socket, host, command);
+      }
+    } catch (error) {
+      const protocol = error instanceof VmHostProtocolError
+        ? error
+        : new VmHostProtocolError("vm_host_failed", errorMessage(error));
+      if (protocol.code !== "stale_lease") {
+        this.#send(socket, { type: "error", code: protocol.code, message: protocol.message });
+      }
+    }
+  }
+
+  webSocketClose(socket: WebSocket): void { this.#retireSocket(socket); }
+
+  webSocketError(socket: WebSocket): void { this.#retireSocket(socket); }
+
+  #claimPool(candidate: HostClaim): boolean {
+    return this.ctx.storage.transactionSync(() => {
+      const current = this.#poolClaim();
+      if (current) {
+        return current.scope === candidate.scope
+          && current.owner_id === candidate.owner_id
+          && current.agent_id === candidate.agent_id
+          && current.pool_locator === candidate.pool_locator;
+      }
+      this.ctx.storage.sql.exec(
+        `INSERT INTO vm_pool_claim
+          (singleton, scope, owner_id, agent_id, pool_locator)
+         VALUES (1, ?, ?, ?, ?)`,
+        candidate.scope,
+        candidate.owner_id,
+        candidate.agent_id,
+        candidate.pool_locator,
+      );
+      return true;
+    });
+  }
+
+  #allows(candidate: Pick<AcquireRequest, "owner_id" | "agent_id" | "pool_locator">): boolean {
+    const claim = this.#poolClaim();
+    if (!claim || claim.pool_locator !== candidate.pool_locator) return false;
+    if (claim.scope === "system") return true;
+    if (claim.owner_id !== candidate.owner_id) return false;
+    return claim.scope === "account" || claim.agent_id === candidate.agent_id;
+  }
+
+  async #acquire(input: AcquireRequest): Promise<Response> {
+    const allocationId = crypto.randomUUID();
+    const bearer = randomOpaque();
+    const now = Date.now();
+    let created = false;
+    let factoryExists = false;
+    let cancelled = false;
+    const allocation = this.ctx.storage.transactionSync(() => {
+      const releaseIntent = this.#releaseIntentRow(input.owner_id, input.agent_id, input.mount_id);
+      if (releaseIntent !== undefined) {
+        if (!sameAcquire(releaseIntent, input)) return undefined;
+        cancelled = true;
+        return null;
+      }
+      const existing = this.ctx.storage.sql.exec<AllocationRow>(
+        `SELECT * FROM vm_allocations
+         WHERE owner_id = ? AND agent_id = ? AND mount_id = ?`,
+        input.owner_id,
+        input.agent_id,
+        input.mount_id,
+      ).toArray()[0];
+      if (existing) {
+        if (!sameAcquire(existing, input)) return undefined;
+        return existing;
+      }
+      const host = this.ctx.storage.sql.exec<HostRow>(
+        "SELECT * FROM vm_hosts WHERE factory_name = ?",
+        input.factory_name,
+      ).toArray()[0];
+      if (!host) return null;
+      factoryExists = true;
+      if (this.#socketFor(host) === undefined) {
+        return null;
+      }
+      const occupied = new Set(this.ctx.storage.sql.exec<{ slot: number }>(
+        `SELECT slot FROM vm_allocations
+         WHERE host_id = ? AND state IN ('provisioning', 'ready', 'releasing')`,
+        host.host_id,
+      ).toArray().map(({ slot }) => slot));
+      let slot = 0;
+      while (slot < host.max_vms && occupied.has(slot)) slot += 1;
+      if (slot >= host.max_vms) return null;
+      const row: AllocationRow = {
+        allocation_id: allocationId,
+        generation: 1,
+        factory_name: input.factory_name,
+        owner_id: input.owner_id,
+        organization_id: input.organization_id,
+        team_id: input.team_id,
+        authorization_epoch: input.authorization_epoch,
+        agent_id: input.agent_id,
+        mount_id: input.mount_id,
+        public_origin: host.public_origin,
+        pool_locator: input.pool_locator,
+        machine_id: `vm:${input.mount_id}`,
+        host_id: host.host_id,
+        lease_id: host.lease_id,
+        host_epoch: host.epoch,
+        slot,
+        bearer,
+        state: "provisioning",
+        created_at: now,
+        updated_at: now,
+      };
+      this.ctx.storage.sql.exec(
+        `INSERT INTO vm_allocations (
+           allocation_id, generation, factory_name, owner_id, organization_id, team_id,
+           authorization_epoch, agent_id, mount_id, public_origin, pool_locator,
+           machine_id, host_id, lease_id, host_epoch, slot, bearer,
+           state, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        row.allocation_id, row.generation, row.factory_name, row.owner_id,
+        row.organization_id, row.team_id, row.authorization_epoch, row.agent_id,
+        row.mount_id, row.public_origin, row.pool_locator, row.machine_id, row.host_id,
+        row.lease_id, row.host_epoch, row.slot, row.bearer, row.state,
+        row.created_at, row.updated_at,
+      );
+      created = true;
+      return row;
+    });
+    if (allocation === undefined) {
+      return Response.json({ error: "allocation_conflict" }, { status: 409 });
+    }
+    if (allocation === null) {
+      if (cancelled) {
+        return Response.json({ error: "allocation_released" }, { status: 409 });
+      }
+      return Response.json({
+        error: factoryExists ? "factory_unavailable" : "factory_not_found",
+      }, { status: factoryExists ? 409 : 404 });
+    }
+    if (allocation.state === "released") {
+      return Response.json({ error: "allocation_released" }, { status: 409 });
+    }
+    if (created) this.#dispatchProvision(allocation);
+    else this.#redrive(allocation);
+    return Response.json(publicAllocation(allocation, this.#currentRouteId(allocation)), {
+      status: created ? 201 : 200,
+      headers: { "cache-control": "no-store" },
+    });
+  }
+
+  #release(identity: AllocationIdentity): Response {
+    let changed = false;
+    const allocation = this.ctx.storage.transactionSync(() => {
+      const row = this.#allocation(identity.allocation_id);
+      if (!row || !sameIdentity(row, identity)) return undefined;
+      if (row.state === "released" || row.state === "releasing") return row;
+      this.ctx.storage.sql.exec(
+        `UPDATE vm_allocations SET state = 'releasing', updated_at = ?
+         WHERE allocation_id = ? AND generation = ?`,
+        Date.now(), row.allocation_id, row.generation,
+      );
+      changed = true;
+      return { ...row, state: "releasing" as const };
+    });
+    if (!allocation) return notFound();
+    if (allocation.state === "releasing") this.#dispatchRelease(allocation);
+    return Response.json({
+      ...publicAllocation(allocation, this.#currentRouteId(allocation)),
+      state: allocation.state,
+    }, {
+      status: changed ? 202 : 200,
+      headers: { "cache-control": "no-store" },
+    });
+  }
+
+  #releaseIntent(intent: AllocationReleaseIntent): Response {
+    const allocation = this.ctx.storage.transactionSync(() => {
+      const retained = this.#releaseIntentRow(intent.owner_id, intent.agent_id, intent.mount_id);
+      if (retained !== undefined && !sameAcquire(retained, intent)) return undefined;
+      if (retained === undefined) {
+        this.ctx.storage.sql.exec(
+          `INSERT INTO vm_allocation_release_intents (
+             owner_id, organization_id, team_id, authorization_epoch, agent_id,
+             mount_id, pool_locator, factory_name, created_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          intent.owner_id,
+          intent.organization_id,
+          intent.team_id,
+          intent.authorization_epoch,
+          intent.agent_id,
+          intent.mount_id,
+          intent.pool_locator,
+          intent.factory_name,
+          Date.now(),
+        );
+      }
+      const row = this.ctx.storage.sql.exec<AllocationRow>(
+        `SELECT * FROM vm_allocations
+         WHERE owner_id = ? AND agent_id = ? AND mount_id = ?`,
+        intent.owner_id, intent.agent_id, intent.mount_id,
+      ).toArray()[0];
+      return row === undefined || sameAcquire(row, intent) ? row ?? null : undefined;
+    });
+    if (allocation === undefined) return notFound();
+    if (allocation === null) {
+      return Response.json({ state: "released" }, {
+        headers: { "cache-control": "no-store" },
+      });
+    }
+    return this.#release({
+      owner_id: allocation.owner_id,
+      agent_id: allocation.agent_id,
+      mount_id: allocation.mount_id,
+      allocation_id: allocation.allocation_id,
+      generation: allocation.generation,
+      pool_locator: allocation.pool_locator,
+    });
+  }
+
+  async #validateAttachment(allocationId: string, bearer: string): Promise<Response> {
+    const allocation = this.#allocation(allocationId);
+    const host = allocation === undefined ? undefined : this.#host(allocation.host_id);
+    const connected = host === undefined ? undefined : this.#socketFor(host);
+    const valid = allocation !== undefined
+      && host !== undefined
+      && connected !== undefined
+      && liveLease(connected.attachment, host, Date.now())
+      && allocation.lease_id === host.lease_id
+      && allocation.host_epoch === host.epoch
+      && (allocation.state === "provisioning" || allocation.state === "ready")
+      && constantTimeEqual(allocation.bearer, bearer);
+    if (!valid || !allocation || !host) return notFound();
+    return Response.json({
+      valid: true,
+      allocation_id: allocation.allocation_id,
+      generation: allocation.generation,
+      owner_id: allocation.owner_id,
+      organization_id: allocation.organization_id,
+      team_id: allocation.team_id,
+      authorization_epoch: allocation.authorization_epoch,
+      agent_id: allocation.agent_id,
+      mount_id: allocation.mount_id,
+      public_origin: allocation.public_origin,
+      machine_id: allocation.machine_id,
+      lease_expires_at: host.lease_expires_at,
+      route_id: vmHostAttachmentRouteId(allocation.allocation_id, host.epoch),
+    }, { headers: { "cache-control": "no-store" } });
+  }
+
+  #ready(identity: AllocationIdentity): Response {
+    const allocation = this.#allocation(identity.allocation_id);
+    if (!allocation || !sameIdentity(allocation, identity)) return notFound();
+    const routeId = this.#currentRouteId(allocation);
+    return Response.json({
+      ...publicAllocation(allocation, routeId),
+      ready: allocation.state === "ready" && routeId !== undefined,
+      state: allocation.state,
+    }, { headers: { "cache-control": "no-store" } });
+  }
+
+  async #attachHost(
+    socket: WebSocket,
+    attachment: HostAttachment,
+    command: Extract<VmHostCommand, { type: "attach" }>,
+  ): Promise<void> {
+    if (attachment.hostId || attachment.leaseId || attachment.epoch) {
+      throw new VmHostProtocolError("already_attached", "this socket already holds a VM host lease");
+    }
+    const existing = this.#host(command.host_id);
+    const named = this.#factory(command.factory_name);
+    if (existing && existing.donor_id !== attachment.donorId) {
+      throw new VmHostProtocolError("host_conflict", "host_id is owned by a different donor");
+    }
+    if (existing && existing.factory_name !== command.factory_name) {
+      throw new VmHostProtocolError(
+        "host_name_conflict",
+        "factory_name is immutable for an existing host_id",
+      );
+    }
+    if (named && named.host_id !== command.host_id) {
+      throw new VmHostProtocolError(
+        "factory_name_conflict",
+        "factory_name is already owned by a different host",
+      );
+    }
+    if (existing && (existing.max_vms !== command.max_vms
+      || existing.vm_cpus !== command.vm.cpus
+      || existing.vm_memory_mib !== command.vm.memory_mib)) {
+      throw new VmHostProtocolError("host_shape_conflict", "host capacity and VM shape are immutable");
+    }
+    if ((existing?.epoch ?? 0) >= Number.MAX_SAFE_INTEGER) {
+      throw new VmHostProtocolError("lease_exhausted", "the VM host lease epoch is exhausted");
+    }
+    if (existing?.lease_id) {
+      await this.#revokeHostAttachments(
+        command.host_id,
+        existing.lease_id,
+        existing.epoch,
+        "VM host control lease was replaced",
+      );
+      const current = this.#host(command.host_id);
+      if (current?.lease_id !== existing.lease_id || current?.epoch !== existing.epoch) {
+        throw new VmHostProtocolError(
+          "host_replacement_raced",
+          "another connection replaced this VM host while its old routes were fenced",
+        );
+      }
+    }
+    const leaseId = crypto.randomUUID();
+    const epoch = (existing?.epoch ?? 0) + 1;
+    const expiresAt = Date.now() + VM_HOST_LEASE_MS;
+    this.ctx.storage.sql.exec(
+      `INSERT INTO vm_hosts
+         (host_id, factory_name, donor_id, max_vms, vm_cpus, vm_memory_mib,
+          public_origin, epoch, lease_id, lease_expires_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(host_id) DO UPDATE SET
+         public_origin = excluded.public_origin,
+         epoch = excluded.epoch,
+         lease_id = excluded.lease_id,
+         lease_expires_at = excluded.lease_expires_at`,
+      command.host_id, command.factory_name, attachment.donorId, command.max_vms,
+      command.vm.cpus, command.vm.memory_mib, attachment.publicOrigin,
+      epoch, leaseId, expiresAt,
+    );
+    this.ctx.storage.sql.exec(
+      `UPDATE vm_allocations SET public_origin = ?, updated_at = ?
+       WHERE host_id = ? AND state IN ('provisioning', 'ready', 'releasing')`,
+      attachment.publicOrigin, Date.now(), command.host_id,
+    );
+    for (const candidate of this.ctx.getWebSockets("vm-host")) {
+      if (candidate === socket) continue;
+      const candidateAttachment = candidate.deserializeAttachment() as HostAttachment | null;
+      if (candidateAttachment?.kind !== "vm-host" || candidateAttachment.hostId !== command.host_id) continue;
+      try {
+        this.#send(candidate, {
+          type: "fenced",
+          epoch,
+          reason: "a newer connection acquired this VM host identity",
+        });
+      } catch { /* Closing is the authoritative fence. */ }
+      closeSocket(candidate, 1008, "VM host lease replaced");
+    }
+    socket.serializeAttachment({
+      ...attachment,
+      hostId: command.host_id,
+      leaseId,
+      epoch,
+    } satisfies HostAttachment);
+    this.#send(socket, {
+      type: "lease",
+      protocol_version: VM_HOST_PROTOCOL_VERSION,
+      lease_id: leaseId,
+      epoch,
+      expires_at: expiresAt,
+      max_vms: command.max_vms,
+      vm: command.vm,
+    });
+    this.ctx.waitUntil(this.#scheduleLeaseAlarm());
+  }
+
+  #requireLease(
+    socket: WebSocket,
+    attachment: HostAttachment,
+    leaseId: string,
+    epoch: number,
+  ): HostRow {
+    const host = attachment.hostId ? this.#host(attachment.hostId) : undefined;
+    if (!host || attachment.leaseId !== leaseId || attachment.epoch !== epoch
+      || !liveLease(attachment, host, Date.now())) {
+      try {
+        this.#send(socket, {
+          type: "fenced",
+          epoch: host?.epoch ?? 0,
+          reason: "the VM host lease is stale or expired",
+        });
+      } catch { /* Closing is the authoritative fence. */ }
+      closeSocket(socket, 1008, "stale VM host lease");
+      throw new VmHostProtocolError("stale_lease", "the VM host lease is stale or expired");
+    }
+    const leaseExpiresAt = Date.now() + VM_HOST_LEASE_MS;
+    this.ctx.storage.sql.exec(
+      `UPDATE vm_hosts SET lease_expires_at = ?
+       WHERE host_id = ? AND lease_id = ? AND epoch = ?`,
+      leaseExpiresAt, host.host_id, leaseId, epoch,
+    );
+    this.ctx.waitUntil(this.#scheduleLeaseAlarm());
+    return { ...host, lease_expires_at: leaseExpiresAt };
+  }
+
+  #renewLease(
+    socket: WebSocket,
+    host: HostRow,
+    command: Extract<VmHostCommand, { type: "ping" }>,
+  ): void {
+    this.#send(socket, {
+      type: "pong",
+      lease_id: command.lease_id,
+      epoch: command.epoch,
+      expires_at: host.lease_expires_at,
+      ...(command.nonce === undefined ? {} : { nonce: command.nonce }),
+    });
+  }
+
+  #reconcile(
+    socket: WebSocket,
+    host: HostRow,
+    command: Extract<VmHostCommand, { type: "reconcile" }>,
+  ): void {
+    const reported = new Map(command.allocations.map((entry) => [entry.allocation_id, entry]));
+    const desired = this.ctx.storage.sql.exec<AllocationRow>(
+      `SELECT * FROM vm_allocations
+       WHERE host_id = ? AND state IN ('provisioning', 'ready', 'releasing')
+       ORDER BY slot ASC`,
+      host.host_id,
+    ).toArray();
+    const desiredIds = new Set(desired.map(({ allocation_id }) => allocation_id));
+    for (const allocation of desired) {
+      const rebound = allocation.lease_id !== host.lease_id
+        || allocation.host_epoch !== host.epoch;
+      const bound = this.#bindAllocation(allocation, host);
+      const actual = reported.get(allocation.allocation_id);
+      if (allocation.state === "releasing") {
+        this.#sendRelease(socket, host, bound);
+      } else if (rebound) {
+        // A successor may already have the VM on disk, but it cannot keep using
+        // the predecessor's attachment capability. Deliver the newly
+        // epoch-bound bearer through the idempotent provision command.
+        this.#sendProvision(socket, host, bound);
+      } else if (actual && actual.generation === allocation.generation
+        && actual.machine_id === allocation.machine_id) {
+        if (allocation.state === "provisioning") this.#markReady(bound);
+      } else {
+        this.#sendProvision(socket, host, bound);
+      }
+    }
+    for (const actual of command.allocations) {
+      if (desiredIds.has(actual.allocation_id)) continue;
+      this.#send(socket, {
+        type: "release",
+        lease_id: host.lease_id!,
+        epoch: host.epoch,
+        allocation_id: actual.allocation_id,
+        generation: actual.generation,
+        machine_id: actual.machine_id,
+      });
+    }
+  }
+
+  #provisioned(
+    _socket: WebSocket,
+    host: HostRow,
+    command: Extract<VmHostCommand, { type: "provisioned" }>,
+  ): void {
+    const allocation = this.#allocation(command.allocation_id);
+    if (!allocation || allocation.host_id !== host.host_id
+      || allocation.generation !== command.generation
+      || allocation.machine_id !== command.machine_id
+      || allocation.state === "released") {
+      throw new VmHostProtocolError("unknown_allocation", "allocation is not provisionable by this host");
+    }
+    if (allocation.state === "releasing") return;
+    this.#markReady(allocation);
+  }
+
+  #released(
+    _socket: WebSocket,
+    host: HostRow,
+    command: Extract<VmHostCommand, { type: "released" }>,
+  ): void {
+    const allocation = this.#allocation(command.allocation_id);
+    if (!allocation || allocation.host_id !== host.host_id
+      || allocation.generation !== command.generation
+      || allocation.machine_id !== command.machine_id) {
+      // Releasing a host-only allocation during reconcile is deliberately
+      // idempotent and has no durable row to update.
+      return;
+    }
+    if (allocation.state !== "releasing" && allocation.state !== "released") {
+      throw new VmHostProtocolError("unexpected_release", "allocation was not pending release");
+    }
+    this.ctx.storage.sql.exec(
+      `UPDATE vm_allocations SET state = 'released', lease_id = NULL,
+         host_epoch = NULL, updated_at = ?
+       WHERE allocation_id = ? AND generation = ?`,
+      Date.now(), allocation.allocation_id, allocation.generation,
+    );
+  }
+
+  #redrive(allocation: AllocationRow): void {
+    if (allocation.state === "provisioning") this.#dispatchProvision(allocation);
+    if (allocation.state === "releasing") this.#dispatchRelease(allocation);
+  }
+
+  #dispatchProvision(allocation: AllocationRow): void {
+    const host = this.#host(allocation.host_id);
+    if (!host) return;
+    const connected = this.#socketFor(host);
+    if (!connected) return;
+    const bound = this.#bindAllocation(allocation, host);
+    this.#sendProvision(connected.socket, host, bound);
+  }
+
+  #dispatchRelease(allocation: AllocationRow): void {
+    const host = this.#host(allocation.host_id);
+    if (!host) return;
+    const connected = this.#socketFor(host);
+    if (!connected) return;
+    const bound = this.#bindAllocation(allocation, host);
+    this.#sendRelease(connected.socket, host, bound);
+  }
+
+  #sendProvision(socket: WebSocket, host: HostRow, allocation: AllocationRow): void {
+    this.#send(socket, {
+      type: "provision",
+      lease_id: host.lease_id!,
+      epoch: host.epoch,
+      allocation_id: allocation.allocation_id,
+      generation: allocation.generation,
+      slot: allocation.slot,
+      machine_id: allocation.machine_id,
+      tool_attachment: {
+        url: attachmentUrl(allocation),
+        bearer: allocation.bearer,
+      },
+    });
+  }
+
+  #sendRelease(socket: WebSocket, host: HostRow, allocation: AllocationRow): void {
+    this.#send(socket, {
+      type: "release",
+      lease_id: host.lease_id!,
+      epoch: host.epoch,
+      allocation_id: allocation.allocation_id,
+      generation: allocation.generation,
+      machine_id: allocation.machine_id,
+    });
+  }
+
+  #bindAllocation(allocation: AllocationRow, host: HostRow): AllocationRow {
+    if (allocation.lease_id === host.lease_id && allocation.host_epoch === host.epoch) {
+      return allocation;
+    }
+    const bearer = randomOpaque();
+    const updatedAt = Date.now();
+    this.ctx.storage.sql.exec(
+      `UPDATE vm_allocations SET lease_id = ?, host_epoch = ?, bearer = ?, updated_at = ?
+       WHERE allocation_id = ? AND generation = ? AND state != 'released'`,
+      host.lease_id, host.epoch, bearer, updatedAt,
+      allocation.allocation_id, allocation.generation,
+    );
+    return {
+      ...allocation,
+      lease_id: host.lease_id,
+      host_epoch: host.epoch,
+      bearer,
+      updated_at: updatedAt,
+    };
+  }
+
+  #markReady(allocation: AllocationRow): void {
+    this.ctx.storage.sql.exec(
+      `UPDATE vm_allocations SET state = 'ready', updated_at = ?
+       WHERE allocation_id = ? AND generation = ? AND state = 'provisioning'`,
+      Date.now(), allocation.allocation_id, allocation.generation,
+    );
+  }
+
+  #retireSocket(socket: WebSocket): void {
+    const attachment = socket.deserializeAttachment() as HostAttachment | null;
+    if (attachment?.kind !== "vm-host" || !attachment.hostId
+      || !attachment.leaseId || attachment.epoch === undefined) return;
+    this.ctx.storage.sql.exec(
+      `UPDATE vm_hosts SET lease_expires_at = 0
+       WHERE host_id = ? AND lease_id = ? AND epoch = ?`,
+      attachment.hostId, attachment.leaseId, attachment.epoch,
+    );
+    this.ctx.waitUntil(this.#revokeHostAttachments(
+      attachment.hostId, attachment.leaseId, attachment.epoch,
+      "VM host control socket closed",
+    ).catch((error) => {
+      console.warn({ type: "vm_host_attachment_revoke_failed", error: errorMessage(error) });
+    }));
+    this.ctx.waitUntil(this.#scheduleLeaseAlarm());
+  }
+
+  async #revokeHostAttachments(
+    hostId: string,
+    leaseId: string,
+    hostEpoch: number,
+    reason: string,
+  ): Promise<void> {
+    const allocations = this.ctx.storage.sql.exec<Pick<
+      AllocationRow,
+      "agent_id" | "allocation_id"
+    >>(
+      `SELECT agent_id, allocation_id FROM vm_allocations
+       WHERE host_id = ? AND lease_id = ? AND host_epoch = ?
+         AND state IN ('provisioning', 'ready', 'releasing')`,
+      hostId, leaseId, hostEpoch,
+    ).toArray();
+    const responses = await Promise.all(allocations.map(({ agent_id: agentId, allocation_id: allocationId }) => (
+      this.#env.NANOCODEX_SESSIONS.getByName(agentId).fetch(
+        "https://session.internal/vm-host-revoke",
+        {
+          method: "POST",
+          headers: {
+            "x-nanocodex-vm-route-id": vmHostAttachmentRouteId(allocationId, hostEpoch),
+            "x-nanocodex-vm-revoke-reason": reason,
+          },
+        },
+      )
+    )));
+    await Promise.all(responses.map(async (response) => {
+      if (!response.ok) {
+        await response.body?.cancel();
+        throw new Error(`VM host attachment revocation failed with HTTP ${response.status}`);
+      }
+      await response.body?.cancel();
+    }));
+  }
+
+  async #scheduleLeaseAlarm(): Promise<void> {
+    const next = this.ctx.storage.sql.exec<{ expires_at: number | null }>(
+      `SELECT MIN(lease_expires_at) AS expires_at FROM vm_hosts
+       WHERE lease_id IS NOT NULL AND lease_expires_at > ?`,
+      Date.now(),
+    ).toArray()[0]?.expires_at;
+    if (next === null || next === undefined) await this.ctx.storage.deleteAlarm();
+    else await this.ctx.storage.setAlarm(next);
+  }
+
+  #socketFor(host: HostRow): { socket: WebSocket; attachment: HostAttachment } | undefined {
+    if (!host.lease_id || host.lease_expires_at < Date.now()) return undefined;
+    const connected = this.#socketForHostLease(host.host_id, host.lease_id, host.epoch);
+    return connected && connected.socket.readyState === WebSocket.OPEN ? connected : undefined;
+  }
+
+  #currentRouteId(allocation: AllocationRow): string | undefined {
+    if (!allocation.lease_id || allocation.host_epoch === null) return undefined;
+    const host = this.#host(allocation.host_id);
+    if (!host || host.lease_id !== allocation.lease_id || host.epoch !== allocation.host_epoch
+      || this.#socketFor(host) === undefined) return undefined;
+    return vmHostAttachmentRouteId(allocation.allocation_id, allocation.host_epoch);
+  }
+
+  #socketForHostLease(
+    hostId: string,
+    leaseId: string,
+    epoch: number,
+  ): { socket: WebSocket; attachment: HostAttachment } | undefined {
+    for (const socket of this.ctx.getWebSockets("vm-host")) {
+      const attachment = socket.deserializeAttachment() as HostAttachment | null;
+      if (attachment?.kind === "vm-host"
+        && attachment.hostId === hostId
+        && attachment.leaseId === leaseId
+        && attachment.epoch === epoch) {
+        return { socket, attachment };
+      }
+    }
+    return undefined;
+  }
+
+  #poolClaim(): PoolClaim | undefined {
+    return this.ctx.storage.sql.exec<PoolClaim>(
+      "SELECT * FROM vm_pool_claim WHERE singleton = 1",
+    ).toArray()[0];
+  }
+
+  #host(hostId: string): HostRow | undefined {
+    return this.ctx.storage.sql.exec<HostRow>(
+      "SELECT * FROM vm_hosts WHERE host_id = ?",
+      hostId,
+    ).toArray()[0];
+  }
+
+  #factory(factoryName: string): HostRow | undefined {
+    return this.ctx.storage.sql.exec<HostRow>(
+      "SELECT * FROM vm_hosts WHERE factory_name = ?",
+      factoryName,
+    ).toArray()[0];
+  }
+
+  #allocation(allocationId: string): AllocationRow | undefined {
+    return this.ctx.storage.sql.exec<AllocationRow>(
+      "SELECT * FROM vm_allocations WHERE allocation_id = ?",
+      allocationId,
+    ).toArray()[0];
+  }
+
+  #releaseIntentRow(
+    ownerId: string,
+    agentId: string,
+    mountId: string,
+  ): AllocationReleaseIntent | undefined {
+    return this.ctx.storage.sql.exec<AllocationReleaseIntent>(
+      `SELECT factory_name, owner_id, organization_id, team_id, authorization_epoch,
+              agent_id, mount_id, pool_locator
+       FROM vm_allocation_release_intents
+       WHERE owner_id = ? AND agent_id = ? AND mount_id = ?`,
+      ownerId, agentId, mountId,
+    ).toArray()[0];
+  }
+
+  #send(socket: WebSocket, message: VmHostServerMessage): void {
+    socket.send(JSON.stringify(message));
+  }
+}
+
+function hostClaim(headers: Headers): HostClaim | undefined {
+  const scope = headers.get(POOL_SCOPE);
+  if (scope !== "agent" && scope !== "account" && scope !== "system") return undefined;
+  const ownerId = headers.get(POOL_OWNER);
+  const agentId = headers.get(POOL_AGENT);
+  const donorId = headers.get(DONOR_ID);
+  const publicOrigin = origin(headers.get(PUBLIC_ORIGIN));
+  const locator = headers.get(POOL_LOCATOR);
+  if (!donorId || !SAFE_ID.test(donorId) || !publicOrigin || !locator || !OPAQUE.test(locator)) {
+    return undefined;
+  }
+  if (scope === "agent" && (!isUserId(ownerId) || !identifier(agentId))) return undefined;
+  if (scope === "account" && (!isUserId(ownerId) || agentId !== null)) return undefined;
+  if (scope === "system" && (ownerId !== null || agentId !== null || donorId !== "system")) return undefined;
+  return {
+    scope,
+    owner_id: ownerId,
+    agent_id: agentId,
+    pool_locator: locator,
+    donorId,
+    publicOrigin,
+  };
+}
+
+function acquireRequest(body: Record<string, unknown>): AcquireRequest | undefined {
+  if (!hasExactKeys(body, [
+    "factory_name", "owner_id", "organization_id", "team_id", "authorization_epoch", "agent_id",
+    "mount_id", "pool_locator",
+  ]) || !isVmFactoryName(body.factory_name) || !isUserId(body.owner_id) || !identifier(body.organization_id)
+    || !identifier(body.team_id) || !nonNegativeInteger(body.authorization_epoch)
+    || !identifier(body.agent_id) || !uuid(body.mount_id)
+    || !opaque(body.pool_locator)) return undefined;
+  return {
+    factory_name: body.factory_name,
+    owner_id: body.owner_id,
+    organization_id: body.organization_id,
+    team_id: body.team_id,
+    authorization_epoch: body.authorization_epoch,
+    agent_id: body.agent_id,
+    mount_id: body.mount_id,
+    pool_locator: body.pool_locator,
+  };
+}
+
+function allocationIdentity(body: Record<string, unknown>): AllocationIdentity | undefined {
+  if (!hasExactKeys(body, [
+    "owner_id", "agent_id", "mount_id", "allocation_id", "generation", "pool_locator",
+  ]) || !isUserId(body.owner_id) || !identifier(body.agent_id) || !uuid(body.mount_id)
+    || !uuidV4(body.allocation_id) || !positiveInteger(body.generation)
+    || !opaque(body.pool_locator)) return undefined;
+  return body as AllocationIdentity;
+}
+
+function sameAcquire(
+  row: Pick<AllocationRow, keyof AcquireRequest>,
+  input: AcquireRequest,
+): boolean {
+  return row.factory_name === input.factory_name
+    && row.owner_id === input.owner_id
+    && row.organization_id === input.organization_id
+    && row.team_id === input.team_id
+    && row.authorization_epoch === input.authorization_epoch
+    && row.agent_id === input.agent_id
+    && row.mount_id === input.mount_id
+    && row.pool_locator === input.pool_locator;
+}
+
+function sameIdentity(row: AllocationRow, identity: AllocationIdentity): boolean {
+  return row.owner_id === identity.owner_id
+    && row.agent_id === identity.agent_id
+    && row.mount_id === identity.mount_id
+    && row.allocation_id === identity.allocation_id
+    && row.generation === identity.generation
+    && row.pool_locator === identity.pool_locator;
+}
+
+function publicAllocation(row: AllocationRow, routeId?: string): Record<string, unknown> {
+  return {
+    allocation_id: row.allocation_id,
+    generation: row.generation,
+    factory_name: row.factory_name,
+    machine_id: row.machine_id,
+    host_id: row.host_id,
+    slot: row.slot,
+    ...(routeId === undefined ? {} : { route_id: routeId }),
+  };
+}
+
+function attachmentUrl(row: AllocationRow): string {
+  const url = new URL(
+    `/v1/vm-host-attachments/${encodeURIComponent(row.pool_locator)}/${encodeURIComponent(row.allocation_id)}/tool-host`,
+    row.public_origin,
+  );
+  if (url.protocol === "https:") url.protocol = "wss:";
+  return url.toString();
+}
+
+async function readObject(request: Request): Promise<Record<string, unknown> | undefined> {
+  try {
+    const value = await request.json<unknown>();
+    return value !== null && typeof value === "object" && !Array.isArray(value)
+      ? value as Record<string, unknown>
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const expected = new Set(keys);
+  return Object.keys(value).length === keys.length
+    && Object.keys(value).every((key) => expected.has(key));
+}
+
+function identifier(value: unknown): value is string {
+  return typeof value === "string" && SAFE_ID.test(value);
+}
+
+function uuid(value: unknown): value is string {
+  return typeof value === "string" && UUID.test(value);
+}
+
+function uuidV4(value: unknown): value is string {
+  return typeof value === "string" && UUID_V4.test(value);
+}
+
+function opaque(value: unknown): value is string {
+  return typeof value === "string" && OPAQUE.test(value);
+}
+
+function positiveInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && Number(value) >= 1;
+}
+
+function nonNegativeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && Number(value) >= 0;
+}
+
+function origin(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "https:" || parsed.origin !== value || parsed.username || parsed.password) {
+      return undefined;
+    }
+    return parsed.origin;
+  } catch {
+    return undefined;
+  }
+}
+
+function randomOpaque(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function constantTimeEqual(left: string, right: string): boolean {
+  if (left.length !== right.length) return false;
+  let difference = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    difference |= left.charCodeAt(index) ^ right.charCodeAt(index);
+  }
+  return difference === 0;
+}
+
+function liveLease(attachment: HostAttachment, host: HostRow, now: number): boolean {
+  return host.lease_id !== null
+    && matchesVmHostLease(attachment, {
+      host_id: host.host_id,
+      lease_id: host.lease_id,
+      epoch: host.epoch,
+      lease_expires_at: host.lease_expires_at,
+    }, now);
+}
+
+function notFound(): Response {
+  return Response.json({ error: "not_found" }, { status: 404 });
+}
+
+function closeSocket(socket: WebSocket, code: number, reason: string): void {
+  try { socket.close(code, reason); } catch { /* Already closed. */ }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/js/managed/src/vm-host-protocol.ts
+++ b/js/managed/src/vm-host-protocol.ts
@@ -1,0 +1,321 @@
+import { isVmFactoryName } from "./vm-factory-name";
+
+export const VM_HOST_PROTOCOL_VERSION = 1 as const;
+export const VM_HOST_LEASE_MS = 60_000;
+export const MAX_VM_HOST_MESSAGE_BYTES = 256 * 1024;
+
+const MAX_VMS = 64;
+const MAX_CPUS = 64;
+const MIN_MEMORY_MIB = 128;
+const MAX_MEMORY_MIB = 262_144;
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const IDENTIFIER = /^[A-Za-z0-9._:-]{1,123}$/;
+const encoder = new TextEncoder();
+
+export type VmShape = {
+  cpus: number;
+  memory_mib: number;
+};
+
+export type VmHostAllocation = {
+  allocation_id: string;
+  generation: number;
+  machine_id: string;
+  state: "ready";
+};
+
+export type VmHostCommand =
+  | {
+    type: "attach";
+    protocol_version: typeof VM_HOST_PROTOCOL_VERSION;
+    host_id: string;
+    factory_name: string;
+    max_vms: number;
+    vm: VmShape;
+  }
+  | {
+    type: "ping";
+    lease_id: string;
+    epoch: number;
+    nonce?: string;
+  }
+  | {
+    type: "provisioned";
+    lease_id: string;
+    epoch: number;
+    allocation_id: string;
+    generation: number;
+    machine_id: string;
+  }
+  | {
+    type: "released";
+    lease_id: string;
+    epoch: number;
+    allocation_id: string;
+    generation: number;
+    machine_id: string;
+  }
+  | {
+    type: "reconcile";
+    lease_id: string;
+    epoch: number;
+    allocations: VmHostAllocation[];
+  };
+
+export type VmHostServerMessage =
+  | {
+    type: "lease";
+    protocol_version: typeof VM_HOST_PROTOCOL_VERSION;
+    lease_id: string;
+    epoch: number;
+    expires_at: number;
+    max_vms: number;
+    vm: VmShape;
+  }
+  | {
+    type: "pong";
+    lease_id: string;
+    epoch: number;
+    expires_at: number;
+    nonce?: string;
+  }
+  | {
+    type: "provision";
+    lease_id: string;
+    epoch: number;
+    allocation_id: string;
+    generation: number;
+    slot: number;
+    machine_id: string;
+    tool_attachment: {
+      url: string;
+      bearer: string;
+    };
+  }
+  | {
+    type: "release";
+    lease_id: string;
+    epoch: number;
+    allocation_id: string;
+    generation: number;
+    machine_id: string;
+  }
+  | {
+    type: "fenced";
+    epoch: number;
+    reason: string;
+  }
+  | {
+    type: "error";
+    code: string;
+    message: string;
+  };
+
+export function matchesVmHostLease(
+  holder: { hostId?: string; leaseId?: string; epoch?: number },
+  state: {
+    host_id: string;
+    lease_id: string;
+    epoch: number;
+    lease_expires_at: number;
+  },
+  now: number,
+): boolean {
+  return holder.hostId !== undefined
+    && holder.hostId === state.host_id
+    && holder.leaseId !== undefined
+    && holder.leaseId === state.lease_id
+    && holder.epoch !== undefined
+    && holder.epoch === state.epoch
+    && state.lease_expires_at >= now;
+}
+
+export function parseVmHostCommand(encoded: string): VmHostCommand {
+  if (encoder.encode(encoded).byteLength > MAX_VM_HOST_MESSAGE_BYTES) {
+    throw new VmHostProtocolError(
+      "message_too_large",
+      `VM-host messages are limited to ${MAX_VM_HOST_MESSAGE_BYTES} bytes`,
+    );
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(encoded);
+  } catch {
+    throw new VmHostProtocolError("invalid_json", "VM-host messages must be JSON objects");
+  }
+  const command = objectValue(value, "VM-host message");
+  if (command.type === "attach") {
+    exactKeys(command, ["type", "protocol_version", "host_id", "factory_name", "max_vms", "vm"]);
+    if (command.protocol_version !== VM_HOST_PROTOCOL_VERSION) {
+      throw new VmHostProtocolError("unsupported_version", "unsupported VM-host protocol version");
+    }
+    return {
+      type: "attach",
+      protocol_version: VM_HOST_PROTOCOL_VERSION,
+      host_id: uuid(command.host_id, "host_id"),
+      factory_name: factoryName(command.factory_name),
+      max_vms: boundedInteger(command.max_vms, 1, MAX_VMS, "max_vms"),
+      vm: vmShape(command.vm),
+    };
+  }
+  if (command.type === "ping") {
+    exactKeys(command, ["type", "lease_id", "epoch", "nonce"]);
+    return {
+      type: "ping",
+      lease_id: uuid(command.lease_id, "lease_id"),
+      epoch: positiveInteger(command.epoch, "epoch"),
+      ...optionalNonce(command.nonce),
+    };
+  }
+  if (command.type === "provisioned" || command.type === "released") {
+    exactKeys(command, [
+      "type",
+      "lease_id",
+      "epoch",
+      "allocation_id",
+      "generation",
+      "machine_id",
+    ]);
+    return {
+      type: command.type,
+      lease_id: uuid(command.lease_id, "lease_id"),
+      epoch: positiveInteger(command.epoch, "epoch"),
+      allocation_id: uuid(command.allocation_id, "allocation_id"),
+      generation: positiveInteger(command.generation, "generation"),
+      machine_id: identifier(command.machine_id, "machine_id"),
+    };
+  }
+  if (command.type === "reconcile") {
+    exactKeys(command, ["type", "lease_id", "epoch", "allocations"]);
+    if (!Array.isArray(command.allocations) || command.allocations.length > MAX_VMS) {
+      throw new VmHostProtocolError(
+        "invalid_allocations",
+        `reconcile allocations must be an array of at most ${MAX_VMS} VMs`,
+      );
+    }
+    const allocations = command.allocations.map((value, index) => allocation(value, index));
+    const allocationIds = new Set<string>();
+    const machineIds = new Set<string>();
+    for (const item of allocations) {
+      if (allocationIds.has(item.allocation_id) || machineIds.has(item.machine_id)) {
+        throw new VmHostProtocolError(
+          "duplicate_allocation",
+          "reconcile allocations must have unique allocation_id and machine_id values",
+        );
+      }
+      allocationIds.add(item.allocation_id);
+      machineIds.add(item.machine_id);
+    }
+    return {
+      type: "reconcile",
+      lease_id: uuid(command.lease_id, "lease_id"),
+      epoch: positiveInteger(command.epoch, "epoch"),
+      allocations,
+    };
+  }
+  throw new VmHostProtocolError("unknown_command", "unsupported VM-host command");
+}
+
+function vmShape(value: unknown): VmShape {
+  const shape = objectValue(value, "vm");
+  exactKeys(shape, ["cpus", "memory_mib"]);
+  return {
+    cpus: boundedInteger(shape.cpus, 1, MAX_CPUS, "vm.cpus"),
+    memory_mib: boundedInteger(
+      shape.memory_mib,
+      MIN_MEMORY_MIB,
+      MAX_MEMORY_MIB,
+      "vm.memory_mib",
+    ),
+  };
+}
+
+function allocation(value: unknown, index: number): VmHostAllocation {
+  const item = objectValue(value, `allocations[${index}]`);
+  exactKeys(item, ["allocation_id", "generation", "machine_id", "state"]);
+  if (item.state !== "ready") {
+    throw new VmHostProtocolError(
+      "invalid_allocation_state",
+      `allocations[${index}].state must be ready`,
+    );
+  }
+  return {
+    allocation_id: uuid(item.allocation_id, `allocations[${index}].allocation_id`),
+    generation: positiveInteger(item.generation, `allocations[${index}].generation`),
+    machine_id: identifier(item.machine_id, `allocations[${index}].machine_id`),
+    state: "ready",
+  };
+}
+
+function optionalNonce(value: unknown): { nonce?: string } {
+  if (value === undefined) return {};
+  if (typeof value !== "string" || value.length > 128) {
+    throw new VmHostProtocolError("invalid_nonce", "ping nonce must be at most 128 characters");
+  }
+  return { nonce: value };
+}
+
+function uuid(value: unknown, name: string): string {
+  if (typeof value !== "string" || !UUID_V4.test(value)) {
+    throw new VmHostProtocolError("invalid_identity", `${name} must be a lowercase UUID v4`);
+  }
+  return value;
+}
+
+function identifier(value: unknown, name: string): string {
+  if (typeof value !== "string" || !IDENTIFIER.test(value)) {
+    throw new VmHostProtocolError(
+      "invalid_identifier",
+      `${name} must be 1-123 letters, numbers, dots, underscores, colons, or hyphens`,
+    );
+  }
+  return value;
+}
+
+function factoryName(value: unknown): string {
+  if (!isVmFactoryName(value)) {
+    throw new VmHostProtocolError(
+      "invalid_factory_name",
+      "factory_name must be a non-reserved lowercase portable identifier of 1-63 characters",
+    );
+  }
+  return value;
+}
+
+function positiveInteger(value: unknown, name: string): number {
+  return boundedInteger(value, 1, Number.MAX_SAFE_INTEGER, name);
+}
+
+function boundedInteger(value: unknown, minimum: number, maximum: number, name: string): number {
+  if (!Number.isSafeInteger(value) || Number(value) < minimum || Number(value) > maximum) {
+    throw new VmHostProtocolError(
+      "invalid_integer",
+      `${name} must be an integer from ${minimum} through ${maximum}`,
+    );
+  }
+  return Number(value);
+}
+
+function objectValue(value: unknown, name: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new VmHostProtocolError("invalid_message", `${name} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(value: Record<string, unknown>, allowed: readonly string[]): void {
+  const fields = new Set(allowed);
+  const unsupported = Object.keys(value).find((key) => !fields.has(key));
+  if (unsupported !== undefined) {
+    throw new VmHostProtocolError(
+      "invalid_message",
+      `VM-host message has unsupported field ${unsupported}`,
+    );
+  }
+}
+
+export class VmHostProtocolError extends Error {
+  constructor(readonly code: string, message: string) {
+    super(message);
+  }
+}

--- a/js/managed/test/account-hosted-tools.test.ts
+++ b/js/managed/test/account-hosted-tools.test.ts
@@ -292,6 +292,42 @@ describe("account Hosted Tools provider", () => {
     expect(requested).toContain(ACCOUNT_B);
   });
 
+  it("rechecks account hand calls against the invoking subagent context", async () => {
+    const invoked: string[] = [];
+    const namespace = fakeNamespace(new Map([[ACCOUNT_A, async (request) => {
+      if (new URL(request.url).pathname === "/snapshot") return Response.json(snapshot);
+      const body = await request.json<{ session_id: string }>();
+      invoked.push(body.session_id);
+      return Response.json({
+        output: "ok",
+        structured_result: null,
+        success: true,
+        metadata: null,
+        value: "ok",
+      });
+    }]]));
+    const provider = new AccountHostedToolsProvider(
+      namespace,
+      ACCOUNT_A,
+      (context) => context === undefined || context.sessionId === "allowed-child",
+    );
+    await provider.refresh();
+    const tool = provider.resolve("fixture__lookup")!;
+
+    const denied = await tool.handler({}, {
+      sessionId: "denied-child",
+      callId: "call-denied",
+    });
+    expect(denied).toMatchObject({
+      success: false,
+      structuredResult: { status: "unavailable" },
+    });
+    expect(invoked).toEqual([]);
+
+    await tool.handler({}, { sessionId: "allowed-child", callId: "call-allowed" });
+    expect(invoked).toEqual(["allowed-child"]);
+  });
+
   it("fails closed for malformed snapshots and duplicate public tool names", async () => {
     const malformed = [
       null,

--- a/js/managed/test/hosted-tools-broker.test.ts
+++ b/js/managed/test/hosted-tools-broker.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { hostedToolCatalogDigest } from "nanocodex/tools/hosted-catalog";
 import {
   EXEC_COMMAND_PARAMETERS,
@@ -80,6 +80,201 @@ describe("HostedToolsBroker socket-owned protocol", () => {
     expect(fixture.broker.machines()).toEqual(machines);
     await fixture.broker.message(host.webSocket, JSON.stringify({ type: "drain" }));
     expect(fixture.broker.machines()).toEqual([]);
+  });
+
+  it("caps leased attachments at their control lease and revokes their exact route", async () => {
+    const fixture = createFixture();
+    const firstRoute = "vm-host:33333333-3333-4333-8333-333333333333:1";
+    const successorRoute = "vm-host:33333333-3333-4333-8333-333333333333:2";
+    const host = fixture.socket(undefined, undefined, undefined, "leased-vm", NOW + 10, firstRoute);
+    await fixture.broker.message(host.webSocket, JSON.stringify({
+      type: "catalog",
+      attachment_id: "leased-vm",
+      tools: [machineEntry("exec_command")],
+      machines: [{
+        id: "leased-vm",
+        name: "Leased VM",
+        workspace: "/workspace",
+        capabilities: ["filesystem"],
+      }],
+    }));
+
+    expect(fixture.persistence.state(firstRoute)?.lease_expires_at).toBe(NOW + 10);
+    await fixture.broker.message(host.webSocket, JSON.stringify({ type: "ping", nonce: "" }));
+    expect(fixture.persistence.state(firstRoute)?.lease_expires_at).toBe(NOW + 10);
+
+    fixture.persistence.routes.get(firstRoute)!.lease_expires_at = NOW - 1;
+    fixture.broker.expire();
+    expect(host.closed).toMatchObject({ code: 1008 });
+
+    const successor = fixture.socket(
+      undefined, undefined, undefined, "leased-vm", NOW + 20, successorRoute,
+    );
+    await fixture.broker.message(successor.webSocket, JSON.stringify({
+      type: "catalog",
+      attachment_id: "leased-vm",
+      tools: [machineEntry("exec_command")],
+      machines: [{
+        id: "leased-vm",
+        name: "Successor VM",
+        workspace: "/workspace",
+        capabilities: ["filesystem"],
+      }],
+    }));
+
+    expect(fixture.broker.revokeRoute(firstRoute, "delayed old revocation")).toBe(false);
+    expect(successor.closed).toBeUndefined();
+    expect(fixture.broker.machines()).toEqual([expect.objectContaining({ id: "leased-vm" })]);
+    expect(fixture.broker.revokeRoute(successorRoute, "current control lease ended")).toBe(true);
+    expect(successor.closed).toMatchObject({ code: 1008 });
+  });
+
+  it("revalidates a leased bearer and keeps the exact route live past its initial control lease", async () => {
+    let now = NOW;
+    const route = "vm-host:33333333-3333-4333-8333-333333333333:4";
+    const renew = vi.fn(async () => now + 60_000);
+    const fixture = createFixture(undefined, {
+      now: () => now,
+      renewLeasedAttachment: renew,
+    });
+    const host = fixture.socket(
+      undefined, undefined, undefined, "leased-vm", NOW + 60_000, route, "opaque-renewal",
+    );
+    await fixture.broker.message(host.webSocket, JSON.stringify({
+      type: "catalog",
+      attachment_id: "leased-vm",
+      tools: [machineEntry("exec_command")],
+      machines: [{
+        id: "leased-vm",
+        name: "Leased VM",
+        workspace: "/workspace",
+        capabilities: ["filesystem"],
+      }],
+    }));
+
+    now += 40_000;
+    await fixture.broker.message(host.webSocket, JSON.stringify({ type: "ping", nonce: "renew" }));
+    expect(renew).toHaveBeenCalledWith({
+      expectedAttachmentId: "leased-vm",
+      fixedRouteId: route,
+      renewalToken: "opaque-renewal",
+    });
+    expect(fixture.persistence.state(route)?.lease_expires_at).toBe(NOW + 100_000);
+
+    now = NOW + 61_000;
+    fixture.broker.expire();
+    expect(host.closed).toBeUndefined();
+    expect(fixture.broker.machineOnRoute(route, "leased-vm")).toBeDefined();
+
+    renew.mockResolvedValueOnce(undefined as never);
+    await fixture.broker.message(host.webSocket, JSON.stringify({ type: "ping", nonce: "stale" }));
+    expect(host.closed).toMatchObject({ code: 1008 });
+    expect(fixture.broker.machineOnRoute(route, "leased-vm")).toBeUndefined();
+  });
+
+  it("durably rejects a leased route revoked before catalog admission", async () => {
+    const fixture = createFixture();
+    const route = "vm-host:44444444-4444-4444-8444-444444444444:7";
+    expect(fixture.broker.revokeRoute(route, "control lease already ended")).toBe(false);
+
+    const delayed = fixture.socket(undefined, undefined, undefined, "leased-vm", NOW + 20, route);
+    await fixture.broker.message(delayed.webSocket, JSON.stringify({
+      type: "catalog",
+      attachment_id: "leased-vm",
+      tools: [machineEntry("exec_command")],
+      machines: [{
+        id: "leased-vm",
+        name: "Delayed stale VM",
+        workspace: "/workspace",
+        capabilities: ["filesystem"],
+      }],
+    }));
+
+    expect(delayed.closed).toMatchObject({
+      code: 1008,
+      reason: expect.stringContaining("route_revoked"),
+    });
+    expect(fixture.broker.machines()).toEqual([]);
+
+    const resumed = new HostedToolsBroker(fixture.context, {
+      persistence: fixture.persistence,
+      now: () => NOW,
+      resumeRetainedSockets: true,
+    });
+    const retried = fixture.socket(undefined, undefined, undefined, "leased-vm", NOW + 30, route);
+    await resumed.message(retried.webSocket, JSON.stringify({
+      type: "catalog",
+      attachment_id: "leased-vm",
+      tools: [machineEntry("exec_command")],
+      machines: [{
+        id: "leased-vm",
+        name: "Retried stale VM",
+        workspace: "/workspace",
+        capabilities: ["filesystem"],
+      }],
+    }));
+    expect(retried.closed?.reason).toContain("route_revoked");
+  });
+
+  it("resolves leased machines and tools only through their exact live route", async () => {
+    const fixture = createFixture();
+    const route = "vm-host:44444444-4444-4444-8444-444444444444:8";
+    const leased = fixture.socket(undefined, undefined, undefined, "vm:mount", NOW + 20, route);
+    await fixture.broker.message(leased.webSocket, JSON.stringify({
+      type: "catalog",
+      attachment_id: "vm:mount",
+      tools: [machineEntry("exec_command")],
+      machines: [{
+        id: "vm:mount",
+        name: "Leased VM",
+        workspace: "/workspace",
+        capabilities: ["filesystem"],
+      }],
+    }));
+
+    expect(fixture.broker.machineOnRoute(route, "vm:mount")).toMatchObject({ id: "vm:mount" });
+    expect(fixture.broker.machineToolOnRoute(route, "vm:mount", "exec_command")).toBeDefined();
+    fixture.broker.revokeRoute(route, "lease replaced");
+
+    const ordinary = fixture.socket();
+    await fixture.broker.message(ordinary.webSocket, JSON.stringify({
+      type: "catalog",
+      attachment_id: "vm:mount",
+      tools: [machineEntry("exec_command")],
+      machines: [{
+        id: "vm:mount",
+        name: "Impostor",
+        workspace: "/tmp/impostor",
+        capabilities: ["filesystem"],
+      }],
+    }));
+
+    expect(fixture.broker.machines()).toEqual([expect.objectContaining({ name: "Impostor" })]);
+    expect(fixture.broker.machineOnRoute(route, "vm:mount")).toBeUndefined();
+    expect(fixture.broker.machineToolOnRoute(route, "vm:mount", "exec_command")).toBeUndefined();
+  });
+
+  it("rejects non-machine tools from leased attachments", async () => {
+    const fixture = createFixture();
+    const route = "vm-host:44444444-4444-4444-8444-444444444444:9";
+    const leased = fixture.socket(undefined, undefined, undefined, "vm:mount", NOW + 20, route);
+    await fixture.broker.message(leased.webSocket, JSON.stringify({
+      type: "catalog",
+      attachment_id: "vm:mount",
+      tools: [machineEntry("exec_command"), entry("fixture__injected")],
+      machines: [{
+        id: "vm:mount",
+        name: "Leased VM",
+        workspace: "/workspace",
+        capabilities: ["filesystem"],
+      }],
+    }));
+
+    expect(leased.closed).toMatchObject({
+      code: 1008,
+      reason: expect.stringContaining("leased tool attachments may publi"),
+    });
+    expect(fixture.broker.provider().definitions()).toEqual([]);
   });
 
   it("replaces the live machine snapshot without rebuilding its broker", async () => {
@@ -755,6 +950,14 @@ function createFixture(
     connectGrantId?: string,
     appToolCatalogDigest?: string,
   ) => boolean,
+  options?: Readonly<{
+    now?: () => number;
+    renewLeasedAttachment?: (renewal: {
+      expectedAttachmentId: string;
+      fixedRouteId: string;
+      renewalToken: string;
+    }) => Promise<number | undefined>;
+  }>,
 ) {
   const persistence = new MemoryPersistence();
   const sockets: FakeSocket[] = [];
@@ -766,7 +969,10 @@ function createFixture(
   } as unknown as HostedToolsBrokerContext;
   const broker = new HostedToolsBroker(context, {
     persistence,
-    now: () => NOW,
+    now: options?.now ?? (() => NOW),
+    ...(options?.renewLeasedAttachment === undefined ? {} : {
+      renewLeasedAttachment: options.renewLeasedAttachment,
+    }),
     ...(entryAllowed === undefined ? {} : { entryAllowed }),
     randomUUID: () => ids.shift() ?? crypto.randomUUID(),
   });
@@ -778,6 +984,10 @@ function createFixture(
       allowedMcpIds?: readonly string[],
       appToolCatalogDigest?: `0x${string}`,
       connectGrantId?: string,
+      expectedAttachmentId?: string,
+      maximumLeaseExpiresAt?: number,
+      fixedRouteId?: string,
+      renewalToken?: string,
     ) {
       const socket = new FakeSocket();
       socket.serializeAttachment({
@@ -786,6 +996,10 @@ function createFixture(
         ...(allowedMcpIds === undefined ? {} : { allowedMcpIds }),
         ...(appToolCatalogDigest === undefined ? {} : { appToolCatalogDigest }),
         ...(connectGrantId === undefined ? {} : { connectGrantId }),
+        ...(expectedAttachmentId === undefined ? {} : { expectedAttachmentId }),
+        ...(maximumLeaseExpiresAt === undefined ? {} : { maximumLeaseExpiresAt }),
+        ...(fixedRouteId === undefined ? {} : { fixedRouteId }),
+        ...(renewalToken === undefined ? {} : { renewalToken }),
       });
       sockets.push(socket);
       return socket;

--- a/js/managed/test/hosted-tools-broker.test.ts
+++ b/js/managed/test/hosted-tools-broker.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   HostedToolsBroker,
   HOSTED_TOOLS_PRE_ADMISSION_UNAVAILABLE,
+  type HostedToolsAuthorizationContext,
   type HostedToolsBrokerContext,
   type HostedToolsBrokerPersistence,
 } from "../src/hosted-tools-broker";
@@ -252,6 +253,60 @@ describe("HostedToolsBroker socket-owned protocol", () => {
     expect(fixture.broker.machines()).toEqual([expect.objectContaining({ name: "Impostor" })]);
     expect(fixture.broker.machineOnRoute(route, "vm:mount")).toBeUndefined();
     expect(fixture.broker.machineToolOnRoute(route, "vm:mount", "exec_command")).toBeUndefined();
+  });
+
+  it.each([
+    ["after its root turn ends", undefined],
+    ["while a differently authorized root is active", "connect"],
+  ] as const)("uses retained child authority for a leased VM %s", async (_label, rootAuthority) => {
+    const childSessionId = "01995555-5555-7555-8555-555555555555";
+    const fixture = createFixture((_entry, _grantId, _digest, context) => {
+      const authority = context?.subagent?.sessionId === childSessionId
+        ? "account"
+        : rootAuthority;
+      return authority === "account";
+    });
+    const route = "vm-host:44444444-4444-4444-8444-444444444444:10";
+    const leased = fixture.socket(undefined, undefined, undefined, "vm:retained", NOW + 20, route);
+    await fixture.broker.message(leased.webSocket, JSON.stringify({
+      type: "catalog",
+      attachment_id: "vm:retained",
+      tools: [machineEntry("exec_command")],
+      machines: [{
+        id: "vm:retained",
+        name: "Retained child VM",
+        workspace: "/workspace",
+        capabilities: ["filesystem"],
+      }],
+    }));
+    const context = {
+      sessionId: childSessionId,
+      callId: `source:${rootAuthority ?? "ended"}`,
+      subagent: {
+        agentId: "child-agent",
+        parentAgentId: null,
+        sessionId: childSessionId,
+        role: "worker",
+        task: "continue after the root turn",
+      },
+    };
+
+    expect(fixture.broker.machineToolOnRoute(
+      route,
+      "vm:retained",
+      "exec_command",
+    )).toBeUndefined();
+    const selected = fixture.broker.machineToolOnRoute(
+      route,
+      "vm:retained",
+      "exec_command",
+      context,
+    );
+    expect(selected).toBeDefined();
+    const pending = selected!.handler({ cmd: "pwd" }, context);
+    const call = leased.sent.find((frame) => frame.type === "call")!;
+    await fixture.broker.message(leased.webSocket, result(call.call_id as string, "retained"));
+    await expect(pending).resolves.toMatchObject({ output: "retained" });
   });
 
   it("rejects non-machine tools from leased attachments", async () => {
@@ -949,6 +1004,7 @@ function createFixture(
     entry: HostedToolCatalogEntry,
     connectGrantId?: string,
     appToolCatalogDigest?: string,
+    context?: HostedToolsAuthorizationContext,
   ) => boolean,
   options?: Readonly<{
     now?: () => number;

--- a/js/managed/test/memory-scope-worker.ts
+++ b/js/managed/test/memory-scope-worker.ts
@@ -1,3 +1,4 @@
 export { MemoryScope } from "../src/memory-scope";
 export { AccountHostedTools } from "../src/account-hosted-tools";
+export { VmHostPool } from "../src/vm-host-pool";
 export { DurableAgentSession } from "../src/index";

--- a/js/managed/test/mount-tool.test.ts
+++ b/js/managed/test/mount-tool.test.ts
@@ -32,32 +32,45 @@ describe("managed mount protocol", () => {
     expect(tool.parameters).toMatchObject({
       required: ["provider", "name"],
       additionalProperties: false,
-      properties: { provider: { enum: ["cloudflare"] } },
+      properties: { provider: { type: "string", pattern: expect.any(String) } },
     });
+    expect((tool.parameters as { properties: { provider: object } }).properties.provider)
+      .not.toHaveProperty("enum");
     expect(tool.outputSchema).toMatchObject({
       required: ["id", "name", "provider", "mount", "status", "created"],
       additionalProperties: false,
     });
     await expect(tool.handler(
-      { provider: "cloudflare", name: "repo-test" },
+      { provider: "cf_sandbox", name: "repo-test" },
       context(),
     )).resolves.toMatchObject({
-      provider: "cloudflare",
+      provider: "cf_sandbox",
       mount: "/mnt-repo-test-01234567",
       status: "mounted",
     });
     expect(handler).toHaveBeenCalledWith(
-      { provider: "cloudflare", name: "repo-test" },
+      { provider: "cf_sandbox", name: "repo-test" },
+      expect.objectContaining({ callId: "call" }),
+    );
+    await expect(tool.handler(
+      { provider: "garage-mac", name: "vm-build" },
+      context(),
+    )).resolves.toMatchObject({ provider: "garage-mac", status: "mounted" });
+    await tool.handler({ provider: "cloudflare", name: "legacy" }, context());
+    expect(handler).toHaveBeenLastCalledWith(
+      { provider: "cf_sandbox", name: "legacy" },
       expect.objectContaining({ callId: "call" }),
     );
   });
 
-  it("rejects unknown providers, unsafe names, and extra fields", () => {
-    expect(() => parseManagedMountRequest({ provider: "future", name: "build" }))
-      .toThrow("provider must be cloudflare");
-    expect(() => parseManagedMountRequest({ provider: "cloudflare", name: "Build Box" }))
+  it("rejects reserved generic hosts, unsafe names, and extra fields", () => {
+    expect(() => parseManagedMountRequest({ provider: "host", name: "build" }))
+      .toThrow("exact non-reserved VM factory name");
+    expect(() => parseManagedMountRequest({ provider: "Build Box", name: "build" }))
       .toThrow("lowercase portable identifier");
-    expect(() => parseManagedMountRequest({ provider: "cloudflare", name: "build", region: "auto" }))
+    expect(() => parseManagedMountRequest({ provider: "cf_sandbox", name: "Build Box" }))
+      .toThrow("lowercase portable identifier");
+    expect(() => parseManagedMountRequest({ provider: "cf_sandbox", name: "build", region: "auto" }))
       .toThrow("unsupported field region");
   });
 
@@ -72,6 +85,10 @@ describe("managed mount protocol", () => {
       "a".repeat(63),
       "01234567-89ab-7def-8123-456789abcdef",
     ).length).toBeLessThanOrEqual(64);
+    expect(() => managedMountRoot(
+      "Build Box",
+      "01234567-89ab-7def-8123-456789abcdef",
+    )).toThrow("mount name must be a lowercase portable identifier");
   });
 
   it("keeps additional Cloudflare sandbox IDs within the provider limit", () => {

--- a/js/managed/test/namespace-tools.test.ts
+++ b/js/managed/test/namespace-tools.test.ts
@@ -80,7 +80,7 @@ describe("cwd-root namespace execution", () => {
       workdir: "/Users/me/repo/crates/core",
       yield_time_ms: 30_000,
     }, expect.anything());
-    expect(resolve).toHaveBeenCalledWith("laptop", "exec_command");
+    expect(resolve).toHaveBeenCalledWith("laptop", "exec_command", expect.anything());
   });
 
   it("lets the real tool router dispatch separate hands concurrently", async () => {
@@ -401,8 +401,8 @@ function createNamespaceExecutionTools(
 ) {
   return createRuntimeNamespaceExecutionTools(
     () => [{ id: "sandbox", root: "/sandbox", workspace: "/workspace" }, ...machines()],
-    (machineId, name) => machineId === "sandbox"
+    (machineId, name, context) => machineId === "sandbox"
       ? sandbox[name]
-      : resolveMachineTool(machineId, name),
+      : resolveMachineTool(machineId, name, context),
   );
 }

--- a/js/managed/test/sandbox-runtime.test.ts
+++ b/js/managed/test/sandbox-runtime.test.ts
@@ -163,6 +163,88 @@ describe("managed sandbox preview wiring", () => {
     expect(sourceHandler).toHaveBeenCalledTimes(1);
   });
 
+  it("refreshes an epoch-bound retained route once before a new subagent namespace snapshot", async () => {
+    const oldRoute = "vm-host:33333333-3333-4333-8333-333333333333:1";
+    const newRoute = "vm-host:33333333-3333-4333-8333-333333333333:2";
+    let currentRoute = oldRoute;
+    let retainedRoute = oldRoute;
+    const oldExec = vi.fn(async () => ({ route: oldRoute }));
+    const newExec = vi.fn(async () => ({ route: newRoute }));
+    const refresh = vi.fn(async () => { retainedRoute = currentRoute; });
+    const tools = createManagedNamespaceTools(
+      () => true,
+      () => [{ id: "sandbox:retained", root: "/repo", workspace: "/workspace" }],
+      (_machineId, name) => name === "exec_command"
+        ? { handler: retainedRoute === oldRoute ? oldExec : newExec }
+        : undefined,
+      refresh,
+    );
+    const exec = tools.find(({ name }) => name === "exec_command")!;
+    const original = toolContext();
+
+    await expect(exec.handler({ cmd: "pwd", workdir: "/repo" }, original))
+      .resolves.toEqual({ route: oldRoute });
+    currentRoute = newRoute;
+    await expect(exec.handler({ cmd: "still pinned", workdir: "/repo" }, {
+      ...original,
+      callId: "same-cell",
+    })).resolves.toEqual({ route: oldRoute });
+
+    const subagent = {
+      ...original,
+      callId: "subagent-call",
+      parentCallId: "subagent-cell",
+      sessionId: "subagent-session",
+      subagent: {
+        agentId: "2",
+        parentAgentId: null,
+        sessionId: "subagent-session",
+        role: "builder",
+        task: "continue in retained cwd",
+      },
+    };
+    await expect(Promise.all([
+      exec.handler({ cmd: "one", workdir: "/repo" }, subagent),
+      exec.handler({ cmd: "two", workdir: "/repo" }, { ...subagent, callId: "parallel" }),
+    ])).resolves.toEqual([{ route: newRoute }, { route: newRoute }]);
+
+    expect(refresh).toHaveBeenCalledTimes(2);
+    expect(oldExec).toHaveBeenCalledTimes(2);
+    expect(newExec).toHaveBeenCalledTimes(2);
+  });
+
+  it("rechecks child authorization before dispatching through a cached namespace binding", async () => {
+    const sourceHandler = vi.fn(async () => ({ ok: true }));
+    const authorized = new Set(["subagent-session"]);
+    const tools = createManagedNamespaceTools(
+      (context) => authorized.has(context.sessionId),
+      () => [{ id: "sandbox:retained", root: "/repo", workspace: "/workspace" }],
+      (_machineId, name) => name === "exec_command" ? { handler: sourceHandler } : undefined,
+    );
+    const exec = tools.find(({ name }) => name === "exec_command")!;
+    const child = {
+      ...toolContext(),
+      sessionId: "subagent-session",
+      parentCallId: "cached-cell",
+      subagent: {
+        agentId: "2",
+        parentAgentId: null,
+        sessionId: "subagent-session",
+        role: "builder",
+        task: "use retained cwd",
+      },
+    };
+
+    await expect(exec.handler({ cmd: "pwd", workdir: "/repo" }, child))
+      .resolves.toEqual({ ok: true });
+    authorized.clear();
+    await expect(exec.handler({ cmd: "pwd", workdir: "/repo" }, {
+      ...child,
+      callId: "later-call",
+    })).rejects.toMatchObject({ status: 403, code: "namespace_forbidden" });
+    expect(sourceHandler).toHaveBeenCalledTimes(1);
+  });
+
   it("opens a bearer capability and strips only its route prefix before proxying", async () => {
     const namespace = {} as DurableObjectNamespace<Sandbox>;
     const secret = "server-only-preview-secret";

--- a/js/managed/test/subagent-authorization.test.ts
+++ b/js/managed/test/subagent-authorization.test.ts
@@ -66,6 +66,41 @@ describe("managed subagent authorization ownership", () => {
       expect(authorization(state.storage, child, account)).toBeUndefined();
     });
   });
+
+  it("reconstructs legacy ref-less children fail-closed and releases them idempotently", async () => {
+    await withSession(async (state) => {
+      insertTurn(state.storage, "account-turn", account);
+      const child = descriptor("legacy", null, ACCOUNT_SESSION, "legacy child");
+      bind(state.storage, "bind", child, "account-turn");
+      expect(authorization(state.storage, child, connect)).toEqual(account);
+
+      const lifecycle = (event: unknown) => state.storage.transactionSync(() => (
+        applyManagedSubagentLifecycle(state.storage, event)
+      ));
+      const reconstruct = {
+        type: "reconstruct",
+        rootSessionId: ROOT_SESSION,
+        sessionId: child.sessionId,
+        descriptor: child,
+        hostContextRef: undefined,
+      };
+      expect(() => lifecycle(reconstruct)).not.toThrow();
+      expect(() => lifecycle(reconstruct)).not.toThrow();
+      expect(authorization(state.storage, child, account)).toBeUndefined();
+
+      const release = {
+        type: "release",
+        rootSessionId: ROOT_SESSION,
+        sessionId: child.sessionId,
+        hostContextRef: undefined,
+      };
+      expect(() => lifecycle(release)).not.toThrow();
+      expect(() => lifecycle(release)).not.toThrow();
+      expect(() => lifecycle({ ...reconstruct, type: "bind" })).toThrow(
+        "invalid managed subagent lifecycle event",
+      );
+    });
+  });
 });
 
 async function withSession(

--- a/js/managed/test/subagent-authorization.test.ts
+++ b/js/managed/test/subagent-authorization.test.ts
@@ -1,0 +1,151 @@
+import { env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+import {
+  applyManagedSubagentLifecycle,
+  managedAuthorizationForToolContext,
+  type DurableAgentSession,
+} from "../src/index";
+
+const ROOT_SESSION = "01992222-2222-7222-8222-222222222222";
+const ACCOUNT_SESSION = "01993333-3333-7333-8333-333333333333";
+const CONNECT_SESSION = "01994444-4444-7444-8444-444444444444";
+const NESTED_SESSION = "01995555-5555-7555-8555-555555555555";
+const account = { capabilities: ["agents:write", "tools:use"] as const };
+const connect = {
+  capabilities: ["agents:write", "tools:use"] as const,
+  connectGrant: {
+    grantId: `0x${"a".repeat(64)}`,
+    connectors: ["chatgpt"] as const,
+    mcpIds: [] as const,
+  },
+};
+
+describe("managed subagent authorization ownership", () => {
+  it("snapshots direct authority, inherits it for nested agents, and reconstructs exactly", async () => {
+    await withSession(async (state) => {
+      insertTurn(state.storage, "account-turn", account);
+      const direct = descriptor("1", null, ACCOUNT_SESSION, "account child");
+      bind(state.storage, "bind", direct, "account-turn");
+
+      expect(authorization(state.storage, direct, connect)).toEqual(account);
+
+      const nested = descriptor("2", "1", NESTED_SESSION, "nested child");
+      bind(state.storage, "bind", nested, "account-turn");
+      expect(authorization(state.storage, nested, connect)).toEqual(account);
+      bind(state.storage, "reconstruct", nested, "account-turn");
+      expect(state.storage.sql.exec<{ count: number }>(
+        "SELECT COUNT(*) AS count FROM managed_subagent_authorizations",
+      ).one().count).toBe(2);
+
+      expect(() => bind(state.storage, "reconstruct", {
+        ...nested,
+        task: "changed task",
+      }, "account-turn")).toThrow("conflicts");
+      expect(() => bind(state.storage, "bind", descriptor(
+        "orphan", "missing", crypto.randomUUID(), "orphan",
+      ), "account-turn")).toThrow("parent is missing");
+    });
+  });
+
+  it("keeps a Connect child denied after a later account root and deletes only an exact ref", async () => {
+    await withSession(async (state) => {
+      insertTurn(state.storage, "connect-turn", connect);
+      const child = descriptor("3", null, CONNECT_SESSION, "connect child");
+      bind(state.storage, "bind", child, "connect-turn");
+
+      expect(authorization(state.storage, child, account)).toEqual(connect);
+      expect(managedAuthorizationForToolContext(
+        state.storage,
+        ROOT_SESSION,
+        account,
+        { ...context(ROOT_SESSION), subagent: child },
+      )).toBeUndefined();
+      expect(() => release(state.storage, child.sessionId, "wrong-turn")).toThrow("does not match");
+      release(state.storage, child.sessionId, "connect-turn");
+      expect(authorization(state.storage, child, account)).toBeUndefined();
+    });
+  });
+});
+
+async function withSession(
+  run: (state: DurableObjectState) => void | Promise<void>,
+): Promise<void> {
+  const sessions = (env as unknown as {
+    NANOCODEX_SESSIONS: DurableObjectNamespace<DurableAgentSession>;
+  }).NANOCODEX_SESSIONS;
+  const stub = sessions.getByName(crypto.randomUUID());
+  await runInDurableObject(stub, async (_session, state) => run(state));
+}
+
+function insertTurn(storage: DurableObjectStorage, id: string, authorization: unknown): void {
+  const now = Date.now();
+  storage.sql.exec(
+    `INSERT INTO managed_turns (
+       id, request_hash, input_json, authorization_json, state, accepted_cursor,
+       may_have_inner_operation, attempt_count, created_at, accepted_at, updated_at
+     ) VALUES (?, ?, '"input"', ?, 'accepted', 0, 0, 0, ?, ?, ?)`,
+    id,
+    `hash-${id}`,
+    JSON.stringify(authorization),
+    now,
+    now,
+    now,
+  );
+}
+
+function descriptor(
+  agentId: string,
+  parentAgentId: string | null,
+  sessionId: string,
+  task: string,
+) {
+  return Object.freeze({ agentId, parentAgentId, sessionId, role: "worker", task });
+}
+
+function bind(
+  storage: DurableObjectStorage,
+  type: "bind" | "reconstruct",
+  child: ReturnType<typeof descriptor>,
+  hostContextRef: string,
+): void {
+  storage.transactionSync(() => applyManagedSubagentLifecycle(storage, {
+    type,
+    rootSessionId: ROOT_SESSION,
+    sessionId: child.sessionId,
+    descriptor: child,
+    hostContextRef,
+  }));
+}
+
+function release(storage: DurableObjectStorage, sessionId: string, hostContextRef: string): void {
+  storage.transactionSync(() => applyManagedSubagentLifecycle(storage, {
+    type: "release",
+    rootSessionId: ROOT_SESSION,
+    sessionId,
+    hostContextRef,
+  }));
+}
+
+function authorization(
+  storage: DurableObjectStorage,
+  child: ReturnType<typeof descriptor>,
+  active: typeof account | typeof connect,
+) {
+  return managedAuthorizationForToolContext(
+    storage,
+    ROOT_SESSION,
+    active,
+    { ...context(child.sessionId), subagent: child },
+  );
+}
+
+function context(sessionId: string) {
+  return {
+    callId: "call",
+    parentCallId: "cell",
+    sessionId,
+    model: "gpt-5.6-sol",
+    signal: new AbortController().signal,
+  };
+}

--- a/js/managed/test/vm-host-pool.test.ts
+++ b/js/managed/test/vm-host-pool.test.ts
@@ -1,0 +1,731 @@
+import { env, runInDurableObject } from "cloudflare:test";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { VmHostPool, type VmHostPoolEnv } from "../src/vm-host-pool";
+
+const OWNER_A = "11111111-1111-4111-8111-111111111111";
+const OWNER_B = "22222222-2222-4222-8222-222222222222";
+const HOST_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const HOST_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const HOST_C = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const FACTORY_A = "garage-mac";
+const FACTORY_B = "linux-builder";
+const MOUNT_A = "10000000-0000-4000-8000-000000000001";
+const MOUNT_B = "10000000-0000-4000-8000-000000000002";
+const MOUNT_C = "10000000-0000-4000-8000-000000000003";
+const LOCATOR = "p".repeat(43);
+const ORIGIN = "https://managed.example";
+
+afterEach(() => vi.useRealTimers());
+
+describe("VM host pool", () => {
+  it("upgrades retained host and allocation tables with public origins", async () => {
+    const stub = pool(crypto.randomUUID());
+    await runInDurableObject(stub, async (_pool, state) => {
+      state.storage.sql.exec(`
+        DROP TABLE vm_allocations;
+        DROP TABLE vm_hosts;
+        CREATE TABLE vm_hosts (
+          host_id TEXT PRIMARY KEY,
+          factory_name TEXT NOT NULL UNIQUE,
+          donor_id TEXT NOT NULL,
+          max_vms INTEGER NOT NULL,
+          vm_cpus INTEGER NOT NULL,
+          vm_memory_mib INTEGER NOT NULL,
+          epoch INTEGER NOT NULL DEFAULT 0,
+          lease_id TEXT,
+          lease_expires_at INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE TABLE vm_allocations (
+          allocation_id TEXT PRIMARY KEY,
+          generation INTEGER NOT NULL,
+          factory_name TEXT NOT NULL,
+          owner_id TEXT NOT NULL,
+          organization_id TEXT NOT NULL,
+          team_id TEXT NOT NULL,
+          authorization_epoch INTEGER NOT NULL,
+          agent_id TEXT NOT NULL,
+          mount_id TEXT NOT NULL,
+          pool_locator TEXT NOT NULL,
+          machine_id TEXT NOT NULL,
+          host_id TEXT NOT NULL,
+          lease_id TEXT,
+          host_epoch INTEGER,
+          slot INTEGER NOT NULL,
+          bearer TEXT NOT NULL,
+          state TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL,
+          UNIQUE(owner_id, agent_id, mount_id)
+        );
+      `);
+
+      new VmHostPool(state, env as unknown as VmHostPoolEnv);
+
+      for (const table of ["vm_hosts", "vm_allocations"]) {
+        const columns = state.storage.sql.exec<{ name: string }>(
+          `PRAGMA table_info(${table})`,
+        ).toArray().map((column) => column.name);
+        expect(columns).toContain("public_origin");
+      }
+    });
+  });
+
+  it("selects exact factories without overcommit and releases only after acknowledgement", async () => {
+    const stub = pool(crypto.randomUUID());
+    const hostA = await connectHost(stub, HOST_A, "donor-a", 1);
+    const hostB = await connectHost(stub, HOST_B, "donor-b", 1);
+
+    const provisionA = nextFrame(hostA.socket);
+    const acquiredA = await acquire(stub, MOUNT_A);
+    expect(acquiredA.response.status).toBe(201);
+    expect(acquiredA.body).toMatchObject({
+      factory_name: FACTORY_A,
+      generation: 1,
+      host_id: HOST_A,
+      machine_id: `vm:${MOUNT_A}`,
+      route_id: expect.stringMatching(/^vm-host:/),
+      slot: 0,
+    });
+    const allocationA = allocationIdentity(acquiredA.body, MOUNT_A);
+    const frameA = await provisionA;
+    expect(frameA).toMatchObject({
+      type: "provision",
+      lease_id: hostA.lease.lease_id,
+      epoch: hostA.lease.epoch,
+      allocation_id: allocationA.allocation_id,
+      generation: 1,
+      slot: 0,
+      machine_id: `vm:${MOUNT_A}`,
+    });
+    expect(frameA).not.toHaveProperty("owner_id");
+    expect(frameA).not.toHaveProperty("agent_id");
+    expect(frameA).not.toHaveProperty("mount_id");
+    const attachment = frameA.tool_attachment as { url: string; bearer: string };
+    expect(attachment.bearer).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(new URL(attachment.url).pathname).toBe(
+      `/v1/vm-host-attachments/${LOCATOR}/${allocationA.allocation_id}/tool-host`,
+    );
+
+    const invalid = await stub.fetch("https://pool.internal/validate-attachment", {
+      method: "POST",
+      body: JSON.stringify({ allocation_id: allocationA.allocation_id, bearer: "x".repeat(43) }),
+    });
+    expect(invalid.status).toBe(404);
+    const valid = await stub.fetch("https://pool.internal/validate-attachment", {
+      method: "POST",
+      body: JSON.stringify({ allocation_id: allocationA.allocation_id, bearer: attachment.bearer }),
+    });
+    expect(valid.status).toBe(200);
+    await expect(valid.json()).resolves.toMatchObject({
+      valid: true,
+      owner_id: OWNER_A,
+      agent_id: "agent-a",
+      mount_id: MOUNT_A,
+      public_origin: ORIGIN,
+      route_id: `vm-host:${allocationA.allocation_id}:1`,
+    });
+
+    hostA.socket.send(JSON.stringify({
+      type: "provisioned",
+      lease_id: hostA.lease.lease_id,
+      epoch: hostA.lease.epoch,
+      allocation_id: allocationA.allocation_id,
+      generation: 1,
+      machine_id: `vm:${MOUNT_A}`,
+    }));
+    await eventuallyReady(stub, allocationA);
+
+    const replay = await acquire(stub, MOUNT_A);
+    expect(replay.response.status).toBe(200);
+    expect(replay.body).toEqual(acquiredA.body);
+
+    const provisionB = nextFrame(hostB.socket);
+    const acquiredB = await acquire(stub, MOUNT_B, FACTORY_B);
+    expect(acquiredB.body).toMatchObject({ host_id: HOST_B, slot: 0 });
+    await expect(provisionB).resolves.toMatchObject({
+      type: "provision",
+      allocation_id: acquiredB.body.allocation_id,
+    });
+
+    const unavailable = await acquire(stub, MOUNT_C);
+    expect(unavailable.response.status).toBe(409);
+    expect(unavailable.body).toEqual({ error: "factory_unavailable" });
+
+    const missing = await acquire(
+      stub,
+      "10000000-0000-4000-8000-000000000004",
+      "missing-factory",
+    );
+    expect(missing.response.status).toBe(404);
+    expect(missing.body).toEqual({ error: "factory_not_found" });
+
+    const emptyPoolMissing = await pool(crypto.randomUUID()).fetch(
+      "https://pool.internal/acquire",
+      {
+        method: "POST",
+        body: JSON.stringify(acquireBody(
+          "10000000-0000-4000-8000-000000000005",
+          { factory_name: "system-only" },
+        )),
+      },
+    );
+    expect(emptyPoolMissing.status).toBe(404);
+    await expect(emptyPoolMissing.json()).resolves.toEqual({ error: "factory_not_found" });
+
+    const retargetedReplay = await acquire(stub, MOUNT_A, FACTORY_B);
+    expect(retargetedReplay.response.status).toBe(409);
+    expect(retargetedReplay.body).toEqual({ error: "allocation_conflict" });
+
+    const releaseFrame = nextFrame(hostA.socket);
+    const releasing = await stub.fetch("https://pool.internal/release", {
+      method: "POST",
+      body: JSON.stringify(allocationA),
+    });
+    expect(releasing.status).toBe(202);
+    await expect(releaseFrame).resolves.toMatchObject({
+      type: "release",
+      allocation_id: allocationA.allocation_id,
+    });
+    expect((await acquire(stub, MOUNT_C)).response.status).toBe(409);
+
+    hostA.socket.send(JSON.stringify({
+      type: "released",
+      lease_id: hostA.lease.lease_id,
+      epoch: hostA.lease.epoch,
+      allocation_id: allocationA.allocation_id,
+      generation: 1,
+      machine_id: `vm:${MOUNT_A}`,
+    }));
+    await eventuallyState(stub, allocationA, "released");
+
+    const reusedSlotFrame = nextFrame(hostA.socket);
+    const acquiredC = await acquire(stub, MOUNT_C);
+    expect(acquiredC.body).toMatchObject({ host_id: HOST_A, slot: 0 });
+    await expect(reusedSlotFrame).resolves.toMatchObject({
+      type: "provision",
+      allocation_id: acquiredC.body.allocation_id,
+    });
+
+    hostA.socket.close(1000, "test complete");
+    hostB.socket.close(1000, "test complete");
+  });
+
+  it("releases a committed acquire by its pre-acquire intent and tombstones release-before-acquire", async () => {
+    const stub = pool(crypto.randomUUID());
+    const host = await connectHost(stub, HOST_A, "donor-a", 2);
+    const provision = nextFrame(host.socket);
+    const acquired = await acquire(stub, MOUNT_A);
+    const provisioned = await provision;
+
+    const release = nextFrame(host.socket);
+    const releasedByIntent = await stub.fetch("https://pool.internal/release-intent", {
+      method: "POST",
+      body: JSON.stringify(acquireBody(MOUNT_A)),
+    });
+    expect(releasedByIntent.status).toBe(202);
+    await expect(release).resolves.toMatchObject({
+      type: "release",
+      allocation_id: acquired.body.allocation_id,
+      generation: acquired.body.generation,
+      machine_id: provisioned.machine_id,
+    });
+
+    const cancelledBeforeAcquire = await stub.fetch("https://pool.internal/release-intent", {
+      method: "POST",
+      body: JSON.stringify(acquireBody(MOUNT_B)),
+    });
+    expect(cancelledBeforeAcquire.status).toBe(200);
+    await expect(cancelledBeforeAcquire.json()).resolves.toEqual({ state: "released" });
+    const lateAcquire = await acquire(stub, MOUNT_B);
+    expect(lateAcquire.response.status).toBe(409);
+    expect(lateAcquire.body).toEqual({ error: "allocation_released" });
+
+    host.socket.close(1000, "test complete");
+  });
+
+  it("keeps the exact epoch bearer valid past its initial lease when control pings renew", async () => {
+    vi.useFakeTimers();
+    const startedAt = 2_000_000;
+    vi.setSystemTime(startedAt);
+    const stub = pool(crypto.randomUUID());
+    const host = await connectHost(stub, HOST_A, "donor-a", 1);
+    const provision = nextFrame(host.socket);
+    const acquired = await acquire(stub, MOUNT_A);
+    const frame = await provision;
+    const bearer = (frame.tool_attachment as { bearer: string }).bearer;
+
+    vi.setSystemTime(startedAt + 40_000);
+    const pong = nextFrame(host.socket);
+    host.socket.send(JSON.stringify({
+      type: "ping",
+      lease_id: host.lease.lease_id,
+      epoch: host.lease.epoch,
+      nonce: "renew-control",
+    }));
+    await expect(pong).resolves.toMatchObject({
+      type: "pong",
+      expires_at: startedAt + 100_000,
+      nonce: "renew-control",
+    });
+
+    vi.setSystemTime(startedAt + 61_000);
+    const validated = await stub.fetch("https://pool.internal/validate-attachment", {
+      method: "POST",
+      body: JSON.stringify({ allocation_id: acquired.body.allocation_id, bearer }),
+    });
+    expect(validated.status).toBe(200);
+    await expect(validated.json()).resolves.toMatchObject({
+      allocation_id: acquired.body.allocation_id,
+      generation: 1,
+      route_id: `vm-host:${acquired.body.allocation_id}:1`,
+      lease_expires_at: startedAt + 100_000,
+    });
+
+    host.socket.close(1000, "test complete");
+  });
+
+  it("fences only a replaced host identity and rejects donor or shape takeover", async () => {
+    const stub = pool(crypto.randomUUID());
+    const original = await connectHost(stub, HOST_A, "donor-a", 2);
+    const independent = await connectHost(stub, HOST_B, "donor-b", 2);
+
+    const fenced = nextFrame(original.socket);
+    const replacement = await connectHost(stub, HOST_A, "donor-a", 2);
+    expect(replacement.lease.epoch).toBe(original.lease.epoch + 1);
+    await expect(fenced).resolves.toMatchObject({
+      type: "fenced",
+      epoch: replacement.lease.epoch,
+    });
+
+    const pong = nextFrame(independent.socket);
+    independent.socket.send(JSON.stringify({
+      type: "ping",
+      lease_id: independent.lease.lease_id,
+      epoch: independent.lease.epoch,
+      nonce: "still-live",
+    }));
+    await expect(pong).resolves.toMatchObject({ type: "pong", nonce: "still-live" });
+
+    const donorTakeover = await upgrade(stub, "donor-other");
+    const donorError = nextFrame(donorTakeover);
+    donorTakeover.send(JSON.stringify(attach(HOST_A, 2)));
+    await expect(donorError).resolves.toMatchObject({ type: "error", code: "host_conflict" });
+
+    const shapeTakeover = await upgrade(stub, "donor-a");
+    const shapeError = nextFrame(shapeTakeover);
+    shapeTakeover.send(JSON.stringify({ ...attach(HOST_A, 2), vm: { cpus: 4, memory_mib: 2048 } }));
+    await expect(shapeError).resolves.toMatchObject({ type: "error", code: "host_shape_conflict" });
+
+    const renamed = await upgrade(stub, "donor-a");
+    const renamedError = nextFrame(renamed);
+    renamed.send(JSON.stringify(attach(HOST_A, 2, "renamed-factory")));
+    await expect(renamedError).resolves.toMatchObject({
+      type: "error",
+      code: "host_name_conflict",
+    });
+
+    const duplicateName = await upgrade(stub, "donor-c");
+    const duplicateNameError = nextFrame(duplicateName);
+    duplicateName.send(JSON.stringify(attach(HOST_C, 2, FACTORY_A)));
+    await expect(duplicateNameError).resolves.toMatchObject({
+      type: "error",
+      code: "factory_name_conflict",
+    });
+
+    replacement.socket.close(1000, "test complete");
+    independent.socket.close(1000, "test complete");
+    donorTakeover.close(1000, "test complete");
+    shapeTakeover.close(1000, "test complete");
+    renamed.close(1000, "test complete");
+    duplicateName.close(1000, "test complete");
+  });
+
+  it("reconciles retained allocations with an epoch-bound bearer and enforces the scope claim", async () => {
+    const stub = pool(crypto.randomUUID());
+    const first = await connectHost(stub, HOST_A, "donor-a", 2);
+    const initialProvision = nextFrame(first.socket);
+    const acquired = await acquire(stub, MOUNT_A);
+    const allocation = allocationIdentity(acquired.body, MOUNT_A);
+    const provision = await initialProvision;
+    const bearer = (provision.tool_attachment as { bearer: string }).bearer;
+
+    const denied = await stub.fetch("https://pool.internal/acquire", {
+      method: "POST",
+      body: JSON.stringify(acquireBody(MOUNT_B, { owner_id: OWNER_B })),
+    });
+    expect(denied.status).toBe(404);
+
+    const replacement = await connectHost(stub, HOST_A, "donor-a", 2);
+    const replayedProvision = nextFrame(replacement.socket);
+    replacement.socket.send(JSON.stringify({
+      type: "reconcile",
+      lease_id: replacement.lease.lease_id,
+      epoch: replacement.lease.epoch,
+      allocations: [{
+        allocation_id: allocation.allocation_id,
+        generation: allocation.generation,
+        machine_id: `vm:${MOUNT_A}`,
+        state: "ready",
+      }],
+    }));
+    const redriven = await replayedProvision;
+    expect(redriven).toMatchObject({
+      type: "provision",
+      allocation_id: allocation.allocation_id,
+      tool_attachment: { bearer: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/) },
+    });
+    const successorBearer = (redriven.tool_attachment as { bearer: string }).bearer;
+    expect(successorBearer).not.toBe(bearer);
+    replacement.socket.send(JSON.stringify({
+      type: "provisioned",
+      lease_id: replacement.lease.lease_id,
+      epoch: replacement.lease.epoch,
+      allocation_id: allocation.allocation_id,
+      generation: allocation.generation,
+      machine_id: `vm:${MOUNT_A}`,
+    }));
+    await eventuallyReady(stub, allocation);
+
+    const predecessor = await stub.fetch("https://pool.internal/validate-attachment", {
+      method: "POST",
+      body: JSON.stringify({ allocation_id: allocation.allocation_id, bearer }),
+    });
+    expect(predecessor.status).toBe(404);
+    const successor = await stub.fetch("https://pool.internal/validate-attachment", {
+      method: "POST",
+      body: JSON.stringify({ allocation_id: allocation.allocation_id, bearer: successorBearer }),
+    });
+    expect(successor.status).toBe(200);
+    await expect(successor.json()).resolves.toMatchObject({
+      route_id: `vm-host:${allocation.allocation_id}:${replacement.lease.epoch}`,
+    });
+
+    const releaseFrame = nextFrame(replacement.socket);
+    await stub.fetch("https://pool.internal/release", {
+      method: "POST",
+      body: JSON.stringify(allocation),
+    });
+    const release = await releaseFrame;
+    expect(release).toMatchObject({ type: "release", allocation_id: allocation.allocation_id });
+
+    const replayedRelease = nextFrame(replacement.socket);
+    replacement.socket.send(JSON.stringify({
+      type: "reconcile",
+      lease_id: replacement.lease.lease_id,
+      epoch: replacement.lease.epoch,
+      allocations: [{
+        allocation_id: allocation.allocation_id,
+        generation: allocation.generation,
+        machine_id: `vm:${MOUNT_A}`,
+        state: "ready",
+      }],
+    }));
+    await expect(replayedRelease).resolves.toMatchObject({
+      type: "release",
+      allocation_id: allocation.allocation_id,
+    });
+
+    first.socket.close(1000, "test complete");
+    replacement.socket.close(1000, "test complete");
+  });
+
+  it("moves only a reconnecting host and its allocations to that host's current origin", async () => {
+    const stub = pool(crypto.randomUUID());
+    const firstA = await connectHost(stub, HOST_A, "donor-a", 1);
+    const hostB = await connectHost(stub, HOST_B, "donor-b", 1);
+    const firstProvision = nextFrame(firstA.socket);
+    const allocationA = await acquire(stub, MOUNT_A);
+    await firstProvision;
+
+    const movedOrigin = "https://moved.example";
+    const replacementA = await connectHost(
+      stub,
+      HOST_A,
+      "donor-a",
+      1,
+      FACTORY_A,
+      movedOrigin,
+    );
+    const movedProvision = nextFrame(replacementA.socket);
+    replacementA.socket.send(JSON.stringify({
+      type: "reconcile",
+      lease_id: replacementA.lease.lease_id,
+      epoch: replacementA.lease.epoch,
+      allocations: [{
+        allocation_id: allocationA.body.allocation_id,
+        generation: 1,
+        machine_id: `vm:${MOUNT_A}`,
+        state: "ready",
+      }],
+    }));
+    const moved = await movedProvision;
+    expect(new URL((moved.tool_attachment as { url: string }).url).origin).toBe(
+      movedOrigin.replace("https:", "wss:"),
+    );
+
+    const provisionB = nextFrame(hostB.socket);
+    await acquire(stub, MOUNT_B, FACTORY_B);
+    const unchanged = await provisionB;
+    expect(new URL((unchanged.tool_attachment as { url: string }).url).origin).toBe(
+      ORIGIN.replace("https:", "wss:"),
+    );
+
+    firstA.socket.close(1000, "test complete");
+    replacementA.socket.close(1000, "test complete");
+    hostB.socket.close(1000, "test complete");
+  });
+
+  it("keeps agent capacity exclusive while system capacity accepts distinct users", async () => {
+    const agentLocator = "a".repeat(43);
+    const agentStub = pool(crypto.randomUUID());
+    const agentHost = await connectScopedHost(agentStub, HOST_A, 2, {
+      "x-nanocodex-pool-scope": "agent",
+      "x-nanocodex-pool-owner": OWNER_A,
+      "x-nanocodex-pool-agent": "agent-a",
+      "x-nanocodex-donor-id": OWNER_A,
+      "x-nanocodex-pool-locator": agentLocator,
+    });
+    const agentProvision = nextFrame(agentHost.socket);
+    const admitted = await agentStub.fetch("https://pool.internal/acquire", {
+      method: "POST",
+      body: JSON.stringify(acquireBody(MOUNT_A, { pool_locator: agentLocator })),
+    });
+    expect(admitted.status).toBe(201);
+    const admittedBody = await admitted.json<Record<string, unknown>>();
+    const agentProvisionFrame = await agentProvision;
+    expect(agentProvisionFrame).toMatchObject({ type: "provision" });
+    const sibling = await agentStub.fetch("https://pool.internal/acquire", {
+      method: "POST",
+      body: JSON.stringify(acquireBody(MOUNT_B, {
+        agent_id: "agent-b",
+        pool_locator: agentLocator,
+      })),
+    });
+    expect(sibling.status).toBe(404);
+    agentHost.socket.close(1000, "control lease ended");
+    await eventuallyAttachmentDenied(
+      agentStub,
+      admittedBody.allocation_id as string,
+      (agentProvisionFrame.tool_attachment as { bearer: string }).bearer,
+    );
+
+    const systemLocator = "s".repeat(43);
+    const systemStub = pool(crypto.randomUUID());
+    const systemHost = await connectScopedHost(systemStub, HOST_B, 2, {
+      "x-nanocodex-pool-scope": "system",
+      "x-nanocodex-donor-id": "system",
+      "x-nanocodex-pool-locator": systemLocator,
+    }, FACTORY_A);
+    const firstProvision = nextFrame(systemHost.socket);
+    const first = await systemStub.fetch("https://pool.internal/acquire", {
+      method: "POST",
+      body: JSON.stringify(acquireBody(MOUNT_B, { pool_locator: systemLocator })),
+    });
+    expect(first.status).toBe(201);
+    await expect(firstProvision).resolves.toMatchObject({ type: "provision" });
+    const secondProvision = nextFrame(systemHost.socket);
+    const second = await systemStub.fetch("https://pool.internal/acquire", {
+      method: "POST",
+      body: JSON.stringify(acquireBody(MOUNT_C, {
+        owner_id: OWNER_B,
+        agent_id: "agent-b",
+        pool_locator: systemLocator,
+      })),
+    });
+    expect(second.status).toBe(201);
+    await expect(secondProvision).resolves.toMatchObject({ type: "provision" });
+
+    systemHost.socket.close(1000, "test complete");
+  });
+});
+
+function pool(name: string): DurableObjectStub<VmHostPool> {
+  const namespace = (env as unknown as {
+    NANOCODEX_VM_HOST_POOLS: DurableObjectNamespace<VmHostPool>;
+  }).NANOCODEX_VM_HOST_POOLS;
+  return namespace.getByName(name);
+}
+
+async function connectHost(
+  stub: DurableObjectStub<VmHostPool>,
+  hostId: string,
+  donorId: string,
+  maxVms: number,
+  factoryName = hostId === HOST_A ? FACTORY_A : FACTORY_B,
+  publicOrigin = ORIGIN,
+): Promise<{ socket: WebSocket; lease: LeaseFrame }> {
+  const socket = await upgrade(stub, donorId, publicOrigin);
+  const leased = nextFrame(socket);
+  socket.send(JSON.stringify(attach(hostId, maxVms, factoryName)));
+  const lease = await leased;
+  expect(lease).toMatchObject({
+    type: "lease",
+    protocol_version: 1,
+    max_vms: maxVms,
+    vm: { cpus: 2, memory_mib: 1024 },
+  });
+  return { socket, lease: lease as unknown as LeaseFrame };
+}
+
+async function connectScopedHost(
+  stub: DurableObjectStub<VmHostPool>,
+  hostId: string,
+  maxVms: number,
+  headers: Record<string, string>,
+  factoryName = hostId === HOST_A ? FACTORY_A : FACTORY_B,
+): Promise<{ socket: WebSocket; lease: LeaseFrame }> {
+  const response = await stub.fetch("https://pool.internal/host", {
+    headers: {
+      upgrade: "websocket",
+      "x-nanocodex-public-origin": ORIGIN,
+      ...headers,
+    },
+  });
+  expect(response.status).toBe(101);
+  const socket = response.webSocket!;
+  socket.accept();
+  const leased = nextFrame(socket);
+  socket.send(JSON.stringify(attach(hostId, maxVms, factoryName)));
+  return { socket, lease: await leased as unknown as LeaseFrame };
+}
+
+type LeaseFrame = {
+  type: "lease";
+  lease_id: string;
+  epoch: number;
+  expires_at: number;
+};
+
+async function upgrade(
+  stub: DurableObjectStub<VmHostPool>,
+  donorId: string,
+  publicOrigin = ORIGIN,
+): Promise<WebSocket> {
+  const response = await stub.fetch("https://pool.internal/host", {
+    headers: {
+      upgrade: "websocket",
+      "x-nanocodex-pool-scope": "account",
+      "x-nanocodex-pool-owner": OWNER_A,
+      "x-nanocodex-donor-id": donorId,
+      "x-nanocodex-public-origin": publicOrigin,
+      "x-nanocodex-pool-locator": LOCATOR,
+    },
+  });
+  expect(response.status).toBe(101);
+  const socket = response.webSocket!;
+  socket.accept();
+  return socket;
+}
+
+function attach(
+  hostId: string,
+  maxVms: number,
+  factoryName = hostId === HOST_A ? FACTORY_A : FACTORY_B,
+) {
+  return {
+    type: "attach",
+    protocol_version: 1,
+    host_id: hostId,
+    factory_name: factoryName,
+    max_vms: maxVms,
+    vm: { cpus: 2, memory_mib: 1024 },
+  };
+}
+
+async function acquire(
+  stub: DurableObjectStub<VmHostPool>,
+  mountId: string,
+  factoryName = FACTORY_A,
+): Promise<{ response: Response; body: Record<string, unknown> }> {
+  const response = await stub.fetch("https://pool.internal/acquire", {
+    method: "POST",
+    body: JSON.stringify(acquireBody(mountId, { factory_name: factoryName })),
+  });
+  return { response, body: await response.clone().json<Record<string, unknown>>() };
+}
+
+function acquireBody(mountId: string, overrides: Record<string, unknown> = {}) {
+  return {
+    factory_name: FACTORY_A,
+    owner_id: OWNER_A,
+    organization_id: "org-a",
+    team_id: "team-a",
+    authorization_epoch: 3,
+    agent_id: "agent-a",
+    mount_id: mountId,
+    pool_locator: LOCATOR,
+    ...overrides,
+  };
+}
+
+function allocationIdentity(body: Record<string, unknown>, mountId: string) {
+  return {
+    owner_id: OWNER_A,
+    agent_id: "agent-a",
+    mount_id: mountId,
+    allocation_id: body.allocation_id as string,
+    generation: body.generation as number,
+    pool_locator: LOCATOR,
+  };
+}
+
+async function eventuallyReady(
+  stub: DurableObjectStub<VmHostPool>,
+  identity: ReturnType<typeof allocationIdentity>,
+): Promise<void> {
+  await eventuallyState(stub, identity, "ready");
+}
+
+async function eventuallyState(
+  stub: DurableObjectStub<VmHostPool>,
+  identity: ReturnType<typeof allocationIdentity>,
+  state: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const response = await stub.fetch("https://pool.internal/ready", {
+      method: "POST",
+      body: JSON.stringify(identity),
+    });
+    const body = await response.json<{ state: string }>();
+    if (body.state === state) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`allocation did not reach ${state}`);
+}
+
+function nextFrame(socket: WebSocket): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const onMessage = (event: MessageEvent) => {
+      cleanup();
+      try { resolve(JSON.parse(String(event.data)) as Record<string, unknown>); }
+      catch (error) { reject(error); }
+    };
+    const onError = () => {
+      cleanup();
+      reject(new Error("VM host socket failed"));
+    };
+    const cleanup = () => {
+      socket.removeEventListener("message", onMessage);
+      socket.removeEventListener("error", onError);
+    };
+    socket.addEventListener("message", onMessage);
+    socket.addEventListener("error", onError);
+  });
+}
+
+async function eventuallyAttachmentDenied(
+  stub: DurableObjectStub<VmHostPool>,
+  allocationId: string,
+  bearer: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const response = await stub.fetch("https://pool.internal/validate-attachment", {
+      method: "POST",
+      body: JSON.stringify({ allocation_id: allocationId, bearer }),
+    });
+    if (response.status === 404) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("attachment bearer remained valid after its control lease ended");
+}

--- a/js/managed/test/vm-host-protocol.test.ts
+++ b/js/managed/test/vm-host-protocol.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MAX_VM_HOST_MESSAGE_BYTES,
+  VM_HOST_PROTOCOL_VERSION,
+  matchesVmHostLease,
+  parseVmHostCommand,
+  type VmHostServerMessage,
+} from "../src/vm-host-protocol";
+
+const HOST_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const LEASE_ID = "22222222-2222-4222-8222-222222222222";
+const ALLOCATION_ID = "33333333-3333-4333-8333-333333333333";
+
+describe("VM-host control protocol", () => {
+  it("strictly parses the v1 attach and heartbeat commands", () => {
+    expect(parseVmHostCommand(JSON.stringify({
+      type: "attach",
+      protocol_version: VM_HOST_PROTOCOL_VERSION,
+      host_id: HOST_ID,
+      factory_name: "garage-mac",
+      max_vms: 4,
+      vm: { cpus: 2, memory_mib: 1_024 },
+    }))).toEqual({
+      type: "attach",
+      protocol_version: 1,
+      host_id: HOST_ID,
+      factory_name: "garage-mac",
+      max_vms: 4,
+      vm: { cpus: 2, memory_mib: 1_024 },
+    });
+    expect(parseVmHostCommand(JSON.stringify({
+      type: "ping",
+      lease_id: LEASE_ID,
+      epoch: 7,
+      nonce: "heartbeat-7",
+    }))).toEqual({
+      type: "ping",
+      lease_id: LEASE_ID,
+      epoch: 7,
+      nonce: "heartbeat-7",
+    });
+    expect(parseVmHostCommand(JSON.stringify({
+      type: "ping",
+      lease_id: LEASE_ID,
+      epoch: 7,
+    }))).toEqual({ type: "ping", lease_id: LEASE_ID, epoch: 7 });
+  });
+
+  it("strictly parses provision, release, and reconciliation acknowledgements", () => {
+    const identity = {
+      lease_id: LEASE_ID,
+      epoch: 7,
+      allocation_id: ALLOCATION_ID,
+      generation: 3,
+      machine_id: "vm:mount-1",
+    };
+    expect(parseVmHostCommand(JSON.stringify({ type: "provisioned", ...identity })))
+      .toEqual({ type: "provisioned", ...identity });
+    expect(parseVmHostCommand(JSON.stringify({ type: "released", ...identity })))
+      .toEqual({ type: "released", ...identity });
+    expect(parseVmHostCommand(JSON.stringify({
+      type: "reconcile",
+      lease_id: LEASE_ID,
+      epoch: 7,
+      allocations: [{
+        allocation_id: ALLOCATION_ID,
+        generation: 3,
+        machine_id: "vm:mount-1",
+        state: "ready",
+      }],
+    }))).toEqual({
+      type: "reconcile",
+      lease_id: LEASE_ID,
+      epoch: 7,
+      allocations: [{
+        allocation_id: ALLOCATION_ID,
+        generation: 3,
+        machine_id: "vm:mount-1",
+        state: "ready",
+      }],
+    });
+  });
+
+  it("rejects unsupported versions, directions, extra fields, and malformed JSON", () => {
+    expect(() => parseVmHostCommand(JSON.stringify({
+      type: "attach",
+      protocol_version: 2,
+      host_id: HOST_ID,
+      factory_name: "garage-mac",
+      max_vms: 4,
+      vm: { cpus: 2, memory_mib: 1_024 },
+    }))).toThrow("unsupported VM-host protocol version");
+    expect(() => parseVmHostCommand(JSON.stringify({
+      type: "attach",
+      protocol_version: 1,
+      host_id: HOST_ID,
+      factory_name: "garage-mac",
+      max_vms: 4,
+      vm: { cpus: 2, memory_mib: 1_024 },
+      account_id: "must-not-be-accepted",
+    }))).toThrow("unsupported field account_id");
+    expect(() => parseVmHostCommand(JSON.stringify({
+      type: "attach",
+      protocol_version: 1,
+      host_id: HOST_ID,
+      max_vms: 4,
+      vm: { cpus: 2, memory_mib: 1_024 },
+    }))).toThrow("factory_name");
+    expect(() => parseVmHostCommand(JSON.stringify({
+      type: "attach",
+      protocol_version: 1,
+      host_id: HOST_ID,
+      factory_name: "garage-mac",
+      max_vms: 4,
+      vm: { cpus: 2, memory_mib: 1_024, network: true },
+    }))).toThrow("unsupported field network");
+    expect(() => parseVmHostCommand(JSON.stringify({ type: "lease" })))
+      .toThrow("unsupported VM-host command");
+    expect(() => parseVmHostCommand("{"))
+      .toThrow("VM-host messages must be JSON objects");
+  });
+
+  it("enforces byte, identity, integer, nonce, and VM shape bounds", () => {
+    expect(() => parseVmHostCommand("x".repeat(MAX_VM_HOST_MESSAGE_BYTES + 1)))
+      .toThrow("limited");
+    for (const [field, value] of [
+      ["host_id", HOST_ID.toUpperCase()],
+      ["factory_name", "Garage Mac"],
+      ["factory_name", "cf_sandbox"],
+      ["factory_name", "cloudflare"],
+      ["factory_name", "host"],
+      ["max_vms", 0],
+      ["max_vms", 65],
+    ] as const) {
+      const attach = {
+        type: "attach",
+        protocol_version: 1,
+        host_id: HOST_ID,
+        factory_name: "garage-mac",
+        max_vms: 4,
+        vm: { cpus: 2, memory_mib: 1_024 },
+        [field]: value,
+      };
+      expect(() => parseVmHostCommand(JSON.stringify(attach))).toThrow();
+    }
+    for (const vm of [
+      { cpus: 0, memory_mib: 1_024 },
+      { cpus: 65, memory_mib: 1_024 },
+      { cpus: 2, memory_mib: 127 },
+      { cpus: 2, memory_mib: 262_145 },
+    ]) {
+      expect(() => parseVmHostCommand(JSON.stringify({
+        type: "attach",
+        protocol_version: 1,
+        host_id: HOST_ID,
+        factory_name: "garage-mac",
+        max_vms: 4,
+        vm,
+      }))).toThrow();
+    }
+    expect(() => parseVmHostCommand(JSON.stringify({
+      type: "ping",
+      lease_id: LEASE_ID,
+      epoch: 0,
+    }))).toThrow("epoch");
+    expect(() => parseVmHostCommand(JSON.stringify({
+      type: "ping",
+      lease_id: LEASE_ID,
+      epoch: 1,
+      nonce: "x".repeat(129),
+    }))).toThrow("nonce");
+  });
+
+  it("bounds and de-duplicates exact reconciliation entries", () => {
+    const allocation = {
+      allocation_id: ALLOCATION_ID,
+      generation: 1,
+      machine_id: "vm:mount-1",
+      state: "ready",
+    };
+    const reconcile = (allocations: unknown[]) => JSON.stringify({
+      type: "reconcile",
+      lease_id: LEASE_ID,
+      epoch: 1,
+      allocations,
+    });
+    expect(() => parseVmHostCommand(reconcile(Array.from({ length: 65 }, () => allocation))))
+      .toThrow("at most 64");
+    expect(() => parseVmHostCommand(reconcile([allocation, allocation])))
+      .toThrow("unique allocation_id and machine_id");
+    expect(() => parseVmHostCommand(reconcile([{ ...allocation, state: "releasing" }])))
+      .toThrow("state must be ready");
+    expect(() => parseVmHostCommand(reconcile([{ ...allocation, owner_id: "secret" }])))
+      .toThrow("unsupported field owner_id");
+  });
+
+  it("fences independent host leases and allocation generations", () => {
+    const lease = {
+      host_id: HOST_ID,
+      lease_id: LEASE_ID,
+      epoch: 9,
+      lease_expires_at: 20_000,
+    };
+    expect(matchesVmHostLease({ hostId: HOST_ID, leaseId: LEASE_ID, epoch: 9 }, lease, 19_999))
+      .toBe(true);
+    expect(matchesVmHostLease({
+      hostId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+      leaseId: LEASE_ID,
+      epoch: 9,
+    }, lease, 19_999)).toBe(false);
+    expect(matchesVmHostLease({ hostId: HOST_ID, leaseId: LEASE_ID, epoch: 8 }, lease, 19_999))
+      .toBe(false);
+    expect(matchesVmHostLease({ hostId: HOST_ID, leaseId: LEASE_ID, epoch: 9 }, lease, 20_001))
+      .toBe(false);
+
+  });
+
+  it("keeps the server frame union pinned to lease and allocation generations", () => {
+    const messages: VmHostServerMessage[] = [
+      {
+        type: "lease",
+        protocol_version: 1,
+        lease_id: LEASE_ID,
+        epoch: 2,
+        expires_at: 20_000,
+        max_vms: 4,
+        vm: { cpus: 2, memory_mib: 1_024 },
+      },
+      { type: "pong", lease_id: LEASE_ID, epoch: 2, expires_at: 20_000, nonce: "n" },
+      {
+        type: "provision",
+        lease_id: LEASE_ID,
+        epoch: 2,
+        allocation_id: ALLOCATION_ID,
+        generation: 3,
+        slot: 0,
+        machine_id: "vm:mount-1",
+        tool_attachment: {
+          url: "wss://managed.example/v1/agents/agent-1/tool-host",
+          bearer: "a".repeat(43),
+        },
+      },
+      {
+        type: "release",
+        lease_id: LEASE_ID,
+        epoch: 2,
+        allocation_id: ALLOCATION_ID,
+        generation: 3,
+        machine_id: "vm:mount-1",
+      },
+      { type: "fenced", epoch: 3, reason: "host lease replaced" },
+      { type: "error", code: "capacity_exhausted", message: "no VM slots remain" },
+    ];
+    expect(messages.map(({ type }) => type)).toEqual([
+      "lease",
+      "pong",
+      "provision",
+      "release",
+      "fenced",
+      "error",
+    ]);
+  });
+});

--- a/js/managed/wrangler.jsonc
+++ b/js/managed/wrangler.jsonc
@@ -89,6 +89,10 @@
         "class_name": "AccountHostedTools"
       },
       {
+        "name": "NANOCODEX_VM_HOST_POOLS",
+        "class_name": "VmHostPool"
+      },
+      {
         "name": "NANOCODEX_ROOMS",
         "class_name": "MultiplayerRoom"
       },
@@ -151,6 +155,10 @@
     {
       "tag": "v7",
       "new_sqlite_classes": ["AccountHostedTools"]
+    },
+    {
+      "tag": "v8",
+      "new_sqlite_classes": ["VmHostPool"]
     }
   ],
   "vars": {
@@ -202,6 +210,7 @@
         "bindings": [
           { "name": "NANOCODEX_SESSIONS", "class_name": "DurableAgentSession" },
           { "name": "NANOCODEX_ACCOUNT_TOOLS", "class_name": "AccountHostedTools" },
+          { "name": "NANOCODEX_VM_HOST_POOLS", "class_name": "VmHostPool" },
           { "name": "NANOCODEX_ROOMS", "class_name": "MultiplayerRoom" },
           { "name": "NANOCODEX_MULTIPLAYER_QUOTA", "class_name": "MultiplayerQuota" },
           { "name": "NANOCODEX_AUTH", "class_name": "NonceStorage" },
@@ -221,6 +230,7 @@
         "NANOCODEX_OTP_HMAC_KEY": "nanocodex-local-sms-otp-hmac-key-v1-only",
         "NANOCODEX_LOCAL_WEBAUTHN_HMAC_KEY": "nanocodex-local-passkey-portability-v1",
         "NANOCODEX_LOCAL_OAUTH_RELAY_HMAC_KEY": "nanocodex-local-oauth-relay-hmac-v1-only",
+        "NANOCODEX_SYSTEM_HOST_TOKEN": "nanocodex-local-system-vm-host-token-v1-ONLY",
         "NANOCODEX_SANDBOX_LOCAL": "true"
       },
       "containers": [

--- a/js/managed/wrangler.test.jsonc
+++ b/js/managed/wrangler.test.jsonc
@@ -24,6 +24,10 @@
         "class_name": "AccountHostedTools"
       },
       {
+        "name": "NANOCODEX_VM_HOST_POOLS",
+        "class_name": "VmHostPool"
+      },
+      {
         "name": "NANOCODEX_SESSIONS",
         "class_name": "DurableAgentSession"
       }
@@ -41,6 +45,10 @@
     {
       "tag": "managed-session-v1",
       "new_sqlite_classes": ["DurableAgentSession"]
+    },
+    {
+      "tag": "vm-host-pool-v1",
+      "new_sqlite_classes": ["VmHostPool"]
     }
   ]
 }

--- a/js/nanocodex-tools/runtime/code-runtime.mjs
+++ b/js/nanocodex-tools/runtime/code-runtime.mjs
@@ -19,7 +19,7 @@ export function createCodeRuntime(toolConfiguration = {}, extras = {}) {
   let nextSourceId = 1;
   let nextCallId = 1;
   const toolByName = new Map();
-  const subagentsBySession = new Map();
+  const subagentBindingsBySession = new Map();
   const subagentSessions = extras.subagentSessions;
 
   function addTools(configuration = {}) {
@@ -64,7 +64,7 @@ export function createCodeRuntime(toolConfiguration = {}, extras = {}) {
         callId,
         model,
         signal: controller.signal,
-        subagent: subagentsBySession.get(sessionId),
+        subagent: subagentBindingsBySession.get(sessionId)?.descriptor,
       });
       return encodeToolOutput(
         outputBody(result),
@@ -162,7 +162,7 @@ export function createCodeRuntime(toolConfiguration = {}, extras = {}) {
             callId,
             model,
             signal: controller.signal,
-            subagent: subagentsBySession.get(sessionId),
+            subagent: subagentBindingsBySession.get(sessionId)?.descriptor,
           });
         } catch (error) {
           const message = errorMessage(error);
@@ -344,9 +344,12 @@ export function createCodeRuntime(toolConfiguration = {}, extras = {}) {
   }
 
   function releaseSession(sessionId) {
-    if (subagentsBySession.has(sessionId)) subagentSessions?.release?.(sessionId);
+    const binding = subagentBindingsBySession.get(sessionId);
+    if (binding !== undefined) {
+      subagentSessions?.release?.(sessionId, binding.hostContextRef);
+    }
     stores.delete(sessionId);
-    subagentsBySession.delete(sessionId);
+    subagentBindingsBySession.delete(sessionId);
     router.releaseSession(sessionId);
     closeCodeObservations(sessionId);
   }
@@ -356,7 +359,7 @@ export function createCodeRuntime(toolConfiguration = {}, extras = {}) {
       execution.controller.abort(new Error(CANCELLATION_MESSAGE));
     }
     stores.clear();
-    subagentsBySession.clear();
+    subagentBindingsBySession.clear();
     closeCodeObservations();
     return ownsRouter ? router.reset() : undefined;
   }
@@ -390,11 +393,25 @@ export function createCodeRuntime(toolConfiguration = {}, extras = {}) {
     executeCode,
     executeCodeObserved,
     executeTool,
-    bindSubagentSession(sessionId, context) {
-      const descriptor = Object.freeze({ ...context });
-      if (sameSubagentDescriptor(subagentsBySession.get(sessionId), descriptor)) return;
-      subagentSessions?.bind?.(sessionId, descriptor);
-      subagentsBySession.set(sessionId, descriptor);
+    bindSubagentSession(sessionId, context, hostContextRef) {
+      if (hostContextRef !== undefined
+        && (typeof hostContextRef !== "string" || hostContextRef.length === 0)) {
+        throw new TypeError("subagent host context ref must be a non-empty string when supplied");
+      }
+      const descriptor = Object.freeze({
+        agentId: context.agentId,
+        parentAgentId: context.parentAgentId,
+        sessionId: context.sessionId,
+        role: context.role,
+        task: context.task,
+      });
+      const existing = subagentBindingsBySession.get(sessionId);
+      if (sameSubagentBinding(existing, descriptor, hostContextRef)) return;
+      subagentSessions?.bind?.(sessionId, descriptor, hostContextRef);
+      subagentBindingsBySession.set(sessionId, Object.freeze({
+        descriptor,
+        hostContextRef,
+      }));
     },
     nextCodeUpdate,
     cancel,
@@ -404,13 +421,15 @@ export function createCodeRuntime(toolConfiguration = {}, extras = {}) {
   });
 }
 
-function sameSubagentDescriptor(left, right) {
+function sameSubagentBinding(binding, descriptor, hostContextRef) {
+  const left = binding?.descriptor;
   return left !== undefined
-    && left.agentId === right.agentId
-    && left.parentAgentId === right.parentAgentId
-    && left.sessionId === right.sessionId
-    && left.role === right.role
-    && left.task === right.task;
+    && left.agentId === descriptor.agentId
+    && left.parentAgentId === descriptor.parentAgentId
+    && left.sessionId === descriptor.sessionId
+    && left.role === descriptor.role
+    && left.task === descriptor.task
+    && binding.hostContextRef === hostContextRef;
 }
 
 async function evaluateNative(source, environment) {

--- a/js/nanocodex-tools/src/hosted/broker-core.ts
+++ b/js/nanocodex-tools/src/hosted/broker-core.ts
@@ -26,6 +26,7 @@ const DEFAULT_MAX_IN_FLIGHT = 64;
 const OPEN = 1;
 const MAX_RETAINED_RECEIPTS = 512;
 const MAX_CALLS_PER_GENERATION = 512;
+const REVOKED_ROUTE_LEASE_EXPIRES_AT = -1;
 const TOOL_RESULT = Symbol.for("nanocodex.toolResult");
 const LEGACY_ROUTE_ID = "$legacy";
 export const HOSTED_MACHINE_TOOL_NAMES = Object.freeze([
@@ -89,6 +90,10 @@ type HostedToolsSocketAttachment = {
   allowedMcpIds?: readonly string[];
   appToolCatalogDigest?: `0x${string}`;
   connectGrantId?: string;
+  expectedAttachmentId?: string;
+  maximumLeaseExpiresAt?: number;
+  fixedRouteId?: string;
+  renewalToken?: string;
   routeId?: string;
   leaseId?: string;
   generation?: number;
@@ -228,6 +233,22 @@ export type HostedToolsBrokerCoreOptions = Readonly<{
     connectGrantId?: string,
     appToolCatalogDigest?: string,
   ) => boolean;
+  renewLeasedAttachment?: (
+    renewal: HostedToolsLeasedAttachmentRenewal,
+  ) => Promise<number | undefined>;
+}>;
+
+export type HostedToolsLeasedAttachmentPolicy = Readonly<{
+  expectedAttachmentId: string;
+  maximumLeaseExpiresAt: number;
+  fixedRouteId: string;
+  renewalToken: string;
+}>;
+
+export type HostedToolsLeasedAttachmentRenewal = Readonly<{
+  expectedAttachmentId: string;
+  fixedRouteId: string;
+  renewalToken: string;
 }>;
 
 /** Owns one reverse-tool attachment over an injected socket and durable ledger. */
@@ -245,6 +266,9 @@ export class HostedToolsBrokerCore {
     connectGrantId?: string,
     appToolCatalogDigest?: string,
   ) => boolean;
+  readonly #renewLeasedAttachment:
+    | ((renewal: HostedToolsLeasedAttachmentRenewal) => Promise<number | undefined>)
+    | undefined;
   #catalogValidator: HostedToolsCatalogValidator | undefined;
   #nextCandidateGeneration: number;
 
@@ -267,6 +291,7 @@ export class HostedToolsBrokerCore {
     this.#persistence = options.persistence;
     this.#onCatalogChanged = options.onCatalogChanged;
     this.#entryAllowed = options.entryAllowed ?? (() => true);
+    this.#renewLeasedAttachment = options.renewLeasedAttachment;
     const now = this.#now();
     const sockets = this.context.sockets();
     const retainHosts = options.resumeRetainedSockets === true && sockets.length > 0;
@@ -338,6 +363,29 @@ export class HostedToolsBrokerCore {
     for (const state of this.#persistence.states()) this.#retireState(state, reason);
   }
 
+  /** Fences one attachment only when its exact durable route is still current. */
+  revokeRoute(routeId: string, reason: string): boolean {
+    const state = this.#persistence.state(routeId) ?? emptyState(routeId);
+    const active = state.lease_id !== null;
+    if (active) {
+      const socket = this.#socketForState(state);
+      if (socket) this.#fence(socket, reason);
+      else this.#retireState(state, reason);
+    }
+    // Revocation can race ahead of catalog publication in another Durable
+    // Object. Retain an exact route tombstone so a previously validated socket
+    // cannot publish after its control-plane fence has completed.
+    const retired = this.#persistence.state(routeId) ?? state;
+    this.#persistence.replaceHost({
+      ...retired,
+      host_id: null,
+      lease_id: null,
+      lease_expires_at: REVOKED_ROUTE_LEASE_EXPIRES_AT,
+      catalog_json: null,
+    });
+    return active;
+  }
+
   isReady(): boolean { return this.#definitions().length > 0; }
 
   hasPendingCalls(): boolean { return this.#pending.size > 0; }
@@ -358,6 +406,39 @@ export class HostedToolsBrokerCore {
       prepared.appToolCatalogDigest,
     )) return undefined;
     return this.#codeTool(name, prepared);
+  }
+
+  /** Resolves one canonical machine primitive only on the named durable route. */
+  machineToolOnRoute(
+    routeId: string,
+    machineId: string,
+    name: HostedMachineToolName,
+  ): HostedToolsCodeTool | undefined {
+    if (!MACHINE_TOOL_NAMES.has(name)) return undefined;
+    const binding = this.#catalogBindings(undefined, true).find((candidate) => (
+      candidate.routeId === routeId
+      && candidate.machine?.id === machineId
+      && candidate.wireName === name
+    ));
+    if (!binding) return undefined;
+    const prepared = this.#preparedTool(binding);
+    if (!this.#entryAllowed(
+      prepared.entry,
+      prepared.connectGrantId,
+      prepared.appToolCatalogDigest,
+    )) return undefined;
+    return this.#codeTool(name, prepared);
+  }
+
+  /** Returns one live machine only when its exact durable route still owns it. */
+  machineOnRoute(routeId: string, machineId: string): HostedMachine | undefined {
+    const state = this.#persistence.state(routeId);
+    if (state === undefined) return undefined;
+    const socket = this.#liveRoutingSocketForState(state);
+    if (socket === undefined) return undefined;
+    const attachment = this.#attachment(socket);
+    if (attachment?.connectGrantId !== undefined) return undefined;
+    return attachment?.machines?.find(({ id }) => id === machineId);
   }
 
   /** Returns the live, non-secret user-machine snapshot for the account-owned host. */
@@ -387,9 +468,18 @@ export class HostedToolsBrokerCore {
     allowedMcpIds?: readonly string[],
     appToolCatalogDigest?: `0x${string}`,
     connectGrantId?: string,
+    leasedAttachment?: HostedToolsLeasedAttachmentPolicy,
   ): void {
     if (allowedMcpIds !== undefined && !isConnectGrantId(connectGrantId)) {
       throw new TypeError("Connect Hosted Tools requires an exact grant ID");
+    }
+    if (leasedAttachment !== undefined && (connectGrantId !== undefined
+      || leasedAttachment.expectedAttachmentId.length === 0
+      || leasedAttachment.fixedRouteId.length === 0
+      || leasedAttachment.renewalToken.length === 0
+      || leasedAttachment.renewalToken.length > 2_048
+      || !Number.isSafeInteger(leasedAttachment.maximumLeaseExpiresAt))) {
+      throw new TypeError("leased Hosted Tools requires one complete ordinary-route policy");
     }
     this.context.writeAttachment(socket, {
       kind: SOCKET_TAG,
@@ -397,6 +487,12 @@ export class HostedToolsBrokerCore {
       ...(allowedMcpIds === undefined ? {} : { allowedMcpIds: [...allowedMcpIds] }),
       ...(appToolCatalogDigest === undefined ? {} : { appToolCatalogDigest }),
       ...(connectGrantId === undefined ? {} : { connectGrantId }),
+      ...(leasedAttachment === undefined ? {} : {
+        expectedAttachmentId: leasedAttachment.expectedAttachmentId,
+        maximumLeaseExpiresAt: leasedAttachment.maximumLeaseExpiresAt,
+        fixedRouteId: leasedAttachment.fixedRouteId,
+        renewalToken: leasedAttachment.renewalToken,
+      }),
     } satisfies HostedToolsSocketAttachment);
     this.context.accept(socket);
   }
@@ -476,7 +572,7 @@ export class HostedToolsBrokerCore {
 
   async #dispatchHostFrame(socket: HostedToolsSocket, frame: HostedToolsHostFrame): Promise<void> {
     if (frame.type === "catalog") await this.#publishCatalog(socket, frame);
-    else if (frame.type === "ping") this.#heartbeat(socket, frame);
+    else if (frame.type === "ping") await this.#heartbeat(socket, frame);
     else if (frame.type === "drain") this.#drain(socket);
     else this.#completeResult(socket, frame);
   }
@@ -495,12 +591,50 @@ export class HostedToolsBrokerCore {
     return attachment;
   }
 
-  #heartbeat(
+  async #heartbeat(
     socket: HostedToolsSocket,
     frame: Extract<HostedToolsHostFrame, { type: "ping" }>,
-  ): void {
-    const attachment = this.#activeAttachment(socket);
-    const expiresAt = this.#now() + HOSTED_TOOLS_LEASE_MS;
+  ): Promise<void> {
+    let attachment = this.#activeAttachment(socket);
+    if (attachment.renewalToken !== undefined) {
+      const renewal = {
+        expectedAttachmentId: attachment.expectedAttachmentId!,
+        fixedRouteId: attachment.fixedRouteId!,
+        renewalToken: attachment.renewalToken,
+      };
+      let maximumLeaseExpiresAt: number | undefined;
+      try {
+        maximumLeaseExpiresAt = await this.#renewLeasedAttachment?.(renewal);
+      } catch {
+        this.#retire(socket, "leased Hosted Tools validation unavailable");
+        closeSocket(socket, 1011, "leased Hosted Tools validation unavailable");
+        return;
+      }
+      if (!Number.isSafeInteger(maximumLeaseExpiresAt)
+        || Number(maximumLeaseExpiresAt) <= this.#now()) {
+        this.revokeRoute(renewal.fixedRouteId, "leased Hosted Tools validation failed");
+        return;
+      }
+      const renewedExpiry = Number(maximumLeaseExpiresAt);
+      const renewed = this.#activeAttachment(socket);
+      if (renewed.routeId !== attachment.routeId
+        || renewed.leaseId !== attachment.leaseId
+        || renewed.generation !== attachment.generation
+        || renewed.fixedRouteId !== renewal.fixedRouteId
+        || renewed.expectedAttachmentId !== renewal.expectedAttachmentId
+        || renewed.renewalToken !== renewal.renewalToken) {
+        throw new HostedToolsProtocolError(
+          "stale_socket",
+          "socket changed while its leased attachment was being validated",
+        );
+      }
+      attachment = { ...renewed, maximumLeaseExpiresAt: renewedExpiry };
+      this.context.writeAttachment(socket, attachment);
+    }
+    const expiresAt = Math.min(
+      this.#now() + HOSTED_TOOLS_LEASE_MS,
+      attachment.maximumLeaseExpiresAt ?? Number.MAX_SAFE_INTEGER,
+    );
     const state = this.#persistence.state(attachment.routeId!)!;
     this.#persistence.replaceHost({ ...state, lease_expires_at: expiresAt });
     this.#send(socket, {
@@ -520,8 +654,39 @@ export class HostedToolsBrokerCore {
     if (this.#nextCandidateGeneration >= Number.MAX_SAFE_INTEGER) {
       throw new HostedToolsProtocolError("generation_exhausted", "Hosted Tools generation is exhausted");
     }
-    const routeId = scopedRouteId(initial.connectGrantId, frame.attachment_id);
+    const routeId = initial.fixedRouteId ?? scopedRouteId(initial.connectGrantId, frame.attachment_id);
+    let maximumLeaseExpiresAt = initial.maximumLeaseExpiresAt;
+    if (initial.renewalToken !== undefined) {
+      const renewal = {
+        expectedAttachmentId: initial.expectedAttachmentId!,
+        fixedRouteId: routeId,
+        renewalToken: initial.renewalToken,
+      };
+      try {
+        const renewed = await this.#renewLeasedAttachment?.(renewal);
+        if (!Number.isSafeInteger(renewed) || Number(renewed) <= this.#now()) {
+          this.revokeRoute(routeId, "leased Hosted Tools validation failed before admission");
+          throw new HostedToolsProtocolError(
+            "route_revoked",
+            "leased Hosted Tools validation failed before admission",
+          );
+        }
+        maximumLeaseExpiresAt = Number(renewed);
+      } catch (error) {
+        if (error instanceof HostedToolsProtocolError) throw error;
+        throw new HostedToolsProtocolError(
+          "lease_validation_unavailable",
+          "leased Hosted Tools validation was unavailable before admission",
+        );
+      }
+    }
     let state = this.#persistence.state(routeId) ?? emptyState(routeId);
+    if (state.lease_id === null && state.lease_expires_at === REVOKED_ROUTE_LEASE_EXPIRES_AT) {
+      throw new HostedToolsProtocolError(
+        "route_revoked",
+        "tool attachment route was revoked before admission",
+      );
+    }
     if (state.lease_id && state.lease_expires_at <= this.#now()) {
       const expiredSocket = this.#socketForState(state);
       if (expiredSocket) this.#fence(expiredSocket, "Hosted Tools lease expired");
@@ -540,9 +705,13 @@ export class HostedToolsBrokerCore {
     }
     const generation = ++this.#nextCandidateGeneration;
     const leaseId = this.#randomUUID();
-    const expiresAt = this.#now() + HOSTED_TOOLS_LEASE_MS;
+    const expiresAt = Math.min(
+      this.#now() + HOSTED_TOOLS_LEASE_MS,
+      maximumLeaseExpiresAt ?? Number.MAX_SAFE_INTEGER,
+    );
     const candidate = {
       ...initial,
+      ...(maximumLeaseExpiresAt === undefined ? {} : { maximumLeaseExpiresAt }),
       routeId,
       leaseId,
       generation,
@@ -567,6 +736,18 @@ export class HostedToolsBrokerCore {
       if ((frame.machines?.length ?? 0) > 0
         && (frame.machines?.length !== 1 || frame.attachment_id !== frame.machines[0]?.id)) {
         throw new Error("an account machine route requires one machine whose id equals attachment_id");
+      }
+      if (initial.expectedAttachmentId !== undefined
+        && (frame.attachment_id !== initial.expectedAttachmentId
+          || frame.machines?.length !== 1
+          || frame.machines[0]?.id !== initial.expectedAttachmentId)) {
+        throw new Error("leased tool attachment must publish its exact assigned machine ID");
+      }
+      if (initial.expectedAttachmentId !== undefined) {
+        const extra = frame.tools.find((entry) => !MACHINE_TOOL_NAMES.has(entry.definition.name));
+        if (extra !== undefined) {
+          throw new Error("leased tool attachments may publish only canonical machine primitives");
+        }
       }
       if (machine !== undefined) validateMachineToolContracts(frame.tools);
       if (initial.allowedMcpIds !== undefined) {

--- a/js/nanocodex-tools/src/hosted/broker-core.ts
+++ b/js/nanocodex-tools/src/hosted/broker-core.ts
@@ -19,6 +19,7 @@ import {
   PREVIEW_OUTPUT_SCHEMA,
   WRITE_STDIN_PARAMETERS,
 } from "../../tools/execution-contract.mjs";
+import type { ToolContext } from "../../tools/types.mjs";
 
 const SOCKET_TAG = "hosted-tools";
 const INVALID_CONNECT_GRANT_ID = "invalid-connect-grant";
@@ -179,9 +180,16 @@ export type HostedToolsCodeTool = Readonly<{
   routeToken?: string;
   handler(
     input: unknown,
-    context: { sessionId: string; callId: string; model?: string; signal?: AbortSignal },
+    context: HostedToolsInvocationContext,
   ): Promise<unknown>;
 }>;
+
+export type HostedToolsInvocationContext = Readonly<
+  Pick<ToolContext, "sessionId" | "callId">
+  & Partial<Pick<ToolContext, "parentCallId" | "model" | "signal" | "subagent">>
+>;
+
+export type HostedToolsAuthorizationContext = Pick<ToolContext, "sessionId" | "subagent">;
 
 export type HostedMachineToolName = (typeof HOSTED_MACHINE_TOOL_NAMES)[number];
 
@@ -232,6 +240,7 @@ export type HostedToolsBrokerCoreOptions = Readonly<{
     entry: HostedToolCatalogEntry,
     connectGrantId?: string,
     appToolCatalogDigest?: string,
+    context?: HostedToolsAuthorizationContext,
   ) => boolean;
   renewLeasedAttachment?: (
     renewal: HostedToolsLeasedAttachmentRenewal,
@@ -265,6 +274,7 @@ export class HostedToolsBrokerCore {
     entry: HostedToolCatalogEntry,
     connectGrantId?: string,
     appToolCatalogDigest?: string,
+    context?: HostedToolsAuthorizationContext,
   ) => boolean;
   readonly #renewLeasedAttachment:
     | ((renewal: HostedToolsLeasedAttachmentRenewal) => Promise<number | undefined>)
@@ -393,7 +403,11 @@ export class HostedToolsBrokerCore {
   provider(): HostedToolsDynamicProvider { return this.#provider; }
 
   /** Resolves one canonical machine primitive against its exact admitted attachment generation. */
-  machineTool(machineId: string, name: HostedMachineToolName): HostedToolsCodeTool | undefined {
+  machineTool(
+    machineId: string,
+    name: HostedMachineToolName,
+    context?: HostedToolsAuthorizationContext,
+  ): HostedToolsCodeTool | undefined {
     if (!MACHINE_TOOL_NAMES.has(name)) return undefined;
     const binding = this.#catalogBindings().find((candidate) => (
       candidate.machine?.id === machineId && candidate.wireName === name
@@ -404,6 +418,7 @@ export class HostedToolsBrokerCore {
       prepared.entry,
       prepared.connectGrantId,
       prepared.appToolCatalogDigest,
+      context,
     )) return undefined;
     return this.#codeTool(name, prepared);
   }
@@ -413,6 +428,7 @@ export class HostedToolsBrokerCore {
     routeId: string,
     machineId: string,
     name: HostedMachineToolName,
+    context?: HostedToolsAuthorizationContext,
   ): HostedToolsCodeTool | undefined {
     if (!MACHINE_TOOL_NAMES.has(name)) return undefined;
     const binding = this.#catalogBindings(undefined, true).find((candidate) => (
@@ -426,6 +442,7 @@ export class HostedToolsBrokerCore {
       prepared.entry,
       prepared.connectGrantId,
       prepared.appToolCatalogDigest,
+      context,
     )) return undefined;
     return this.#codeTool(name, prepared);
   }
@@ -979,12 +996,13 @@ export class HostedToolsBrokerCore {
       timeoutMs: prepared.entry.timeout_ms,
       handler: async (
         input: unknown,
-        context: { sessionId: string; callId: string; model?: string; signal?: AbortSignal },
+        context: HostedToolsInvocationContext,
       ) => {
         if (!this.#entryAllowed(
           prepared.entry,
           prepared.connectGrantId,
           prepared.appToolCatalogDigest,
+          context,
         )) {
           return toolResult("Hosted tool is outside the active grant", {
             status: "unavailable",

--- a/js/nanocodex/browser/InlineAgent.mjs
+++ b/js/nanocodex/browser/InlineAgent.mjs
@@ -155,11 +155,9 @@ export async function create(options = {}) {
           const restoredSubagents = subagentSessions?.restore?.() ?? [];
           if (restoredSubagents.length > 0) {
             const restoredHostContextRefs = Object.fromEntries(
-              restoredSubagents.flatMap((descriptor) => {
+              restoredSubagents.map((descriptor) => {
                 const hostContextRef = subagentSessions?.hostContextRef?.(descriptor.sessionId);
-                return hostContextRef === undefined
-                  ? []
-                  : [[descriptor.sessionId, hostContextRef]];
+                return [descriptor.sessionId, hostContextRef ?? null];
               }),
             );
             await raw.restoreSubagents(

--- a/js/nanocodex/browser/InlineAgent.mjs
+++ b/js/nanocodex/browser/InlineAgent.mjs
@@ -154,7 +154,18 @@ export async function create(options = {}) {
           activateCloudflareAgentSession(cloudflareReservation);
           const restoredSubagents = subagentSessions?.restore?.() ?? [];
           if (restoredSubagents.length > 0) {
-            await raw.restoreSubagents(JSON.stringify(restoredSubagents));
+            const restoredHostContextRefs = Object.fromEntries(
+              restoredSubagents.flatMap((descriptor) => {
+                const hostContextRef = subagentSessions?.hostContextRef?.(descriptor.sessionId);
+                return hostContextRef === undefined
+                  ? []
+                  : [[descriptor.sessionId, hostContextRef]];
+              }),
+            );
+            await raw.restoreSubagents(
+              JSON.stringify(restoredSubagents),
+              JSON.stringify(restoredHostContextRefs),
+            );
           }
         }
         return raw;

--- a/js/nanocodex/cloudflare/Agent.mjs
+++ b/js/nanocodex/cloudflare/Agent.mjs
@@ -316,6 +316,10 @@ async function createOwned(module, resolved, options, hostAgent, lifecycle) {
     && (!internalRuntime || typeof internalRuntime !== "object" || Array.isArray(internalRuntime))) {
     throw new TypeError("Cloudflare Agent internal runtime options must be an object");
   }
+  if (internalRuntime?.subagentLifecycle !== undefined
+    && typeof internalRuntime.subagentLifecycle !== "function") {
+    throw new TypeError("Cloudflare Agent subagent lifecycle hook must be a function");
+  }
   validateInternalConfiguration(internalConfiguration);
   const eventSocket = eventPersistence === "durable"
     ? createCloudflareEventSocket(context)
@@ -346,6 +350,7 @@ async function createOwned(module, resolved, options, hostAgent, lifecycle) {
   const subagentSessions = cloudflareSubagentSessions(
     context.storage,
     sessionReservation,
+    internalRuntime?.subagentLifecycle,
   );
   let agent;
   let watcher;
@@ -633,40 +638,99 @@ function initializeAgentStorage(storage) {
     CREATE TABLE IF NOT EXISTS nanocodex_cloudflare_subagents (
       session_id TEXT PRIMARY KEY,
       agent_id TEXT NOT NULL UNIQUE,
-      descriptor_json TEXT NOT NULL
+      descriptor_json TEXT NOT NULL,
+      host_context_ref TEXT
     )
   `);
+  const subagentColumns = storage.sql.exec(
+    "PRAGMA table_info('nanocodex_cloudflare_subagents')",
+  ).toArray();
+  if (!subagentColumns.some(({ name }) => name === "host_context_ref")) {
+    storage.sql.exec(
+      "ALTER TABLE nanocodex_cloudflare_subagents ADD COLUMN host_context_ref TEXT",
+    );
+  }
 }
 
-function cloudflareSubagentSessions(storage, reservation) {
+function cloudflareSubagentSessions(storage, reservation, lifecycle) {
+  const restoredHostContextRefs = new Map();
   return Object.freeze({
     restore() {
       const restored = storage.sql.exec(
-        "SELECT descriptor_json FROM nanocodex_cloudflare_subagents",
-      ).toArray().map(({ descriptor_json }) => Object.freeze(JSON.parse(descriptor_json)));
+        "SELECT descriptor_json, host_context_ref FROM nanocodex_cloudflare_subagents",
+      ).toArray().map(({ descriptor_json, host_context_ref }) => {
+        const descriptor = Object.freeze(JSON.parse(descriptor_json));
+        restoredHostContextRefs.set(
+          descriptor.sessionId,
+          host_context_ref === null ? undefined : host_context_ref,
+        );
+        return descriptor;
+      });
       return Object.freeze(restored);
     },
-    bind(sessionId, descriptor) {
-      if (!mayBindCloudflareSubagentSession(reservation)) return;
-      storage.sql.exec(
-        `INSERT INTO nanocodex_cloudflare_subagents
-           (session_id, agent_id, descriptor_json) VALUES (?, ?, ?)
-         ON CONFLICT (session_id) DO UPDATE SET
-           agent_id = excluded.agent_id,
-           descriptor_json = excluded.descriptor_json`,
-        sessionId,
-        descriptor.agentId,
-        JSON.stringify(descriptor),
-      );
+    hostContextRef(sessionId) {
+      return restoredHostContextRefs.get(sessionId);
     },
-    release(sessionId) {
+    bind(sessionId, descriptor, hostContextRef) {
+      if (!mayBindCloudflareSubagentSession(reservation)) return;
+      if (hostContextRef !== undefined
+        && (typeof hostContextRef !== "string" || hostContextRef.length === 0)) {
+        throw new TypeError("subagent host context ref must be a non-empty string when supplied");
+      }
+      const type = restoredHostContextRefs.has(sessionId) ? "reconstruct" : "bind";
+      storage.transactionSync(() => {
+        storage.sql.exec(
+          `INSERT INTO nanocodex_cloudflare_subagents
+             (session_id, agent_id, descriptor_json, host_context_ref) VALUES (?, ?, ?, ?)
+           ON CONFLICT (session_id) DO UPDATE SET
+             agent_id = excluded.agent_id,
+             descriptor_json = excluded.descriptor_json,
+             host_context_ref = excluded.host_context_ref`,
+          sessionId,
+          descriptor.agentId,
+          JSON.stringify(descriptor),
+          hostContextRef ?? null,
+        );
+        notifySubagentLifecycle(lifecycle, {
+          type,
+          rootSessionId: reservation.sessionId,
+          sessionId,
+          descriptor,
+          hostContextRef,
+        });
+      });
+      restoredHostContextRefs.delete(sessionId);
+    },
+    release(sessionId, hostContextRef) {
       if (!mayReleaseCloudflareSubagentSession(reservation)) return;
-      storage.sql.exec(
-        "DELETE FROM nanocodex_cloudflare_subagents WHERE session_id = ?",
-        sessionId,
-      );
+      storage.transactionSync(() => {
+        const retained = storage.sql.exec(
+          `SELECT 1 AS retained FROM nanocodex_cloudflare_subagents
+           WHERE session_id = ? AND host_context_ref IS ?`,
+          sessionId,
+          hostContextRef ?? null,
+        ).toArray();
+        if (retained.length === 0) return;
+        notifySubagentLifecycle(lifecycle, {
+          type: "release",
+          rootSessionId: reservation.sessionId,
+          sessionId,
+          hostContextRef,
+        });
+        storage.sql.exec(
+          `DELETE FROM nanocodex_cloudflare_subagents
+           WHERE session_id = ? AND host_context_ref IS ?`,
+          sessionId,
+          hostContextRef ?? null,
+        );
+      });
     },
   });
+}
+
+function notifySubagentLifecycle(lifecycle, event) {
+  if (lifecycle === undefined) return;
+  lifecycle(Object.freeze(event));
 }
 
 function storedSessionId(storage) {

--- a/js/nanocodex/internal.mjs
+++ b/js/nanocodex/internal.mjs
@@ -482,7 +482,13 @@ const hostBridge = Object.freeze({
     }
     return host.sleep(milliseconds);
   },
-  bindSubagentSession(hostDefinitionId, rootSessionId, sessionId, contextJson) {
+  bindSubagentSession(
+    hostDefinitionId,
+    rootSessionId,
+    sessionId,
+    contextJson,
+    hostContextRef,
+  ) {
     let host;
     if (contextJson === undefined) {
       contextJson = sessionId;
@@ -501,7 +507,7 @@ const hostBridge = Object.freeze({
         throw new Error(`Nanocodex subagent session ID is already active: ${sessionId}`);
       }
     }
-    host.bindSubagentSession(sessionId, JSON.parse(contextJson));
+    host.bindSubagentSession(sessionId, JSON.parse(contextJson), hostContextRef);
     hostSessions.set(sessionId, host);
   },
   releaseSubagentSession(hostDefinitionId, rootSessionId, sessionId) {

--- a/js/nanocodex/src/wasm.rs
+++ b/js/nanocodex/src/wasm.rs
@@ -1078,7 +1078,7 @@ impl WasmSubagents {
         &self,
         root_session_id: &str,
         descriptors: Vec<AgentDescriptor>,
-        host_contexts: HashMap<String, Arc<str>>,
+        host_contexts: HashMap<String, Option<Arc<str>>>,
     ) -> Result<(), JsValue> {
         self.registry
             .restore_with_host_contexts(root_session_id, descriptors.clone(), host_contexts.clone())
@@ -1092,7 +1092,7 @@ impl WasmSubagents {
                 descriptor,
                 host_contexts
                     .get(&descriptor.session_id)
-                    .map(AsRef::<str>::as_ref),
+                    .and_then(|host_context| host_context.as_deref()),
             )?;
         }
         Ok(())
@@ -1279,14 +1279,14 @@ impl WasmNanocodex {
             .collect::<Result<Vec<_>, _>>()?;
         let host_contexts = host_contexts_json
             .map(|encoded| {
-                serde_json::from_str::<HashMap<String, String>>(&encoded).map_err(|error| {
+                serde_json::from_str::<HashMap<String, Option<String>>>(&encoded).map_err(|error| {
                     js_error(format!("invalid restored subagent host contexts: {error}"))
                 })
             })
             .transpose()?
             .unwrap_or_default();
         for (session_id, host_context) in &host_contexts {
-            if host_context.is_empty() {
+            if host_context.as_ref().is_some_and(String::is_empty) {
                 return Err(js_error(format!(
                     "restored subagent host context for {session_id} must not be empty"
                 )));
@@ -1302,7 +1302,7 @@ impl WasmNanocodex {
         }
         let host_contexts = host_contexts
             .into_iter()
-            .map(|(session_id, host_context)| (session_id, Arc::<str>::from(host_context)))
+            .map(|(session_id, host_context)| (session_id, host_context.map(Arc::<str>::from)))
             .collect();
         let subagents = self
             .subagents

--- a/js/nanocodex/src/wasm.rs
+++ b/js/nanocodex/src/wasm.rs
@@ -3,7 +3,7 @@ use std::{
     collections::{HashMap, VecDeque},
     path::PathBuf,
     rc::Rc,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, Weak},
     time::Duration,
 };
 
@@ -183,6 +183,7 @@ extern "C" {
         root_session_id: &str,
         session_id: &str,
         context_json: &str,
+        host_context_ref: Option<&str>,
     ) -> Result<(), JsValue>;
 
     #[wasm_bindgen(catch, js_namespace = ["globalThis", "nanocodexHost"], js_name = releaseSubagentSession)]
@@ -1031,6 +1032,7 @@ impl WasmSubagents {
         let event_forwarders = Rc::new(Cell::new(0));
         forward_subagent_updates(
             host_definition_id,
+            Arc::downgrade(&registry),
             updates,
             Rc::clone(&sessions),
             Rc::clone(&event_forwarders),
@@ -1076,9 +1078,10 @@ impl WasmSubagents {
         &self,
         root_session_id: &str,
         descriptors: Vec<AgentDescriptor>,
+        host_contexts: HashMap<String, Arc<str>>,
     ) -> Result<(), JsValue> {
         self.registry
-            .restore(root_session_id, descriptors.clone())
+            .restore_with_host_contexts(root_session_id, descriptors.clone(), host_contexts.clone())
             .await
             .map_err(js_error)?;
         for descriptor in &descriptors {
@@ -1087,6 +1090,9 @@ impl WasmSubagents {
                 &self.sessions,
                 root_session_id,
                 descriptor,
+                host_contexts
+                    .get(&descriptor.session_id)
+                    .map(AsRef::<str>::as_ref),
             )?;
         }
         Ok(())
@@ -1261,18 +1267,49 @@ impl WasmNanocodex {
     /// Rejects malformed descriptors, disabled subagents, duplicate restoration,
     /// or an invalid persisted topology.
     #[wasm_bindgen(js_name = restoreSubagents)]
-    pub async fn restore_subagents(&self, descriptors_json: &str) -> Result<(), JsValue> {
+    pub async fn restore_subagents(
+        &self,
+        descriptors_json: &str,
+        host_contexts_json: Option<String>,
+    ) -> Result<(), JsValue> {
         let descriptors = serde_json::from_str::<Vec<WasmRestoredSubagent>>(descriptors_json)
             .map_err(|error| js_error(format!("invalid restored subagents: {error}")))?
             .into_iter()
             .map(WasmRestoredSubagent::descriptor)
             .collect::<Result<Vec<_>, _>>()?;
+        let host_contexts = host_contexts_json
+            .map(|encoded| {
+                serde_json::from_str::<HashMap<String, String>>(&encoded).map_err(|error| {
+                    js_error(format!("invalid restored subagent host contexts: {error}"))
+                })
+            })
+            .transpose()?
+            .unwrap_or_default();
+        for (session_id, host_context) in &host_contexts {
+            if host_context.is_empty() {
+                return Err(js_error(format!(
+                    "restored subagent host context for {session_id} must not be empty"
+                )));
+            }
+            if !descriptors
+                .iter()
+                .any(|descriptor| descriptor.session_id == *session_id)
+            {
+                return Err(js_error(format!(
+                    "restored subagent host context refers to unknown session {session_id}"
+                )));
+            }
+        }
+        let host_contexts = host_contexts
+            .into_iter()
+            .map(|(session_id, host_context)| (session_id, Arc::<str>::from(host_context)))
+            .collect();
         let subagents = self
             .subagents
             .as_ref()
             .ok_or_else(|| js_error("this agent was not created with the subagent extension"))?;
         subagents
-            .restore(self.inner.session_id(), descriptors)
+            .restore(self.inner.session_id(), descriptors, host_contexts)
             .await
     }
 
@@ -2786,6 +2823,7 @@ fn forward_events(mut events: AgentEvents, forwarding: Rc<Cell<bool>>) {
 
 fn forward_subagent_updates(
     host_definition_id: u32,
+    registry: Weak<SubagentRegistry>,
     mut updates: tokio::sync::mpsc::UnboundedReceiver<ScopedAgentUpdate>,
     sessions: Rc<RefCell<HashMap<(String, SubagentId), String>>>,
     event_forwarders: Rc<Cell<usize>>,
@@ -2796,11 +2834,16 @@ fn forward_subagent_updates(
             let root_session_id = scoped.root_session_id;
             match scoped.update {
                 SubagentUpdate::Added(descriptor) => {
+                    let Some(registry) = registry.upgrade() else {
+                        break;
+                    };
+                    let host_context = registry.host_context(&root_session_id, descriptor.id).await;
                     if let Err(error) = bind_subagent_session(
                         host_definition_id,
                         &sessions,
                         &root_session_id,
                         &descriptor,
+                        host_context.as_deref(),
                     ) {
                         report_subagent_host_error("binding a subagent session", &error);
                     }
@@ -2858,6 +2901,7 @@ fn bind_subagent_session(
     sessions: &Rc<RefCell<HashMap<(String, SubagentId), String>>>,
     root_session_id: &str,
     descriptor: &AgentDescriptor,
+    host_context_ref: Option<&str>,
 ) -> Result<(), JsValue> {
     let context = serde_json::json!({
         "agentId": descriptor.id.to_string(),
@@ -2871,6 +2915,7 @@ fn bind_subagent_session(
         root_session_id,
         &descriptor.session_id,
         &context.to_string(),
+        host_context_ref,
     )?;
     sessions.borrow_mut().insert(
         (root_session_id.to_owned(), descriptor.id),

--- a/js/nanocodex/test/browser-host.test.mjs
+++ b/js/nanocodex/test/browser-host.test.mjs
@@ -212,8 +212,12 @@ test("browser host gives inherited tools the Rust-owned subagent descriptor", as
   const sessionLifecycle = [];
   const host = createBrowserHost({
     subagentSessions: {
-      bind: (sessionId, descriptor) => sessionLifecycle.push(["bind", sessionId, descriptor]),
-      release: (sessionId) => sessionLifecycle.push(["release", sessionId]),
+      bind: (sessionId, descriptor, hostContextRef) => {
+        sessionLifecycle.push(["bind", sessionId, descriptor, hostContextRef]);
+      },
+      release: (sessionId, hostContextRef) => {
+        sessionLifecycle.push(["release", sessionId, hostContextRef]);
+      },
     },
     toolMode: "direct",
     tools: {
@@ -230,10 +234,29 @@ test("browser host gives inherited tools the Rust-owned subagent descriptor", as
     role: "world-resident:fern",
     task: "Act as Fern.",
   };
-  host.bindSubagentSession("child-session", descriptor);
-  host.bindSubagentSession("child-session", { ...descriptor });
-  assert.deepEqual(sessionLifecycle, [["bind", "child-session", descriptor]]);
+  const hostContextRef = "opaque-root-turn";
+  host.bindSubagentSession("child-session", descriptor, hostContextRef);
+  host.bindSubagentSession("child-session", { ...descriptor }, hostContextRef);
+  assert.deepEqual(sessionLifecycle, [[
+    "bind", "child-session", descriptor, hostContextRef,
+  ]]);
   assert.equal(Object.isFrozen(sessionLifecycle[0][2]), true);
+  assert.deepEqual(Object.keys(sessionLifecycle[0][2]).sort(), [
+    "agentId", "parentAgentId", "role", "sessionId", "task",
+  ]);
+  assert.equal(JSON.stringify(sessionLifecycle[0][2]).includes(hostContextRef), false);
+  const replacementHostContextRef = "opaque-retried-root-turn";
+  host.bindSubagentSession(
+    "child-session",
+    { ...descriptor, hostContextRef: "must-not-be-public", ignored: true },
+    replacementHostContextRef,
+  );
+  assert.deepEqual(sessionLifecycle[1], [
+    "bind", "child-session", descriptor, replacementHostContextRef,
+  ]);
+  assert.deepEqual(Object.keys(sessionLifecycle[1][2]).sort(), [
+    "agentId", "parentAgentId", "role", "sessionId", "task",
+  ]);
 
   const child = JSON.parse(await host.executeTool(
     "identity", "{}", "child-session", "call-child",
@@ -254,13 +277,72 @@ test("browser host gives inherited tools the Rust-owned subagent descriptor", as
   host.releaseSession("child-session");
   host.releaseSession("child-session");
   assert.deepEqual(sessionLifecycle, [
-    ["bind", "child-session", descriptor],
-    ["release", "child-session"],
+    ["bind", "child-session", descriptor, hostContextRef],
+    ["bind", "child-session", descriptor, replacementHostContextRef],
+    ["release", "child-session", replacementHostContextRef],
   ]);
   const released = JSON.parse(await host.executeTool(
     "identity", "{}", "child-session", "call-released",
   ));
   assert.equal(released.structured_result, null);
+});
+
+test("browser subagent lifecycle failures leave bindings retryable", async () => {
+  const descriptor = {
+    agentId: "9",
+    parentAgentId: "1",
+    sessionId: "retry-child",
+    role: "retry",
+    task: "Retry lifecycle transitions.",
+  };
+  let bindAttempts = 0;
+  let releaseAttempts = 0;
+  const host = createBrowserHost({
+    subagentSessions: {
+      bind() {
+        bindAttempts += 1;
+        if (bindAttempts === 1) throw new Error("bind failed");
+      },
+      release() {
+        releaseAttempts += 1;
+        if (releaseAttempts === 1) throw new Error("release failed");
+      },
+    },
+    toolMode: "direct",
+    tools: {
+      identity: {
+        parameters: { type: "object", additionalProperties: false },
+        handler: (_input, context) => context.subagent ?? null,
+      },
+    },
+  });
+
+  assert.throws(
+    () => host.bindSubagentSession("retry-child", descriptor, "retry-ref"),
+    /bind failed/,
+  );
+  let routed = JSON.parse(await host.executeTool(
+    "identity", "{}", "retry-child", "before-bind-retry",
+  ));
+  assert.equal(routed.structured_result, null);
+  host.bindSubagentSession("retry-child", descriptor, "retry-ref");
+  routed = JSON.parse(await host.executeTool(
+    "identity", "{}", "retry-child", "after-bind-retry",
+  ));
+  assert.deepEqual(routed.structured_result, descriptor);
+
+  assert.throws(() => host.releaseSession("retry-child"), /release failed/);
+  routed = JSON.parse(await host.executeTool(
+    "identity", "{}", "retry-child", "before-release-retry",
+  ));
+  assert.deepEqual(routed.structured_result, descriptor);
+  host.releaseSession("retry-child");
+  routed = JSON.parse(await host.executeTool(
+    "identity", "{}", "retry-child", "after-release-retry",
+  ));
+  assert.equal(routed.structured_result, null);
+  assert.equal(bindAttempts, 2);
+  assert.equal(releaseAttempts, 2);
 });
 
 test("browser host never flattens remote MCP tools into direct mode", () => {

--- a/js/nanocodex/test/cloudflare-agent.test.mjs
+++ b/js/nanocodex/test/cloudflare-agent.test.mjs
@@ -27,6 +27,8 @@ class MemoryStorage {
     this.stateRevisions = new Map();
     this.owners = new Map();
     this.subagents = new Map();
+    this.subagentHostContextColumn = true;
+    this.subagentSchemaAlterations = 0;
     this.meta = { total_bytes: 0, stream_error: null };
     this.sessionId = undefined;
     this.stateId = undefined;
@@ -38,10 +40,14 @@ class MemoryStorage {
   #exec(sql, args) {
     const statement = sql.replace(/\s+/g, " ").trim();
     let rows = [];
+    let rowsWritten = 0;
     if (statement.startsWith("CREATE TABLE")) {
       // Schema setup is idempotent.
+    } else if (statement.startsWith("ALTER TABLE nanocodex_cloudflare_subagents")) {
+      this.subagentHostContextColumn = true;
+      this.subagentSchemaAlterations += 1;
     } else if (statement.startsWith("PRAGMA table_info")) {
-      rows = durabilityPragmaRows(statement);
+      rows = durabilityPragmaRows(statement, this.subagentHostContextColumn);
     } else if (statement.startsWith("INSERT OR IGNORE INTO nanocodex_cloudflare_event_meta")) {
       // The in-memory meta row exists from construction.
     } else if (statement.startsWith("SELECT total_bytes, stream_error")) {
@@ -77,16 +83,38 @@ class MemoryStorage {
       if (this.stateId !== undefined) throw new Error("duplicate Cloudflare durability identity");
       this.stateId = args[0];
     } else if (statement.startsWith(
-      "SELECT descriptor_json FROM nanocodex_cloudflare_subagents",
+      "SELECT descriptor_json, host_context_ref FROM nanocodex_cloudflare_subagents",
     )) {
       this.onSubagentLoad?.();
       rows = [...this.subagents.values()]
-        .map(({ descriptorJson }) => ({ descriptor_json: descriptorJson }));
+        .map(({ descriptorJson, hostContextRef }) => ({
+          descriptor_json: descriptorJson,
+          host_context_ref: hostContextRef ?? null,
+        }));
     } else if (statement.startsWith("INSERT INTO nanocodex_cloudflare_subagents")) {
-      this.subagents.set(args[0], { agentId: args[1], descriptorJson: args[2] });
+      this.subagents.set(args[0], {
+        agentId: args[1],
+        descriptorJson: args[2],
+        hostContextRef: args[3],
+      });
+      rowsWritten = 1;
+    } else if (statement.startsWith(
+      "SELECT 1 AS retained FROM nanocodex_cloudflare_subagents",
+    )) {
+      const retained = this.subagents.get(args[0]);
+      rows = retained?.hostContextRef === args[1] ? [{ retained: 1 }] : [];
     } else if (statement.startsWith("DELETE FROM nanocodex_cloudflare_subagents")) {
-      if (args.length > 0) this.subagents.delete(args[0]);
-      else this.subagents.clear();
+      if (args.length > 1) {
+        const retained = this.subagents.get(args[0]);
+        if (retained?.hostContextRef === args[1]) {
+          rowsWritten = Number(this.subagents.delete(args[0]));
+        }
+      } else if (args.length > 0) {
+        rowsWritten = Number(this.subagents.delete(args[0]));
+      } else {
+        rowsWritten = this.subagents.size;
+        this.subagents.clear();
+      }
     } else if (statement.startsWith("SELECT owner_id, fence FROM nanocodex_durable_owners")) {
       const owner = this.owners.get(args[0]);
       rows = owner === undefined ? [] : [{ owner_id: owner.ownerId, fence: owner.fence }];
@@ -143,13 +171,20 @@ class MemoryStorage {
     } else {
       throw new Error(`unexpected SQL: ${statement}`);
     }
-    return { toArray: () => rows };
+    return { rowsWritten, toArray: () => rows };
   }
 }
 
-function durabilityPragmaRows(sql) {
+function durabilityPragmaRows(sql, subagentHostContextColumn = true) {
   let shapes;
-  if (sql.includes("nanocodex_durable_owners")) {
+  if (sql.includes("nanocodex_cloudflare_subagents")) {
+    shapes = [
+      ["session_id", "TEXT", 0, 1],
+      ["agent_id", "TEXT", 1, 0],
+      ["descriptor_json", "TEXT", 1, 0],
+      ...(subagentHostContextColumn ? [["host_context_ref", "TEXT", 0, 0]] : []),
+    ];
+  } else if (sql.includes("nanocodex_durable_owners")) {
     shapes = [["state_id", "TEXT", 0, 1], ["owner_id", "TEXT", 1, 0], ["fence", "TEXT", 1, 0]];
   } else if (sql.includes("nanocodex_durable_states")) {
     shapes = [["state_id", "TEXT", 0, 1], ["revision", "TEXT", 1, 0], ["payload", "TEXT", 1, 0]];
@@ -244,6 +279,14 @@ test("Cloudflare Agent owns credentials, transport, and durability options", asy
       [Symbol.for("nanocodex.cloudflare.internalRuntime")]: [],
     }),
     /internal runtime options must be an object/,
+  );
+  await assert.rejects(
+    create(module, durableOwner(new MemoryStorage()), {
+      [Symbol.for("nanocodex.cloudflare.internalRuntime")]: {
+        subagentLifecycle: true,
+      },
+    }),
+    /subagent lifecycle hook must be a function/,
   );
   await assert.rejects(
     create(module, { env: { NANOCODEX: egressBinding() } }),
@@ -406,10 +449,17 @@ test("Cloudflare Agent reconstructs interrupted subagents without stale-owner cl
       handler: (_input, context) => ({ source, subagent: context.subagent ?? null }),
     },
   });
+  const predecessorLifecycle = [];
+  const predecessorOptions = { tools: identity("predecessor") };
+  Object.defineProperty(
+    predecessorOptions,
+    Symbol.for("nanocodex.cloudflare.internalRuntime"),
+    { value: { subagentLifecycle: (event) => predecessorLifecycle.push(event) } },
+  );
   const first = await create(
     module,
     durableOwner(storage, binding, FIRST_OBJECT_ID),
-    { tools: identity("predecessor") },
+    predecessorOptions,
   );
   const bridge = globalThis.nanocodexHost;
   const predecessorBinds = [];
@@ -445,16 +495,43 @@ test("Cloudflare Agent reconstructs interrupted subagents without stale-owner cl
     .map(({ descriptorJson }) => JSON.parse(descriptorJson))
     .find((candidate) => candidate.agentId === String(continued.agent_id));
   const predecessorBind = predecessorBinds.find((args) => args[2] === descriptor.sessionId);
+  const hostContextRef = "opaque-root-turn";
+  bridge.bindSubagentSession(
+    predecessorBind[0],
+    predecessorBind[1],
+    predecessorBind[2],
+    predecessorBind[3],
+    hostContextRef,
+  );
+  assert.equal(storage.subagents.get(descriptor.sessionId).hostContextRef, hostContextRef);
+  assert.equal(JSON.stringify(descriptor).includes(hostContextRef), false);
+  assert.deepEqual(
+    predecessorLifecycle
+      .filter(({ hostContextRef: retained }) => retained === hostContextRef)
+      .map(({ type, sessionId, hostContextRef: retained }) => ({
+        type,
+        sessionId,
+        hostContextRef: retained,
+      })),
+    [{ type: "bind", sessionId: descriptor.sessionId, hostContextRef }],
+  );
   const predecessorFence = storage.owners.get(storage.stateId).fence;
   storage.onSubagentLoad = () => assert.ok(
     BigInt(storage.owners.get(storage.stateId).fence) > BigInt(predecessorFence),
     "restored descriptors must load only after the replacement acquires its durability fence",
   );
 
+  const replacementLifecycle = [];
+  const replacementOptions = { tools: identity("replacement") };
+  Object.defineProperty(
+    replacementOptions,
+    Symbol.for("nanocodex.cloudflare.internalRuntime"),
+    { value: { subagentLifecycle: (event) => replacementLifecycle.push(event) } },
+  );
   const reconstructed = await create(
     module,
     durableOwner(storage, binding, FIRST_OBJECT_ID),
-    { tools: identity("replacement") },
+    replacementOptions,
   );
   storage.onSubagentLoad = undefined;
   const listed = await Subagents.list(reconstructed, {
@@ -468,6 +545,16 @@ test("Cloudflare Agent reconstructs interrupted subagents without stale-owner cl
     { state: "interrupted" },
   );
   assert.equal(descriptor.agentId, String(started.agent_id));
+  assert.deepEqual(
+    replacementLifecycle
+      .filter(({ hostContextRef: retained }) => retained === hostContextRef)
+      .map(({ type, sessionId, hostContextRef: retained }) => ({
+        type,
+        sessionId,
+        hostContextRef: retained,
+      })),
+    [{ type: "reconstruct", sessionId: descriptor.sessionId, hostContextRef }],
+  );
 
   let routed = JSON.parse(await globalThis.nanocodexHost.executeTool(
     "identity", "{}", descriptor.sessionId, "replacement-before-stale-release",
@@ -481,12 +568,16 @@ test("Cloudflare Agent reconstructs interrupted subagents without stale-owner cl
   assert.deepEqual(routed.structured_result.subagent, continuedDescriptor);
 
   const staleDescriptor = { ...descriptor, role: "stale-predecessor-rebind" };
+  const predecessorLifecycleCount = predecessorLifecycle.length;
+  const replacementLifecycleCount = replacementLifecycle.length;
   bridge.bindSubagentSession(
     predecessorBind[0],
     predecessorBind[1],
     predecessorBind[2],
     JSON.stringify(staleDescriptor),
   );
+  assert.equal(predecessorLifecycle.length, predecessorLifecycleCount);
+  assert.equal(replacementLifecycle.length, replacementLifecycleCount);
   assert.equal(
     storage.subagents.get(descriptor.sessionId).descriptorJson,
     JSON.stringify(descriptor),
@@ -499,6 +590,8 @@ test("Cloudflare Agent reconstructs interrupted subagents without stale-owner cl
   assert.deepEqual(routed.structured_result.subagent, descriptor);
 
   await first.session.shutdown();
+  assert.equal(predecessorLifecycle.length, predecessorLifecycleCount);
+  assert.equal(replacementLifecycle.length, replacementLifecycleCount);
   routed = JSON.parse(await globalThis.nanocodexHost.executeTool(
     "identity", "{}", descriptor.sessionId, "replacement-after-stale-release",
   ));
@@ -507,12 +600,118 @@ test("Cloudflare Agent reconstructs interrupted subagents without stale-owner cl
 
   await reconstructed.session.shutdown();
   assert.equal(storage.subagents.size, 0);
+  assert.deepEqual(
+    replacementLifecycle
+      .filter(({ hostContextRef: retained }) => retained === hostContextRef)
+      .map(({ type, sessionId, hostContextRef: retained }) => ({
+        type,
+        sessionId,
+        hostContextRef: retained,
+      })),
+    [
+      { type: "reconstruct", sessionId: descriptor.sessionId, hostContextRef },
+      { type: "release", sessionId: descriptor.sessionId, hostContextRef },
+    ],
+  );
   assert.throws(
     () => globalThis.nanocodexHost.executeTool(
       "identity", "{}", descriptor.sessionId, "after-planned-release",
     ),
     /no Nanocodex host is active/,
   );
+});
+
+test("Cloudflare Agent migrates and restores legacy subagent rows without private refs", async () => {
+  const module = await readFile(new URL("../pkg-web/nanocodex_bg.wasm", import.meta.url));
+  const storage = new MemoryStorage();
+  const binding = egressBinding();
+  const first = await create(
+    module,
+    durableOwner(storage, binding, FIRST_OBJECT_ID),
+  );
+  const started = await Subagents.spawn(first, {
+    role: "legacy-ref",
+    task: "Remain reconstructable without private provenance.",
+    outputSchema: { type: "object" },
+  });
+  await eventually(() => assert.equal(storage.subagents.size, 1));
+  const retained = [...storage.subagents.values()][0];
+  delete retained.hostContextRef;
+  storage.subagentHostContextColumn = false;
+
+  const reconstructed = await create(
+    module,
+    durableOwner(storage, binding, FIRST_OBJECT_ID),
+  );
+  assert.equal(storage.subagentHostContextColumn, true);
+  assert.equal(storage.subagentSchemaAlterations, 1);
+  const listed = await Subagents.list(reconstructed, { includeCompleted: true });
+  assert.deepEqual(
+    listed.agents.find(({ agent_id }) => agent_id === started.agent_id)?.status,
+    { state: "interrupted" },
+  );
+  assert.equal([...storage.subagents.values()][0].hostContextRef, null);
+
+  first.dispose();
+  await reconstructed.session.shutdown();
+  assert.equal(storage.subagents.size, 0);
+});
+
+test("Cloudflare Agent keeps failed private releases exactly retryable", async () => {
+  const module = await readFile(new URL("../pkg-web/nanocodex_bg.wasm", import.meta.url));
+  const storage = new MemoryStorage();
+  let releaseAttempts = 0;
+  const lifecycle = (event) => {
+    if (event.type !== "release") return;
+    releaseAttempts += 1;
+    if (releaseAttempts === 1) throw new Error("private release failed");
+  };
+  const options = {};
+  Object.defineProperty(
+    options,
+    Symbol.for("nanocodex.cloudflare.internalRuntime"),
+    { value: { subagentLifecycle: lifecycle } },
+  );
+  const agent = await create(
+    module,
+    durableOwner(storage, egressBinding(), FIRST_OBJECT_ID),
+    options,
+  );
+  const bridge = globalThis.nanocodexHost;
+  const binds = [];
+  globalThis.nanocodexHost = Object.freeze({
+    ...bridge,
+    bindSubagentSession(...args) {
+      binds.push(args);
+      return bridge.bindSubagentSession(...args);
+    },
+  });
+  let started;
+  try {
+    started = await Subagents.spawn(agent, {
+      role: "release-retry",
+      task: "Keep the private release retryable.",
+      outputSchema: { type: "object" },
+    });
+  } finally {
+    globalThis.nanocodexHost = bridge;
+  }
+  await eventually(() => assert.equal(storage.subagents.size, 1));
+  await Subagents.interrupt(agent, started.agent_id);
+  const bind = binds[0];
+  assert.ok(bind);
+
+  assert.throws(
+    () => bridge.releaseSubagentSession(bind[0], bind[1], bind[2]),
+    /private release failed/,
+  );
+  assert.equal(storage.subagents.size, 1);
+  bridge.releaseSubagentSession(bind[0], bind[1], bind[2]);
+  assert.equal(storage.subagents.size, 0);
+  assert.equal(releaseAttempts, 2);
+
+  await agent.session.shutdown();
+  assert.equal(releaseAttempts, 2);
 });
 
 test("Cloudflare Agent reconstruction rejects a different durable owner before fencing", async () => {


### PR DESCRIPTION
## Summary
- add named VM-hand factories that can supply multiple isolated VM allocations at agent, account, or system scope
- route canonical Code Mode tools by mounted cwd while preserving cross-mount filesystem access
- fence factory leases, durable allocations, hosted-tool attachments, and subagent provenance across reconnect/reconstruction
- add nanocodex2 host CLI support, observability, docs, bindings, migrations, and focused protocol/runtime coverage

## Verified
- `node --test test/browser-host.test.mjs test/cloudflare-agent.test.mjs` (56 passed)
- `pnpm test` in `js/managed` (296 passed)
- `pnpm run typecheck` in `js/managed`
- `wrangler deploy --dry-run --env=""` in `js/managed`
- `cargo fmt --all -- --check`
- `git diff --check`

Additional Rust/package gates and end-to-end verification are in progress.