### PR TITLE
fix(managed): refresh direct tool bindings after reconnect

### DIFF
--- a/js/managed/src/namespace-tools.ts
+++ b/js/managed/src/namespace-tools.ts
@@ -76,7 +76,9 @@ export function createNamespaceExecutionRuntime(
   const sessions = new Map<number, ProcessBinding>();
 
   const cell = (context: ToolContext): CellBinding => {
-    const key = `${context.sessionId}\u0000${context.parentCallId}`;
+    // Direct tools have an empty parentCallId. Pin those to their own call,
+    // while nested Code Mode tools keep sharing their parent's captured lease.
+    const key = `${context.sessionId}\u0000${context.parentCallId || context.callId}`;
     const retained = cells.get(key);
     if (retained !== undefined) return retained;
     const created = createCellBinding(brain, machines(), resolveMachineTool, key);

--- a/js/managed/test/namespace-tools.test.ts
+++ b/js/managed/test/namespace-tools.test.ts
@@ -141,6 +141,28 @@ describe("cwd-root namespace execution", () => {
     expect(newExec.mock.calls[0]![0]).toMatchObject({ workdir: "/new" });
   });
 
+  it("captures a fresh binding for each top-level call while retaining the same call on replay", async () => {
+    const oldExec = vi.fn(async () => ({ output: "old", wall_time_seconds: 0, exit_code: 0 }));
+    const newExec = vi.fn(async () => ({ output: "new", wall_time_seconds: 0, exit_code: 0 }));
+    let currentExec = oldExec;
+    const tools = createRuntimeNamespaceExecutionTools(
+      () => [{ id: "laptop", workspace: "/workspace" }],
+      (_id, name) => name === "exec_command" ? { handler: currentExec } : undefined,
+    );
+    const firstCall = context({ parentCallId: "", callId: "first-call" });
+    const secondCall = context({ parentCallId: "", callId: "second-call" });
+
+    await expect(tools.exec_command!.handler({ cmd: "pwd", workdir: "/laptop" }, firstCall))
+      .resolves.toMatchObject({ output: "old" });
+    currentExec = newExec; // The same machine reconnects with a new attachment lease.
+    await expect(tools.exec_command!.handler({ cmd: "pwd", workdir: "/laptop" }, secondCall))
+      .resolves.toMatchObject({ output: "new" });
+    await expect(tools.exec_command!.handler({ cmd: "pwd", workdir: "/laptop" }, firstCall))
+      .resolves.toMatchObject({ output: "old" });
+    expect(oldExec).toHaveBeenCalledTimes(2);
+    expect(newExec).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps a mount created after capture out of the calling cell", async () => {
     let machines: readonly { id: string; root: string; workspace: string }[] = [];
     const exec = vi.fn(async () => ({ output: "mounted", wall_time_seconds: 0, exit_code: 0 }));


### PR DESCRIPTION
Direct tool calls have an empty parentCallId, so calls from the same session were sharing a captured execution attachment. After a Hand reconnects, the next direct call could keep using the retired attachment.

Use callId for top-level bindings while retaining parentCallId for nested Code Mode calls. Replaying the same call keeps its original binding.

Validation: all 13 namespace-tools tests pass in the Cloudflare Workers test runtime, including the new reconnect/replay regression. The full desktop two-turn journey still needs verification against a service running this fix.
