### PR TITLE
refactor(astra): remove catalog entitlement projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,9 @@ snapshots, see [`examples/lifecycle.rs`](examples/lifecycle.rs),
 
 Nanocodex supports OpenAI `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, and
 `gpt-6-astra`. Sol remains the SDK default. The managed `nanocodex2` terminal
-selects Astra directly for new conversations; the account app still uses its
-brokered model catalog when choosing a default. Astra requires at least low
+and account app select Astra directly for new conversations, as does the native
+CLI when using ChatGPT authentication. Native API-key and generic SDK defaults
+remain Sol; sponsored homepage sessions remain Luna. Astra requires at least low
 reasoning. Nanocodex owns the typed Responses WebSocket behavior for this closed
 model family. An API-key gateway may prefix the on-wire model identifier with
 `NANOCODEX_MODEL_ID_PREFIX`, but that does not create an alternate-provider or

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -369,7 +369,7 @@ impl AgentArgs {
         };
         let model = match self.model {
             Some(model) => model,
-            None => connected_account_default_model(&auth).await,
+            None => connected_account_default_model(auth.mode()),
         };
         let direct_websocket_url = direct_websocket_url(self.websocket_url, auth.mode());
         let mpp_adapter = self.mpp.start().await?;
@@ -695,95 +695,10 @@ fn direct_websocket_url(explicit: Option<String>, auth_mode: OpenAiAuthMode) -> 
     explicit.unwrap_or_else(|| auth_mode.default_websocket_url().to_owned())
 }
 
-async fn connected_account_default_model(auth: &OpenAiAuth) -> Model {
-    const MAX_CATALOG_BYTES: usize = 2 * 1024 * 1024;
-    if auth.mode() != OpenAiAuthMode::ChatGpt {
-        return Model::Sol;
-    }
-    let client = match reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::none())
-        .build()
-    {
-        Ok(client) => client,
-        Err(_) => return Model::Sol,
-    };
-    let mut snapshot = match auth.snapshot().await {
-        Ok(snapshot) => snapshot,
-        Err(_) => return Model::Sol,
-    };
-    for attempt in 0..2 {
-        let mut request = client
-            .get("https://chatgpt.com/backend-api/codex/models?client_version=0.5.0")
-            .bearer_auth(snapshot.bearer())
-            .header(
-                "chatgpt-account-id",
-                snapshot.account_id().unwrap_or_default(),
-            )
-            .header("originator", "codex_cli_rs")
-            .header("user-agent", "nanocodex/0.5.0");
-        if snapshot.is_fedramp() {
-            request = request.header("x-openai-fedramp", "true");
-        }
-        let Ok(mut response) = request.send().await else {
-            return Model::Sol;
-        };
-        if response.status() == reqwest::StatusCode::UNAUTHORIZED && attempt == 0 {
-            if auth.recover_unauthorized(&snapshot).await.is_err() {
-                return Model::Sol;
-            }
-            let Ok(refreshed) = auth.snapshot().await else {
-                return Model::Sol;
-            };
-            snapshot = refreshed;
-            continue;
-        }
-        if !response.status().is_success()
-            || response
-                .content_length()
-                .is_some_and(|length| length > u64::try_from(MAX_CATALOG_BYTES).unwrap_or(u64::MAX))
-        {
-            return Model::Sol;
-        }
-        let mut encoded = Vec::new();
-        loop {
-            match response.chunk().await {
-                Ok(Some(chunk))
-                    if encoded.len().saturating_add(chunk.len()) <= MAX_CATALOG_BYTES =>
-                {
-                    encoded.extend_from_slice(&chunk);
-                }
-                Ok(Some(_)) | Err(_) => return Model::Sol,
-                Ok(None) => break,
-            }
-        }
-        return account_catalog_default_model(&encoded);
-    }
-    Model::Sol
-}
-
-#[derive(serde::Deserialize)]
-struct AccountModelCatalog {
-    models: Vec<AccountModelAvailability>,
-}
-
-#[derive(serde::Deserialize)]
-struct AccountModelAvailability {
-    slug: String,
-    visibility: String,
-}
-
-fn account_catalog_default_model(encoded: &[u8]) -> Model {
-    let Ok(catalog) = serde_json::from_slice::<AccountModelCatalog>(encoded) else {
-        return Model::Sol;
-    };
-    if catalog
-        .models
-        .iter()
-        .any(|model| model.slug == Model::Astra.as_str() && model.visibility == "list")
-    {
-        Model::Astra
-    } else {
-        Model::Sol
+const fn connected_account_default_model(auth_mode: OpenAiAuthMode) -> Model {
+    match auth_mode {
+        OpenAiAuthMode::ChatGpt => Model::Astra,
+        OpenAiAuthMode::ApiKey => Model::Sol,
     }
 }
 
@@ -933,24 +848,19 @@ mod tests {
     use nanocodex::{Model, oai::auth::OpenAiAuthMode};
 
     #[test]
-    fn account_catalog_defaults_to_only_picker_visible_astra() {
+    fn default_model_follows_the_selected_auth_mode() {
         assert_eq!(
-            account_catalog_default_model(
-                br#"{"models":[{"slug":"gpt-6-astra","visibility":"list"}]}"#,
-            ),
+            connected_account_default_model(OpenAiAuthMode::ChatGpt),
             Model::Astra
         );
         assert_eq!(
-            account_catalog_default_model(
-                br#"{"models":[{"slug":"gpt-6-astra","visibility":"hide"}]}"#,
-            ),
+            connected_account_default_model(OpenAiAuthMode::ApiKey),
             Model::Sol
         );
-        assert_eq!(account_catalog_default_model(b"not-json"), Model::Sol);
     }
 
     use super::{
-        SUBAGENT_INSTRUCTIONS, account_catalog_default_model, direct_websocket_url, select_auth,
+        SUBAGENT_INSTRUCTIONS, connected_account_default_model, direct_websocket_url, select_auth,
         select_auth_with_default, selected_api_base_url, selected_subagent_tools,
         session_instructions,
     };

--- a/crates/nanocodex-managed/src/client.rs
+++ b/crates/nanocodex-managed/src/client.rs
@@ -13,9 +13,9 @@ use nanocodex_oai_api::{Model, ReasoningMode, Thinking};
 use crate::{
     AgentList, AgentReceipt, AgentSettings, AgentSettingsPatch, AgentSettingsResponse, AgentState,
     EventCursor, EventHistoryPage, FindSessionsRequest, FindSessionsResponse, ManagedApiKey,
-    ManagedError, ManagedEventStream, MemoryKey, MemoryListResponse, MemoryRecord,
-    ModelCapabilities, PromptInput, ReadSessionBody, ReadSessionRequest, ReadSessionResponse,
-    TurnAction, TurnSteer, TurnSubmission, TurnView,
+    ManagedError, ManagedEventStream, MemoryKey, MemoryListResponse, MemoryRecord, PromptInput,
+    ReadSessionBody, ReadSessionRequest, ReadSessionResponse, TurnAction, TurnSteer,
+    TurnSubmission, TurnView,
 };
 
 const MAX_HISTORY_PAGE: u16 = 256;
@@ -145,19 +145,6 @@ impl ManagedClient {
     pub async fn create(&self) -> Result<AgentReceipt, ManagedError> {
         let receipt = self.json(Method::POST, "v1/agents", None, None).await?;
         validate_agent_receipt(receipt)
-    }
-
-    /// Resolves the model availability advertised by the connected account.
-    ///
-    /// This is an authoritative, fail-closed server projection; provider
-    /// credentials and the raw remote model catalog never cross this boundary.
-    ///
-    /// # Errors
-    ///
-    /// Returns a transport, HTTP, size, or response-schema failure.
-    pub async fn model_capabilities(&self) -> Result<ModelCapabilities, ManagedError> {
-        self.json(Method::GET, "v1/model-capabilities", None, None)
-            .await
     }
 
     pub(crate) async fn create_with_settings(

--- a/crates/nanocodex-managed/src/types.rs
+++ b/crates/nanocodex-managed/src/types.rs
@@ -322,14 +322,6 @@ pub struct AgentSettings {
     pub fast_mode: bool,
 }
 
-/// Account-scoped model availability resolved by the managed credential broker.
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
-#[serde(deny_unknown_fields)]
-pub struct ModelCapabilities {
-    /// Whether the connected ChatGPT account exposes GPT-6 Astra in its picker catalog.
-    pub astra_entitled: bool,
-}
-
 impl Default for AgentSettings {
     fn default() -> Self {
         Self {

--- a/docs/GPT_6_ASTRA.md
+++ b/docs/GPT_6_ASTRA.md
@@ -1,10 +1,10 @@
 # GPT-6 Astra readiness
 
 Nanocodex recognizes the provider model ID `gpt-6-astra`. Callers can explicitly
-create Astra agents after their account is entitled. Brokered ChatGPT connections
-query the authenticated Codex model catalog and default new conversations to Astra
-only when the exact model is listed. Existing managed agents keep their retained
-settings, while API-key and sponsored Luna traffic retain their existing defaults.
+create Astra agents. New native ChatGPT, `nanocodex2`, and account-app conversations
+select Astra directly and treat an explicit provider rejection as the availability
+signal. Existing managed agents keep their retained settings, native API-key and
+generic SDK defaults remain Sol, and sponsored homepage sessions remain Luna.
 
 This support is based on OpenAI's current contracts:
 
@@ -31,7 +31,7 @@ This support is based on OpenAI's current contracts:
 | Knowledge cutoff | April 30, 2026; this is documentation only and does not affect request encoding. |
 | Base token rates | Estimates $10 input, $1 cached input, $12.50 cache write, and $50 output per million tokens. |
 | Long-context rates | For more than 272,000 input tokens, estimates 2x input/cache rates and 1.5x output rates for the whole request. |
-| Fast mode | Keeps the account-app Astra default off. Astra standard requests explicitly send `service_tier: "default"` so a project Fast default cannot change their accounting. Fast requests use Codex's accepted compatibility value `priority`; requested-tier cost estimates label Astra fast mode as `fast`, while GPT-5.6 retains `priority`. Deployments using EU data residency must not enable Astra fast mode. |
+| Fast mode | Keeps Astra fast mode off by default. Astra standard requests explicitly send `service_tier: "default"` so a project Fast default cannot change their accounting. Fast requests use Codex's accepted compatibility value `priority`; requested-tier cost estimates label Astra fast mode as `fast`, while GPT-5.6 retains `priority`. Deployments using EU data residency must not enable Astra fast mode. |
 
 OpenAI currently describes Astra as rolling out first through its Trusted Access
 Program, with API and Plus, Pro, Business, and Enterprise access following in the
@@ -209,10 +209,9 @@ provider steering protocol.
 
 ## Rollout and live evidence
 
-The managed `nanocodex2` terminal selects Astra directly for new conversations;
-an explicit provider rejection is its availability signal. The account app still
-uses the authenticated Codex model catalog to choose its default and fails closed
-when that projection is unavailable. The selector is available only before the
+The native CLI with ChatGPT authentication, managed `nanocodex2` terminal, and
+account app select Astra directly for new conversations; an explicit provider
+rejection is the availability signal. The selector is available only before the
 first accepted turn, while thinking and Fast remain live settings.
 
 Both native terminal clients expose the complete Sol, Terra, Luna, and Astra

--- a/js/account/src/AgentExperience.tsx
+++ b/js/account/src/AgentExperience.tsx
@@ -37,7 +37,6 @@ import "./Home.css";
 import { formatDollars } from "./walletFunding";
 import { useWalletFunding } from "./useWalletFunding";
 import { homeTerminalWelcome } from "./homeTerminalWelcome";
-import type { ManagedCreateSettings } from "nanocodex/managed";
 
 /** Ephemeral homepage consumer and managed-durable Agent demo. */
 export const AgentExperience = memo(function AgentExperience({
@@ -69,16 +68,6 @@ export const AgentExperience = memo(function AgentExperience({
   const [sponsoredExhausted, setSponsoredExhausted] = useState(false);
   const hasCredential = credentialSource === "brokered" || credentialSource === "sponsored";
   const hasDurableCredential = credentialSource === "brokered";
-  const managedCreateSettings = useMemo<ManagedCreateSettings | undefined>(() => (
-    authStatus?.state === "ready" && authStatus.astraEntitled
-      ? Object.freeze({
-          model: "gpt-6-astra",
-          thinking: "high",
-          reasoningMode: "standard",
-          fastMode: false,
-        })
-      : undefined
-  ), [authStatus]);
   const showHomepageSms = landing
     && account.status !== "checking"
     && account.account?.persistent !== true;
@@ -126,7 +115,6 @@ export const AgentExperience = memo(function AgentExperience({
       routeAgentId: agentId,
       retainedAgentId: safeGet(managedSelectionKey(accountId)) ?? undefined,
       hasCredential,
-      createSettings: managedCreateSettings,
       refresh,
     }).then((selection) => {
       if (cancelled) return;
@@ -149,7 +137,6 @@ export const AgentExperience = memo(function AgentExperience({
     agentId,
     hasDurableCredential,
     landing,
-    managedCreateSettings,
     managedAttempt,
     onAgentChange,
   ]);
@@ -190,7 +177,7 @@ export const AgentExperience = memo(function AgentExperience({
     if (conversationPending || !account.account) return;
     setConversationPending(true);
     setManagedError(undefined);
-    void createManagedConversation(account.account.id, managedCreateSettings).then((conversation) => {
+    void createManagedConversation(account.account.id).then((conversation) => {
       setManagedConversations((current) => [conversation, ...current]);
       setManagedConversationId(conversation.id);
       safeSet(managedSelectionKey(account.account!.id), conversation.id);
@@ -199,7 +186,7 @@ export const AgentExperience = memo(function AgentExperience({
       onAgentChange?.(conversation.id);
     }).catch((error) => setManagedError(errorMessage(error)))
       .finally(() => setConversationPending(false));
-  }, [account.account, conversationPending, managedCreateSettings, onAgentChange]);
+  }, [account.account, conversationPending, onAgentChange]);
   const retryManagedConversations = useCallback(() => {
     setManagedError(undefined);
     refreshManagedList.current = true;

--- a/js/account/src/AgentTerminal.tsx
+++ b/js/account/src/AgentTerminal.tsx
@@ -120,10 +120,10 @@ const BrowserAgentTerminal = memo(function BrowserAgentTerminal({
 }: AgentTerminalProps & {
   accountMcpConnections: readonly BrowserAccountMcpConnection[];
 }) {
-  const defaultSettings = terminalDefaultSettings(source, authStatus);
+  const defaultSettings = terminalDefaultSettings(source);
   const [settings, setSettings] = useState(defaultSettings);
   const [conversationStarted, setConversationStarted] = useState(false);
-  const settingsIdentity = `${threadId}:${source ?? "none"}:${authStatus?.state === "ready" && authStatus.astraEntitled}`;
+  const settingsIdentity = `${threadId}:${source ?? "none"}`;
   useEffect(() => {
     setSettings(defaultSettings);
     setConversationStarted(false);
@@ -138,14 +138,14 @@ const BrowserAgentTerminal = memo(function BrowserAgentTerminal({
         thinking: "none" as const,
         reasoningMode: "standard" as const,
         fastMode: false,
-      } : source === "brokered" && authStatus?.state === "ready" && authStatus.astraEntitled ? {
+      } : {
         model: "gpt-6-astra" as const,
         thinking: "high" as const,
         reasoningMode: "standard" as const,
         fastMode: false,
-      } : {}),
+      }),
     },
-  }), [accountMcpConnections, authStatus, source, threadId]);
+  }), [accountMcpConnections, source, threadId]);
   const {
     data: agent,
     error,
@@ -239,7 +239,7 @@ export const ManagedAgentTerminal = memo(function ManagedAgentTerminal({
   const managed = useMemo(() => openManagedAgent(agentId), [agentId]);
   const agent = useMemo(() => managedTerminalAgent(managed), [managed]);
   const [settings, setSettings] = useState<ManagedCreateSettings>(() => (
-    terminalDefaultSettings(source, authStatus)
+    terminalDefaultSettings(source)
   ));
   const [settingsReady, setSettingsReady] = useState(false);
   const [conversationStarted, setConversationStarted] = useState(true);
@@ -349,17 +349,12 @@ export const ManagedAgentTerminal = memo(function ManagedAgentTerminal({
   );
 });
 
-function terminalDefaultSettings(
-  source: CredentialSource | undefined,
-  authStatus: ModelSessionStatus | undefined,
-): ManagedCreateSettings {
+function terminalDefaultSettings(source: CredentialSource | undefined): ManagedCreateSettings {
   if (source === "sponsored") {
     return { model: "gpt-5.6-luna", thinking: "none", reasoningMode: "standard", fastMode: false };
   }
   return {
-    model: authStatus?.state === "ready" && authStatus.astraEntitled
-      ? "gpt-6-astra"
-      : "gpt-5.6-sol",
+    model: "gpt-6-astra",
     thinking: "high",
     reasoningMode: "standard",
     fastMode: false,

--- a/js/account/src/deploymentHealth.test.ts
+++ b/js/account/src/deploymentHealth.test.ts
@@ -13,7 +13,6 @@ test("projects sponsored homepage access without enabling voice", async () => {
 
   assert.deepEqual(health, {
     agentConfigured: true,
-    astraEntitled: false,
     credentialSource: "sponsored",
     deploymentSha: undefined,
     freePromptsRemaining: 3,
@@ -33,27 +32,9 @@ test("retains user-owned and brokered credential projections", async () => {
       voice_enabled: true,
     })).read();
     assert.equal(health.credentialSource, expected);
-    assert.equal(health.astraEntitled, false);
     assert.equal(health.freePromptsRemaining, null);
     assert.equal(health.voiceEnabled, true);
   }
-});
-
-test("projects Astra only for an entitled brokered account", async () => {
-  const entitled = await createDeploymentHealthResource(async () => Response.json({
-    agent_configured: true,
-    astra_entitled: true,
-    credential_source: "brokered",
-  })).read();
-  const sponsored = await createDeploymentHealthResource(async () => Response.json({
-    agent_configured: true,
-    astra_entitled: true,
-    credential_source: "sponsored",
-    free_prompts_remaining: 1,
-  })).read();
-
-  assert.equal(entitled.astraEntitled, true);
-  assert.equal(sponsored.astraEntitled, false);
 });
 
 test("fails closed for sponsored access without a valid remaining prompt count", async () => {
@@ -62,6 +43,5 @@ test("fails closed for sponsored access without a valid remaining prompt count",
     credential_source: "sponsored",
   })).read();
   assert.equal(health.agentConfigured, false);
-  assert.equal(health.astraEntitled, false);
   assert.equal(health.credentialSource, null);
 });

--- a/js/account/src/deploymentHealth.ts
+++ b/js/account/src/deploymentHealth.ts
@@ -2,7 +2,6 @@ export type DeploymentCredentialSource = "brokered" | "sponsored" | null;
 
 export type DeploymentHealth = Readonly<{
   agentConfigured: boolean;
-  astraEntitled: boolean;
   credentialSource: DeploymentCredentialSource;
   deploymentSha: string | undefined;
   freePromptsRemaining: number | null;
@@ -11,7 +10,6 @@ export type DeploymentHealth = Readonly<{
 
 type HealthPayload = {
   agent_configured?: unknown;
-  astra_entitled?: unknown;
   credential_source?: unknown;
   deployment_sha?: unknown;
   free_prompts_remaining?: unknown;
@@ -51,7 +49,6 @@ export function createDeploymentHealthResource(
             : payload.credential_source === "user" ? "brokered" : null;
       return Object.freeze({
         agentConfigured: credentialSource !== null,
-        astraEntitled: credentialSource === "brokered" && payload.astra_entitled === true,
         credentialSource,
         deploymentSha: typeof payload.deployment_sha === "string"
           ? payload.deployment_sha

--- a/js/account/src/managedAgentRuntime.test.ts
+++ b/js/account/src/managedAgentRuntime.test.ts
@@ -88,7 +88,7 @@ test("an exact agent route survives a successful list cached before another clie
   assert.deepEqual(exactCalls, [SECOND_AGENT_ID, FORBIDDEN_AGENT_ID]);
 });
 
-test("an entitled empty account creates its first durable conversation with Astra settings", async (t) => {
+test("an empty account creates its first durable conversation with Astra settings", async (t) => {
   const originalLocation = Object.getOwnPropertyDescriptor(globalThis, "location");
   const originalFetch = globalThis.fetch;
   Object.defineProperty(globalThis, "location", {
@@ -114,16 +114,9 @@ test("an entitled empty account creates its first durable conversation with Astr
     else Reflect.deleteProperty(globalThis, "location");
   });
 
-  const settings = {
-    model: "gpt-6-astra" as const,
-    thinking: "high" as const,
-    reasoningMode: "standard" as const,
-    fastMode: false,
-  };
   const selected = await loadManagedConversationSelection({
     accountId: "astra-empty-account",
     hasCredential: true,
-    createSettings: settings,
   });
 
   assert.equal(selected.selectedId, FIRST_AGENT_ID);

--- a/js/account/src/managedAgentRuntime.ts
+++ b/js/account/src/managedAgentRuntime.ts
@@ -13,6 +13,12 @@ const MANAGED_HISTORY_INITIAL_ATTEMPTS = 3;
 const MANAGED_HISTORY_ATTEMPT_TIMEOUT_MS = 10_000;
 const MANAGED_HISTORY_RETRY_INITIAL_MS = 1_000;
 const MANAGED_HISTORY_RETRY_MAX_MS = 30_000;
+const DEFAULT_MANAGED_CREATE_SETTINGS: ManagedCreateSettings = Object.freeze({
+  model: "gpt-6-astra",
+  thinking: "high",
+  reasoningMode: "standard",
+  fastMode: false,
+});
 export const MAX_MANAGED_RETAINED_ENVELOPES = MANAGED_HISTORY_PAGE_SIZE * 2;
 const managedAgents = new Map<string, ManagedAgent>();
 const managedLists = new Map<string, Promise<readonly ManagedConversation[]>>();
@@ -92,12 +98,12 @@ export async function loadManagedConversationSelection(options: Readonly<{
 
 export function createManagedConversation(
   accountId = "default",
-  settings?: ManagedCreateSettings,
+  settings: ManagedCreateSettings = DEFAULT_MANAGED_CREATE_SETTINGS,
 ): Promise<ManagedConversation> {
-  const creationKey = `${accountId}:${settings === undefined ? "default" : JSON.stringify(settings)}`;
+  const creationKey = `${accountId}:${JSON.stringify(settings)}`;
   const retained = managedCreates.get(creationKey);
   if (retained) return retained;
-  const creating = Agent.create(settings === undefined ? {} : { settings }).then((agent) => {
+  const creating = Agent.create({ settings }).then((agent) => {
     managedAgents.set(agent.id, agent);
     managedLists.delete(accountId);
     return Object.freeze({

--- a/js/account/src/modelSession.tsx
+++ b/js/account/src/modelSession.tsx
@@ -9,7 +9,7 @@ import { invalidateModelHealthForAccountTransition } from "./modelHealthAccount"
 export type CredentialSource = "brokered" | "sponsored" | null;
 export type ModelSessionStatus =
   | { state: "signed_out" }
-  | { state: "ready"; astraEntitled: boolean; freePromptsRemaining: number | null; ready: boolean; voiceEnabled: boolean }
+  | { state: "ready"; freePromptsRemaining: number | null; ready: boolean; voiceEnabled: boolean }
   | { state: "error"; error: string };
 
 export type SessionPresentation = {
@@ -164,7 +164,6 @@ export function useModelSession({
         if (generation.current !== current) return;
         publish({
           state: "ready",
-          astraEntitled: health.astraEntitled,
           freePromptsRemaining: health.freePromptsRemaining,
           ready: health.agentConfigured,
           voiceEnabled: health.voiceEnabled,

--- a/js/account/worker/index.ts
+++ b/js/account/worker/index.ts
@@ -180,7 +180,6 @@ export default {
         const model = await managedModelStatus(managed);
         return json({
           agent_configured: model.ready,
-          astra_entitled: model.astraEntitled,
           credential_source: model.source === "sponsored"
             ? "sponsored"
             : model.ready ? "brokered" : null,
@@ -205,7 +204,6 @@ export default {
       }
       return json({
         agent_configured: Boolean(credential),
-        astra_entitled: false,
         credential_source: credential?.source ?? null,
         voice_enabled: credential?.kind === "chatgpt",
         deployment_sha: GIT_SHA_PATTERN.test(env.DEPLOYMENT_SHA ?? "")

--- a/js/account/worker/managedModel.test.ts
+++ b/js/account/worker/managedModel.test.ts
@@ -13,12 +13,10 @@ test("preserves the sponsored source while disabling shared-account voice", asyn
     active: "chatgpt",
     free_prompts_remaining: 3,
     source: "sponsored",
-    astra_entitled: true,
   });
   const sponsored = await managedModelStatus(sponsoredAccess.access);
   assert.equal(sponsoredAccess.requestedUrl(), "https://broker.internal/.well-known/nanocodex/model-status");
   assert.deepEqual(sponsored, {
-    astraEntitled: false,
     freePromptsRemaining: 3,
     ready: true,
     source: "sponsored",
@@ -29,10 +27,8 @@ test("preserves the sponsored source while disabling shared-account voice", asyn
     ready: true,
     active: "chatgpt",
     source: "user",
-    astra_entitled: true,
   }).access);
   assert.deepEqual(user, {
-    astraEntitled: true,
     freePromptsRemaining: null,
     ready: true,
     source: "brokered",
@@ -46,7 +42,6 @@ test("fails closed when the credential source is absent or malformed", async () 
     { ready: true, active: "openai", source: "sponsored-owner-id" },
   ]) {
     assert.deepEqual(await managedModelStatus(access(value).access), {
-      astraEntitled: false,
       freePromptsRemaining: null,
       ready: false,
       source: null,

--- a/js/account/worker/managedModel.ts
+++ b/js/account/worker/managedModel.ts
@@ -9,7 +9,6 @@ export type ManagedModelAccess = Readonly<{
 }>;
 
 export type ManagedModelStatus = Readonly<{
-  astraEntitled: boolean;
   freePromptsRemaining: number | null;
   ready: boolean;
   source: "brokered" | "sponsored" | null;
@@ -69,11 +68,11 @@ export async function managedModelStatus(access: ManagedModelAccess): Promise<Ma
       || response.headers.get("cache-control") !== "no-store"
       || !response.headers.get("content-type")?.toLowerCase().startsWith("application/json")) {
       await response.body?.cancel();
-      return { astraEntitled: false, freePromptsRemaining: null, ready: false, source: null, voiceEnabled: false };
+      return { freePromptsRemaining: null, ready: false, source: null, voiceEnabled: false };
     }
     const encoded = await response.text();
     if (encoded.length > 1_024) {
-      return { astraEntitled: false, freePromptsRemaining: null, ready: false, source: null, voiceEnabled: false };
+      return { freePromptsRemaining: null, ready: false, source: null, voiceEnabled: false };
     }
     const value = JSON.parse(encoded) as Record<string, unknown>;
     const ready = value !== null
@@ -89,16 +88,13 @@ export async function managedModelStatus(access: ManagedModelAccess): Promise<Ma
       ? "sponsored"
       : ready && value.source === "user" ? "brokered" : null;
     return {
-      astraEntitled: source === "brokered"
-        && value.active === "chatgpt"
-        && value.astra_entitled === true,
       freePromptsRemaining: source === "sponsored" ? sponsoredRemaining : null,
       ready: source !== null,
       source,
       voiceEnabled: source === "brokered" && value.active === "chatgpt",
     };
   } catch {
-    return { astraEntitled: false, freePromptsRemaining: null, ready: false, source: null, voiceEnabled: false };
+    return { freePromptsRemaining: null, ready: false, source: null, voiceEnabled: false };
   }
 }
 

--- a/js/account/worker/managedProxy.test.ts
+++ b/js/account/worker/managedProxy.test.ts
@@ -29,8 +29,8 @@ test("the account Worker projects opaque sandbox preview capabilities", () => {
   assert.equal(isManagedRoutePath("/sandbox-preview/"), false);
 });
 
-test("the account Worker projects model capabilities through the managed service", () => {
-  assert.equal(isManagedRoutePath("/v1/model-capabilities"), true);
+test("the removed model capabilities route is not projected", () => {
+  assert.equal(isManagedRoutePath("/v1/model-capabilities"), false);
 });
 
 test("the account hand WebSocket stays on the managed service boundary", async () => {

--- a/js/account/worker/managedProxy.ts
+++ b/js/account/worker/managedProxy.ts
@@ -2,7 +2,7 @@ export type ManagedProxyEnv = {
   NANOCODEX_BACKEND?: Fetcher;
 };
 
-const MANAGED_ROUTE = /^(?:\/auth(?:\/.*)?|\/webauthn\/.*|\/sandbox-preview\/[^/]+(?:\/.*)?|\/v1\/(?:auth(?:\/.*)?|me|model-capabilities|account\/(?:tool-host|vm-host)|system\/vm-host|vm-host-attachments\/[A-Za-z0-9_-]{43}\/[0-9a-f-]{36}\/tool-host|wallet(?:\/(?:balance|connect|revoke-access-key))?|egress|api-keys(?:\/.*)?|credentials(?:\/.*)?|connect(?:\/.*)?|connectors(?:\/.*)?|agents(?:\/.*)?|rooms(?:\/.*)?|history(?:\/.*)?|memory(?:\/.*)?|organization(?:\/.*)?))$/;
+const MANAGED_ROUTE = /^(?:\/auth(?:\/.*)?|\/webauthn\/.*|\/sandbox-preview\/[^/]+(?:\/.*)?|\/v1\/(?:auth(?:\/.*)?|me|account\/(?:tool-host|vm-host)|system\/vm-host|vm-host-attachments\/[A-Za-z0-9_-]{43}\/[0-9a-f-]{36}\/tool-host|wallet(?:\/(?:balance|connect|revoke-access-key))?|egress|api-keys(?:\/.*)?|credentials(?:\/.*)?|connect(?:\/.*)?|connectors(?:\/.*)?|agents(?:\/.*)?|rooms(?:\/.*)?|history(?:\/.*)?|memory(?:\/.*)?|organization(?:\/.*)?))$/;
 
 export function isManagedRoutePath(pathname: string): boolean {
   return MANAGED_ROUTE.test(pathname);

--- a/js/egress/src/egress.ts
+++ b/js/egress/src/egress.ts
@@ -61,7 +61,6 @@ const MAX_CHATGPT_IMPORT_BODY_BYTES = 64 * 1024;
 const MAX_VAULT_BODY_BYTES = 12 * 1024;
 const MAX_BROKER_RESPONSE_BYTES = 4 * 1024;
 const MAX_MODEL_BODY_BYTES = 32 * 1024 * 1024;
-const MAX_MODEL_CATALOG_BYTES = 2 * 1024 * 1024;
 const MAX_SSH_BODY_BYTES = 72 * 1024;
 const MAX_VAULT_EGRESS_ENVELOPE_BYTES = 96 * 1024;
 const MAX_VAULT_EGRESS_TARGET_BYTES = 8 * 1024;
@@ -94,7 +93,6 @@ const VAULT_PROVIDER_HOSTS = new Set([
 const RELAY_CAPABILITY_PATH = /^\/v1\/[A-Za-z0-9_-]{43,}$/;
 const RELAY_HTTP_ROUTES: Readonly<Record<ModelOperation["id"], string | undefined>> = {
   responses: undefined,
-  models: undefined,
   search: "codex-web-search",
   "image-generation": "codex-image-generation",
   "image-edit": "codex-image-edit",
@@ -220,7 +218,7 @@ export class ChiefOfStaffEgress extends WorkerEntrypoint<EgressEnv> {
 }
 
 type ModelOperation = Readonly<{
-  id: "responses" | "models" | "search" | "image-generation" | "image-edit"
+  id: "responses" | "search" | "image-generation" | "image-edit"
     | "realtime-call" | "realtime-sideband";
   method: "GET" | "POST";
   path: `/v1/${string}`;
@@ -284,16 +282,6 @@ const OPERATIONS: readonly ModelOperation[] = [
     directChatGpt: true,
   },
 ];
-
-const MODELS_OPERATION: ModelOperation = Object.freeze({
-  id: "models",
-  method: "GET",
-  path: "/v1/models",
-  websocket: false,
-  openai: "https://api.openai.com/v1/models",
-  chatgpt: "https://chatgpt.com/backend-api/codex/models?client_version=0.5.0",
-  chatGptOnly: true,
-});
 
 export default {
   fetch(request: Request, env: EgressEnv, ctx: ExecutionContext): Promise<Response> {
@@ -2021,76 +2009,15 @@ async function handleModelStatus(request: Request, env: EgressEnv): Promise<Resp
     const sponsoredPrompts = credential.source === "sponsored"
       ? await sponsoredPromptStatus(env, userId)
       : undefined;
-    const astraEntitled = credential.source === "user" && credential.kind === "chatgpt"
-      ? await accountHasVisibleAstra(env, userId, credential)
-      : false;
     return json({
       ready: true,
       active: credential.kind,
       source: credential.source,
-      astra_entitled: astraEntitled,
       ...(sponsoredPrompts
         ? { free_prompts_remaining: sponsoredPrompts.remaining }
         : {}),
     }, 200);
   } catch { return jsonError(503, "broker_not_ready"); }
-}
-
-async function accountHasVisibleAstra(
-  env: EgressEnv,
-  userId: string,
-  initial: ResolvedModelCredential,
-): Promise<boolean> {
-  let credential = initial;
-  for (let attempt = 0; attempt < 2; attempt += 1) {
-    try {
-      const request = buildUpstreamRequest(
-        new Request("https://nanocodex.internal/v1/models", {
-          headers: { "user-agent": "nanocodex/0.5.0" },
-        }),
-        env,
-        MODELS_OPERATION,
-        credential,
-        null,
-      );
-      const response = await fetchUpstream(
-        env,
-        userId,
-        credential,
-        MODELS_OPERATION,
-        request,
-        fetch,
-      );
-      if (response.status === 401 && attempt === 0) {
-        await cancelResponseBody(response);
-        const refreshed = await resolveCredential(env, userId, true, credential.revision);
-        if (refreshed.kind !== "chatgpt" || refreshed.source !== "user") return false;
-        credential = refreshed;
-        continue;
-      }
-      if (!response.ok || REDIRECT_STATUS.has(response.status)) {
-        await cancelResponseBody(response);
-        return false;
-      }
-      const encoded = await readBoundedText(response, MAX_MODEL_CATALOG_BYTES);
-      return catalogHasVisibleAstra(JSON.parse(encoded));
-    } catch {
-      return false;
-    }
-  }
-  return false;
-}
-
-export function catalogHasVisibleAstra(value: unknown): boolean {
-  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
-  const models = (value as { models?: unknown }).models;
-  return Array.isArray(models) && models.some((model) => (
-    model !== null
-    && typeof model === "object"
-    && !Array.isArray(model)
-    && (model as { slug?: unknown }).slug === "gpt-6-astra"
-    && (model as { visibility?: unknown }).visibility === "list"
-  ));
 }
 
 async function handleSponsoredTrialReset(request: Request, env: EgressEnv): Promise<Response> {

--- a/js/egress/test/sponsored-homepage.test.ts
+++ b/js/egress/test/sponsored-homepage.test.ts
@@ -4,7 +4,6 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 
 import {
   handleEgress,
-  catalogHasVisibleAstra,
   isLegacyLocalBootstrapCredential,
   sponsoredResponsesFrame,
   type EgressEnv,
@@ -54,18 +53,6 @@ beforeAll(async () => {
 });
 
 describe("sponsored homepage model access", () => {
-  it("treats only picker-visible Astra as entitlement", () => {
-    expect(catalogHasVisibleAstra({
-      models: [{ slug: "gpt-6-astra", visibility: "list" }],
-    })).toBe(true);
-    expect(catalogHasVisibleAstra({
-      models: [{ slug: "gpt-6-astra", visibility: "hide" }],
-    })).toBe(false);
-    expect(catalogHasVisibleAstra({ models: [{ slug: "gpt-5.6-sol", visibility: "list" }] }))
-      .toBe(false);
-    expect(catalogHasVisibleAstra({ models: "not-an-array" })).toBe(false);
-  });
-
   it("treats only an unmarked local bootstrap account as a legacy auto-claim", () => {
     const legacy = {
       kind: "chatgpt" as const,
@@ -108,7 +95,6 @@ describe("sponsored homepage model access", () => {
       ready: true,
       active: "chatgpt",
       source: "sponsored",
-      astra_entitled: false,
       free_prompts_remaining: 3,
     });
 
@@ -636,7 +622,6 @@ describe("sponsored homepage model access", () => {
         ready: true,
         active: "openai",
         source: "user",
-        astra_entitled: false,
       });
     }
   });

--- a/js/managed/src/index.ts
+++ b/js/managed/src/index.ts
@@ -186,7 +186,6 @@ import {
 import { initializeManagedAgentSettingsSchema } from "./agent-settings-schema";
 import {
   bindAgentCredential,
-  browserModelSubject,
   routeCredentialRequest,
   unbindAgentCredential,
 } from "./credentials";
@@ -1258,33 +1257,6 @@ async function managedFetch(
     }
     if (request.method === "GET" && url.pathname === "/health") {
       return json({ service: "nanocodex", runtime: "cloudflare-durable-objects", status: "ok" });
-    }
-    if (request.method === "GET" && url.pathname === "/v1/model-capabilities") {
-      if (url.search !== "") return json({ error: "invalid_request" }, { status: 400 });
-      const principal = trustedAgentPrincipal ?? await authenticate(request, env, url);
-      if (!principal) return json({ error: "unauthorized" }, { status: 401 });
-      if (!principal.capabilities.includes("agents:read")) {
-        return json({ error: "forbidden" }, { status: 403 });
-      }
-      if (principal.connectGrant
-        && !principal.connectGrant.connectors.includes("chatgpt")) {
-        return json({ error: "connector_forbidden" }, { status: 403 });
-      }
-      try {
-        const subject = await browserModelSubject(principal.userId);
-        await bindAgentCredential(env.NANOCODEX, subject, principal.userId);
-        const response = await env.NANOCODEX.fetch(
-          "https://broker.internal/.well-known/nanocodex/model-status",
-          { headers: { "x-nanocodex-subject": subject } },
-        );
-        const value = response.ok
-          ? await response.json<{ astra_entitled?: unknown }>()
-          : undefined;
-        await response.body?.cancel().catch(() => {});
-        return json({ astra_entitled: value?.astra_entitled === true });
-      } catch {
-        return json({ astra_entitled: false });
-      }
     }
     const leasedVmHost = url.pathname.match(
       /^\/v1\/vm-host-attachments\/([A-Za-z0-9_-]{43})\/([0-9a-f-]{36})\/tool-host$/,


### PR DESCRIPTION
Removes the catalog-derived Astra entitlement API and status projection across Rust, managed Workers, egress, and the account app. New ChatGPT/account-app conversations select Astra directly and rely on explicit provider rejection; generic SDK and native API-key defaults remain Sol, while sponsored sessions remain Luna.\n\nValidated with Rust managed/native tests, egress 16/16, account 74/74, managed 302/302, dependency-aware typechecks, production app/Worker builds, and the egress broker dry run.