### PR TITLE
feat(eval): import frontier tasks and serve remote task packages

### DIFF
--- a/crates/experimental/nanocodex-eval-adapters/src/lib.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/lib.rs
@@ -115,7 +115,7 @@ struct AdapterManifest {
 const INSTALLED_ADAPTERS: &[InstalledAdapter] = &[
     InstalledAdapter {
         kind: "harbor",
-        names: &["terminal-bench-2.1", "deep-swe-v1.1"],
+        names: &["terminal-bench-2.1", "deep-swe-v1.1", "frontier-swe-v2"],
         import: import_harbor,
         matches: matches_harbor_task,
     },
@@ -207,6 +207,7 @@ const INSTALLED_ADAPTERS: &[InstalledAdapter] = &[
 
 const TERMINAL_BENCH_REVISION: &str = "5c8eadf1f393183288fa08b8f73ca9a469cc5e00";
 const DEEP_SWE_REVISION: &str = "e016041a6ccf8da29906afc9a3f5a8df940a1f78";
+const FRONTIER_SWE_V2_REVISION: &str = "8ba3afe785a0f99a78d1017127b97eef60e63b3b";
 const ARENA_HARD_REVISION: &str = "196f6b826783b3da7310e361a805fa36f0be83f3";
 const SWE_VERIFIED_ROW_RESPONSE_SHA256: &str =
     "7c62220a467830a3a330dda51211ab4c1ba099124dffc8371fbec057933c47b8";
@@ -294,6 +295,16 @@ fn import_harbor(
                 )?
                 .join("tasks"),
             format!("datacurve-ai/deep-swe@{DEEP_SWE_REVISION}"),
+        ),
+        "frontier-swe-v2" => (
+            sources
+                .git_checkout(
+                    "frontier-swe-v2",
+                    "https://github.com/Proximal-Labs/frontier-swe.git",
+                    FRONTIER_SWE_V2_REVISION,
+                )?
+                .join("tasks"),
+            format!("Proximal-Labs/frontier-swe@{FRONTIER_SWE_V2_REVISION}"),
         ),
         _ => return Err(AdapterError::UnknownBenchmark(request.name.clone())),
     };

--- a/crates/experimental/nanocodex-eval/src/coordinator.rs
+++ b/crates/experimental/nanocodex-eval/src/coordinator.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use crate::{
-    CoordinateClaim, Evaluation, EvaluationClaim, EvaluationSelector, EvaluationTreatment,
+    CoordinateClaim, Evaluation, EvaluationClaim, EvaluationSelector, EvaluationTreatment, Task,
     api::EvalApi, cluster::HostSampler,
 };
 use axum::{
@@ -169,6 +169,11 @@ struct ClaimRequest {
     worker: Option<String>,
 }
 
+#[derive(Deserialize)]
+struct TaskPackageQuery {
+    key: String,
+}
+
 #[derive(Serialize, Deserialize)]
 struct WireTreatment {
     harness: String,
@@ -311,7 +316,9 @@ impl CoordinatorServer {
                 get(eval_task_outcomes),
             )
             .route("/v1/evals/cases/{id}", get(eval_case))
+            .route("/v1/task-package", get(task_package))
             .route("/v1/claims", post(claim))
+            .route("/v1/claims/{token}/heartbeat", post(heartbeat))
             .route("/v1/claims/{token}/artifacts", put(upload_artifacts))
             .route("/v1/claims/{token}/finish", post(finish))
             .route("/v1/workers/exited", post(worker_exited))
@@ -848,6 +855,34 @@ async fn eval_task_outcomes(
         .ok_or_else(|| ApiError::not_found("evaluation task was not found"))
 }
 
+async fn task_package(
+    State(state): State<CoordinatorState>,
+    Query(query): Query<TaskPackageQuery>,
+) -> Result<Response, ApiError> {
+    let task = {
+        let active = state.active.lock().await;
+        active
+            .get(&query.key)
+            .map(|active| active.claim.task().clone())
+            .ok_or_else(|| ApiError::not_found("active task package was not found"))?
+    };
+    let (writer, reader) = tokio::io::duplex(ARCHIVE_BUFFER_BYTES);
+    let archive = tokio::task::spawn_blocking(move || {
+        write_task_package_archive(&task, SyncIoBridge::new(writer))
+    });
+    tokio::spawn(async move {
+        match archive.await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => tracing::warn!(%error, "task package archive stream failed"),
+            Err(error) => tracing::warn!(%error, "task package archive task failed"),
+        }
+    });
+    Response::builder()
+        .header(reqwest::header::CONTENT_TYPE, ARCHIVE_CONTENT_TYPE)
+        .body(Body::from_stream(ReaderStream::new(reader)))
+        .map_err(ApiError::internal)
+}
+
 async fn claim(
     State(state): State<CoordinatorState>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
@@ -891,17 +926,16 @@ async fn claim(
             let repetition = claim.repetition();
             let family_key = claim.family_key().to_owned();
             let task = claim.task_selector().to_owned();
-            let task_root = claim.task().root().to_path_buf();
             let task_digest = claim.task().package_digest().to_owned();
             let treatment = WireTreatment::from(claim.treatment());
             let claim = insert_claim(&state, claim, host).await;
             ClaimResponse::Run {
+                task_package: Some(claim.clone()),
                 claim,
                 repetition,
                 family_key,
                 task,
-                task_root: Some(task_root),
-                task_package: None,
+                task_root: None,
                 task_digest,
                 treatment,
             }
@@ -979,6 +1013,16 @@ async fn upload_artifacts(
         claim.claim.output_directory().to_path_buf()
     };
     receive_archive(body, &output, &token).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn heartbeat(
+    State(state): State<CoordinatorState>,
+    AxumPath(token): AxumPath<String>,
+) -> Result<StatusCode, ApiError> {
+    if !state.active.lock().await.contains_key(&token) {
+        return Err(ApiError::not_found("claim is absent or expired"));
+    }
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -1195,7 +1239,14 @@ fn extract_task_package_archive(
                 .components()
                 .all(|component| matches!(component, Component::Normal(_)));
         let entry_type = entry.header().entry_type();
-        if !safe_path || !(entry_type.is_file() || entry_type.is_dir()) {
+        let safe_symlink = if entry_type.is_symlink() {
+            entry
+                .link_name()?
+                .is_some_and(|target| safe_task_symlink_target(&path, &target))
+        } else {
+            false
+        };
+        if !safe_path || !(entry_type.is_file() || entry_type.is_dir() || safe_symlink) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 format!("task archive contained an unsafe entry: {}", path.display()),
@@ -1222,6 +1273,77 @@ fn extract_task_package_archive(
         ));
     }
     std::fs::rename(staging, output)
+}
+
+fn safe_task_symlink_target(path: &Path, target: &Path) -> bool {
+    if target.as_os_str().is_empty() || target.is_absolute() {
+        return false;
+    }
+    let Some(source_boundary) = path.components().next() else {
+        return false;
+    };
+    let mut resolved = Vec::new();
+    for component in path
+        .parent()
+        .into_iter()
+        .flat_map(Path::components)
+        .chain(target.components())
+    {
+        match component {
+            Component::Normal(component) => resolved.push(component),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if resolved.pop().is_none() {
+                    return false;
+                }
+            }
+            Component::Prefix(_) | Component::RootDir => return false,
+        }
+    }
+    resolved
+        .first()
+        .is_some_and(|resolved_boundary| source_boundary.as_os_str() == *resolved_boundary)
+}
+
+fn write_task_package_archive<W: Write>(task: &Task, writer: W) -> std::io::Result<()> {
+    let directory = tempfile::tempdir()?;
+    let package = directory.path().join("package");
+    task.materialize_package(&package)
+        .map_err(std::io::Error::other)?;
+    let encoder = zstd::Encoder::new(writer, 3)?;
+    let mut archive = tar::Builder::new(encoder);
+    archive.follow_symlinks(false);
+    append_task_package(&mut archive, &package, &package)?;
+    let encoder = archive.into_inner()?;
+    encoder.finish()?.flush()
+}
+
+fn append_task_package<W: Write>(
+    archive: &mut tar::Builder<W>,
+    root: &Path,
+    directory: &Path,
+) -> std::io::Result<()> {
+    let mut entries = std::fs::read_dir(directory)?.collect::<Result<Vec<_>, _>>()?;
+    entries.sort_by_key(std::fs::DirEntry::file_name);
+    for entry in entries {
+        let path = entry.path();
+        let relative = path
+            .strip_prefix(root)
+            .map_err(|_| std::io::Error::other("task package escaped its archive root"))?;
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            archive.append_dir(relative, &path)?;
+            append_task_package(archive, root, &path)?;
+        } else if file_type.is_file() || file_type.is_symlink() {
+            archive.append_path_with_name(&path, relative)?;
+        } else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("unsupported task package entry: {}", path.display()),
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn write_evidence_archive<W: Write>(directory: &Path, writer: W) -> std::io::Result<()> {
@@ -1459,6 +1581,7 @@ allow_internet = false
         .unwrap();
         fs::write(task.join("instruction.md"), "do it").unwrap();
         fs::write(task.join("environment/Dockerfile"), "FROM scratch").unwrap();
+        std::os::unix::fs::symlink("Dockerfile", task.join("environment/Dockerfile.link")).unwrap();
         fs::write(task.join("tests/test.sh"), "#!/bin/sh\n").unwrap();
     }
 
@@ -1534,16 +1657,27 @@ thinking = ["high"]
             panic!("second worker should run");
         };
         assert_ne!(first_repetition, second_repetition);
-        let RemoteTaskSource::Filesystem {
-            root: first_task_root,
-            ..
+        first_client.heartbeat(&first_claim).await.unwrap();
+        second_client.heartbeat(&second_claim).await.unwrap();
+        let RemoteTaskSource::Package {
+            key: first_task_package,
+            digest: first_task_digest,
         } = first_task_source
         else {
-            panic!("loopback coordinator should retain a filesystem task source");
+            panic!("coordinator should retain a downloadable task package");
         };
+        let first_task_root = directory.path().join("materialized-task");
+        first_client
+            .materialize_task_package(&first_task_package, &first_task_root)
+            .await
+            .unwrap();
         assert_eq!(
-            first_task_root,
-            fs::canonicalize(directory.path().join("one")).unwrap()
+            Task::load(&first_task_root).unwrap().package_digest(),
+            first_task_digest
+        );
+        assert_eq!(
+            fs::read_link(first_task_root.join("environment/Dockerfile.link")).unwrap(),
+            Path::new("Dockerfile")
         );
 
         let status = client.status().await.unwrap();
@@ -1589,6 +1723,13 @@ thinking = ["high"]
             fs::write(output.join("vm/config.json"), "{}\n").unwrap();
             client.succeed(claim, &output, &evidence).await.unwrap();
         }
+        assert!(matches!(
+            first_client.heartbeat(&first_claim).await.unwrap_err(),
+            CoordinatorError::Rejected {
+                status: StatusCode::NOT_FOUND,
+                ..
+            }
+        ));
         assert!(
             stale_marker.exists(),
             "one attempt must not erase sibling evidence"
@@ -1962,6 +2103,7 @@ thinking = ["high"]
         let file = fs::File::create(&archive_path).unwrap();
         let encoder = zstd::Encoder::new(file, 3).unwrap();
         let mut archive = tar::Builder::new(encoder);
+        archive.follow_symlinks(false);
         archive
             .append_path_with_name(source.join("task.toml"), "task.toml")
             .unwrap();
@@ -1975,6 +2117,12 @@ thinking = ["high"]
             .append_path_with_name(
                 source.join("environment/Dockerfile"),
                 "environment/Dockerfile",
+            )
+            .unwrap();
+        archive
+            .append_path_with_name(
+                source.join("environment/Dockerfile.link"),
+                "environment/Dockerfile.link",
             )
             .unwrap();
         archive.append_dir("tests", source.join("tests")).unwrap();

--- a/crates/experimental/nanocodex-eval/src/digest.rs
+++ b/crates/experimental/nanocodex-eval/src/digest.rs
@@ -36,6 +36,7 @@ struct TaskPackageEntry {
 enum TaskPackageEntryKind {
     Directory,
     File { bytes: u64, digest: [u8; 32] },
+    Symlink { target: PathBuf },
 }
 
 impl TaskPackage {
@@ -89,7 +90,7 @@ impl TaskPackage {
             .iter()
             .filter_map(|entry| match &entry.kind {
                 TaskPackageEntryKind::File { bytes, .. } => Some(*bytes),
-                TaskPackageEntryKind::Directory => None,
+                TaskPackageEntryKind::Directory | TaskPackageEntryKind::Symlink { .. } => None,
             })
             .fold(0_u64, u64::saturating_add)
     }
@@ -101,7 +102,7 @@ impl TaskPackage {
             .find(|entry| entry.relative == relative)
             .and_then(|entry| match &entry.kind {
                 TaskPackageEntryKind::File { bytes, digest } => Some((*bytes, *digest)),
-                TaskPackageEntryKind::Directory => None,
+                TaskPackageEntryKind::Directory | TaskPackageEntryKind::Symlink { .. } => None,
             })
         else {
             return Ok(None);
@@ -156,6 +157,9 @@ impl TaskPackage {
                     set_mode(&target, entry.mode)?;
                     normalize_times(&target)?;
                 }
+                TaskPackageEntryKind::Symlink {
+                    target: link_target,
+                } => std::os::unix::fs::symlink(link_target, &target)?,
             }
         }
         if !found {
@@ -198,6 +202,9 @@ impl TaskPackage {
                     set_mode(&target, entry.mode)?;
                     normalize_times(&target)?;
                 }
+                TaskPackageEntryKind::Symlink {
+                    target: link_target,
+                } => std::os::unix::fs::symlink(link_target, &target)?,
             }
         }
         for (directory, mode) in directory_modes.into_iter().rev() {
@@ -222,14 +229,8 @@ fn collect_package_entry(
     let mode = metadata_mode(&metadata);
     let kind = if metadata.file_type().is_symlink() {
         let target = fs::read_link(path)?;
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!(
-                "task package symlinks are unsupported: {} -> {}",
-                path.display(),
-                target.display()
-            ),
-        ));
+        validate_symlink_target(root, path, &target)?;
+        TaskPackageEntryKind::Symlink { target }
     } else if metadata.is_dir() {
         TaskPackageEntryKind::Directory
     } else if metadata.is_file() {
@@ -264,6 +265,10 @@ fn package_digest(entries: &[TaskPackageEntry]) -> String {
         digest.update(entry.mode.to_le_bytes());
         match &entry.kind {
             TaskPackageEntryKind::Directory => digest.update(b"d"),
+            TaskPackageEntryKind::Symlink { target } => {
+                digest.update(b"l");
+                update_field(&mut digest, target.as_os_str().as_encoded_bytes());
+            }
             TaskPackageEntryKind::File {
                 bytes,
                 digest: file,
@@ -275,6 +280,47 @@ fn package_digest(entries: &[TaskPackageEntry]) -> String {
         }
     }
     hex::encode(digest.finalize())
+}
+
+fn validate_symlink_target(root: &Path, path: &Path, target: &Path) -> io::Result<()> {
+    if target.is_absolute() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "task package symlink target must be relative: {} -> {}",
+                path.display(),
+                target.display()
+            ),
+        ));
+    }
+    let resolved = fs::canonicalize(path)?;
+    let source_relative = path.strip_prefix(root).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("task package symlink is outside its root: {error}"),
+        )
+    })?;
+    let resolved_relative = resolved.strip_prefix(root).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "task package symlink escapes its root: {} -> {}",
+                path.display(),
+                target.display()
+            ),
+        )
+    })?;
+    if source_relative.components().next() != resolved_relative.components().next() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "task package symlink crosses execution-input boundaries: {} -> {}",
+                path.display(),
+                target.display()
+            ),
+        ));
+    }
+    Ok(())
 }
 
 fn update_field(digest: &mut Sha256, bytes: &[u8]) {
@@ -451,7 +497,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn rejects_symlinks_in_the_task_package() {
+    fn rejects_absolute_symlinks_in_the_task_package() {
         let task = package();
         let link = task.path().join("environment/current");
         std::os::unix::fs::symlink("/etc/passwd", &link).unwrap();
@@ -459,7 +505,11 @@ mod tests {
         let error = TaskPackage::load(task.path()).unwrap_err();
 
         assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
-        assert!(error.to_string().contains("symlinks are unsupported"));
+        assert!(
+            error
+                .to_string()
+                .contains("symlink target must be relative")
+        );
         assert!(error.to_string().contains("/etc/passwd"));
     }
 

--- a/crates/experimental/nanocodex-eval/src/task.rs
+++ b/crates/experimental/nanocodex-eval/src/task.rs
@@ -177,7 +177,7 @@ pub enum TaskLoadError {
     },
 
     /// The manifest declares an unsupported schema revision.
-    #[error("unsupported task schema version {found:?}; expected \"1.1\" or \"1.3\"")]
+    #[error("unsupported task schema version {found:?}; expected \"1.0\", \"1.1\", or \"1.3\"")]
     UnsupportedSchema {
         /// Unsupported revision read from the manifest.
         found: String,
@@ -255,11 +255,29 @@ impl Task {
             path: config_path.clone(),
             source,
         })?;
-        if !matches!(raw.schema_version.as_str(), "1.1" | "1.3") {
+        let schema_version = match (&raw.schema_version, &raw.version) {
+            (Some(schema), None) | (None, Some(schema)) => schema.as_str(),
+            (Some(schema), Some(version)) if schema == version => schema.as_str(),
+            (Some(schema), Some(version)) => {
+                return Err(TaskLoadError::Invalid {
+                    path: config_path,
+                    message: format!(
+                        "schema_version {schema:?} conflicts with version {version:?}"
+                    ),
+                });
+            }
+            (None, None) => {
+                return Err(TaskLoadError::UnsupportedSchema {
+                    found: "<missing>".to_owned(),
+                });
+            }
+        };
+        if !matches!(schema_version, "1.0" | "1.1" | "1.3") {
             return Err(TaskLoadError::UnsupportedSchema {
-                found: raw.schema_version,
+                found: schema_version.to_owned(),
             });
         }
+        let legacy_schema = schema_version == "1.0";
 
         let instruction_path = root.join(TASK_INSTRUCTION);
         let prompt = strip_leading_canary(&read_package_file(&package, &root, TASK_INSTRUCTION)?);
@@ -304,15 +322,36 @@ impl Task {
         }
 
         let (network, verifier_network) = raw.network_policies(&config_path)?;
-        let name = required_string(&config_path, "task.name", raw.task.name)?;
-        if raw.task.benchmark_prompt_chars == Some(0) {
+        let task_info = match raw.task {
+            Some(task) => task,
+            None if legacy_schema => RawTaskInfo {
+                name: root
+                    .file_name()
+                    .and_then(std::ffi::OsStr::to_str)
+                    .ok_or_else(|| TaskLoadError::Invalid {
+                        path: config_path.clone(),
+                        message: "version 1.0 task directory name must be valid UTF-8".to_owned(),
+                    })?
+                    .to_owned(),
+                description: String::new(),
+                benchmark_prompt_chars: None,
+                benchmark_case_type: None,
+            },
+            None => {
+                return Err(TaskLoadError::Invalid {
+                    path: config_path,
+                    message: "task table is required by this schema version".to_owned(),
+                });
+            }
+        };
+        let name = required_string(&config_path, "task.name", task_info.name)?;
+        if task_info.benchmark_prompt_chars == Some(0) {
             return Err(TaskLoadError::Invalid {
                 path: config_path,
                 message: "task.benchmark_prompt_chars must be positive when present".to_owned(),
             });
         }
-        let benchmark_case_type = raw
-            .task
+        let benchmark_case_type = task_info
             .benchmark_case_type
             .map(|value| required_string(&config_path, "task.benchmark_case_type", value))
             .transpose()?
@@ -331,7 +370,7 @@ impl Task {
             dataset: None,
             dataset_revision: None,
             name: name.into_boxed_str(),
-            description: raw.task.description.into_boxed_str(),
+            description: task_info.description.into_boxed_str(),
             prompt_chars: u64::try_from(
                 transcript
                     .iter()
@@ -340,7 +379,7 @@ impl Task {
                     .saturating_add(prompt.chars().count()),
             )
             .unwrap_or(u64::MAX),
-            benchmark_prompt_chars: raw.task.benchmark_prompt_chars,
+            benchmark_prompt_chars: task_info.benchmark_prompt_chars,
             benchmark_case_type,
             prompt: prompt.into_boxed_str(),
             transcript,
@@ -834,12 +873,16 @@ impl VerifierEnvironmentMode {
 
 #[derive(Deserialize)]
 struct RawTask {
-    schema_version: String,
+    #[serde(default)]
+    schema_version: Option<String>,
+    #[serde(default)]
+    version: Option<String>,
     #[serde(default)]
     artifacts: Vec<RawTaskArtifact>,
     #[serde(default)]
     output: TaskOutput,
-    task: RawTaskInfo,
+    #[serde(default)]
+    task: Option<RawTaskInfo>,
     #[serde(default)]
     metadata: RawMetadata,
     agent: RawPhase,
@@ -1243,6 +1286,47 @@ MODE = "test"
     }
 
     #[test]
+    fn loads_harbor_1_0_task_name_from_its_directory() {
+        let parent = tempdir().unwrap();
+        let directory = parent.path().join("frontier-task");
+        fs::create_dir(&directory).unwrap();
+        fs::create_dir(directory.join("tests")).unwrap();
+        fs::create_dir(directory.join("environment")).unwrap();
+        fs::write(
+            directory.join("task.toml"),
+            r#"
+version = "1.0"
+
+[agent]
+timeout_sec = 72000.0
+
+[verifier]
+timeout_sec = 86400.0
+
+[environment]
+docker_image = "example/frontier-task:v1"
+cpus = 8
+memory_mb = 32768
+storage_mb = 51200
+gpus = 0
+allow_internet = false
+"#,
+        )
+        .unwrap();
+        fs::write(directory.join("instruction.md"), "Optimize it.").unwrap();
+        fs::write(directory.join("tests/test.sh"), "#!/bin/sh\n").unwrap();
+
+        let task = Task::load(&directory).unwrap();
+
+        assert_eq!(task.name(), "frontier-task");
+        assert_eq!(task.agent_timeout(), std::time::Duration::from_secs(72_000));
+        assert_eq!(
+            task.verifier().timeout(),
+            std::time::Duration::from_secs(86_400)
+        );
+    }
+
+    #[test]
     fn loads_and_fingerprints_a_synthetic_transcript() {
         let directory = tempdir().unwrap();
         fs::create_dir(directory.path().join("tests")).unwrap();
@@ -1373,7 +1457,7 @@ storage_mb = 1
 
     #[cfg(unix)]
     #[test]
-    fn rejects_symlinks_in_execution_inputs() {
+    fn rejects_symlinks_that_escape_execution_inputs() {
         let directory = tempdir().unwrap();
         fs::create_dir(directory.path().join("tests")).unwrap();
         fs::create_dir(directory.path().join("environment")).unwrap();
@@ -1403,8 +1487,60 @@ storage_mb = 1
         let error = Task::load(directory.path()).unwrap_err();
 
         assert!(matches!(error, super::TaskLoadError::Fingerprint { .. }));
-        assert!(error.to_string().contains("symlinks are unsupported"));
+        assert!(
+            error
+                .to_string()
+                .contains("symlink target must be relative")
+        );
         assert!(error.to_string().contains("/etc/passwd"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preserves_relative_symlinks_within_execution_inputs() {
+        let directory = tempdir().unwrap();
+        fs::create_dir(directory.path().join("tests")).unwrap();
+        fs::create_dir_all(directory.path().join("environment/docs")).unwrap();
+        fs::write(
+            directory.path().join("task.toml"),
+            r#"
+schema_version = "1.1"
+[task]
+name = "terminal-bench/symlink"
+[agent]
+timeout_sec = 1.0
+[verifier]
+timeout_sec = 1.0
+[environment]
+docker_image = "example/task:latest"
+cpus = 1
+memory_mb = 1
+storage_mb = 1
+"#,
+        )
+        .unwrap();
+        fs::write(directory.path().join("instruction.md"), "Do it.").unwrap();
+        fs::write(directory.path().join("tests/test.sh"), "exit 0\n").unwrap();
+        fs::write(
+            directory.path().join("environment/docs/target"),
+            "contents\n",
+        )
+        .unwrap();
+        std::os::unix::fs::symlink("docs/target", directory.path().join("environment/link"))
+            .unwrap();
+
+        let task = Task::load(directory.path()).unwrap();
+        let materialized = tempdir().unwrap();
+        task.materialize_environment(materialized.path()).unwrap();
+
+        assert_eq!(
+            fs::read_link(materialized.path().join("link")).unwrap(),
+            PathBuf::from("docs/target")
+        );
+        assert_eq!(
+            fs::read_to_string(materialized.path().join("link")).unwrap(),
+            "contents\n"
+        );
     }
 
     #[test]

--- a/nanocodex.toml
+++ b/nanocodex.toml
@@ -28,6 +28,69 @@ trials = 1
 model = ["sol"]
 thinking = ["high"]
 
+# Exact public task set from FrontierHarness Eval v1:
+# https://github.com/runta-dev/frontier-harness-eval
+[profiles.frontier-harness-v1]
+benchmarks = [
+  "terminal-bench-2.1/build-cython-ext",
+  "terminal-bench-2.1/chess-best-move",
+  "terminal-bench-2.1/code-from-image",
+  "terminal-bench-2.1/constraints-scheduling",
+  "terminal-bench-2.1/db-wal-recovery",
+  "terminal-bench-2.1/dna-insert",
+  "terminal-bench-2.1/extract-elf",
+  "terminal-bench-2.1/gcode-to-text",
+  "terminal-bench-2.1/git-leak-recovery",
+  "terminal-bench-2.1/kv-store-grpc",
+  "terminal-bench-2.1/largest-eigenval",
+  "terminal-bench-2.1/log-summary-date-ranges",
+  "terminal-bench-2.1/merge-diff-arc-agi-task",
+  "terminal-bench-2.1/modernize-scientific-stack",
+  "terminal-bench-2.1/multi-source-data-merger",
+  "terminal-bench-2.1/openssl-selfsigned-cert",
+  "terminal-bench-2.1/polyglot-c-py",
+  "terminal-bench-2.1/regex-log",
+  "terminal-bench-2.1/sanitize-git-repo",
+  "terminal-bench-2.1/sqlite-db-truncate",
+  "terminal-bench-2.1/vulnerable-secret",
+  "deep-swe-v1.1/anko-typed-variable-bindings",
+  "deep-swe-v1.1/arktype-json-schema-refs-dependencies",
+  "deep-swe-v1.1/expr-try-catch-errors",
+  "deep-swe-v1.1/fastapi-deprecation-response-headers",
+  "deep-swe-v1.1/httpx-multipart-response-parsing",
+  "deep-swe-v1.1/katex-multicolumn-array-spans",
+  "deep-swe-v1.1/meriyah-explicit-resource-declarations",
+  "deep-swe-v1.1/python-statemachine-state-data-scoping",
+  "deep-swe-v1.1/scc-bounded-memory-spilling",
+]
+trials = 1
+model = ["sol"]
+thinking = ["high"]
+
+[profiles.frontier-swe-v2]
+benchmarks = [
+  "frontier-swe-v2/cranelift-codegen-opt",
+  "frontier-swe-v2/dart-style-haskell",
+  "frontier-swe-v2/dependent-type-checker",
+  "frontier-swe-v2/ffmpeg-swscale-rewrite",
+  "frontier-swe-v2/frogsgame-rl",
+  "frontier-swe-v2/git-to-zig",
+  "frontier-swe-v2/granite-mamba2-inference-optimization",
+  "frontier-swe-v2/inference-system-optimization",
+  "frontier-swe-v2/libexpat-to-x86asm",
+  "frontier-swe-v2/lua-native-compiler",
+  "frontier-swe-v2/modular-stack-wan21",
+  "frontier-swe-v2/notebook-compression",
+  "frontier-swe-v2/optimizer-design",
+  "frontier-swe-v2/pcqm4mv2-autoresearch",
+  "frontier-swe-v2/postgres-sqlite-wire-adapter",
+  "frontier-swe-v2/pyright-type-checking-optimization",
+  "frontier-swe-v2/revideo-perf-opt",
+]
+trials = 1
+model = ["sol"]
+thinking = ["high"]
+
 [profiles.arena-hard-smoke]
 benchmarks = ["arena-hard-v2/2edbb5f36f5b42be"]
 trials = 1


### PR DESCRIPTION
Add the pinned Frontier SWE v2 Harbor adapter and explicit Frontier Harness v1 / Frontier SWE v2 profiles. Load Harbor 1.0 manifests and preserve relative symlinks within an execution-input boundary.

Coordinator claims now provide downloadable, digest-checked task packages instead of coordinator-local paths. Active claims also expose heartbeat checks; finished or absent claims return 404.

Validation:
- 107 nanocodex-eval tests and 31 adapter tests pass, including task-package transport, symlink materialization, claim heartbeat, and Harbor 1.0 loading.
- cargo fmt --all --check passes.
- Clippy passes for both crates and all targets with the same missing_const_for_fn allowance used in CI.

No full Frontier benchmark evaluation was run.
