### PR TITLE
fix(nanocodex2): select Astra directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,12 +150,13 @@ snapshots, see [`examples/lifecycle.rs`](examples/lifecycle.rs),
 [`examples/resume.rs`](examples/resume.rs).
 
 Nanocodex supports OpenAI `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, and
-`gpt-6-astra`. Sol remains the SDK default; connected terminal applications
-select Astra for a new conversation only when the account's authoritative
-model catalog exposes it. Astra requires at least low reasoning. Nanocodex owns
-the typed Responses WebSocket behavior for this closed model family. An API-key gateway may prefix the on-wire
-model identifier with `NANOCODEX_MODEL_ID_PREFIX`, but that does not create an
-alternate-provider or arbitrary-model API.
+`gpt-6-astra`. Sol remains the SDK default. The managed `nanocodex2` terminal
+selects Astra directly for new conversations; the account app still uses its
+brokered model catalog when choosing a default. Astra requires at least low
+reasoning. Nanocodex owns the typed Responses WebSocket behavior for this closed
+model family. An API-key gateway may prefix the on-wire model identifier with
+`NANOCODEX_MODEL_ID_PREFIX`, but that does not create an alternate-provider or
+arbitrary-model API.
 
 ## One agent, owned end to end
 

--- a/bin/nanocodex/src/nanocodex2/tui/mod.rs
+++ b/bin/nanocodex/src/nanocodex2/tui/mod.rs
@@ -962,7 +962,7 @@ async fn run_inner(
     let initial_settings = if matches!(attach, Some(Some(_))) {
         AgentSettings::default()
     } else {
-        account_default_settings(client).await
+        new_agent_settings()
     };
     let initial_effort = effort_from_thinking(initial_settings.thinking);
     let initial_reasoning_mode = reasoning_mode_from_managed(initial_settings.reasoning_mode);
@@ -1827,15 +1827,12 @@ async fn run_inner(
     }
 }
 
-async fn account_default_settings(client: &ManagedClient) -> AgentSettings {
-    match client.model_capabilities().await {
-        Ok(capabilities) if capabilities.astra_entitled => AgentSettings {
-            model: Model::Astra,
-            thinking: Thinking::High,
-            reasoning_mode: ManagedReasoningMode::Standard,
-            fast_mode: false,
-        },
-        Ok(_) | Err(_) => AgentSettings::default(),
+fn new_agent_settings() -> AgentSettings {
+    AgentSettings {
+        model: Model::Astra,
+        thinking: Thinking::High,
+        reasoning_mode: ManagedReasoningMode::Standard,
+        fast_mode: false,
     }
 }
 
@@ -2479,13 +2476,15 @@ mod tests {
         HistoryPrefetch, HistoryWindow, ManagedActiveTurns, SteerResolution, SteerTarget,
         cursor_at_or_before, decimal_successor, history_projection,
         history_projection_with_sequences, history_replay_matches, live_managed_projection,
-        prepare_history_replay, session_summaries, take_waiting_steer_failures,
+        new_agent_settings, prepare_history_replay, session_summaries, take_waiting_steer_failures,
     };
     use crate::config::ReasoningEffort;
     use crate::tui::{components::QueueId, pane::PaneId, prompt::Submission, transcript::TurnId};
+    use nanocodex::Model;
     use nanocodex_managed::{
         AgentList, AgentSettings, AgentSummary, EventHistoryPage, ManagedApiKey, ManagedClient,
-        ManagedEvent, ManagedEventData, PromptInput,
+        ManagedEvent, ManagedEventData, PromptInput, ReasoningMode as ManagedReasoningMode,
+        Thinking,
     };
     use serde_json::{json, value::to_raw_value};
     use std::{
@@ -2493,6 +2492,19 @@ mod tests {
         path::Path,
     };
     use tokio::task::JoinSet;
+
+    #[test]
+    fn new_agents_select_astra_without_an_entitlement_probe() {
+        assert_eq!(
+            new_agent_settings(),
+            AgentSettings {
+                model: Model::Astra,
+                thinking: Thinking::High,
+                reasoning_mode: ManagedReasoningMode::Standard,
+                fast_mode: false,
+            }
+        );
+    }
 
     fn history_runtime(history: HistoryWindow) -> DriverRuntime {
         let mut history_sequences = HashMap::new();

--- a/docs/GPT_6_ASTRA.md
+++ b/docs/GPT_6_ASTRA.md
@@ -209,10 +209,10 @@ provider steering protocol.
 
 ## Rollout and live evidence
 
-New brokered ChatGPT conversations use Astra only after the authenticated Codex
-model catalog lists the exact `gpt-6-astra` slug with `visibility: "list"`.
-Catalog failures fail closed to the existing model default; API-key and sponsored
-connections never infer Astra access. The selector is available only before the
+The managed `nanocodex2` terminal selects Astra directly for new conversations;
+an explicit provider rejection is its availability signal. The account app still
+uses the authenticated Codex model catalog to choose its default and fails closed
+when that projection is unavailable. The selector is available only before the
 first accepted turn, while thinking and Fast remain live settings.
 
 Both native terminal clients expose the complete Sol, Terra, Luna, and Astra


### PR DESCRIPTION
## Summary
- remove the unreliable astra_entitled lookup from new nanocodex2 terminal sessions
- select Astra/high directly and let explicit provider rejection be the availability signal
- document the narrower account-app catalog behavior

## Validation
- cargo test --locked --package nanocodex2-bin (382 passed)
- cargo clippy --locked --package nanocodex2-bin --bins --no-deps -- -D warnings
- cargo fmt --all -- --check
- git diff --check