### PR TITLE
feat(cli): add model and thinking slash commands

### DIFF
--- a/bin/nanocodex/src/nanocodex2/config.rs
+++ b/bin/nanocodex/src/nanocodex2/config.rs
@@ -44,6 +44,23 @@ impl ReasoningEffort {
     }
 }
 
+impl std::str::FromStr for ReasoningEffort {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "low" => Ok(Self::Low),
+            "medium" => Ok(Self::Medium),
+            "high" => Ok(Self::High),
+            "xhigh" => Ok(Self::Xhigh),
+            "max" => Ok(Self::Max),
+            _ => Err(format!(
+                "invalid thinking level {value:?}; expected low, medium, high, xhigh, or max"
+            )),
+        }
+    }
+}
+
 /// Reasoning mode displayed by the Tact composer.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize, ValueEnum)]
 #[serde(rename_all = "lowercase")]

--- a/bin/nanocodex/src/nanocodex2/tui/components/actions.rs
+++ b/bin/nanocodex/src/nanocodex2/tui/components/actions.rs
@@ -4,6 +4,7 @@
 //! Searchable modal menu for actions exposed by the TUI.
 
 use super::{
+    composer::SettingsCommand,
     floating::Floating,
     node::{Component, ComponentUpdate, RenderRequest},
 };
@@ -67,6 +68,7 @@ pub(super) enum Action {
 pub(super) enum ActionsEffect {
     Dismiss,
     Trigger(Action),
+    Settings(SettingsCommand),
 }
 
 pub(super) struct ActionsMenu {
@@ -173,6 +175,12 @@ impl ActionsMenu {
     }
 
     fn trigger_selected(&self) -> ComponentUpdate<ActionsEffect> {
+        if let Some(command) = SettingsCommand::parse(&format!("/{}", self.query)) {
+            return ComponentUpdate {
+                effects: vec![ActionsEffect::Settings(command)],
+                render: RenderRequest::Immediate,
+            };
+        }
         let Some(action) = self.matches.get(self.selected) else {
             return ComponentUpdate::none();
         };
@@ -400,8 +408,13 @@ fn visible_query_tail(query: &str, width: usize) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use super::{Action, ActionAvailability, ActionsEffect, ActionsEvent, ActionsMenu, Component};
+    use super::{
+        Action, ActionAvailability, ActionsEffect, ActionsEvent, ActionsMenu, Component,
+        SettingsCommand,
+    };
+    use crate::config::ReasoningEffort;
     use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+    use nanocodex::Model;
 
     fn availability(fast_mode: bool, model: bool) -> ActionAvailability {
         ActionAvailability {
@@ -457,6 +470,39 @@ mod tests {
             KeyModifiers::NONE,
         ))));
         assert_eq!(update.effects, [ActionsEffect::Trigger(Action::FastMode)]);
+    }
+
+    #[test]
+    fn direct_settings_queries_trigger_even_without_an_action_match() {
+        let mut menu = ActionsMenu::new(availability(false, true));
+        menu.update(ActionsEvent::Terminal(Event::Paste(
+            "model astra".to_owned(),
+        )));
+        let update = menu.update(ActionsEvent::Terminal(Event::Key(KeyEvent::new(
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+        ))));
+        assert_eq!(
+            update.effects,
+            [ActionsEffect::Settings(SettingsCommand::SetModel(
+                Model::Astra
+            ))]
+        );
+
+        let mut menu = ActionsMenu::new(availability(false, true));
+        menu.update(ActionsEvent::Terminal(Event::Paste(
+            "reasoning max".to_owned(),
+        )));
+        let update = menu.update(ActionsEvent::Terminal(Event::Key(KeyEvent::new(
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+        ))));
+        assert_eq!(
+            update.effects,
+            [ActionsEffect::Settings(SettingsCommand::SetEffort(
+                ReasoningEffort::Max
+            ))]
+        );
     }
 
     #[test]

--- a/bin/nanocodex/src/nanocodex2/tui/components/composer.rs
+++ b/bin/nanocodex/src/nanocodex2/tui/components/composer.rs
@@ -54,6 +54,54 @@ pub(crate) enum ComposerEffect {
     Queue(Submission),
     RunShell(String),
     OpenDraftEditor,
+    Settings(SettingsCommand),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum SettingsCommand {
+    OpenEffort,
+    SetEffort(ReasoningEffort),
+    OpenModel,
+    SetModel(Model),
+    Invalid(String),
+}
+
+impl SettingsCommand {
+    pub(super) fn parse(input: &str) -> Option<Self> {
+        let mut parts = input.split_whitespace();
+        let command = parts.next()?;
+        match command {
+            "/model" => {
+                let Some(argument) = parts.next() else {
+                    return Some(Self::OpenModel);
+                };
+                if parts.next().is_some() {
+                    return Some(Self::Invalid(
+                        "Usage: /model [sol|terra|luna|astra]".to_owned(),
+                    ));
+                }
+                Some(match argument.parse() {
+                    Ok(model) => Self::SetModel(model),
+                    Err(error) => Self::Invalid(error),
+                })
+            }
+            "/effort" | "/reasoning" | "/thinking" => {
+                let Some(argument) = parts.next() else {
+                    return Some(Self::OpenEffort);
+                };
+                if parts.next().is_some() {
+                    return Some(Self::Invalid(
+                        "Usage: /thinking [low|medium|high|xhigh|max]".to_owned(),
+                    ));
+                }
+                Some(match argument.parse() {
+                    Ok(effort) => Self::SetEffort(effort),
+                    Err(error) => Self::Invalid(error),
+                })
+            }
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -797,11 +845,15 @@ impl Composer {
     }
 
     fn submit(&mut self) -> ComposerUpdate {
-        let trimmed = self.draft.trim();
-        if trimmed.is_empty() {
+        if self.draft.trim().is_empty() {
             return ComposerUpdate::unchanged();
         }
 
+        if let Some(command) = self.take_settings_command() {
+            return command;
+        }
+
+        let trimmed = self.draft.trim();
         if self.images.is_empty() && self.draft.starts_with('!') {
             let command = trimmed.trim_start_matches('!').trim().to_owned();
             if command.is_empty() {
@@ -820,11 +872,27 @@ impl Composer {
     }
 
     fn queue(&mut self) -> ComposerUpdate {
+        if let Some(command) = self.take_settings_command() {
+            return command;
+        }
         let Some(prompt) = self.take_submission() else {
             return ComposerUpdate::unchanged();
         };
         self.history.record(prompt.display_text().to_owned());
         ComposerUpdate::effect(ComposerEffect::Queue(prompt), true)
+    }
+
+    fn take_settings_command(&mut self) -> Option<ComposerUpdate> {
+        if !self.images.is_empty() {
+            return None;
+        }
+        let command = SettingsCommand::parse(self.draft.trim())?;
+        self.history.record(self.draft.trim().to_owned());
+        self.replace_draft(String::new());
+        Some(ComposerUpdate::effect(
+            ComposerEffect::Settings(command),
+            true,
+        ))
     }
 
     fn move_up(&mut self) -> bool {
@@ -1699,7 +1767,7 @@ fn render_selection(
 mod tests {
     use super::{
         super::selection::{Selection, Surface, TextRange},
-        Composer, ComposerEffect, ComposerEvent, context_percent,
+        Composer, ComposerEffect, ComposerEvent, SettingsCommand, context_percent,
     };
     use crate::{
         config::{ReasoningEffort, ReasoningMode},
@@ -2698,6 +2766,51 @@ mod tests {
         assert_eq!(context_percent(0), 0);
         assert_eq!(context_percent(136_000), 50);
         assert_eq!(context_percent(1_400), 1);
+    }
+
+    #[test]
+    fn slash_settings_commands_open_pickers_and_accept_direct_values() {
+        let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
+
+        composer.replace_draft("/model".to_owned());
+        assert_eq!(
+            composer.submit().effect,
+            Some(ComposerEffect::Settings(SettingsCommand::OpenModel))
+        );
+        composer.replace_draft("/model astra".to_owned());
+        assert_eq!(
+            composer.submit().effect,
+            Some(ComposerEffect::Settings(SettingsCommand::SetModel(
+                Model::Astra
+            )))
+        );
+
+        for alias in ["/effort", "/reasoning", "/thinking"] {
+            composer.replace_draft(alias.to_owned());
+            assert_eq!(
+                composer.submit().effect,
+                Some(ComposerEffect::Settings(SettingsCommand::OpenEffort))
+            );
+            composer.replace_draft(format!("{alias} high"));
+            assert_eq!(
+                composer.submit().effect,
+                Some(ComposerEffect::Settings(SettingsCommand::SetEffort(
+                    ReasoningEffort::High
+                )))
+            );
+        }
+    }
+
+    #[test]
+    fn similarly_prefixed_prompts_are_not_treated_as_settings_commands() {
+        let mut composer = Composer::new(Path::new("/work"), ReasoningEffort::Medium);
+        composer.replace_draft("/modeling the system".to_owned());
+
+        assert!(matches!(
+            composer.submit().effect,
+            Some(ComposerEffect::Submit(prompt))
+                if prompt.display_text() == "/modeling the system"
+        ));
     }
 
     #[test]

--- a/bin/nanocodex/src/nanocodex2/tui/components/root.rs
+++ b/bin/nanocodex/src/nanocodex2/tui/components/root.rs
@@ -5,7 +5,10 @@
 
 use super::{
     actions::{Action, ActionAvailability, ActionsEffect, ActionsEvent, ActionsMenu},
-    composer::{Composer, ComposerChromeTarget, ComposerDraft, ComposerEffect, ComposerEvent},
+    composer::{
+        Composer, ComposerChromeTarget, ComposerDraft, ComposerEffect, ComposerEvent,
+        SettingsCommand,
+    },
     context_diagnostics::{
         ContextDiagnosticsEffect, ContextDiagnosticsEvent, ContextDiagnosticsPanel,
     },
@@ -594,6 +597,7 @@ impl RootNode {
         let preserve_active_submission = self.has_active_turns()
             || !self.queue.component().is_empty()
             || self.queue.component().has_pending_steer();
+        let started = preserve_active_submission || !projection.recent_prompts.is_empty();
         if preserve_active_submission {
             self.workspace = workspace.to_path_buf();
             let _ = self
@@ -629,7 +633,11 @@ impl RootNode {
                 .component_mut()
                 .update(ComposerEvent::ContextTokens(tokens));
         }
-        self.thread = ThreadState::Started;
+        self.thread = if started {
+            ThreadState::Started
+        } else {
+            ThreadState::New
+        };
     }
 
     pub(crate) const fn composer(&self) -> &Composer {
@@ -1481,6 +1489,10 @@ impl RootNode {
         let update = actions.update(ActionsEvent::Terminal(event));
         match update.effects.into_iter().next() {
             Some(ActionsEffect::Dismiss) => self.overlay = None,
+            Some(ActionsEffect::Settings(command)) => {
+                self.overlay = None;
+                return self.apply_settings_command(command);
+            }
             Some(ActionsEffect::Trigger(Action::Effort)) => {
                 return self.open_effort();
             }
@@ -1628,7 +1640,11 @@ impl RootNode {
 
     fn open_model(&mut self) -> ComponentUpdate<RootEffect> {
         if self.thread != ThreadState::New {
-            return ComponentUpdate::none();
+            self.notification = Some(Notification::plain(
+                "The model can only be changed before the first prompt".to_owned(),
+                Color::Red,
+            ));
+            return ComponentUpdate::render(RenderRequest::Immediate);
         }
         self.overlay = Some(Overlay::Model(Node::new(ModelSelector::new(
             self.composer.component().model(),
@@ -1945,38 +1961,40 @@ impl RootNode {
         self.overlay = None;
         match effect {
             EffortEffect::Dismiss => ComponentUpdate::render(RenderRequest::Immediate),
-            EffortEffect::Apply(effort, pro) => {
-                let reasoning_mode = if pro {
-                    ReasoningMode::Pro
-                } else {
-                    ReasoningMode::Standard
-                };
-                let previous_reasoning_mode = self.preferred_reasoning_mode;
-                self.preferred_reasoning_mode = reasoning_mode;
-                if reasoning_mode != previous_reasoning_mode {
-                    let state = if pro { "enabled" } else { "disabled" };
-                    let suffix = if self.composer.component().reasoning_mode() != reasoning_mode {
-                        " · start a new session to apply."
-                    } else {
-                        "."
-                    };
-                    let message = format!("Pro {state} for new sessions{suffix}");
-                    self.notification = Some(Notification::plain(message, Color::Green));
-                }
-                self.transcript.component_mut().set_effort(effort);
-                self.subagents.set_effort(effort);
-                let _ = self
-                    .composer
-                    .component_mut()
-                    .update(ComposerEvent::SetEffort(effort));
-                ComponentUpdate {
-                    effects: vec![RootEffect::SetEffort {
-                        effort,
-                        reasoning_mode,
-                    }],
-                    render: RenderRequest::Immediate,
-                }
-            }
+            EffortEffect::Apply(effort, pro) => self.apply_effort(effort, pro),
+        }
+    }
+
+    fn apply_effort(&mut self, effort: ReasoningEffort, pro: bool) -> ComponentUpdate<RootEffect> {
+        let reasoning_mode = if pro {
+            ReasoningMode::Pro
+        } else {
+            ReasoningMode::Standard
+        };
+        let previous_reasoning_mode = self.preferred_reasoning_mode;
+        self.preferred_reasoning_mode = reasoning_mode;
+        if reasoning_mode != previous_reasoning_mode {
+            let state = if pro { "enabled" } else { "disabled" };
+            let suffix = if self.composer.component().reasoning_mode() != reasoning_mode {
+                " · start a new session to apply."
+            } else {
+                "."
+            };
+            let message = format!("Pro {state} for new sessions{suffix}");
+            self.notification = Some(Notification::plain(message, Color::Green));
+        }
+        self.transcript.component_mut().set_effort(effort);
+        self.subagents.set_effort(effort);
+        let _ = self
+            .composer
+            .component_mut()
+            .update(ComposerEvent::SetEffort(effort));
+        ComponentUpdate {
+            effects: vec![RootEffect::SetEffort {
+                effort,
+                reasoning_mode,
+            }],
+            render: RenderRequest::Immediate,
         }
     }
 
@@ -1998,24 +2016,33 @@ impl RootNode {
         }
         match effect {
             ModelSelectorEffect::Dismiss => ComponentUpdate::render(RenderRequest::Immediate),
-            ModelSelectorEffect::Apply(model) if model == self.composer.component().model() => {
-                ComponentUpdate::render(RenderRequest::Immediate)
-            }
-            ModelSelectorEffect::Apply(model) => {
-                self.interactive = false;
-                let _ = self
-                    .composer
-                    .component_mut()
-                    .update(ComposerEvent::Activity {
-                        active: true,
-                        status: Some(format!("Starting {} session…", model_name(model))),
-                        now: Instant::now(),
-                    });
-                ComponentUpdate {
-                    effects: vec![RootEffect::SetModel(model)],
-                    render: RenderRequest::Immediate,
-                }
-            }
+            ModelSelectorEffect::Apply(model) => self.apply_model(model),
+        }
+    }
+
+    fn apply_model(&mut self, model: Model) -> ComponentUpdate<RootEffect> {
+        if self.thread != ThreadState::New {
+            self.notification = Some(Notification::plain(
+                "The model can only be changed before the first prompt".to_owned(),
+                Color::Red,
+            ));
+            return ComponentUpdate::render(RenderRequest::Immediate);
+        }
+        if model == self.composer.component().model() {
+            return ComponentUpdate::render(RenderRequest::Immediate);
+        }
+        self.interactive = false;
+        let _ = self
+            .composer
+            .component_mut()
+            .update(ComposerEvent::Activity {
+                active: true,
+                status: Some(format!("Starting {} session…", model_name(model))),
+                now: Instant::now(),
+            });
+        ComponentUpdate {
+            effects: vec![RootEffect::SetModel(model)],
+            render: RenderRequest::Immediate,
         }
     }
 
@@ -2120,6 +2147,9 @@ impl RootNode {
         priority: RenderRequest,
     ) -> ComponentUpdate<RootEffect> {
         let update = self.composer.component_mut().update(event);
+        if let Some(ComposerEffect::Settings(command)) = &update.effect {
+            return self.apply_settings_command(command.clone());
+        }
         let delivered = matches!(
             &update.effect,
             Some(ComposerEffect::Submit(_) | ComposerEffect::Queue(_))
@@ -2159,6 +2189,9 @@ impl RootNode {
                 vec![RootEffect::RunShell(command)]
             }
             Some(ComposerEffect::OpenDraftEditor) => vec![RootEffect::OpenDraftEditor],
+            Some(ComposerEffect::Settings(_)) => {
+                unreachable!("settings commands return before prompt delivery")
+            }
             None => Vec::new(),
         };
 
@@ -2179,6 +2212,21 @@ impl RootNode {
         render = render.max(controls);
 
         ComponentUpdate { effects, render }
+    }
+
+    fn apply_settings_command(&mut self, command: SettingsCommand) -> ComponentUpdate<RootEffect> {
+        match command {
+            SettingsCommand::OpenEffort => self.open_effort(),
+            SettingsCommand::SetEffort(effort) => {
+                self.apply_effort(effort, self.preferred_reasoning_mode == ReasoningMode::Pro)
+            }
+            SettingsCommand::OpenModel => self.open_model(),
+            SettingsCommand::SetModel(model) => self.apply_model(model),
+            SettingsCommand::Invalid(message) => {
+                self.notification = Some(Notification::plain(message, Color::Red));
+                ComponentUpdate::render(RenderRequest::Immediate)
+            }
+        }
     }
 
     fn submit_reflection(&mut self) -> ComponentUpdate<RootEffect> {
@@ -3342,10 +3390,13 @@ mod history_tests {
 #[cfg(test)]
 mod live_control_tests {
     use super::{Component, RootEffect, RootEvent, RootNode};
-    use crate::config::ReasoningEffort;
+    use crate::config::{ReasoningEffort, ReasoningMode};
     use crate::tui::transcript::TranscriptRecord;
     use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
-    use nanocodex::agent::events::{AgentEvent, AgentEventKind};
+    use nanocodex::{
+        Model,
+        agent::events::{AgentEvent, AgentEventKind},
+    };
     use serde_json::{json, value::to_raw_value};
     use std::{path::Path, sync::Arc};
 
@@ -3372,6 +3423,81 @@ mod live_control_tests {
         );
         assert_eq!(root.in_flight_turns, 1);
         assert!(root.queue.component().is_empty());
+    }
+
+    #[test]
+    fn slash_model_command_routes_as_a_hosted_setting_instead_of_a_prompt() {
+        let mut root = root_with_draft("/model astra");
+
+        let update = root.update(key(KeyCode::Enter));
+
+        assert!(matches!(
+            update.effects.as_slice(),
+            [RootEffect::SetModel(Model::Astra)]
+        ));
+        assert!(matches!(root.thread, super::ThreadState::New));
+        assert!(root.composer.component().draft().is_empty());
+        assert_eq!(root.in_flight_turns, 0);
+    }
+
+    #[test]
+    fn slash_action_overlay_routes_direct_model_command() {
+        let mut root = root_with_draft("");
+        let _ = root.update(key(KeyCode::Char('/')));
+        for character in "model astra".chars() {
+            let _ = root.update(key(KeyCode::Char(character)));
+        }
+
+        let update = root.update(key(KeyCode::Enter));
+
+        assert!(matches!(
+            update.effects.as_slice(),
+            [RootEffect::SetModel(Model::Astra)]
+        ));
+        assert!(matches!(root.thread, super::ThreadState::New));
+        assert_eq!(root.in_flight_turns, 0);
+    }
+
+    #[test]
+    fn empty_attached_agent_keeps_model_selection_unlocked() {
+        let mut root = root_with_draft("");
+        let projection = RootNode::project_open_session(ReasoningEffort::Medium, Vec::new());
+        root.install_session_projection(
+            Path::new("/workspace"),
+            ReasoningEffort::Medium,
+            ReasoningMode::Standard,
+            ReasoningMode::Standard,
+            false,
+            projection,
+        );
+        let _ = root.update(key(KeyCode::Char('/')));
+        for character in "model astra".chars() {
+            let _ = root.update(key(KeyCode::Char(character)));
+        }
+
+        let update = root.update(key(KeyCode::Enter));
+
+        assert!(matches!(
+            update.effects.as_slice(),
+            [RootEffect::SetModel(Model::Astra)]
+        ));
+    }
+
+    #[test]
+    fn slash_thinking_alias_routes_as_a_durable_effort_setting() {
+        let mut root = root_with_draft("/reasoning high");
+
+        let update = root.update(key(KeyCode::Enter));
+
+        assert!(matches!(
+            update.effects.as_slice(),
+            [RootEffect::SetEffort {
+                effort: ReasoningEffort::High,
+                ..
+            }]
+        ));
+        assert_eq!(root.composer.component().effort(), ReasoningEffort::High);
+        assert_eq!(root.in_flight_turns, 0);
     }
 
     #[test]

--- a/bin/nanocodex/src/tui/app.rs
+++ b/bin/nanocodex/src/tui/app.rs
@@ -63,6 +63,13 @@ pub(super) const STANDARD_THINKING_OPTIONS: [(Thinking, &str, &str); 4] = [
     ),
 ];
 
+pub(super) const MODEL_OPTIONS: [(Model, &str); 4] = [
+    (Model::Luna, "Luna"),
+    (Model::Terra, "Terra"),
+    (Model::Sol, "Sol"),
+    (Model::Astra, "Astra"),
+];
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum ReasoningPicker {
     Standard { selected: usize },
@@ -73,6 +80,11 @@ pub(super) enum ReasoningPicker {
 pub(super) enum ReasoningPickerAction {
     OpenedAdvanced,
     Selected(Thinking),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ModelPickerAction {
+    Selected(Model),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1198,6 +1210,7 @@ pub(super) struct App {
     fast_mode: bool,
     model: Model,
     thinking: Thinking,
+    model_picker: Option<usize>,
     reasoning_picker: Option<ReasoningPicker>,
 }
 
@@ -1251,6 +1264,7 @@ impl App {
             fast_mode: false,
             model: Model::default(),
             thinking: Thinking::default(),
+            model_picker: None,
             reasoning_picker: None,
         }
     }
@@ -2815,6 +2829,36 @@ impl App {
     pub(super) fn model_change_failed(&mut self, error: &str) {
         self.push_active_error(format!("Could not change model: {error}"));
         self.set_active_status("Model unchanged");
+    }
+
+    pub(super) const fn model_picker(&self) -> Option<usize> {
+        self.model_picker
+    }
+
+    pub(super) fn open_model_picker(&mut self) {
+        let selected = MODEL_OPTIONS
+            .iter()
+            .position(|(model, _)| *model == self.model)
+            .unwrap_or(0);
+        self.model_picker = Some(selected);
+    }
+
+    pub(super) fn move_model_picker(&mut self, direction: isize) {
+        let Some(selected) = &mut self.model_picker else {
+            return;
+        };
+        *selected = selected
+            .saturating_add_signed(direction)
+            .min(MODEL_OPTIONS.len().saturating_sub(1));
+    }
+
+    pub(super) fn confirm_model_picker(&mut self) -> Option<ModelPickerAction> {
+        let selected = self.model_picker.take()?;
+        Some(ModelPickerAction::Selected(MODEL_OPTIONS[selected].0))
+    }
+
+    pub(super) const fn close_model_picker(&mut self) {
+        self.model_picker = None;
     }
 
     pub(super) const fn reasoning_picker(&self) -> Option<ReasoningPicker> {

--- a/bin/nanocodex/src/tui/mod.rs
+++ b/bin/nanocodex/src/tui/mod.rs
@@ -49,7 +49,7 @@ use tokio::{
 use tracing::{Instrument, info_span};
 
 use self::{
-    app::{App, EscapeAction, PaneId, ReasoningPickerAction, SubmittedPrompt},
+    app::{App, EscapeAction, ModelPickerAction, PaneId, ReasoningPickerAction, SubmittedPrompt},
     notification::Notifier,
     scheduler::{ANIMATION_TICK_INTERVAL, RenderScheduler, RenderScope, STREAM_FRAME_INTERVAL},
     telemetry::{StreamTelemetry, ViewTelemetry},
@@ -659,8 +659,10 @@ enum Submission {
     Cancel,
     Trace,
     Fast(Option<bool>),
+    ModelPicker,
     Model(Model),
     ReasoningPicker,
+    Thinking(Thinking),
     Voice(VoiceControl),
     McpLogin(String),
     McpReload(String),
@@ -2647,6 +2649,10 @@ fn handle_key(
         return Ok(TerminalAction::Redraw);
     }
 
+    if let Some(action) = handle_model_picker_key(key, app, commands)? {
+        return Ok(action);
+    }
+
     if let Some(action) = handle_reasoning_picker_key(key, app, commands)? {
         return Ok(action);
     }
@@ -2745,6 +2751,37 @@ fn handle_key(
         | KeyCode::Modifier(_) => {}
     }
     Ok(TerminalAction::Redraw)
+}
+
+fn handle_model_picker_key(
+    key: KeyEvent,
+    app: &mut App,
+    commands: &mpsc::UnboundedSender<WorkerCommand>,
+) -> Result<Option<TerminalAction>> {
+    if app.model_picker().is_none() {
+        return Ok(None);
+    }
+    if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
+        return Ok(Some(TerminalAction::Quit));
+    }
+    if key.modifiers.is_empty() {
+        match key.code {
+            KeyCode::Up | KeyCode::Left | KeyCode::Char('k' | 'h') => {
+                app.move_model_picker(-1);
+            }
+            KeyCode::Down | KeyCode::Right | KeyCode::Char('j' | 'l') => {
+                app.move_model_picker(1);
+            }
+            KeyCode::Enter => {
+                if let Some(ModelPickerAction::Selected(model)) = app.confirm_model_picker() {
+                    send_command(commands, WorkerCommand::SetModel { model })?;
+                }
+            }
+            KeyCode::Esc | KeyCode::Char('q') => app.close_model_picker(),
+            _ => {}
+        }
+    }
+    Ok(Some(TerminalAction::Redraw))
 }
 
 fn handle_reasoning_picker_key(
@@ -3179,6 +3216,13 @@ fn submit(
             let enabled = enabled.unwrap_or(!app.fast_mode());
             send_command(commands, WorkerCommand::SetFastMode { enabled })?;
         }
+        Submission::ModelPicker => {
+            if !app.can_change_start_settings() {
+                app.push_active_error("The model can only be changed before the first prompt");
+                return Ok(());
+            }
+            app.open_model_picker();
+        }
         Submission::Model(model) => {
             if !app.can_change_start_settings() {
                 app.push_active_error("The model can only be changed before the first prompt");
@@ -3187,6 +3231,9 @@ fn submit(
             send_command(commands, WorkerCommand::SetModel { model })?;
         }
         Submission::ReasoningPicker => app.open_reasoning_picker(),
+        Submission::Thinking(thinking) => {
+            send_command(commands, WorkerCommand::SetThinking { thinking })?;
+        }
         Submission::Voice(control) => {
             send_command(commands, WorkerCommand::Voice(control))?;
         }
@@ -3305,20 +3352,37 @@ fn classify_submission(input: impl Into<SubmittedPrompt>) -> Submission {
             _ => Submission::InvalidCommand("Usage: /fast [on|off]".to_owned()),
         };
     }
-    if trimmed == "/thinking" {
-        return Submission::ReasoningPicker;
-    }
-    if let Some(argument) = trimmed.strip_prefix("/model ") {
-        return match argument.trim().parse() {
-            Ok(model) => Submission::Model(model),
-            Err(error) => Submission::InvalidCommand(error),
-        };
-    }
-    if trimmed == "/model" {
-        return Submission::InvalidCommand("Usage: /model <sol|terra|luna|astra>".to_owned());
-    }
-    if trimmed.starts_with("/thinking ") {
-        return Submission::InvalidCommand("Usage: /thinking".to_owned());
+    let mut settings = trimmed.split_whitespace();
+    match settings.next() {
+        Some("/model") => {
+            let Some(argument) = settings.next() else {
+                return Submission::ModelPicker;
+            };
+            if settings.next().is_some() {
+                return Submission::InvalidCommand(
+                    "Usage: /model [sol|terra|luna|astra]".to_owned(),
+                );
+            }
+            return match argument.parse() {
+                Ok(model) => Submission::Model(model),
+                Err(error) => Submission::InvalidCommand(error),
+            };
+        }
+        Some("/effort" | "/reasoning" | "/thinking") => {
+            let Some(argument) = settings.next() else {
+                return Submission::ReasoningPicker;
+            };
+            if settings.next().is_some() {
+                return Submission::InvalidCommand(
+                    "Usage: /thinking [none|low|medium|high|xhigh|max]".to_owned(),
+                );
+            }
+            return match argument.parse() {
+                Ok(thinking) => Submission::Thinking(thinking),
+                Err(error) => Submission::InvalidCommand(error),
+            };
+        }
+        _ => {}
     }
     if let Some(name) = trimmed.strip_prefix("/mcp login ") {
         let name = name.trim();
@@ -3700,22 +3764,18 @@ mod tests {
             classify_submission("/fast turbo"),
             Submission::InvalidCommand("Usage: /fast [on|off]".to_owned())
         );
-        assert_eq!(
-            classify_submission("/model"),
-            Submission::InvalidCommand("Usage: /model <sol|terra|luna|astra>".to_owned())
-        );
+        assert_eq!(classify_submission("/model"), Submission::ModelPicker);
         assert_eq!(
             classify_submission("/model astra"),
             Submission::Model(Model::Astra)
         );
-        assert_eq!(
-            classify_submission(" /thinking "),
-            Submission::ReasoningPicker
-        );
-        assert_eq!(
-            classify_submission("/thinking high"),
-            Submission::InvalidCommand("Usage: /thinking".to_owned())
-        );
+        for alias in ["/effort", "/reasoning", "/thinking"] {
+            assert_eq!(classify_submission(alias), Submission::ReasoningPicker);
+            assert_eq!(
+                classify_submission(format!("{alias} high")),
+                Submission::Thinking(Thinking::High)
+            );
+        }
         assert_eq!(
             classify_submission(" /mcp login centaur-tempo "),
             Submission::McpLogin("centaur-tempo".to_owned())
@@ -3955,6 +4015,36 @@ mod tests {
         )
         .unwrap();
         assert_eq!(app.thinking(), Thinking::Medium);
+    }
+
+    #[test]
+    fn model_picker_exposes_and_applies_astra_before_the_first_prompt() {
+        let (commands, mut worker) = mpsc::unbounded_channel();
+        let mut app = App::new("/workspace".into());
+        app.open_model_picker();
+
+        handle_key(
+            KeyEvent::new(KeyCode::Right, KeyModifiers::NONE),
+            &mut app,
+            "main-session",
+            &commands,
+        )
+        .unwrap();
+        handle_key(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &mut app,
+            "main-session",
+            &commands,
+        )
+        .unwrap();
+
+        assert!(app.model_picker().is_none());
+        assert!(matches!(
+            worker.try_recv(),
+            Ok(WorkerCommand::SetModel {
+                model: Model::Astra
+            })
+        ));
     }
 
     #[test]

--- a/bin/nanocodex/src/tui/view.rs
+++ b/bin/nanocodex/src/tui/view.rs
@@ -8,7 +8,7 @@ use ratatui::{
 use std::time::Instant;
 
 use super::{
-    app::{App, Conversation, PaneId, ReasoningPicker, STANDARD_THINKING_OPTIONS},
+    app::{App, Conversation, MODEL_OPTIONS, PaneId, ReasoningPicker, STANDARD_THINKING_OPTIONS},
     composer::ComposerLayout,
     transcript::InlineEdit,
 };
@@ -28,6 +28,7 @@ pub(super) fn render(frame: &mut Frame<'_>, app: &mut App) {
     ));
     render_footer(frame, app, layout.footer);
     app.render_mouse_selection(frame.buffer_mut(), selectable_areas.as_slice());
+    render_model_picker(frame, app);
     render_reasoning_picker(frame, app);
 }
 
@@ -35,7 +36,51 @@ pub(super) fn render_animation(frame: &mut Frame<'_>, app: &mut App) {
     let layout = view_layout(frame.area(), app);
     render_composer(frame, app, layout.composer, &layout.composer_layout);
     render_footer(frame, app, layout.footer);
+    render_model_picker(frame, app);
     render_reasoning_picker(frame, app);
+}
+
+fn render_model_picker(frame: &mut Frame<'_>, app: &App) {
+    let Some(selected) = app.model_picker() else {
+        return;
+    };
+    let area = frame.area();
+    let popup_height = 9.min(area.height);
+    let popup_width = area.width.min(64);
+    let popup = Rect::new(
+        area.x + area.width.saturating_sub(popup_width) / 2,
+        area.y + area.height.saturating_sub(popup_height),
+        popup_width,
+        popup_height,
+    );
+    frame.render_widget(Clear, popup);
+
+    let mut lines = vec![
+        Line::styled(
+            "  Select Model",
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Line::default(),
+    ];
+    for (index, (model, label)) in MODEL_OPTIONS.iter().enumerate() {
+        let current = if *model == app.model() {
+            " (current)"
+        } else {
+            ""
+        };
+        lines.push(reasoning_option_line(
+            index == selected,
+            index + 1,
+            &format!("{label}{current}"),
+            model.as_str(),
+        ));
+    }
+    lines.push(Line::default());
+    lines.push(Line::styled(
+        "  Press enter to confirm or esc to cancel",
+        Style::default().fg(Color::DarkGray),
+    ));
+    frame.render_widget(Paragraph::new(lines), popup);
 }
 
 struct ViewLayout {
@@ -813,6 +858,20 @@ mod tests {
         let rendered = terminal.backend().to_string();
         assert!(rendered.contains("Working (1m 05s)"));
         assert!(!rendered.contains("Running exec_command"));
+    }
+
+    #[test]
+    fn model_picker_renders_astra_as_a_selectable_option() {
+        let mut terminal = Terminal::new(TestBackend::new(80, 16)).unwrap();
+        let mut app = App::new("/workspace".into());
+        app.open_model_picker();
+
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        let rendered = terminal.backend().to_string();
+
+        assert!(rendered.contains("Select Model"));
+        assert!(rendered.contains("Astra"));
+        assert!(rendered.contains("gpt-6-astra"));
     }
 
     #[test]

--- a/docs/GPT_6_ASTRA.md
+++ b/docs/GPT_6_ASTRA.md
@@ -195,6 +195,14 @@ Catalog failures fail closed to the existing model default; API-key and sponsore
 connections never infer Astra access. The selector is available only before the
 first accepted turn, while thinking and Fast remain live settings.
 
+Both native terminal clients expose the complete Sol, Terra, Luna, and Astra
+roster through `/model`; `/model astra` applies the same selection directly.
+`/effort`, `/reasoning`, and `/thinking` are aliases for the reasoning picker and
+accept a direct `low`, `medium`, `high`, `xhigh`, or `max` value. In the managed
+client these commands update the hosted agent's retained settings and are never
+submitted or recorded as model prompts. The hosted service continues to enforce
+the first-accepted-turn model lock and validates incompatible Astra settings.
+
 On September 4, 2026, a local subscription-authenticated smoke test reached
 `gpt-6-astra` over the Responses WebSocket with max thinking and standard service
 tier. It ran a workspace `pwd`, spawned and joined a low-thinking child agent,


### PR DESCRIPTION
## Summary
- add Astra to the legacy nanocodex model picker and support direct model selection
- add effort, reasoning, and thinking aliases with direct effort values in both native CLIs
- route managed commands through durable hosted settings without consuming a prompt
- keep empty attached hosted agents eligible for pre-conversation model selection

## Verification
- cargo fmt --all -- --check
- cargo check -p nanocodex-bin -p nanocodex2-bin
- cargo test -p nanocodex-bin --bin nanocodex
- cargo test -p nanocodex2-bin --bin nanocodex2
- cargo clippy for both binaries with the pre-existing missing-const lint allowed
- real local and managed TUI dogfood with Astra and max thinking; hosted durable state verified and disposable agent deleted