### PR TITLE
fix(managed): keep browser prompt behind Rust Code Mode

### DIFF
--- a/js/managed/src/browser-runtime.ts
+++ b/js/managed/src/browser-runtime.ts
@@ -38,6 +38,12 @@ const BROWSERBASE_API_ORIGIN = "https://api.browserbase.com";
 const DEFAULT_KEEP_ALIVE_MS = 10 * 60_000;
 const DEFAULT_TOOL_TIMEOUT_MS = 30_000;
 const MAX_BROWSERBASE_RESPONSE_BYTES = 256 * 1024;
+const BROWSER_EXECUTE_SCOPE_BOUNDARY = [
+  "Scope boundary: the instructions below apply only to JavaScript passed in this tool's `code` parameter.",
+  "`codemode`, `cdp`, and connector globals exist only inside that nested browser sandbox; they are not available in the surrounding Nanocodex Code Mode runtime.",
+  "From Nanocodex Code Mode, call this tool through `tools.browser_execute(...)`, and use `tools.web__run(...)` for ordinary web search.",
+  "Never call `codemode.search(...)` or `codemode.describe(...)` outside the `browser_execute` code string.",
+].join("\n");
 const MODEL_SAFE_CDP_METHODS = new Set([
   "Target.getTargets",
   "Target.createTarget",
@@ -424,9 +430,12 @@ export async function adaptAiSdkTools(
     if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) {
       throw new TypeError(`AI SDK browser tool ${name} has a non-object input schema`);
     }
-    const description = typeof tool.description === "string"
+    const upstreamDescription = typeof tool.description === "string"
       ? tool.description
       : "Use the managed browser runtime.";
+    const description = name === "browser_execute"
+      ? `${BROWSER_EXECUTE_SCOPE_BOUNDARY}\n\n${upstreamDescription}`
+      : upstreamDescription;
     return Object.freeze({
       name,
       description,

--- a/js/managed/src/browser-runtime.ts
+++ b/js/managed/src/browser-runtime.ts
@@ -38,11 +38,12 @@ const BROWSERBASE_API_ORIGIN = "https://api.browserbase.com";
 const DEFAULT_KEEP_ALIVE_MS = 10 * 60_000;
 const DEFAULT_TOOL_TIMEOUT_MS = 30_000;
 const MAX_BROWSERBASE_RESPONSE_BYTES = 256 * 1024;
-const BROWSER_EXECUTE_SCOPE_BOUNDARY = [
-  "Scope boundary: the instructions below apply only to JavaScript passed in this tool's `code` parameter.",
-  "`codemode`, `cdp`, and connector globals exist only inside that nested browser sandbox; they are not available in the surrounding Nanocodex Code Mode runtime.",
-  "From Nanocodex Code Mode, call this tool through `tools.browser_execute(...)`, and use `tools.web__run(...)` for ordinary web search.",
-  "Never call `codemode.search(...)` or `codemode.describe(...)` outside the `browser_execute` code string.",
+const MANAGED_BROWSER_EXECUTE_DESCRIPTION = [
+  "Run browser automation in the retained managed browser session.",
+  "The `code` parameter runs in a separate nested JavaScript sandbox. Its `cdp` connector and `codemode` helper are not globals in the surrounding Nanocodex Code Mode cell, whose nested-tool API is `tools.*`.",
+  "From the surrounding cell, invoke this tool as `await tools.browser_execute({ code })`.",
+  "Only inside the `code` string, use `codemode.search(...)` and `codemode.describe(...)` before calling unfamiliar `cdp` methods; never guess method names.",
+  "For ordinary public-web search, use `tools.web__run(...)` in the surrounding Nanocodex Code Mode cell.",
 ].join("\n");
 const MODEL_SAFE_CDP_METHODS = new Set([
   "Target.getTargets",
@@ -430,12 +431,11 @@ export async function adaptAiSdkTools(
     if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) {
       throw new TypeError(`AI SDK browser tool ${name} has a non-object input schema`);
     }
-    const upstreamDescription = typeof tool.description === "string"
-      ? tool.description
-      : "Use the managed browser runtime.";
     const description = name === "browser_execute"
-      ? `${BROWSER_EXECUTE_SCOPE_BOUNDARY}\n\n${upstreamDescription}`
-      : upstreamDescription;
+      ? MANAGED_BROWSER_EXECUTE_DESCRIPTION
+      : typeof tool.description === "string"
+        ? tool.description
+        : "Use the managed browser runtime.";
     return Object.freeze({
       name,
       description,

--- a/js/managed/src/browser-runtime.ts
+++ b/js/managed/src/browser-runtime.ts
@@ -40,9 +40,12 @@ const DEFAULT_TOOL_TIMEOUT_MS = 30_000;
 const MAX_BROWSERBASE_RESPONSE_BYTES = 256 * 1024;
 const MANAGED_BROWSER_EXECUTE_DESCRIPTION = [
   "Run browser automation in the retained managed browser session.",
-  "The `code` parameter runs in a separate nested JavaScript sandbox. Its `cdp` connector and `codemode` helper are not globals in the surrounding Nanocodex Code Mode cell, whose nested-tool API is `tools.*`.",
-  "From the surrounding cell, invoke this tool as `await tools.browser_execute({ code })`.",
-  "Only inside the `code` string, use `codemode.search(...)` and `codemode.describe(...)` before calling unfamiliar `cdp` methods; never guess method names.",
+  "Outer contract (Nanocodex Rust/WASM Code Mode): nested tools exist only on `tools.*`; `cdp` and `codemode` are not globals. Invoke this tool as the final expression: `await tools.browser_execute({ code })`.",
+  "Inner contract (`code` only): this is a separate Cloudflare Code Mode sandbox whose only host globals are `cdp` and `codemode` (plus standard JavaScript). There is no `tools` or `text`; make the value to return the final expression.",
+  "Inner discovery signatures take strings: `await codemode.search(\"short intent\")`, then `await codemode.describe(\"cdp.method\")`. Search indexes connector methods, not raw Chrome protocol commands; use `await cdp.spec({})` for those. Never guess method names or argument shapes.",
+  "Inner `cdp` methods take one object argument, for example `await cdp.send({ method: \"Target.getTargets\" })`, `await cdp.attachToTarget({ targetId })`, and `await cdp.send({ method: \"Page.navigate\", params: { url }, sessionId })`.",
+  "This managed surface rejects credential-bearing or unrestricted capabilities, including `Runtime.evaluate` and `Runtime.callFunctionOn`; use allowed Target, Page, and DOM commands instead.",
+  "To read a title safely after `Page.navigate`, wait for loading and call `Target.getTargets` again, then select the matching `targetId`; each result contains its URL and title. `Target.getTargetInfo` is not available.",
   "For ordinary public-web search, use `tools.web__run(...)` in the surrounding Nanocodex Code Mode cell.",
 ].join("\n");
 const MODEL_SAFE_CDP_METHODS = new Set([

--- a/js/managed/test/browser-runtime.test.ts
+++ b/js/managed/test/browser-runtime.test.ts
@@ -261,6 +261,35 @@ describe("AI SDK browser tool adapter", () => {
     expect(execute).toHaveBeenCalledOnce();
   });
 
+  it("scopes the official codemode instructions to the nested browser sandbox", async () => {
+    const upstreamDescription = [
+      "Execute JavaScript in a sandbox with access to connector SDKs.",
+      "Call `codemode.search(query)` before using the `cdp` connector.",
+    ].join("\n");
+    const [adapted] = await adaptAiSdkTools({
+      browser_execute: tool({
+        description: upstreamDescription,
+        inputSchema: jsonSchema({
+          type: "object",
+          properties: { code: { type: "string" } },
+          required: ["code"],
+          additionalProperties: false,
+        }),
+        execute: async () => ({ ok: true }),
+      }),
+    });
+
+    expect(adapted?.description).toContain(
+      "`codemode`, `cdp`, and connector globals exist only inside that nested browser sandbox",
+    );
+    expect(adapted?.description).toContain("call this tool through `tools.browser_execute(...)`");
+    expect(adapted?.description).toContain("use `tools.web__run(...)` for ordinary web search");
+    expect(adapted?.description).toContain(
+      "Never call `codemode.search(...)` or `codemode.describe(...)` outside",
+    );
+    expect(adapted?.description.endsWith(upstreamDescription)).toBe(true);
+  });
+
   it("redacts provider URLs and scalar cookie material", () => {
     expect(sanitizeBrowserToolResult({
       provider: "https://live.browser.run/session/signed",

--- a/js/managed/test/browser-runtime.test.ts
+++ b/js/managed/test/browser-runtime.test.ts
@@ -261,12 +261,13 @@ describe("AI SDK browser tool adapter", () => {
     expect(execute).toHaveBeenCalledOnce();
   });
 
-  it("scopes the official codemode instructions to the nested browser sandbox", async () => {
+  it("replaces the foreign codemode prompt with the Rust Code Mode tool contract", async () => {
     const upstreamDescription = [
       "Execute JavaScript in a sandbox with access to connector SDKs.",
+      "## Workflow",
       "Call `codemode.search(query)` before using the `cdp` connector.",
     ].join("\n");
-    const [adapted] = await adaptAiSdkTools({
+    const tools = await adaptAiSdkTools({
       browser_execute: tool({
         description: upstreamDescription,
         inputSchema: jsonSchema({
@@ -277,17 +278,29 @@ describe("AI SDK browser tool adapter", () => {
         }),
         execute: async () => ({ ok: true }),
       }),
+      browser_markdown: tool({
+        description: "Read a page as Markdown.",
+        inputSchema: jsonSchema({ type: "object", additionalProperties: false }),
+        execute: async () => "page",
+      }),
     });
+    const adapted = tools.find(({ name }) => name === "browser_execute");
+    const ordinary = tools.find(({ name }) => name === "browser_markdown");
 
     expect(adapted?.description).toContain(
-      "`codemode`, `cdp`, and connector globals exist only inside that nested browser sandbox",
+      "`code` parameter runs in a separate nested JavaScript sandbox",
     );
-    expect(adapted?.description).toContain("call this tool through `tools.browser_execute(...)`");
-    expect(adapted?.description).toContain("use `tools.web__run(...)` for ordinary web search");
     expect(adapted?.description).toContain(
-      "Never call `codemode.search(...)` or `codemode.describe(...)` outside",
+      "surrounding Nanocodex Code Mode cell, whose nested-tool API is `tools.*`",
     );
-    expect(adapted?.description.endsWith(upstreamDescription)).toBe(true);
+    expect(adapted?.description).toContain("`await tools.browser_execute({ code })`");
+    expect(adapted?.description).toContain(
+      "Only inside the `code` string, use `codemode.search(...)` and `codemode.describe(...)`",
+    );
+    expect(adapted?.description).toContain("use `tools.web__run(...)`");
+    expect(adapted?.description).not.toContain(upstreamDescription);
+    expect(adapted?.description).not.toContain("## Workflow");
+    expect(ordinary?.description).toBe("Read a page as Markdown.");
   });
 
   it("redacts provider URLs and scalar cookie material", () => {

--- a/js/managed/test/browser-runtime.test.ts
+++ b/js/managed/test/browser-runtime.test.ts
@@ -288,15 +288,26 @@ describe("AI SDK browser tool adapter", () => {
     const ordinary = tools.find(({ name }) => name === "browser_markdown");
 
     expect(adapted?.description).toContain(
-      "`code` parameter runs in a separate nested JavaScript sandbox",
+      "Outer contract (Nanocodex Rust/WASM Code Mode)",
     );
     expect(adapted?.description).toContain(
-      "surrounding Nanocodex Code Mode cell, whose nested-tool API is `tools.*`",
+      "nested tools exist only on `tools.*`; `cdp` and `codemode` are not globals",
     );
     expect(adapted?.description).toContain("`await tools.browser_execute({ code })`");
     expect(adapted?.description).toContain(
-      "Only inside the `code` string, use `codemode.search(...)` and `codemode.describe(...)`",
+      "only host globals are `cdp` and `codemode`",
     );
+    expect(adapted?.description).toContain(
+      '`await codemode.search("short intent")`',
+    );
+    expect(adapted?.description).toContain(
+      '`await codemode.describe("cdp.method")`',
+    );
+    expect(adapted?.description).toContain(
+      '`await cdp.send({ method: "Target.getTargets" })`',
+    );
+    expect(adapted?.description).toContain("including `Runtime.evaluate`");
+    expect(adapted?.description).toContain("`Target.getTargetInfo` is not available");
     expect(adapted?.description).toContain("use `tools.web__run(...)`");
     expect(adapted?.description).not.toContain(upstreamDescription);
     expect(adapted?.description).not.toContain("## Workflow");


### PR DESCRIPTION
## Summary

- keep the managed agent model-facing runtime on the canonical Rust/WASM Code Mode `exec` and `tools.*` contract
- replace the foreign Cloudflare codemode prompt when adapting `browser_execute` instead of projecting its inner workflow into the outer tool catalog
- scope `cdp` and `codemode.search/describe` to the nested `browser_execute.code` string and direct ordinary public-web search to outer `tools.web__run(...)`
- pin the inner string signatures, CDP object argument shape, result semantics, and managed CDP policy so the model does not guess across the two runtimes
- prove adversarial upstream prompt text is removed while unrelated AI SDK tool descriptions remain unchanged

## Verification

- `pnpm --filter nanocodex-managed-service exec vitest run test/browser-runtime.test.ts` (9 tests)
- `pnpm turbo run typecheck test build --filter=nanocodex-managed-service` (32 test files, 272 tests, typecheck, Wrangler dry run)

## Local managed-agent evidence

Ran the complete branch worktree stack with `PORTLESS_PORT=1355 pnpm dev`, verified a local account, connected the local ChatGPT subscription relay, and started a fresh durable agent at `https://browser-codemode-scope.nanocodex.localhost:1355/agent`.

Prompt:

> Use the browser_execute browser automation tool to open https://example.com and report the page title. Do not use public web search.

The terminal showed exactly one outer Rust/WASM Code Mode `exec` containing one nested `browser_execute`. Its `code` payload used only the inner `cdp` global (`Target.getTargets`, `attachToTarget`, `Page.enable`, `Page.navigate`, then `Target.getTargets` again). The nested execution succeeded in 4.29s and the assistant returned:

> The page title is “Example Domain.”

The browser reported no uncaught page errors. The managed turn POST returned 202, turn reads returned 200, and the Worker logged `managed.turn.transition` with `state: completed` and `outcome: success`.
