### PR TITLE
feat(astra): add one-shot MACH trial app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,20 +266,23 @@ jobs:
           name: nanocodex-web-wasm
           path: js/nanocodex/pkg-web
       - name: Install JavaScript workspace
-        run: pnpm install --frozen-lockfile
+        run: |
+          pnpm install --frozen-lockfile
+          npm ci --prefix examples/astra-mpp-trial
       - name: Build account Worker dependencies
         run: pnpm exec turbo run build --filter nanocodex-connect-protocol
       - name: Test the account Worker
         run: pnpm --filter nanocodex-web run test:web
       - name: Build JavaScript apps
-        run: >-
-          pnpm exec turbo run build --only
-          --filter nanocodex-tools
-          --filter nanocodex-connect-ui
-          --filter nanocodex-terminal
-          --filter @nanocodex/connect-dialog
-          --filter @nanocodex/connect-playground
-          --filter nanocodex-web
+        run: |
+          pnpm exec turbo run build --only \
+            --filter nanocodex-tools \
+            --filter nanocodex-connect-ui \
+            --filter nanocodex-terminal \
+            --filter @nanocodex/connect-dialog \
+            --filter @nanocodex/connect-playground \
+            --filter nanocodex-web
+          npm run check --prefix examples/astra-mpp-trial
   codeql:
     name: CodeQL actions
     runs-on: ubuntu-latest

--- a/examples/astra-mpp-trial/.gitignore
+++ b/examples/astra-mpp-trial/.gitignore
@@ -1,0 +1,4 @@
+.dev.vars
+dist/
+node_modules/
+public/client.js

--- a/examples/astra-mpp-trial/README.md
+++ b/examples/astra-mpp-trial/README.md
@@ -1,0 +1,85 @@
+# Astra one-shot
+
+This is a standalone third-party Nanocodex Connect application. It proves the
+OAuth-like integration while keeping all trial state, MPP settlement, and
+sponsor-account access outside the main Nanocodex application.
+
+The visitor signs into Nanocodex Connect. The app sends the resulting app-scoped
+grant token back to the Connect API on every protected request and accepts only
+an active `agent.run` grant for this exact app ID and origin. The stable
+Nanocodex account ID selects one `AstraTrial` Durable Object, so an account can
+claim at most one prompt. Account creation, passkey/SMS verification, and login
+rate limits remain owned by Nanocodex Connect rather than a parallel Twilio
+identity system in this app.
+
+The payment route is an MPP `tempo/charge` endpoint. Production challenges ask
+for 50 MACH, require the paying address to match the connected Nanocodex account,
+accept pull mode only, and request fee sponsorship from the Tempo relay. The
+development environment issues a zero-value proof challenge: the same wallet
+must sign, but no token transfer occurs.
+
+Connect registers the production app ID and origin as one high-value OAuth
+client. Its delegated key is limited to 50 MACH per day and one
+`transferWithMemo` scope whose sole recipient is displayed in the consent UI.
+That grant cannot use Connect's generic MPP route. Every other Connect client
+keeps the existing 0.25-MACH request and 10-MACH daily policy. Local proof mode
+uses that ordinary low-value policy because it transfers no tokens.
+
+After payment, the Durable Object uses a server-only managed API key belonging
+to the sponsor account. It creates a fresh managed agent with the complete fixed
+settings below and submits exactly the visitor's one prompt:
+
+```json
+{
+  "model": "gpt-6-astra",
+  "thinking": "max",
+  "reasoningMode": "standard",
+  "fastMode": false
+}
+```
+
+There is deliberately no public managed API proxy. The browser cannot select a
+model, supply an agent ID, change settings, attach tools, read the sponsor's
+agent list, or call another managed route. The sponsor key is read only inside
+the Worker. Internal managed IDs are not returned by the public trial API.
+
+## Local proof mode
+
+```sh
+cp .dev.vars.example .dev.vars
+npm install
+npm run dev
+```
+
+Set `NANOCODEX_ASTRA_MANAGED_API_KEY` to the sponsor account's managed key and
+replace `NANOCODEX_ASTRA_MPP_SECRET` with at least 32 random characters. The
+development recipient may be any valid Tempo address because a zero-value proof
+does not transfer funds. `TEMPO_MPP_API_KEY` is not used by zero-value proof
+mode, but is required by production.
+
+Open `https://localhost:8787`. Connect runs as a top-level popup, which is the
+third-party OAuth-style boundary; the app cannot embed the Nanocodex account UI.
+Wrangler serves local TLS because Connect accepts dynamic third-party apps only
+from secure origins. If Wrangler uses another port or hostname, change
+`NANOCODEX_CONNECT_APP_ORIGIN` in the development environment to the exact
+browser origin before connecting.
+
+## Production configuration
+
+Set these Worker secrets:
+
+```sh
+npx wrangler secret put NANOCODEX_ASTRA_MANAGED_API_KEY
+npx wrangler secret put NANOCODEX_ASTRA_MPP_SECRET
+npx wrangler secret put TEMPO_MPP_API_KEY
+```
+
+Set `NANOCODEX_ASTRA_MACH_RECIPIENT` to the sponsor's intended Tempo recipient.
+Confirm that `NANOCODEX_CONNECT_APP_ORIGIN` exactly matches the deployed HTTPS
+origin. The app fails closed when any sponsor, payment, origin, or Connect
+configuration is absent or malformed.
+
+`Add $50 MACH` invokes Connect's existing MACH funding dialog for the connected
+account. The prompt submission itself uses MPP; its fee-payer transaction is
+relayed server-side and the MPP receipt reference is retained with the one-shot
+state.

--- a/examples/astra-mpp-trial/package-lock.json
+++ b/examples/astra-mpp-trial/package-lock.json
@@ -1,0 +1,1981 @@
+{
+  "name": "nanocodex-astra-mpp-trial",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nanocodex-astra-mpp-trial",
+      "version": "0.1.0",
+      "dependencies": {
+        "mppx": "0.9.1",
+        "nanocodex": "file:../../js/nanocodex",
+        "viem": "2.54.0"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "5.20260831.1",
+        "@types/node": "22.20.1",
+        "esbuild": "0.28.1",
+        "typescript": "5.9.3",
+        "wrangler": "4.127.1"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "../../js/nanocodex": {
+      "version": "0.5.0",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cfworker/json-schema": "4.1.1",
+        "@eduoj/wasm-clang": "1.0.0",
+        "@microsoft/dev-tunnels-ssh": "3.12.40",
+        "@microsoft/dev-tunnels-ssh-keys": "3.12.40",
+        "@modelcontextprotocol/sdk": "1.30.0",
+        "buffer": "6.0.3",
+        "diff": "^9.0.0",
+        "isomorphic-git": "^1.41.5",
+        "minisearch": "7.2.0",
+        "mppx": "0.9.1",
+        "nanocodex-tools": "workspace:*",
+        "ox": "1.6.2",
+        "pako": "2.1.0",
+        "pyodide": "314.0.5",
+        "sprintf-js": "1.1.3",
+        "viem": "2.55.13",
+        "wata": "0.4.0",
+        "ws": "^8.18.3"
+      },
+      "devDependencies": {
+        "@jitl/quickjs-wasmfile-release-asyncify": "0.32.0",
+        "binaryen": "132.0.0",
+        "hyparquet-writer": "0.16.6",
+        "pkg-pr-new": "0.0.79",
+        "quickjs-emscripten-core": "0.32.0",
+        "typescript": "5.9.3"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260828.1.tgz",
+      "integrity": "sha512-CVd+xPhqUESg8Xhq09TZx0wl4FSirfJGOzvbPz2yHhBIvmNHFFQkSN3rkd7wEwnhQQk37Xi0/aD6ykPLJbmGiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260828.1.tgz",
+      "integrity": "sha512-5HDPXRM152vU5JveByGFk34X57TVyIsfp4cabepAf45DC0MKvm52ucJqAjW1h8bvW4X+zRw9GU35OHF9FEC9Ww==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260828.1.tgz",
+      "integrity": "sha512-MQ1Ll9P7F72HHUKizbb7BlDfbY8fRoNMpbIpZoU6uKsSkneFICWSKv6UlgU9EQZ+w0i7TMa12iUgJ8l29eRI9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260828.1.tgz",
+      "integrity": "sha512-FBTaUQ1xcU9jcp4OyBPcH8x0QiFvc1iuZL2GkD8zp2q1WyTVHYOptRDQUU+cuHjt0rQ2EIKVPBjahPxfa0joBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260828.1.tgz",
+      "integrity": "sha512-yvr77hC7dUbvK5K+SCg062kkPq3sx+drV1PcgHslzHDYcJBtT0V3X80qLE49LW1vq2svaeNmsVQS+vHsqWu8cQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "5.20260831.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260831.1.tgz",
+      "integrity": "sha512-yXg4pwfYjhsDH9rYc3qZ3K+z62DCSvO/aj7GiZo6AyDeWGZpyFRpPMYcQ6LF/zfaf1x0Ngw2gSqL8JjuUtMGlA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "9.13.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-9.13.0.tgz",
+      "integrity": "sha512-/0c72BUgzzVkVTlsw5uBn8x3waTdVJ/PZGfQ6jY1eu6K7olUPf4d9lgDPA9/0sIdsR8j7o3QIG8fOCO6ItcL7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.3.0.tgz",
+      "integrity": "sha512-fk6Te+bojIFrMvMZrnOO+SxCB+RUksTGOzq/60ZRvs1L+BVzvi2bqt9L3W/17ZLdZsyM1FuYf65P5nlmoiH1Bg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "5.20260828.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260828.0-alpha.tgz",
+      "integrity": "sha512-6nbxhZEcz/UET3Y1OnYPsrAUjUmuFoib3ynUqteRdn1YnDxsLg8cwgZJZCk9QmtOmGzXwzXzgE/d/C0dJAPtVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260828.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/miniflare/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mppx": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/mppx/-/mppx-0.9.1.tgz",
+      "integrity": "sha512-mmzOHcUnyvxXBFJQWWFeaT6+uwRuphqmzFZXfJjDKlmEQ559oEseQusaXs68husPKSYZU9WCwRElhi55+5I+5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@stripe/stripe-js": "9.13.0",
+        "eventsource-parser": "3.1.1",
+        "ox": "0.14.33",
+        "structured-headers": "2.0.3",
+        "zod": "^4.4.3"
+      },
+      "bin": {
+        "mppx": "dist/bin.js"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": ">=1.25.0",
+        "@x402/core": ">=2.22.0",
+        "@x402/express": ">=2.22.0",
+        "@x402/hono": ">=2.22.0",
+        "@x402/mcp": ">=2.22.0",
+        "@x402/next": ">=2.22.0",
+        "elysia": ">=1",
+        "express": ">=5",
+        "hono": ">=4.12.25",
+        "next": ">=16.2.6",
+        "viem": ">=2.54.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        },
+        "@x402/core": {
+          "optional": true
+        },
+        "@x402/express": {
+          "optional": true
+        },
+        "@x402/hono": {
+          "optional": true
+        },
+        "@x402/mcp": {
+          "optional": true
+        },
+        "@x402/next": {
+          "optional": true
+        },
+        "elysia": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        },
+        "hono": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nanocodex": {
+      "resolved": "../../js/nanocodex",
+      "link": true
+    },
+    "node_modules/ox": {
+      "version": "0.14.33",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.33.tgz",
+      "integrity": "sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
+    "node_modules/structured-headers": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/structured-headers/-/structured-headers-2.0.3.tgz",
+      "integrity": "sha512-4g5yxhlDMClRwCcfKfLeS7Z8yAVdOWGDADwm80Poh1iReU2KVKLGBlqwpHWJ2qovq0+ZIf1atAEO1eua2o9Rgg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/viem": {
+      "version": "2.54.0",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.54.0.tgz",
+      "integrity": "sha512-DW6KW3m89+3MLozFNPuI9Nhz2hJw375hUo1bpbo3qXipBvjdjF26B/d3U5adVyLGKOfqK4XeA1wPDWQTFQ/ltA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.29",
+        "ws": "8.20.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/ox": {
+      "version": "0.14.29",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.29.tgz",
+      "integrity": "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260828.1.tgz",
+      "integrity": "sha512-pB9yvt0kkwZDAGZHmpY59r0o3hM0DzdW6BJERqwZOhunZ3ssOyDSgQxOQer2cSZW4YCFeOTIQYN1qwhK5wv/Cw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260828.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260828.1",
+        "@cloudflare/workerd-linux-64": "1.20260828.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260828.1",
+        "@cloudflare/workerd-windows-64": "1.20260828.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.127.1",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.127.1.tgz",
+      "integrity": "sha512-OzsiNgaI8i681L/+KnAKc+uEZ5D57xK5JuNvCOpRKICF4/5Q3Cu1oTGuUiT/f3GDUqQb3gzXNT0tfOHGMEtknw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260828.0-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260828.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260828.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/examples/astra-mpp-trial/package.json
+++ b/examples/astra-mpp-trial/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "nanocodex-astra-mpp-trial",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
+  "scripts": {
+    "build:client": "esbuild src/client.ts --bundle --format=esm --minify --outfile=public/client.js",
+    "build": "npm run build:client && wrangler deploy --dry-run --env=\"\" --outdir dist",
+    "dev": "npm run build:client && wrangler dev --env development --local-protocol https --port 8787",
+    "deploy": "npm run build:client && wrangler deploy --env=\"\"",
+    "test": "node --experimental-strip-types --test test/*.test.ts",
+    "typecheck": "tsc --noEmit",
+    "check": "npm run typecheck && npm test && npm run build"
+  },
+  "dependencies": {
+    "mppx": "0.9.1",
+    "nanocodex": "file:../../js/nanocodex",
+    "viem": "2.54.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "5.20260831.1",
+    "@types/node": "22.20.1",
+    "esbuild": "0.28.1",
+    "typescript": "5.9.3",
+    "wrangler": "4.127.1"
+  },
+  "overrides": {
+    "esbuild": "0.28.1"
+  }
+}

--- a/examples/astra-mpp-trial/public/index.html
+++ b/examples/astra-mpp-trial/public/index.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="dark">
+    <title>One prompt with Astra</title>
+    <meta name="description" content="Connect a Nanocodex account, pay once in MACH, and try one max-thinking Astra prompt.">
+    <link rel="stylesheet" href="/styles.css">
+  </head>
+  <body>
+    <main>
+      <nav aria-label="Demo status">
+        <a class="brand" href="/">nanocodex<span>/astra</span></a>
+        <div class="account-row">
+          <span id="account">Not connected</span>
+          <button class="text-button" id="logout" hidden type="button">Disconnect</button>
+        </div>
+      </nav>
+
+      <section class="hero" aria-labelledby="title">
+        <p class="eyebrow">A one-shot third-party demo</p>
+        <h1 id="title">Ask Astra<br><em>one good question.</em></h1>
+        <p class="lede">
+          Sign in with Nanocodex Connect. Your payment unlocks one isolated
+          GPT-6 Astra prompt at max thinking on our hosted account.
+        </p>
+      </section>
+
+      <section class="card" aria-live="polite">
+        <div class="policy">
+          <div><span>Model</span><strong>Astra</strong></div>
+          <div><span>Thinking</span><strong>Max</strong></div>
+          <div><span>Mode</span><strong>Standard</strong></div>
+          <div><span>Allowance</span><strong>1 prompt</strong></div>
+        </div>
+
+        <div id="intro">
+          <p class="fine-print">
+            Connect authenticates your account and wallet. It does not grant this
+            site access to your conversations, cloud accounts, or model output.
+          </p>
+          <button class="primary" id="connect" type="button">Connect Nanocodex</button>
+        </div>
+
+        <form id="prompt-form" hidden>
+          <label for="prompt">Your one prompt</label>
+          <textarea
+            id="prompt"
+            maxlength="16000"
+            placeholder="Ask something worthy of max thinking…"
+            required
+            rows="7"
+          ></textarea>
+          <div class="payment-row">
+            <div>
+              <span class="payment-label">Unlock price</span>
+              <strong id="payment">Loading policy…</strong>
+            </div>
+            <button class="secondary" id="fund" type="button">Add $50 MACH</button>
+          </div>
+          <button class="primary" id="submit" type="submit">Pay &amp; ask Astra</button>
+        </form>
+
+        <p class="status" id="status">Connect to claim your one prompt.</p>
+        <p class="error" id="error" role="alert"></p>
+        <pre class="result" id="result"></pre>
+      </section>
+
+      <footer>
+        <span>Identity by Nanocodex Connect</span>
+        <span>Payment on Tempo · gas sponsored</span>
+        <span>No generic managed API proxy</span>
+      </footer>
+    </main>
+    <script type="module" src="/client.js"></script>
+  </body>
+</html>

--- a/examples/astra-mpp-trial/public/styles.css
+++ b/examples/astra-mpp-trial/public/styles.css
@@ -1,0 +1,208 @@
+:root {
+  color: #f6f3ed;
+  background: #0a0a0b;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 72% 18%, rgba(151, 105, 255, 0.17), transparent 32rem),
+    radial-gradient(circle at 18% 70%, rgba(255, 98, 125, 0.08), transparent 28rem),
+    #0a0a0b;
+}
+
+button, textarea { font: inherit; }
+button { cursor: pointer; }
+button:disabled { cursor: wait; opacity: 0.55; }
+
+main {
+  width: min(1060px, calc(100% - 40px));
+  margin: 0 auto;
+  padding: 28px 0 42px;
+}
+
+nav, .account-row, .payment-row, footer {
+  display: flex;
+  align-items: center;
+}
+
+nav { justify-content: space-between; }
+
+.brand {
+  color: inherit;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 14px;
+  letter-spacing: -0.03em;
+  text-decoration: none;
+}
+
+.brand span { color: #ad91ff; }
+.account-row { gap: 14px; color: #aaa6ad; font-size: 13px; }
+
+.text-button {
+  border: 0;
+  padding: 0;
+  color: #d9cffc;
+  background: transparent;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: 1.6fr 0.9fr;
+  gap: 64px;
+  align-items: end;
+  padding: 112px 0 54px;
+}
+
+.eyebrow {
+  grid-column: 1 / -1;
+  margin: 0 0 -42px;
+  color: #a798ce;
+  font: 12px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font: 500 clamp(54px, 8.3vw, 104px)/0.88 Georgia, "Times New Roman", serif;
+  letter-spacing: -0.065em;
+}
+
+h1 em {
+  color: #af91ff;
+  font-weight: 400;
+}
+
+.lede {
+  margin: 0 0 5px;
+  color: #aaa6ad;
+  font-size: 17px;
+  line-height: 1.65;
+}
+
+.card {
+  overflow: hidden;
+  border: 1px solid #302d34;
+  border-radius: 18px;
+  background: rgba(18, 17, 20, 0.88);
+  box-shadow: 0 24px 100px rgba(0, 0, 0, 0.35);
+}
+
+.policy {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-bottom: 1px solid #302d34;
+}
+
+.policy div {
+  display: grid;
+  gap: 7px;
+  padding: 20px 24px;
+  border-right: 1px solid #302d34;
+}
+
+.policy div:last-child { border-right: 0; }
+.policy span, .payment-label { color: #77727d; font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; }
+.policy strong { font-size: 14px; font-weight: 550; }
+
+#intro, form { padding: 32px; }
+.fine-print { max-width: 680px; margin: 0 0 24px; color: #8f8b94; font-size: 14px; line-height: 1.6; }
+
+.primary, .secondary {
+  border-radius: 9px;
+  font-weight: 650;
+  transition: transform 120ms ease, border-color 120ms ease, background 120ms ease;
+}
+
+.primary:hover:not(:disabled), .secondary:hover:not(:disabled) { transform: translateY(-1px); }
+
+.primary {
+  width: 100%;
+  border: 0;
+  padding: 15px 22px;
+  color: #100d15;
+  background: linear-gradient(135deg, #d7c9ff, #a783ff 65%, #f1a6d3);
+}
+
+#intro .primary { width: auto; }
+
+.secondary {
+  border: 1px solid #49424f;
+  padding: 10px 14px;
+  color: #ddd6e8;
+  background: #211f24;
+}
+
+form label { display: block; margin-bottom: 10px; color: #cbc5cf; font-size: 13px; }
+
+textarea {
+  width: 100%;
+  resize: vertical;
+  border: 1px solid #3b3740;
+  border-radius: 10px;
+  outline: none;
+  padding: 17px;
+  color: #f6f3ed;
+  background: #0d0c0f;
+  line-height: 1.55;
+}
+
+textarea:focus { border-color: #9474e8; box-shadow: 0 0 0 3px rgba(148, 116, 232, 0.12); }
+textarea::placeholder { color: #59555f; }
+
+.payment-row {
+  justify-content: space-between;
+  gap: 20px;
+  margin: 18px 0;
+}
+
+.payment-row > div { display: grid; gap: 5px; }
+.payment-row strong { font-size: 14px; }
+
+.status, .error { margin: 0; padding: 0 32px 22px; font-size: 13px; }
+.status { color: #85808b; }
+.error { color: #ff8e9f; }
+.error:empty { display: none; }
+
+.result {
+  margin: 0;
+  border: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: #e9e4ed;
+  background: #0d0c0f;
+  font: 15px/1.7 ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.result:not(:empty) { border-top: 1px solid #302d34; padding: 32px; }
+
+footer {
+  justify-content: space-between;
+  gap: 20px;
+  padding: 18px 3px;
+  color: #5f5a64;
+  font: 11px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+[hidden] { display: none !important; }
+
+@media (max-width: 720px) {
+  main { width: min(100% - 24px, 1060px); padding-top: 18px; }
+  .hero { grid-template-columns: 1fr; gap: 24px; padding: 76px 4px 38px; }
+  .eyebrow { margin: 0; }
+  h1 { font-size: clamp(51px, 17vw, 76px); }
+  .policy { grid-template-columns: repeat(2, 1fr); }
+  .policy div:nth-child(2) { border-right: 0; }
+  .policy div:nth-child(-n+2) { border-bottom: 1px solid #302d34; }
+  #intro, form { padding: 24px; }
+  .status, .error { padding-inline: 24px; }
+  footer { align-items: flex-start; flex-direction: column; }
+}

--- a/examples/astra-mpp-trial/src/client.ts
+++ b/examples/astra-mpp-trial/src/client.ts
@@ -1,0 +1,428 @@
+import { Mppx, tempo as mppTempo } from "mppx/client";
+import { Client, Dialog, Transport, type Connection } from "nanocodex/connect";
+import { createWalletClient, custom } from "viem";
+import { tempo as tempoChain } from "viem/chains";
+import { MACH, TEMPO_CHAIN_ID, TIP20_CHANNEL_ESCROW, USDC_E } from "./policy";
+
+type AppConfiguration = Readonly<{
+  amount: "0" | "50";
+  chain_id: number;
+  connect: Readonly<{
+    api_url: string;
+    app_id: string;
+    app_origin: string;
+    dialog_url: string;
+  }>;
+  currency: `0x${string}`;
+  payment_enabled: boolean;
+  recipient?: `0x${string}`;
+}>;
+
+type TrialView = Readonly<{
+  error?: string;
+  final_message?: string;
+  payment_reference?: string;
+  phase: "available" | "payment_pending" | "paid" | "running" | "completed" | "failed";
+}>;
+
+type StoredGrant = Readonly<{ grantId: `0x${string}`; token: string }>;
+
+const CONNECT_RESOURCES = [
+  "urn:nanocodex:agent:run",
+  "urn:nanocodex:capability:mercator:boost",
+  "urn:nanocodex:mpp:machusd:spend",
+] as const;
+const MERCATOR_SETTLEMENT = "0xa295c42fbcc026a62304a7701f25b4c91799b0da" as const;
+const DEFAULT_ACCESS_KEY_LIMIT = 10_000_000n;
+const ASTRA_ACCESS_KEY_LIMIT = 50_000_000n;
+const ACCESS_KEY_PERIOD = 86_400;
+
+const elements = {
+  account: requiredElement("account"),
+  connect: requiredButton("connect"),
+  error: requiredElement("error"),
+  fund: requiredButton("fund"),
+  form: requiredElement("prompt-form") as HTMLFormElement,
+  intro: requiredElement("intro"),
+  logout: requiredButton("logout"),
+  payment: requiredElement("payment"),
+  prompt: requiredElement("prompt") as HTMLTextAreaElement,
+  result: requiredElement("result"),
+  status: requiredElement("status"),
+  submit: requiredButton("submit"),
+};
+
+let configuration: AppConfiguration;
+let connection: Connection | undefined;
+let grant: StoredGrant | undefined;
+let client: ReturnType<typeof createAppClient>;
+let busy = false;
+let trialClaimed = false;
+
+void initialize().catch(showError);
+
+async function initialize(): Promise<void> {
+  configuration = await apiJson<AppConfiguration>("/api/config");
+  if (configuration.chain_id !== TEMPO_CHAIN_ID || configuration.currency.toLowerCase() !== MACH) {
+    throw new Error("The Astra trial payment policy is invalid.");
+  }
+  const storage = recordingStorage();
+  client = createAppClient(configuration, storage);
+
+  elements.payment.textContent = configuration.amount === "0"
+    ? "Local proof mode: your wallet signs, but no MACH moves."
+    : "$50 in MACH · one prompt · gas sponsored";
+  elements.connect.addEventListener("click", () => void connectAccount(storage));
+  elements.logout.addEventListener("click", () => void disconnectAccount());
+  elements.fund.addEventListener("click", () => void fundAccount());
+  elements.form.addEventListener("submit", (event) => void submitPrompt(event));
+
+  const restored = await client.connection.reconnect(connectRequest()).catch(() => undefined);
+  if (restored) {
+    connection = restored;
+    grant = storage.grant();
+    if (grant) await establishSession();
+  }
+  render();
+}
+
+function createAppClient(
+  app: AppConfiguration,
+  storage: ReturnType<typeof recordingStorage>,
+) {
+  const apiUrl = app.connect.api_url.replace(/\/+$/, "");
+  const accessKey = accessKeyPolicy(app);
+  return Client.create({
+    appId: app.connect.app_id,
+    appOrigin: app.connect.app_origin,
+    auth: {
+      challenge: `${apiUrl}/v1/connect/auth/challenge`,
+      verify: `${apiUrl}/v1/connect/auth`,
+      logout: `${apiUrl}/v1/connect/auth/logout`,
+      resources: CONNECT_RESOURCES,
+      returnToken: true,
+    },
+    accessKey: {
+      authorize: {
+        expiry: Math.floor(Date.now() / 1_000) + 30 * 86_400,
+        limits: accessKey.limits,
+        reuse: {
+          minExpiry: Math.floor(Date.now() / 1_000) + 7 * 86_400,
+          minLimits: accessKey.limits,
+        },
+        scopes: accessKey.scopes,
+      },
+    },
+    dialog: Dialog.popup({
+      host: app.connect.dialog_url,
+      key: "astra-one-shot",
+      name: "Astra One-Shot",
+    }),
+    session: storage,
+    transport: Transport.http(app.connect.api_url),
+  });
+}
+
+function accessKeyPolicy(app: AppConfiguration) {
+  if (app.amount === "50") {
+    if (!app.payment_enabled || !app.recipient) {
+      throw new Error("The Astra trial payment recipient is not configured.");
+    }
+    return {
+      limits: [{ token: MACH, limit: ASTRA_ACCESS_KEY_LIMIT, period: ACCESS_KEY_PERIOD }],
+      scopes: [{ address: MACH, selector: "0x95777d59", recipients: [app.recipient] }],
+    } as const;
+  }
+  return {
+    limits: [
+      { token: MACH, limit: DEFAULT_ACCESS_KEY_LIMIT, period: ACCESS_KEY_PERIOD },
+      { token: USDC_E, limit: DEFAULT_ACCESS_KEY_LIMIT, period: ACCESS_KEY_PERIOD },
+    ],
+    scopes: [
+      { address: USDC_E, selector: "0xa9059cbb", recipients: [MERCATOR_SETTLEMENT] },
+      { address: USDC_E, selector: "0x95777d59", recipients: [MERCATOR_SETTLEMENT] },
+      { address: MACH, selector: "0xa9059cbb", recipients: [MERCATOR_SETTLEMENT] },
+      { address: MACH, selector: "0x95777d59", recipients: [MERCATOR_SETTLEMENT] },
+      { address: TIP20_CHANNEL_ESCROW, selector: "0xedc53b00" },
+      { address: TIP20_CHANNEL_ESCROW, selector: "0xdc48471e" },
+    ],
+  } as const;
+}
+
+function connectRequest() {
+  return {
+    authorization: "access_key" as const,
+    capabilities: {
+      agent: {
+        finalMessages: false,
+        actionSummaries: false,
+        conversationHistory: false,
+        rawTraces: false,
+      },
+    },
+    permission: "agent.run",
+  };
+}
+
+async function connectAccount(storage: ReturnType<typeof recordingStorage>): Promise<void> {
+  if (busy) return;
+  setBusy(true, "Opening Nanocodex Connect…");
+  try {
+    connection = await client.connection.connect(connectRequest());
+    grant = storage.grant();
+    if (!grant || grant.grantId.toLowerCase() !== connection.grant.id.toLowerCase()) {
+      throw new Error("Nanocodex Connect did not retain an app session.");
+    }
+    await establishSession();
+  } catch (error) {
+    connection = undefined;
+    grant = undefined;
+    trialClaimed = false;
+    showError(error);
+  } finally {
+    setBusy(false);
+    render();
+  }
+}
+
+async function establishSession(): Promise<void> {
+  const session = await authenticatedJson<{ account_address: string; authenticated: true }>("/api/session");
+  if (!connection || session.account_address.toLowerCase() !== connection.accountAddress.toLowerCase()) {
+    throw new Error("The Connect account does not match the app session.");
+  }
+  elements.account.textContent = shortAddress(connection.accountAddress);
+  await refreshTrial();
+}
+
+async function disconnectAccount(): Promise<void> {
+  if (busy) return;
+  setBusy(true, "Disconnecting…");
+  try {
+    await client.connection.disconnect();
+  } catch {
+    // The local app session is cleared even when the remote grant has already expired.
+  } finally {
+    connection = undefined;
+    grant = undefined;
+    trialClaimed = false;
+    elements.account.textContent = "Not connected";
+    elements.result.textContent = "";
+    elements.status.textContent = "Connect to claim your one prompt.";
+    setBusy(false);
+    render();
+  }
+}
+
+async function fundAccount(): Promise<void> {
+  if (!connection || busy) return;
+  setBusy(true, "Opening the $50 MACH onramp…");
+  try {
+    await client.machineUsd.fund({
+      accountAddress: connection.accountAddress,
+      grantId: connection.grant.id,
+      usdAmountCents: 5_000,
+    });
+    elements.status.textContent = "MACH funded. Your one Astra prompt is ready.";
+  } catch (error) {
+    showError(error);
+  } finally {
+    setBusy(false);
+    render();
+  }
+}
+
+async function submitPrompt(event: SubmitEvent): Promise<void> {
+  event.preventDefault();
+  if (!connection || !grant || busy) return;
+  const prompt = elements.prompt.value.trim();
+  if (!prompt) return;
+  if (!configuration.payment_enabled || !configuration.recipient) {
+    showError(new Error("The trial payment or sponsor account is not configured."));
+    return;
+  }
+  setBusy(true, configuration.amount === "0" ? "Requesting wallet proof…" : "Authorizing 50 MACH…");
+  const requestKey = crypto.randomUUID();
+  try {
+    const wallet = createWalletClient({
+      account: connection.accountAddress,
+      chain: tempoChain,
+      transport: custom(client.provider),
+    });
+    const payments = Mppx.create({
+      methods: [mppTempo.charge({
+        account: connection.accountAddress,
+        expectedChainId: TEMPO_CHAIN_ID,
+        expectedRecipients: [configuration.recipient],
+        getClient: () => wallet,
+        mode: "pull",
+      })],
+      polyfill: false,
+    });
+    const response = await payments.fetch("/api/prompt", {
+      method: "POST",
+      headers: authenticatedHeaders({
+        "content-type": "application/json",
+        "idempotency-key": requestKey,
+      }),
+      body: JSON.stringify({ prompt }),
+    });
+    const view = await response.json() as TrialView & { error?: string };
+    if (!response.ok) throw new Error(humanError(view.error));
+    presentTrial(view);
+    if (view.phase === "running" || view.phase === "paid") await pollTrial();
+  } catch (error) {
+    showError(error);
+  } finally {
+    setBusy(false);
+    render();
+  }
+}
+
+async function refreshTrial(): Promise<void> {
+  const response = await authenticatedFetch("/api/trial");
+  const view = await response.json() as TrialView & { error?: string };
+  if (!response.ok) throw new Error(humanError(view.error));
+  presentTrial(view);
+  if (view.phase === "running" || view.phase === "paid") void pollTrial();
+}
+
+async function pollTrial(): Promise<void> {
+  for (let attempt = 0; attempt < 600; attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+    const response = await authenticatedFetch("/api/trial");
+    const view = await response.json() as TrialView;
+    if (!response.ok) throw new Error("Unable to refresh the Astra prompt.");
+    presentTrial(view);
+    if (view.phase === "completed" || view.phase === "failed" || view.phase === "payment_pending") return;
+  }
+  throw new Error("The Astra prompt is still running. Reload to check it again.");
+}
+
+function presentTrial(view: TrialView): void {
+  elements.result.textContent = view.final_message ?? "";
+  elements.status.textContent = ({
+    available: "One Astra prompt is available for this Nanocodex account.",
+    payment_pending: "Payment outcome is pending. No second charge will be attempted.",
+    paid: "Payment accepted. Creating the locked Astra agent…",
+    running: "Astra is thinking at max effort…",
+    completed: view.payment_reference
+      ? `Completed · payment ${shortReference(view.payment_reference)}`
+      : "Completed.",
+    failed: view.error ?? "The Astra prompt failed.",
+  } satisfies Record<TrialView["phase"], string>)[view.phase];
+  const claimed = view.phase !== "available";
+  trialClaimed = claimed;
+  elements.prompt.disabled = claimed || busy;
+  elements.submit.disabled = claimed || busy;
+}
+
+function authenticatedFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  return fetch(path, { ...init, headers: authenticatedHeaders(init.headers) });
+}
+
+async function authenticatedJson<value>(path: string): Promise<value> {
+  const response = await authenticatedFetch(path);
+  const body = await response.json() as value & { error?: string };
+  if (!response.ok) throw new Error(humanError(body.error));
+  return body;
+}
+
+function authenticatedHeaders(headers?: HeadersInit): Headers {
+  if (!grant) throw new Error("Connect to Nanocodex first.");
+  const result = new Headers(headers);
+  result.set("authorization", `Bearer ${grant.token}`);
+  result.set("x-nanocodex-grant-id", grant.grantId);
+  return result;
+}
+
+async function apiJson<value>(path: string): Promise<value> {
+  const response = await fetch(path, { headers: { accept: "application/json" } });
+  const body = await response.json() as value & { error?: string };
+  if (!response.ok) throw new Error(humanError(body.error));
+  return body;
+}
+
+function recordingStorage() {
+  const prefix = "astra-trial:";
+  let latest: string | null = null;
+  return {
+    getItem(key: string) {
+      latest = sessionStorage.getItem(`${prefix}${key}`);
+      return latest;
+    },
+    setItem(key: string, value: string) {
+      latest = value;
+      sessionStorage.setItem(`${prefix}${key}`, value);
+    },
+    removeItem(key: string) {
+      latest = null;
+      sessionStorage.removeItem(`${prefix}${key}`);
+    },
+    grant(): StoredGrant | undefined {
+      if (!latest) return undefined;
+      try {
+        const value = JSON.parse(latest) as Record<string, unknown>;
+        return typeof value.grantId === "string" && /^0x[0-9a-fA-F]{64}$/.test(value.grantId)
+          && typeof value.token === "string" && /^[A-Za-z0-9_-]{43}$/.test(value.token)
+          ? { grantId: value.grantId.toLowerCase() as `0x${string}`, token: value.token }
+          : undefined;
+      } catch {
+        return undefined;
+      }
+    },
+  };
+}
+
+function render(): void {
+  const connected = Boolean(connection && grant);
+  elements.intro.hidden = connected;
+  elements.form.hidden = !connected;
+  elements.logout.hidden = !connected;
+  elements.fund.hidden = !connected || configuration.amount === "0";
+  elements.connect.disabled = busy;
+  elements.logout.disabled = busy;
+  elements.fund.disabled = busy;
+  elements.prompt.disabled = busy || trialClaimed;
+  elements.submit.disabled = busy || trialClaimed;
+}
+
+function setBusy(value: boolean, message?: string): void {
+  busy = value;
+  elements.error.textContent = "";
+  if (message) elements.status.textContent = message;
+  render();
+}
+
+function showError(error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  elements.error.textContent = message;
+}
+
+function humanError(value: string | undefined): string {
+  return ({
+    astra_agent_unavailable: "The sponsor Astra account is temporarily unavailable.",
+    astra_trial_already_claimed: "This Nanocodex account has already claimed its prompt.",
+    connect_session_invalid: "Your Nanocodex Connect session expired. Connect again.",
+    connect_session_required: "Connect to Nanocodex first.",
+    payment_account_mismatch: "The paying wallet must match the connected Nanocodex account.",
+    payment_outcome_pending: "The payment outcome is pending and will not be charged twice.",
+  } as Record<string, string>)[value ?? ""] ?? "The request could not be completed.";
+}
+
+function shortAddress(value: string): string {
+  return `${value.slice(0, 6)}…${value.slice(-4)}`;
+}
+
+function shortReference(value: string): string {
+  return value.length > 18 ? `${value.slice(0, 10)}…${value.slice(-6)}` : value;
+}
+
+function requiredElement(id: string): HTMLElement {
+  const element = document.getElementById(id);
+  if (!element) throw new Error(`Missing #${id}`);
+  return element;
+}
+
+function requiredButton(id: string): HTMLButtonElement {
+  return requiredElement(id) as HTMLButtonElement;
+}

--- a/examples/astra-mpp-trial/src/client.ts
+++ b/examples/astra-mpp-trial/src/client.ts
@@ -243,29 +243,37 @@ async function submitPrompt(event: SubmitEvent): Promise<void> {
   setBusy(true, configuration.amount === "0" ? "Requesting wallet proof…" : "Authorizing 50 MACH…");
   const requestKey = crypto.randomUUID();
   try {
-    const wallet = createWalletClient({
-      account: connection.accountAddress,
-      chain: tempoChain,
-      transport: custom(client.provider),
-    });
-    const payments = Mppx.create({
-      methods: [mppTempo.charge({
+    let response: Response;
+    try {
+      // Popup Connect intentionally closes after login. Reopen it for the
+      // delegated access-key signature, then close it as soon as MPP settles.
+      client.dialog.showWallet?.();
+      const wallet = createWalletClient({
         account: connection.accountAddress,
-        expectedChainId: TEMPO_CHAIN_ID,
-        expectedRecipients: [configuration.recipient],
-        getClient: () => wallet,
-        mode: "pull",
-      })],
-      polyfill: false,
-    });
-    const response = await payments.fetch("/api/prompt", {
-      method: "POST",
-      headers: authenticatedHeaders({
-        "content-type": "application/json",
-        "idempotency-key": requestKey,
-      }),
-      body: JSON.stringify({ prompt }),
-    });
+        chain: tempoChain,
+        transport: custom(client.provider),
+      });
+      const payments = Mppx.create({
+        methods: [mppTempo.charge({
+          account: connection.accountAddress,
+          expectedChainId: TEMPO_CHAIN_ID,
+          expectedRecipients: [configuration.recipient],
+          getClient: () => wallet,
+          mode: "pull",
+        })],
+        polyfill: false,
+      });
+      response = await payments.fetch("/api/prompt", {
+        method: "POST",
+        headers: authenticatedHeaders({
+          "content-type": "application/json",
+          "idempotency-key": requestKey,
+        }),
+        body: JSON.stringify({ prompt }),
+      });
+    } finally {
+      client.dialog.hideWallet?.();
+    }
     const view = await response.json() as TrialView & { error?: string };
     if (!response.ok) throw new Error(humanError(view.error));
     presentTrial(view);

--- a/examples/astra-mpp-trial/src/connect.ts
+++ b/examples/astra-mpp-trial/src/connect.ts
@@ -1,0 +1,141 @@
+const GRANT_ID = /^0x[0-9a-fA-F]{64}$/;
+const GRANT_TOKEN = /^[A-Za-z0-9_-]{43}$/;
+const ACCOUNT_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const ADDRESS = /^0x[0-9a-fA-F]{40}$/;
+
+export type ConnectConfiguration = Readonly<{
+  apiUrl: string;
+  appId: string;
+  appOrigin: string;
+  dialogUrl: string;
+}>;
+
+export type ConnectIdentity = Readonly<{
+  accountAddress: `0x${string}`;
+  accountId: string;
+  expiresAt: number;
+  grantId: `0x${string}`;
+}>;
+
+export class ConnectVerificationError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "ConnectVerificationError";
+    this.status = status;
+  }
+}
+
+export function connectConfiguration(env: {
+  NANOCODEX_CONNECT_API_URL?: string;
+  NANOCODEX_CONNECT_APP_ID?: string;
+  NANOCODEX_CONNECT_APP_ORIGIN?: string;
+  NANOCODEX_CONNECT_DIALOG_URL?: string;
+}): ConnectConfiguration | undefined {
+  const appId = env.NANOCODEX_CONNECT_APP_ID?.trim();
+  const appOrigin = exactPublicOrigin(env.NANOCODEX_CONNECT_APP_ORIGIN?.trim());
+  const apiUrl = exactServiceUrl(env.NANOCODEX_CONNECT_API_URL?.trim());
+  const dialogUrl = exactServiceUrl(env.NANOCODEX_CONNECT_DIALOG_URL?.trim());
+  if (!appId || !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(appId)
+    || !appOrigin || !apiUrl || !dialogUrl) return undefined;
+  return { apiUrl, appId, appOrigin, dialogUrl };
+}
+
+export function connectCredentials(request: Request): Readonly<{
+  grantId: `0x${string}`;
+  token: string;
+}> | undefined {
+  const token = request.headers.get("authorization")?.match(/^Bearer ([A-Za-z0-9_-]{43})$/i)?.[1];
+  const grantId = request.headers.get("x-nanocodex-grant-id")?.trim();
+  if (!token || !GRANT_TOKEN.test(token) || !grantId || !GRANT_ID.test(grantId)) return undefined;
+  return { grantId: grantId.toLowerCase() as `0x${string}`, token };
+}
+
+export async function verifyConnectIdentity(
+  credentials: Readonly<{ grantId: `0x${string}`; token: string }>,
+  configuration: ConnectConfiguration,
+  fetcher: typeof fetch = fetch,
+): Promise<ConnectIdentity> {
+  let response: Response;
+  try {
+    response = await fetcher(
+      new URL(`/v1/grants/${credentials.grantId}`, configuration.apiUrl),
+      {
+        headers: {
+          accept: "application/json",
+          authorization: `Bearer ${credentials.token}`,
+          origin: configuration.appOrigin,
+          "x-nanocodex-app-id": configuration.appId,
+        },
+      },
+    );
+  } catch {
+    throw new ConnectVerificationError(503, "connect_unavailable");
+  }
+  const value = await response.json().catch(() => undefined);
+  if (!response.ok) {
+    throw new ConnectVerificationError(
+      response.status === 401 || response.status === 403 ? 401 : 503,
+      response.status === 401 || response.status === 403
+        ? "connect_session_invalid"
+        : "connect_unavailable",
+    );
+  }
+  return connectIdentityFromWire(value, credentials.grantId);
+}
+
+export function connectIdentityFromWire(value: unknown, expectedGrantId: string): ConnectIdentity {
+  if (!isRecord(value) || typeof value.account_id !== "string" || !ACCOUNT_ID.test(value.account_id)
+    || typeof value.account_address !== "string" || !ADDRESS.test(value.account_address)
+    || value.authorization_mode !== "access_key" || !isRecord(value.grant)
+    || typeof value.grant.id !== "string"
+    || value.grant.id.toLowerCase() !== expectedGrantId.toLowerCase()
+    || value.grant.status !== "active" || value.grant.permission !== "agent.run"
+    || !Number.isSafeInteger(value.grant.expires_at)
+    || Number(value.grant.expires_at) <= Math.floor(Date.now() / 1_000)
+    || !Array.isArray(value.grant.capabilities)
+    || !value.grant.capabilities.includes("nanocodex.agent")
+    || !value.grant.capabilities.includes("mpp.mach")) {
+    throw new ConnectVerificationError(401, "connect_session_invalid");
+  }
+  return {
+    accountAddress: value.account_address.toLowerCase() as `0x${string}`,
+    accountId: value.account_id,
+    expiresAt: Number(value.grant.expires_at),
+    grantId: value.grant.id.toLowerCase() as `0x${string}`,
+  };
+}
+
+function exactServiceUrl(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    const url = new URL(value);
+    if (url.username || url.password || url.hash || !publicProtocol(url)) return undefined;
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function exactPublicOrigin(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    const url = new URL(value);
+    return url.origin === value && publicProtocol(url) && !url.username && !url.password
+      ? value
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function publicProtocol(url: URL): boolean {
+  const loopback = url.hostname === "localhost" || url.hostname.endsWith(".localhost")
+    || url.hostname === "127.0.0.1" || url.hostname === "[::1]";
+  return url.protocol === "https:" || (url.protocol === "http:" && loopback);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/examples/astra-mpp-trial/src/index.ts
+++ b/examples/astra-mpp-trial/src/index.ts
@@ -1,0 +1,485 @@
+import { DurableObject } from "cloudflare:workers";
+import { Agent, type ManagedTurn } from "nanocodex/managed";
+import {
+  ConnectVerificationError,
+  connectConfiguration,
+  connectCredentials,
+  verifyConnectIdentity,
+  type ConnectIdentity,
+} from "./connect";
+import {
+  paymentCredential,
+  paymentOptions,
+  paymentReceiptHeader,
+  paymentServer,
+  type PaymentConfiguration,
+} from "./payment";
+import {
+  ASTRA_SETTINGS,
+  MACH,
+  paymentAmount,
+  publicTrialState,
+  reservePrompt,
+  TEMPO_CHAIN_ID,
+  type TrialState,
+} from "./policy";
+
+const ACCOUNT_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const ADDRESS = /^0x[0-9a-f]{40}$/;
+const API_KEY = /^ncx_live_[A-Za-z0-9_-]{12}_[A-Za-z0-9_-]{43}$/;
+const REQUEST_KEY = /^[A-Za-z0-9._:-]{1,128}$/;
+const MAX_PROMPT_BYTES = 32 * 1024;
+const MAX_BODY_BYTES = MAX_PROMPT_BYTES + 1_024;
+
+export type Env = {
+  ASSETS: Fetcher;
+  TRIALS: DurableObjectNamespace<AstraTrial>;
+  ENVIRONMENT?: string;
+  NANOCODEX_ASTRA_MACH_RECIPIENT?: string;
+  NANOCODEX_ASTRA_MANAGED_API_KEY?: string;
+  NANOCODEX_ASTRA_MPP_SECRET?: string;
+  NANOCODEX_CONNECT_API_URL?: string;
+  NANOCODEX_CONNECT_APP_ID?: string;
+  NANOCODEX_CONNECT_APP_ORIGIN?: string;
+  NANOCODEX_CONNECT_DIALOG_URL?: string;
+  NANOCODEX_MANAGED_URL?: string;
+  TEMPO_MPP_API_KEY?: string;
+};
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    if (!url.pathname.startsWith("/api/")) {
+      return secureAsset(await env.ASSETS.fetch(request), connectConfiguration(env));
+    }
+    const connect = connectConfiguration(env);
+    if (!connect) return problem(503, "connect_not_configured");
+    if (url.origin !== connect.appOrigin) return problem(421, "wrong_app_origin");
+    if (request.method !== "GET" && request.headers.get("origin") !== url.origin) {
+      return problem(403, "forbidden_origin");
+    }
+
+    try {
+      if (request.method === "GET" && url.pathname === "/api/config") {
+        const trial = trialConfiguration(env);
+        return json({
+          amount: paymentAmount(env.ENVIRONMENT),
+          chain_id: TEMPO_CHAIN_ID,
+          connect: {
+            api_url: connect.apiUrl,
+            app_id: connect.appId,
+            app_origin: connect.appOrigin,
+            dialog_url: connect.dialogUrl,
+          },
+          currency: MACH,
+          payment_enabled: Boolean(trial),
+          recipient: trial?.payment.recipient,
+        });
+      }
+
+      if (!["/api/session", "/api/trial", "/api/prompt"].includes(url.pathname)) {
+        return problem(404, "not_found");
+      }
+      if (request.method === "POST" && url.pathname === "/api/prompt"
+        && request.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase()
+          !== "application/json") return problem(415, "json_required");
+      const credentials = connectCredentials(request);
+      if (!credentials) return problem(401, "connect_session_required");
+      const identity = await verifyConnectIdentity(credentials, connect);
+      if (request.method === "GET" && url.pathname === "/api/session") {
+        return json({
+          account_address: identity.accountAddress,
+          authenticated: true,
+          expires_at: identity.expiresAt,
+        });
+      }
+      const trial = env.TRIALS.getByName(identity.accountId);
+      if (request.method === "GET" && url.pathname === "/api/trial") {
+        return trial.fetch(internalRequest("/status", identity));
+      }
+      if (request.method === "POST" && url.pathname === "/api/prompt") {
+        return trial.fetch(internalRequest("/prompt", identity, request));
+      }
+      return problem(405, "method_not_allowed");
+    } catch (error) {
+      if (error instanceof ConnectVerificationError) return problem(error.status, error.message);
+      console.error({ type: "astra_trial.request_failed", error: errorName(error) });
+      return problem(500, "internal_error");
+    }
+  },
+} satisfies ExportedHandler<Env>;
+
+export class AstraTrial extends DurableObject<Env> {
+  #observedTurns = new Set<string>();
+  #tail: Promise<void> = Promise.resolve();
+
+  fetch(request: Request): Promise<Response> {
+    return this.#exclusive(async () => this.#dispatch(request));
+  }
+
+  async #exclusive<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.#tail;
+    let release!: () => void;
+    this.#tail = new Promise<void>((resolve) => { release = resolve; });
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  async #dispatch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const identity = internalIdentity(request);
+    if (!identity) return problem(401, "invalid_internal_identity");
+    if (request.method === "GET" && url.pathname === "/status") {
+      let state = await this.#state();
+      if (state?.phase === "running") state = await this.#resume(state);
+      return json(publicTrialState(state));
+    }
+    if (request.method === "POST" && url.pathname === "/prompt") {
+      return this.#prompt(request, identity);
+    }
+    return problem(404, "not_found");
+  }
+
+  async #prompt(request: Request, identity: InternalIdentity): Promise<Response> {
+    const configuration = trialConfiguration(this.env);
+    if (!configuration) return problem(503, "astra_trial_not_configured");
+    const body = await boundedJson(request, MAX_BODY_BYTES);
+    const prompt = body && typeof body === "object" && !Array.isArray(body)
+      && Object.keys(body).length === 1 && typeof (body as { prompt?: unknown }).prompt === "string"
+      ? (body as { prompt: string }).prompt.trim()
+      : "";
+    const requestKey = request.headers.get("idempotency-key");
+    if (!prompt || new TextEncoder().encode(prompt).byteLength > MAX_PROMPT_BYTES
+      || !requestKey || !REQUEST_KEY.test(requestKey)) {
+      return problem(400, "invalid_prompt");
+    }
+    const promptHash = await digest(prompt);
+    let state = await this.#state();
+    const reserved = reservePrompt(state, promptHash, requestKey);
+    if (reserved === "conflict") return problem(409, "astra_trial_already_claimed");
+    if (state?.phase === "completed" || state?.phase === "failed") {
+      return json(publicTrialState(state));
+    }
+    if (state?.phase === "running") return json(publicTrialState(state), 202);
+    if (state?.phase === "payment_pending") {
+      return problem(202, "payment_outcome_pending", { "retry-after": "10" });
+    }
+
+    let receiptHeader: string | undefined;
+    if (state?.phase !== "paid") {
+      const payment = paymentServer(this.ctx.storage, configuration.payment);
+      const options = paymentOptions(configuration.payment, identity.accountId, promptHash);
+      const credential = paymentCredential(request);
+      if (!credential) {
+        const result = await payment.charge(options)(request);
+        return result.status === 402 ? result.challenge : problem(500, "payment_protocol_error");
+      }
+      const { description: _description, scope, ...expectedRequest } = options;
+      let validation;
+      try {
+        validation = await payment.validateCredential(credential, {
+          request: expectedRequest,
+          scope,
+        });
+      } catch {
+        const retry = await payment.charge(options)(request);
+        return retry.status === 402 ? retry.challenge : problem(402, "payment_rejected");
+      }
+      const sender = validationSender(validation.details);
+      if (!sender || sender !== identity.accountAddress) return problem(403, "payment_account_mismatch");
+
+      state = { ...reserved, prompt };
+      await this.ctx.storage.put("trial", state);
+      let receipt;
+      try {
+        receipt = await payment.broadcastCredential(credential, {
+          request: expectedRequest,
+          scope,
+        });
+      } catch (error) {
+        console.error({ type: "astra_trial.payment_ambiguous", error: errorName(error) });
+        return problem(503, "payment_outcome_pending", { "retry-after": "10" });
+      }
+      receiptHeader = paymentReceiptHeader(receipt);
+      state = {
+        ...state,
+        paymentReference: receipt.reference,
+        phase: "paid",
+        updatedAt: Date.now(),
+      };
+      await this.ctx.storage.put("trial", state);
+    }
+
+    try {
+      const managed = configuration.managed;
+      const agent = state.agentId
+        ? await Agent.get(state.agentId, managed)
+        : await Agent.create({ ...managed, settings: ASTRA_SETTINGS });
+      if (!state.agentId) {
+        state = { ...state, agentId: agent.id, updatedAt: Date.now() };
+        await this.ctx.storage.put("trial", state);
+      }
+      const settings = await agent.settings.read();
+      if (!astraSettings(settings)) throw new Error("managed Astra policy mismatch");
+      const turn = agent.turn.prompt({
+        id: "astra-trial",
+        idempotencyKey: `astra-trial:${requestKey}`,
+        input: prompt,
+      });
+      const turnId = await turn.accepted();
+      state = { ...state, phase: "running", turnId, updatedAt: Date.now() };
+      await this.ctx.storage.put("trial", state);
+      this.#watchTurn(turn, state);
+      const response = json(publicTrialState(state), 202);
+      return receiptHeader
+        ? new Response(response.body, {
+            status: response.status,
+            headers: { ...Object.fromEntries(response.headers), "payment-receipt": receiptHeader },
+          })
+        : response;
+    } catch (error) {
+      console.error({ type: "astra_trial.agent_unavailable", error: errorName(error) });
+      return problem(503, "astra_agent_unavailable", { "retry-after": "2" });
+    }
+  }
+
+  #state(): Promise<TrialState | undefined> {
+    return this.ctx.storage.get<TrialState>("trial");
+  }
+
+  async #resume(state: TrialState): Promise<TrialState> {
+    if (!state.agentId || !state.turnId || !state.requestKey || !state.prompt) return state;
+    const configuration = trialConfiguration(this.env);
+    if (!configuration) return state;
+    try {
+      const agent = await Agent.get(state.agentId, configuration.managed);
+      const turn = agent.turn.prompt({
+        id: "astra-trial",
+        idempotencyKey: `astra-trial:${state.requestKey}`,
+        input: state.prompt,
+      });
+      const view = await turn.state();
+      if (view.terminal?.type === "turn_completed") {
+        const completed = {
+          ...state,
+          finalMessage: view.terminal.final_message,
+          phase: "completed",
+          updatedAt: Date.now(),
+        } satisfies TrialState;
+        await this.ctx.storage.put("trial", completed);
+        return completed;
+      }
+      if (view.state === "failed" || view.state === "cancelled") {
+        const failed = failedTrial(state);
+        await this.ctx.storage.put("trial", failed);
+        return failed;
+      }
+      this.#watchTurn(turn, state);
+    } catch (error) {
+      console.error({ type: "astra_trial.resume_failed", error: errorName(error) });
+    }
+    return state;
+  }
+
+  #watchTurn(turn: ManagedTurn, state: TrialState): void {
+    if (!state.turnId || this.#observedTurns.has(state.turnId)) return;
+    this.#observedTurns.add(state.turnId);
+    const completion = turn.result().then(async (result) => {
+      await this.ctx.storage.put("trial", {
+        ...state,
+        finalMessage: result.finalMessage,
+        phase: "completed",
+        updatedAt: Date.now(),
+      } satisfies TrialState);
+    }).catch(async (error) => {
+      console.error({ type: "astra_trial.turn_failed", error: errorName(error) });
+      const view = await turn.state().catch(() => undefined);
+      if (view?.terminal?.type === "turn_completed") {
+        await this.ctx.storage.put("trial", {
+          ...state,
+          finalMessage: view.terminal.final_message,
+          phase: "completed",
+          updatedAt: Date.now(),
+        } satisfies TrialState);
+      } else if (view?.state === "failed" || view?.state === "cancelled") {
+        await this.ctx.storage.put("trial", failedTrial(state));
+      }
+    }).finally(() => {
+      this.#observedTurns.delete(state.turnId!);
+    });
+    this.ctx.waitUntil(completion);
+  }
+}
+
+type InternalIdentity = Readonly<{ accountAddress: `0x${string}`; accountId: string }>;
+
+type TrialConfiguration = Readonly<{
+  managed: Readonly<{ apiKey: string; baseUrl: string }>;
+  payment: PaymentConfiguration;
+}>;
+
+function trialConfiguration(env: Env): TrialConfiguration | undefined {
+  const amount = paymentAmount(env.ENVIRONMENT);
+  const apiKey = env.NANOCODEX_ASTRA_MANAGED_API_KEY?.trim();
+  const baseUrl = serviceUrl(env.NANOCODEX_MANAGED_URL?.trim());
+  const recipient = env.NANOCODEX_ASTRA_MACH_RECIPIENT?.trim().toLowerCase();
+  const secret = env.NANOCODEX_ASTRA_MPP_SECRET?.trim();
+  const tempoApiKey = env.TEMPO_MPP_API_KEY?.trim();
+  if (!apiKey || !API_KEY.test(apiKey) || !baseUrl || !recipient || !ADDRESS.test(recipient)
+    || !secret || secret.length < 32 || (amount !== "0" && !tempoApiKey)) return undefined;
+  return {
+    managed: { apiKey, baseUrl },
+    payment: {
+      amount,
+      recipient: recipient as `0x${string}`,
+      secret,
+      ...(tempoApiKey ? { tempoApiKey } : {}),
+    },
+  };
+}
+
+function internalRequest(path: string, identity: ConnectIdentity, original?: Request): Request {
+  const headers = new Headers({
+    "x-trial-account-address": identity.accountAddress,
+    "x-trial-account-id": identity.accountId,
+  });
+  if (original) {
+    for (const name of ["content-type", "idempotency-key", "payment-authorization"]) {
+      const value = original.headers.get(name);
+      if (value) headers.set(name, value);
+    }
+  }
+  return new Request(`https://trial.internal${path}`, {
+    method: original?.method ?? "GET",
+    headers,
+    body: original?.body,
+  });
+}
+
+function internalIdentity(request: Request): InternalIdentity | undefined {
+  const accountId = request.headers.get("x-trial-account-id");
+  const accountAddress = request.headers.get("x-trial-account-address")?.toLowerCase();
+  return accountId && ACCOUNT_ID.test(accountId) && accountAddress && ADDRESS.test(accountAddress)
+    ? { accountAddress: accountAddress as `0x${string}`, accountId }
+    : undefined;
+}
+
+function validationSender(value: unknown): string | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const sender = (value as { sender?: unknown }).sender;
+  return typeof sender === "string" && ADDRESS.test(sender.toLowerCase())
+    ? sender.toLowerCase()
+    : undefined;
+}
+
+function astraSettings(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const settings = value as Record<string, unknown>;
+  return settings.model === ASTRA_SETTINGS.model
+    && settings.thinking === ASTRA_SETTINGS.thinking
+    && settings.reasoningMode === ASTRA_SETTINGS.reasoningMode
+    && settings.fastMode === ASTRA_SETTINGS.fastMode;
+}
+
+function serviceUrl(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    const url = new URL(value);
+    const loopback = url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "[::1]";
+    if (url.username || url.password || url.hash
+      || (url.protocol !== "https:" && !(url.protocol === "http:" && loopback))) return undefined;
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+async function digest(value: string): Promise<string> {
+  const bytes = new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value)));
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+async function boundedJson(request: Request, maximumBytes: number): Promise<unknown> {
+  const reader = request.body?.getReader();
+  if (!reader) return undefined;
+  const chunks: Uint8Array[] = [];
+  let length = 0;
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      length += next.value.byteLength;
+      if (length > maximumBytes) {
+        await reader.cancel();
+        return undefined;
+      }
+      chunks.push(next.value);
+    }
+    const bytes = new Uint8Array(length);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+  } catch {
+    return undefined;
+  }
+}
+
+function errorName(error: unknown): string {
+  return error instanceof Error ? error.name : typeof error;
+}
+
+function failedTrial(state: TrialState): TrialState {
+  return {
+    ...state,
+    error: "Astra was unable to complete this prompt.",
+    phase: "failed",
+    updatedAt: Date.now(),
+  };
+}
+
+function secureAsset(response: Response, connect: ReturnType<typeof connectConfiguration>): Response {
+  const headers = new Headers(response.headers);
+  const connectOrigin = connect ? new URL(connect.apiUrl).origin : "";
+  headers.set("content-security-policy", [
+    "default-src 'self'",
+    "base-uri 'none'",
+    `connect-src 'self' ${connectOrigin}`.trim(),
+    "font-src 'self'",
+    "frame-src 'none'",
+    "frame-ancestors 'none'",
+    "form-action 'self'",
+    "img-src 'self' data:",
+    "object-src 'none'",
+    "script-src 'self'",
+    "style-src 'self'",
+  ].join("; "));
+  headers.set("permissions-policy", "camera=(), geolocation=(), microphone=()");
+  headers.set("referrer-policy", "no-referrer");
+  headers.set("x-content-type-options", "nosniff");
+  headers.set("x-frame-options", "DENY");
+  return new Response(response.body, { status: response.status, headers });
+}
+
+function problem(status: number, error: string, headers?: HeadersInit): Response {
+  return json({ error }, status, headers);
+}
+
+function json(body: unknown, status = 200, headers?: HeadersInit): Response {
+  return Response.json(body, {
+    status,
+    headers: {
+      "cache-control": "no-store",
+      "x-content-type-options": "nosniff",
+      ...Object.fromEntries(new Headers(headers)),
+    },
+  });
+}

--- a/examples/astra-mpp-trial/src/payment.ts
+++ b/examples/astra-mpp-trial/src/payment.ts
@@ -1,0 +1,91 @@
+import { Receipt } from "mppx";
+import { Mppx, Store, tempo } from "mppx/server";
+import { MACH, TEMPO_CHAIN_ID } from "./policy";
+
+export type PaymentConfiguration = Readonly<{
+  amount: "0" | "50";
+  recipient: `0x${string}`;
+  secret: string;
+  tempoApiKey?: string;
+}>;
+
+export function paymentServer(
+  storage: DurableObjectStorage,
+  configuration: PaymentConfiguration,
+) {
+  const store = durablePaymentStore(storage);
+  return Mppx.create({
+    methods: [tempo.charge({
+      store,
+      sponsorBudget: false,
+      ...(configuration.tempoApiKey
+        ? { relay: { apiKey: configuration.tempoApiKey } }
+        : {}),
+    })],
+    realm: "Nanocodex Astra one-shot",
+    requiresAuth: true,
+    secretKey: configuration.secret,
+  });
+}
+
+export function paymentOptions(
+  configuration: PaymentConfiguration,
+  accountId: string,
+  promptHash: string,
+) {
+  return {
+    amount: configuration.amount,
+    chainId: TEMPO_CHAIN_ID,
+    currency: MACH,
+    decimals: 6,
+    description: "One GPT-6 Astra max-thinking prompt",
+    externalId: `astra:${accountId}:${promptHash}`,
+    feePayer: true,
+    recipient: configuration.recipient,
+    scope: paymentScope(accountId),
+    supportedModes: ["pull"] as ("pull")[],
+  };
+}
+
+export function paymentCredential(request: Request): string | undefined {
+  const value = request.headers.get("payment-authorization")?.trim();
+  return value?.replace(/^Payment\s+/i, "") || undefined;
+}
+
+export function paymentReceiptHeader(receipt: Receipt.Receipt): string {
+  return Receipt.serialize(receipt);
+}
+
+export function paymentScope(accountId: string): string {
+  return `astra-trial:prompt:${accountId}`;
+}
+
+function durablePaymentStore(storage: DurableObjectStorage) {
+  const key = (name: string) => `mpp:${name}`;
+  return Store.from({
+    async get(name: string) {
+      return await storage.get<unknown>(key(name)) ?? null;
+    },
+    async put(name: string, value: unknown) {
+      await storage.put(key(name), value);
+    },
+    async delete(name: string) {
+      await storage.delete(key(name));
+    },
+    async update<result>(name: string, changeValue: (current: unknown | null) => Readonly<{
+      op: "noop" | "delete";
+      result: result;
+    }> | Readonly<{
+      op: "set";
+      result: result;
+      value: unknown;
+    }>): Promise<result> {
+      return storage.transaction(async (transaction) => {
+        const change = changeValue(await transaction.get<unknown>(key(name)) ?? null);
+        if (change.op === "set") await transaction.put(key(name), change.value);
+        if (change.op === "delete") await transaction.delete(key(name));
+        return change.result;
+      });
+    },
+  });
+}

--- a/examples/astra-mpp-trial/src/policy.ts
+++ b/examples/astra-mpp-trial/src/policy.ts
@@ -1,0 +1,60 @@
+export const MACH = "0x20c000000000000000000000f37de3740adec032" as const;
+export const USDC_E = "0x20c000000000000000000000b9537d11c60e8b50" as const;
+export const TIP20_CHANNEL_ESCROW = "0x33b901018174ddabe4841042ab76ba85d4e24f25" as const;
+export const TEMPO_CHAIN_ID = 4_217;
+export const ASTRA_SETTINGS = Object.freeze({
+  model: "gpt-6-astra" as const,
+  thinking: "max" as const,
+  reasoningMode: "standard" as const,
+  fastMode: false,
+});
+
+export type TrialPhase =
+  | "available"
+  | "payment_pending"
+  | "paid"
+  | "running"
+  | "completed"
+  | "failed";
+
+export type TrialState = Readonly<{
+  agentId?: string;
+  error?: string;
+  finalMessage?: string;
+  paymentReference?: string;
+  phase: TrialPhase;
+  prompt?: string;
+  promptHash?: string;
+  requestKey?: string;
+  turnId?: string;
+  updatedAt: number;
+}>;
+
+export function paymentAmount(environment: string | undefined): "0" | "50" {
+  const value = environment?.trim().toLowerCase();
+  return value === "development" || value === "local" || value === "test" ? "0" : "50";
+}
+
+export function reservePrompt(
+  current: TrialState | undefined,
+  promptHash: string,
+  requestKey: string,
+  now = Date.now(),
+): TrialState | "conflict" {
+  if (!current || current.phase === "available") {
+    return { phase: "payment_pending", promptHash, requestKey, updatedAt: now };
+  }
+  return current.promptHash === promptHash && current.requestKey === requestKey
+    ? current
+    : "conflict";
+}
+
+export function publicTrialState(state: TrialState | undefined): Record<string, unknown> {
+  const current = state ?? { phase: "available", updatedAt: 0 };
+  return {
+    phase: current.phase,
+    ...(current.finalMessage ? { final_message: current.finalMessage } : {}),
+    ...(current.error ? { error: current.error } : {}),
+    ...(current.paymentReference ? { payment_reference: current.paymentReference } : {}),
+  };
+}

--- a/examples/astra-mpp-trial/test/connect.test.ts
+++ b/examples/astra-mpp-trial/test/connect.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ConnectVerificationError,
+  connectConfiguration,
+  connectCredentials,
+  connectIdentityFromWire,
+  verifyConnectIdentity,
+} from "../src/connect.ts";
+
+const grantId = `0x${"ab".repeat(32)}` as const;
+const token = "t".repeat(43);
+const accountId = "d9428888-122b-4c26-96af-2d8cf03b2e33";
+const accountAddress = "0x1234567890abcdef1234567890abcdef12345678";
+const configuration = {
+  apiUrl: "https://connect.example/",
+  appId: "astra-demo",
+  appOrigin: "https://astra.example",
+  dialogUrl: "https://dialog.example/",
+};
+
+function wire(overrides: Record<string, unknown> = {}) {
+  return {
+    account_id: accountId,
+    account_address: accountAddress,
+    authorization_mode: "access_key",
+    grant: {
+      id: grantId,
+      permission: "agent.run",
+      status: "active",
+      expires_at: Math.floor(Date.now() / 1_000) + 3_600,
+      capabilities: ["nanocodex.agent", "mpp.mach"],
+    },
+    ...overrides,
+  };
+}
+
+test("accepts only exact public Connect configuration", () => {
+  assert.deepEqual(connectConfiguration({
+    NANOCODEX_CONNECT_API_URL: configuration.apiUrl,
+    NANOCODEX_CONNECT_APP_ID: configuration.appId,
+    NANOCODEX_CONNECT_APP_ORIGIN: configuration.appOrigin,
+    NANOCODEX_CONNECT_DIALOG_URL: configuration.dialogUrl,
+  }), configuration);
+  assert.equal(connectConfiguration({
+    NANOCODEX_CONNECT_API_URL: configuration.apiUrl,
+    NANOCODEX_CONNECT_APP_ID: configuration.appId,
+    NANOCODEX_CONNECT_APP_ORIGIN: "https://astra.example/path",
+    NANOCODEX_CONNECT_DIALOG_URL: configuration.dialogUrl,
+  }), undefined);
+  assert.equal(connectConfiguration({
+    NANOCODEX_CONNECT_API_URL: configuration.apiUrl,
+    NANOCODEX_CONNECT_APP_ID: configuration.appId,
+    NANOCODEX_CONNECT_APP_ORIGIN: "http://astra.nanocodex.localhost:8787",
+    NANOCODEX_CONNECT_DIALOG_URL: configuration.dialogUrl,
+  })?.appOrigin, "http://astra.nanocodex.localhost:8787");
+  assert.equal(connectConfiguration({
+    NANOCODEX_CONNECT_API_URL: configuration.apiUrl,
+    NANOCODEX_CONNECT_APP_ID: configuration.appId,
+    NANOCODEX_CONNECT_APP_ORIGIN: "http://astra.example",
+    NANOCODEX_CONNECT_DIALOG_URL: configuration.dialogUrl,
+  }), undefined);
+});
+
+test("reads the grant token only from bearer auth and the grant ID header", () => {
+  const request = new Request("https://astra.example/api/session", {
+    headers: {
+      authorization: `Bearer ${token}`,
+      "x-nanocodex-grant-id": grantId,
+    },
+  });
+  assert.deepEqual(connectCredentials(request), { grantId, token });
+  assert.equal(connectCredentials(new Request(request.url)), undefined);
+});
+
+test("projects only a live account access-key grant", () => {
+  assert.deepEqual(connectIdentityFromWire(wire(), grantId), {
+    accountAddress,
+    accountId,
+    expiresAt: (wire().grant as { expires_at: number }).expires_at,
+    grantId,
+  });
+  assert.throws(
+    () => connectIdentityFromWire(wire({ authorization_mode: "hosted" }), grantId),
+    ConnectVerificationError,
+  );
+  assert.throws(
+    () => connectIdentityFromWire(wire({ grant: { ...(wire().grant as object), status: "revoked" } }), grantId),
+    ConnectVerificationError,
+  );
+});
+
+test("introspects through the exact Connect app and never forwards browser cookies", async () => {
+  let observed: Request | undefined;
+  const identity = await verifyConnectIdentity({ grantId, token }, configuration, async (input, init) => {
+    observed = new Request(input, init);
+    return Response.json(wire());
+  });
+  assert.equal(identity.accountId, accountId);
+  assert.equal(observed?.url, `https://connect.example/v1/grants/${grantId}`);
+  assert.equal(observed?.headers.get("authorization"), `Bearer ${token}`);
+  assert.equal(observed?.headers.get("origin"), configuration.appOrigin);
+  assert.equal(observed?.headers.get("x-nanocodex-app-id"), configuration.appId);
+  assert.equal(observed?.headers.get("cookie"), null);
+});
+
+test("fails closed when Connect rejects or cannot resolve the grant", async () => {
+  await assert.rejects(
+    verifyConnectIdentity({ grantId, token }, configuration, async () => Response.json({}, { status: 401 })),
+    (error: unknown) => error instanceof ConnectVerificationError && error.status === 401,
+  );
+  await assert.rejects(
+    verifyConnectIdentity({ grantId, token }, configuration, async () => { throw new Error("offline"); }),
+    (error: unknown) => error instanceof ConnectVerificationError && error.status === 503,
+  );
+});

--- a/examples/astra-mpp-trial/test/policy.test.ts
+++ b/examples/astra-mpp-trial/test/policy.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ASTRA_SETTINGS,
+  paymentAmount,
+  publicTrialState,
+  reservePrompt,
+  type TrialState,
+} from "../src/policy.ts";
+
+test("locks the sponsor model policy to supported Astra max settings", () => {
+  assert.deepEqual(ASTRA_SETTINGS, {
+    model: "gpt-6-astra",
+    thinking: "max",
+    reasoningMode: "standard",
+    fastMode: false,
+  });
+  assert.equal(Object.isFrozen(ASTRA_SETTINGS), true);
+});
+
+test("charges only a wallet proof outside production", () => {
+  assert.equal(paymentAmount("development"), "0");
+  assert.equal(paymentAmount("LOCAL"), "0");
+  assert.equal(paymentAmount("test"), "0");
+  assert.equal(paymentAmount("production"), "50");
+  assert.equal(paymentAmount(undefined), "50");
+});
+
+test("reserves one exact prompt and rejects every different claim", () => {
+  const reserved = reservePrompt(undefined, "hash-a", "request-a", 10);
+  assert.deepEqual(reserved, {
+    phase: "payment_pending",
+    promptHash: "hash-a",
+    requestKey: "request-a",
+    updatedAt: 10,
+  });
+  assert.notEqual(reserved, "conflict");
+  if (reserved === "conflict") return;
+  assert.deepEqual(reservePrompt(reserved, "hash-a", "request-a", 20), reserved);
+  assert.equal(reservePrompt(reserved, "hash-b", "request-a", 20), "conflict");
+  assert.equal(reservePrompt(reserved, "hash-a", "request-b", 20), "conflict");
+});
+
+test("public state never exposes sponsor managed identifiers", () => {
+  const internal: TrialState = {
+    agentId: "agent-secret",
+    finalMessage: "hello",
+    paymentReference: "0xreceipt",
+    phase: "completed",
+    promptHash: "hash",
+    requestKey: "request",
+    turnId: "turn-secret",
+    updatedAt: 123,
+  };
+  assert.deepEqual(publicTrialState(internal), {
+    final_message: "hello",
+    payment_reference: "0xreceipt",
+    phase: "completed",
+  });
+});

--- a/examples/astra-mpp-trial/tsconfig.json
+++ b/examples/astra-mpp-trial/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "allowImportingTsExtensions": true,
+    "checkJs": false,
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2024",
+    "types": ["@cloudflare/workers-types", "node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/examples/astra-mpp-trial/wrangler.jsonc
+++ b/examples/astra-mpp-trial/wrangler.jsonc
@@ -1,0 +1,47 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "nanocodex-astra-mpp-trial",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-07-29",
+  "compatibility_flags": ["nodejs_compat"],
+  "assets": {
+    "binding": "ASSETS",
+    "directory": "./public",
+    "run_worker_first": true
+  },
+  "durable_objects": {
+    "bindings": [
+      { "name": "TRIALS", "class_name": "AstraTrial" }
+    ]
+  },
+  "migrations": [
+    { "tag": "v1", "new_sqlite_classes": ["AstraTrial"] }
+  ],
+  "vars": {
+    "ENVIRONMENT": "production",
+    "NANOCODEX_CONNECT_API_URL": "https://nanocodex-connect-api.gakonst.workers.dev",
+    "NANOCODEX_CONNECT_APP_ID": "astra-one-shot",
+    "NANOCODEX_CONNECT_APP_ORIGIN": "https://nanocodex-astra-mpp-trial.gakonst.workers.dev",
+    "NANOCODEX_CONNECT_DIALOG_URL": "https://nanocodex.gakonst.workers.dev/connect-dialog/",
+    "NANOCODEX_MANAGED_URL": "https://nanocodex.gakonst.workers.dev"
+  },
+  "env": {
+    "development": {
+      "name": "nanocodex-astra-mpp-trial-dev",
+      "durable_objects": {
+        "bindings": [
+          { "name": "TRIALS", "class_name": "AstraTrial" }
+        ]
+      },
+      "vars": {
+        "ENVIRONMENT": "development",
+        "NANOCODEX_CONNECT_API_URL": "https://nanocodex-connect-api.gakonst.workers.dev",
+        "NANOCODEX_CONNECT_APP_ID": "astra-one-shot-local",
+        "NANOCODEX_CONNECT_APP_ORIGIN": "https://localhost:8787",
+        "NANOCODEX_CONNECT_DIALOG_URL": "https://nanocodex.gakonst.workers.dev/connect-dialog/",
+        "NANOCODEX_MANAGED_URL": "https://nanocodex.gakonst.workers.dev",
+        "NANOCODEX_ASTRA_MACH_RECIPIENT": "0xa295c42fbcc026a62304a7701f25b4c91799b0da"
+      }
+    }
+  }
+}

--- a/js/connect-api/src/astraTrialPolicy.mts
+++ b/js/connect-api/src/astraTrialPolicy.mts
@@ -1,0 +1,43 @@
+export const astraTrialAppId = "astra-one-shot";
+export const astraTrialAppOrigin = "https://nanocodex-astra-mpp-trial.gakonst.workers.dev";
+export const astraTrialMppLimit = 50_000_000n;
+
+export function hasConsistentAstraTrialIdentity(appId: unknown, origin: unknown): boolean {
+  const claimsIdentity = appId === astraTrialAppId || origin === astraTrialAppOrigin;
+  return !claimsIdentity || (appId === astraTrialAppId && origin === astraTrialAppOrigin);
+}
+
+const MACH = "0x20c000000000000000000000f37de3740adec032";
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+const PERIOD = 86_400;
+const TRANSFER_WITH_MEMO = "0x95777d59";
+
+export function hasAstraTrialSpendPolicy(limits: unknown[], scopes: unknown[]): boolean {
+  if (limits.length !== 1 || scopes.length !== 1) return false;
+  const limit = record(limits[0]);
+  const scope = record(scopes[0]);
+  if (!limit || !scope || !Array.isArray(scope.recipients) || scope.recipients.length !== 1) {
+    return false;
+  }
+  const recipient = address(scope.recipients[0]);
+  return address(limit.token) === MACH
+    && limit.limit === astraTrialMppLimit.toString()
+    && limit.period === PERIOD
+    && address(scope.address) === MACH
+    && typeof scope.selector === "string"
+    && scope.selector.toLowerCase() === TRANSFER_WITH_MEMO
+    && recipient !== undefined
+    && recipient !== ZERO_ADDRESS;
+}
+
+function address(value: unknown): string | undefined {
+  return typeof value === "string" && /^0x[0-9a-fA-F]{40}$/.test(value)
+    ? value.toLowerCase()
+    : undefined;
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}

--- a/js/connect-api/src/index.ts
+++ b/js/connect-api/src/index.ts
@@ -3,6 +3,13 @@ import { custom } from "viem";
 import { KeyAuthorization } from "ox/tempo";
 
 import {
+  astraTrialAppId as ASTRA_TRIAL_APP_ID,
+  astraTrialMppLimit as ASTRA_TRIAL_MPP_LIMIT,
+  hasConsistentAstraTrialIdentity,
+  hasAstraTrialSpendPolicy,
+} from "./astraTrialPolicy.mts";
+
+import {
   chatGptCredentialImportDigest,
   credentialImportDigestFromResources,
   parseChatGptCredentialImport,
@@ -2409,6 +2416,17 @@ function validateGrantAccessKey(
     }
     return;
   }
+  if (appId === ASTRA_TRIAL_APP_ID) {
+    if (!resources.includes("urn:nanocodex:mpp:machusd:spend")
+      || !hasAstraTrialSpendPolicy(accessKey.limits, accessKey.scopes)) {
+      throw new ApiFailure(
+        403,
+        "invalid_access_key_policy",
+        "The Astra trial key must contain only its one-shot MACH payment authority.",
+      );
+    }
+    return;
+  }
   const limits = new Map<string, { limit: string; period?: number }>();
   for (const value of accessKey.limits) {
     if (!isRecord(value) || typeof value.limit !== "string") {
@@ -3173,6 +3191,7 @@ function grantAuthorization(grant: GrantRecord) {
   const accessKey = grant.accessKey;
   const limits = accessKey && Array.isArray(accessKey.limits) ? accessKey.limits : [];
   const scopes = accessKey && Array.isArray(accessKey.scopes) ? accessKey.scopes : [];
+  const mppPolicy = grantMppPolicy(grant);
   return {
     appId: grant.appId,
     permission: grant.permission,
@@ -3214,9 +3233,9 @@ function grantAuthorization(grant: GrantRecord) {
       token: MACHINE_USD,
       symbol: "MACH",
       spent: grant.spentAtomics,
-      limit: MPP_LIMIT.toString(),
+      limit: mppPolicy.limit.toString(),
       period: MPP_PERIOD,
-      maxPerRequest: MPP_MAX_PER_REQUEST.toString(),
+      maxPerRequest: mppPolicy.maxPerRequest.toString(),
     } } : { authority: "hosted" }),
   };
 }
@@ -4234,6 +4253,13 @@ async function chargeGrant(
   body: Record<string, unknown>,
 ) {
   if (grant.status !== "active") throw new ApiFailure(409, "grant_inactive", "The grant is not active.");
+  if (grant.appId === ASTRA_TRIAL_APP_ID) {
+    throw new ApiFailure(
+      403,
+      "mpp_route_unavailable",
+      "The Astra trial authority is usable only by its recipient-bound payment challenge.",
+    );
+  }
   if (!grant.capabilities.includes("mpp.mach") || !grant.accessKey || !grant.accountAddress) {
     throw new ApiFailure(403, "mpp_not_granted", "This connection has no MPP authority.");
   }
@@ -5810,6 +5836,7 @@ function connectionWire(grant: GrantRecord, grantToken: string) {
   }
   const balancesReady = grant.balanceAtomics !== undefined
     && grant.settlementBalanceAtomics !== undefined;
+  const mppPolicy = grantMppPolicy(grant);
   return {
     grant_token: grantToken,
     account_id: grant.brokerUserId,
@@ -5832,12 +5859,18 @@ function connectionWire(grant: GrantRecord, grantToken: string) {
         settlement_symbol: "USDC.e",
         settlement_balance_atomics: grant.settlementBalanceAtomics ?? "0",
         spent_atomics: grant.spentAtomics,
-        limit_atomics: MPP_LIMIT.toString(),
+        limit_atomics: mppPolicy.limit.toString(),
         period: MPP_PERIOD,
-        max_per_request_atomics: MPP_MAX_PER_REQUEST.toString(),
+        max_per_request_atomics: mppPolicy.maxPerRequest.toString(),
       },
     } : {}),
   };
+}
+
+function grantMppPolicy(grant: Pick<GrantRecord, "appId">) {
+  return grant.appId === ASTRA_TRIAL_APP_ID
+    ? { limit: ASTRA_TRIAL_MPP_LIMIT, maxPerRequest: ASTRA_TRIAL_MPP_LIMIT }
+    : { limit: MPP_LIMIT, maxPerRequest: MPP_MAX_PER_REQUEST };
 }
 
 function grantWire(grant: GrantRecord) {
@@ -6151,6 +6184,9 @@ function validateCallerApp(appId: unknown, origin: unknown): CallerApp {
   }
   if (origin === CLI_APP_ORIGIN && appId !== CLI_APP_ID) {
     throw new ApiFailure(403, "app_identity_mismatch", "The registered app id does not match this origin.");
+  }
+  if (!hasConsistentAstraTrialIdentity(appId, origin)) {
+    throw new ApiFailure(403, "app_identity_mismatch", "The Astra trial app id and origin must match.");
   }
   if (appId === REGISTERED_APP_ID
     && origin !== PLAYGROUND_ORIGIN

--- a/js/connect-api/test/astraTrialPolicy.test.mjs
+++ b/js/connect-api/test/astraTrialPolicy.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  astraTrialAppId,
+  astraTrialAppOrigin,
+  astraTrialMppLimit,
+  hasConsistentAstraTrialIdentity,
+  hasAstraTrialSpendPolicy,
+} from "../src/astraTrialPolicy.mts";
+
+const mach = "0x20c000000000000000000000f37de3740adec032";
+const recipient = "0x1234567890abcdef1234567890abcdef12345678";
+
+function policy() {
+  return {
+    limits: [{ token: mach, limit: astraTrialMppLimit.toString(), period: 86_400 }],
+    scopes: [{ address: mach, selector: "0x95777d59", recipients: [recipient] }],
+  };
+}
+
+test("pins the registered Astra trial identity and one-shot amount", () => {
+  assert.equal(astraTrialAppId, "astra-one-shot");
+  assert.equal(astraTrialAppOrigin, "https://nanocodex-astra-mpp-trial.gakonst.workers.dev");
+  assert.equal(astraTrialMppLimit, 50_000_000n);
+  assert.equal(hasConsistentAstraTrialIdentity(astraTrialAppId, astraTrialAppOrigin), true);
+  assert.equal(hasConsistentAstraTrialIdentity("another-app", "https://another.example"), true);
+  assert.equal(hasConsistentAstraTrialIdentity(astraTrialAppId, "https://another.example"), false);
+  assert.equal(hasConsistentAstraTrialIdentity("another-app", astraTrialAppOrigin), false);
+  const value = policy();
+  assert.equal(hasAstraTrialSpendPolicy(value.limits, value.scopes), true);
+});
+
+test("accepts only one MACH transferWithMemo scope to one nonzero recipient", () => {
+  const value = policy();
+  assert.equal(hasAstraTrialSpendPolicy([
+    ...value.limits,
+    { token: mach, limit: "1", period: 86_400 },
+  ], value.scopes), false);
+  assert.equal(hasAstraTrialSpendPolicy(value.limits, [
+    ...value.scopes,
+    { address: mach, selector: "0xa9059cbb", recipients: [recipient] },
+  ]), false);
+  assert.equal(hasAstraTrialSpendPolicy(value.limits, [{
+    ...value.scopes[0],
+    selector: "0xa9059cbb",
+  }]), false);
+  assert.equal(hasAstraTrialSpendPolicy(value.limits, [{
+    ...value.scopes[0],
+    recipients: ["0x0000000000000000000000000000000000000000"],
+  }]), false);
+  assert.equal(hasAstraTrialSpendPolicy([{ ...value.limits[0], limit: "49999999" }], value.scopes), false);
+});

--- a/js/connect-dialog/test/connectPolicy.test.mjs
+++ b/js/connect-dialog/test/connectPolicy.test.mjs
@@ -16,6 +16,7 @@ import {
   hostPrincipalExchangeFromResources,
   mcpConnectionApprovalDisposition,
   mcpConnectionsFromWire,
+  mppConsentDetails,
   parseConnectPolicy,
   productionConnectApiOrigin,
   registeredApp,
@@ -77,6 +78,7 @@ test("canonical Nanocodex localhost dialogs use the portable server ceremony", (
 });
 
 const playground = "https://nanocodex-connect-playground.gakonst.workers.dev";
+const astraDemo = "https://nanocodex-astra-mpp-trial.gakonst.workers.dev";
 const chromeExtension = "chrome-extension://jpkimkgbgbpcaldbnhlhbkbadmpeffle";
 const productionDialog = "https://nanocodex.gakonst.workers.dev/connect-dialog/?mode=iframe";
 const cli = "https://cli.nanocodex.xyz";
@@ -221,6 +223,15 @@ test("production Connect policy pins the API and registered embedding app", () =
     name: "Atlas Workspace",
     origin: playground,
   });
+  assert.deepEqual(registeredApp(astraDemo, "astra-one-shot", productionDialog, false), {
+    id: "astra-one-shot",
+    name: "Astra One-Shot",
+    origin: astraDemo,
+  });
+  assert.throws(
+    () => registeredApp(astraDemo, "astra-one-shot-local", productionDialog, false),
+    /does not match/,
+  );
   assert.deepEqual(registeredApp(chromeExtension, "nanocodex-chrome", productionDialog, false), {
     id: "nanocodex-chrome",
     name: "Nanocodex for Chrome",
@@ -231,6 +242,26 @@ test("production Connect policy pins the API and registered embedding app", () =
     name: "Nanocodex CLI",
     origin: cli,
   });
+});
+
+test("Astra consent exposes its exact 50 MACH recipient-bound authority", () => {
+  const token = "0x20c000000000000000000000f37de3740adec032";
+  const recipient = "0x1234567890abcdef1234567890abcdef12345678";
+  assert.deepEqual(mppConsentDetails("astra-one-shot", token, 50_000_000n, [{
+    address: token,
+    selector: "0x95777d59",
+    recipients: [recipient],
+  }]), { maxPerRequest: 50_000_000n, recipient });
+  assert.deepEqual(mppConsentDetails("another-app", token, 10_000_000n, [{
+    address: token,
+    selector: "0x95777d59",
+    recipients: [recipient],
+  }]), { maxPerRequest: 250_000n, recipient });
+  assert.deepEqual(mppConsentDetails("astra-one-shot", token, 50_000_000n, [{
+    address: token,
+    selector: "0xa9059cbb",
+    recipients: [recipient],
+  }]), { maxPerRequest: 50_000_000n });
 });
 
 test("only top-level popup dialogs admit unknown secure app origins", () => {

--- a/js/nanocodex-connect-ui/src/App.tsx
+++ b/js/nanocodex-connect-ui/src/App.tsx
@@ -59,6 +59,7 @@ import {
   isLocalDevelopmentOrigin,
   mcpConnectionApprovalDisposition,
   mcpConnectionsFromWire,
+  mppConsentDetails,
   parseConnectPolicy,
   registeredApp,
   restoreMcpCallbackContinuation,
@@ -1774,7 +1775,7 @@ function WizardRequestSummary({ appVisibility, request }: Readonly<{
             <span>✓</span>
             <div>
               <strong>MACH spend</strong>
-              <small>{formatToken(request.mpp.maxPerRequest, request.mpp.symbol)} per request · {formatToken(request.mpp.limit, request.mpp.symbol)} per day</small>
+              <small>{formatToken(request.mpp.maxPerRequest, request.mpp.symbol)} per request · {formatToken(request.mpp.limit, request.mpp.symbol)} per day{request.mpp.recipient ? ` · to ${shortAddress(request.mpp.recipient)}` : ""}</small>
             </div>
           </div>
         ) : null}
@@ -1784,6 +1785,7 @@ function WizardRequestSummary({ appVisibility, request }: Readonly<{
         <dl className="key-details">
           <Detail label="App" value={request.app.origin} />
           {request.mpp ? <Detail label="Spend" value={`${formatToken(request.mpp.maxPerRequest, request.mpp.symbol)} / request · ${formatToken(request.mpp.limit, request.mpp.symbol)} / day`} /> : null}
+          {request.mpp?.recipient ? <Detail label="Recipient" value={request.mpp.recipient} /> : null}
           {hostedAuthorization ? (
             <Detail label="Key" value="None — no spending or contract authority" />
           ) : request.accessKey ? (
@@ -2203,6 +2205,7 @@ function walletView(request: WalletRequest): ConnectionView {
     limit: 10_000_000n,
     period: 86_400,
   };
+  const mppConsent = mppConsentDetails(app.id, primary.token, primary.limit, scopes);
   const preparedAccessKey = typeof access.address === "string" && typeof access.publicKey === "string"
     ? {
         address: hex(access.address),
@@ -2242,7 +2245,7 @@ function walletView(request: WalletRequest): ConnectionView {
         symbol: "MACH",
         limit: primary.limit,
         period: primary.period ?? 86_400,
-        maxPerRequest: 250_000n,
+        ...mppConsent,
       },
     } : {}),
   };

--- a/js/nanocodex-connect-ui/src/connectPolicy.mts
+++ b/js/nanocodex-connect-ui/src/connectPolicy.mts
@@ -210,6 +210,11 @@ const signedAppVisibility = Object.freeze([
 ] satisfies readonly Readonly<VisibilityPermission & { name: string }>[]);
 
 const productionApps = new Map<string, RegisteredApp>([
+  ["https://nanocodex-astra-mpp-trial.gakonst.workers.dev", Object.freeze({
+    id: "astra-one-shot",
+    name: "Astra One-Shot",
+    origin: "https://nanocodex-astra-mpp-trial.gakonst.workers.dev",
+  })],
   ["https://nanocodex-connect-playground.gakonst.workers.dev", Object.freeze({
     id: "atlas-workspace",
     name: "Atlas Workspace",
@@ -249,6 +254,28 @@ export function registeredApp(
     return Object.freeze({ id: appId, name: url.hostname, origin: embeddingOrigin });
   }
   throw new Error("This application is not registered with Nanocodex Connect.");
+}
+
+export function mppConsentDetails(
+  appId: string,
+  token: string,
+  limit: bigint,
+  scopes: readonly Readonly<{
+    address: string;
+    selector?: string | undefined;
+    recipients?: readonly string[] | undefined;
+  }>[],
+): Readonly<{ maxPerRequest: bigint; recipient?: `0x${string}` | undefined }> {
+  const recipients = [...new Set(scopes
+    .filter((scope) => scope.address.toLowerCase() === token.toLowerCase()
+      && scope.selector?.toLowerCase() === "0x95777d59")
+    .flatMap((scope) => scope.recipients ?? [])
+    .filter((recipient) => /^0x[0-9a-fA-F]{40}$/.test(recipient))
+    .map((recipient) => recipient.toLowerCase() as `0x${string}`))];
+  return Object.freeze({
+    maxPerRequest: appId === "astra-one-shot" ? limit : 250_000n,
+    ...(recipients.length === 1 ? { recipient: recipients[0] } : {}),
+  });
 }
 
 export function isPopupPresentation(dialogUrl: string, isTopLevel: boolean): boolean {

--- a/js/nanocodex/cloud/Dialog.d.mts
+++ b/js/nanocodex/cloud/Dialog.d.mts
@@ -44,6 +44,8 @@ export type ConnectionRequest = Readonly<{
     limit: bigint;
     period: number;
     maxPerRequest: bigint;
+    /** Exact recipient when the delegated payment authority is recipient-bound. */
+    recipient?: `0x${string}` | undefined;
   }> | undefined;
 }>;
 


### PR DESCRIPTION
## Summary

- add a standalone Cloudflare Worker demo for one Connect-authenticated, MPP-gated Astra max-thinking prompt
- isolate one-shot state per Nanocodex account in a Durable Object and keep the sponsor managed key server-only
- register an exact 50 MACH, recipient-bound Connect consent policy for the production demo while leaving every other Connect grant unchanged
- add the standalone app to JavaScript app CI

## Security boundary

The public Worker exposes only config, session verification, one-shot status, and prompt submission. It never proxies managed APIs or returns sponsor agent/turn IDs. Production accepts only a single 50 MACH transferWithMemo scope to the consent-screen recipient; the grant cannot use the generic Connect MPP route. Local mode signs a zero-value proof.

## Verification

- npm run check --prefix examples/astra-mpp-trial
- pnpm --dir js/connect-api test and typecheck
- pnpm --dir js/nanocodex-connect-ui test
- pnpm --dir js/connect-dialog build and test
- pnpm --dir js/nanocodex test:typecheck and check:package
- browser smoke: secure local UI, Connect popup/SMS screen, API route/origin denials, CSP headers, zero accessibility violations