### PR TITLE
ci: configure Astra trial runtime

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -169,6 +169,30 @@ jobs:
       - name: Deploy Astra trial application
         working-directory: examples/astra-mpp-trial
         run: npx wrangler deploy --env="" --message "$DEPLOY_MESSAGE"
+      - name: Configure Astra trial secrets
+        working-directory: examples/astra-mpp-trial
+        env:
+          ASTRA_MANAGED_API_KEY: ${{ secrets.NANOCODEX_ASTRA_MANAGED_API_KEY }}
+          ASTRA_MPP_SECRET: ${{ secrets.NANOCODEX_ASTRA_MPP_SECRET }}
+          TEMPO_API_KEY: ${{ secrets.TEMPO_MPP_API_KEY }}
+        run: |
+          missing=()
+          [ -n "$ASTRA_MANAGED_API_KEY" ] || missing+=(NANOCODEX_ASTRA_MANAGED_API_KEY)
+          [ -n "$ASTRA_MPP_SECRET" ] || missing+=(NANOCODEX_ASTRA_MPP_SECRET)
+          [ -n "$TEMPO_API_KEY" ] || missing+=(TEMPO_MPP_API_KEY)
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::notice::Astra trial remains fail-closed; missing repository secrets: ${missing[*]}"
+          fi
+          if [ "${#missing[@]}" -lt 3 ]; then
+            node --input-type=module -e '
+              const entries = [
+                ["NANOCODEX_ASTRA_MANAGED_API_KEY", process.env.ASTRA_MANAGED_API_KEY],
+                ["NANOCODEX_ASTRA_MPP_SECRET", process.env.ASTRA_MPP_SECRET],
+                ["TEMPO_MPP_API_KEY", process.env.TEMPO_API_KEY],
+              ].filter(([, value]) => value);
+              process.stdout.write(JSON.stringify(Object.fromEntries(entries)));
+            ' | npx wrangler secret bulk --env=""
+          fi
       - name: Deploy Chief of Staff integration
         working-directory: js/chief-of-staff
         run: npx wrangler deploy --config wrangler.jsonc --message "$DEPLOY_MESSAGE"

--- a/examples/astra-mpp-trial/README.md
+++ b/examples/astra-mpp-trial/README.md
@@ -66,18 +66,20 @@ browser origin before connecting.
 
 ## Production configuration
 
-Set these Worker secrets:
+The Cloudflare production workflow syncs these GitHub repository secrets to the
+Worker after each deployment:
 
 ```sh
-npx wrangler secret put NANOCODEX_ASTRA_MANAGED_API_KEY
-npx wrangler secret put NANOCODEX_ASTRA_MPP_SECRET
-npx wrangler secret put TEMPO_MPP_API_KEY
+NANOCODEX_ASTRA_MANAGED_API_KEY
+NANOCODEX_ASTRA_MPP_SECRET
+TEMPO_MPP_API_KEY
 ```
 
-Set `NANOCODEX_ASTRA_MACH_RECIPIENT` to the sponsor's intended Tempo recipient.
-Confirm that `NANOCODEX_CONNECT_APP_ORIGIN` exactly matches the deployed HTTPS
-origin. The app fails closed when any sponsor, payment, origin, or Connect
-configuration is absent or malformed.
+`TEMPO_MPP_API_KEY` must have the `mpp:write` scope. The MACH policy settlement
+address is committed as `NANOCODEX_ASTRA_MACH_RECIPIENT`. Confirm that
+`NANOCODEX_CONNECT_APP_ORIGIN` exactly matches the deployed HTTPS origin. The
+app fails closed when any sponsor, payment, origin, or Connect configuration is
+absent or malformed.
 
 `Add $50 MACH` invokes Connect's existing MACH funding dialog for the connected
 account. The prompt submission itself uses MPP; its fee-payer transaction is

--- a/examples/astra-mpp-trial/wrangler.jsonc
+++ b/examples/astra-mpp-trial/wrangler.jsonc
@@ -23,7 +23,8 @@
     "NANOCODEX_CONNECT_APP_ID": "astra-one-shot",
     "NANOCODEX_CONNECT_APP_ORIGIN": "https://nanocodex-astra-mpp-trial.gakonst.workers.dev",
     "NANOCODEX_CONNECT_DIALOG_URL": "https://nanocodex.gakonst.workers.dev/connect-dialog/",
-    "NANOCODEX_MANAGED_URL": "https://nanocodex.gakonst.workers.dev"
+    "NANOCODEX_MANAGED_URL": "https://nanocodex.gakonst.workers.dev",
+    "NANOCODEX_ASTRA_MACH_RECIPIENT": "0xa295c42fbcc026a62304a7701f25b4c91799b0da"
   },
   "env": {
     "development": {


### PR DESCRIPTION
## Summary
- sync the standalone Astra trial runtime secrets from GitHub during production deploys
- bind the production MACH recipient to the existing settlement-policy address
- document the CI-managed production configuration and Tempo relay scope

## Verification
- `actionlint .github/workflows/cloudflare.yml`
- `npm run check` in `examples/astra-mpp-trial`