### PR TITLE
ci(astra): deploy trial app through Cloudflare

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -57,6 +57,8 @@ jobs:
           tool: wasm-bindgen-cli@0.2.126
       - name: Install deployment packages
         run: pnpm install --frozen-lockfile
+      - name: Install Astra trial package
+        run: npm ci --prefix examples/astra-mpp-trial
       - name: Prepare managed evaluator asset
         working-directory: js/managed
         run: npm run prepare:code-evaluator
@@ -68,6 +70,8 @@ jobs:
             --filter @nanocodex/connect-dialog \
             --filter @nanocodex/connect-playground \
             --filter nanocodex-web
+      - name: Build Astra trial application
+        run: npm run build:client --prefix examples/astra-mpp-trial
       # Cloudflare does not issue preview URLs for Durable Object or container
       # Workers. Dry-run those and publish previews only for asset Workers.
       - name: Validate egress Worker
@@ -82,6 +86,9 @@ jobs:
       - name: Validate Connect API Worker
         working-directory: js/connect-api
         run: npx wrangler deploy --dry-run --config wrangler.jsonc
+      - name: Validate Astra trial Worker
+        working-directory: examples/astra-mpp-trial
+        run: npx wrangler deploy --dry-run --env="" --outdir dist
       - name: Validate Chief of Staff Worker
         working-directory: js/chief-of-staff
         run: npm run check
@@ -132,6 +139,8 @@ jobs:
           tool: wasm-bindgen-cli@0.2.126
       - name: Install deployment packages
         run: pnpm install --frozen-lockfile
+      - name: Install Astra trial package
+        run: npm ci --prefix examples/astra-mpp-trial
       - name: Prepare managed evaluator asset
         working-directory: js/managed
         run: npm run prepare:code-evaluator
@@ -143,6 +152,8 @@ jobs:
             --filter @nanocodex/connect-dialog \
             --filter @nanocodex/connect-playground \
             --filter nanocodex-web
+      - name: Build Astra trial application
+        run: npm run build:client --prefix examples/astra-mpp-trial
       - name: Deploy egress broker
         working-directory: js/egress
         run: npx wrangler deploy --config wrangler.broker.jsonc --message "$DEPLOY_MESSAGE"
@@ -155,6 +166,9 @@ jobs:
       - name: Deploy Connect API
         working-directory: js/connect-api
         run: npx wrangler deploy --config wrangler.jsonc --message "$DEPLOY_MESSAGE"
+      - name: Deploy Astra trial application
+        working-directory: examples/astra-mpp-trial
+        run: npx wrangler deploy --env="" --message "$DEPLOY_MESSAGE"
       - name: Deploy Chief of Staff integration
         working-directory: js/chief-of-staff
         run: npx wrangler deploy --config wrangler.jsonc --message "$DEPLOY_MESSAGE"


### PR DESCRIPTION
## Summary

- install and build the standalone Astra trial app in the Cloudflare workflow
- dry-run its Durable Object Worker on pull requests
- deploy it from master with the production Cloudflare account and canonical gakonst.workers.dev hostname

## Verification

- npm run check --prefix examples/astra-mpp-trial
- actionlint .github/workflows/cloudflare.yml

The Worker remains fail-closed until its production recipient and server-side secrets are configured in Cloudflare.