### PR TITLE
fix(connect): unblock SMS wallet provisioning

### DIFF
--- a/examples/astra-mpp-trial/README.md
+++ b/examples/astra-mpp-trial/README.md
@@ -13,13 +13,13 @@ rate limits remain owned by Nanocodex Connect rather than a parallel Twilio
 identity system in this app.
 
 The payment route is an MPP `tempo/charge` endpoint. Production challenges ask
-for 50 MACH, require the paying address to match the connected Nanocodex account,
+for 0.1 MACH, require the paying address to match the connected Nanocodex account,
 accept pull mode only, and request fee sponsorship from the Tempo relay. The
 development environment issues a zero-value proof challenge: the same wallet
 must sign, but no token transfer occurs.
 
 Connect registers the production app ID and origin as one high-value OAuth
-client. Its delegated key is limited to 50 MACH per day and one
+client. Its delegated key is limited to 0.1 MACH per day and one
 `transferWithMemo` scope whose sole recipient is displayed in the consent UI.
 That grant cannot use Connect's generic MPP route. Every other Connect client
 keeps the existing 0.25-MACH request and 10-MACH daily policy. Local proof mode
@@ -81,7 +81,7 @@ address is committed as `NANOCODEX_ASTRA_MACH_RECIPIENT`. Confirm that
 app fails closed when any sponsor, payment, origin, or Connect configuration is
 absent or malformed.
 
-`Add $50 MACH` invokes Connect's existing MACH funding dialog for the connected
-account. The prompt submission itself uses MPP; its fee-payer transaction is
-relayed server-side and the MPP receipt reference is retained with the one-shot
-state.
+`Add $5 MACH` invokes Connect's existing MACH funding dialog at its minimum
+funding amount for the connected account. The prompt itself costs 0.1 MACH and
+uses MPP; its fee-payer transaction is relayed server-side and the MPP receipt
+reference is retained with the one-shot state.

--- a/examples/astra-mpp-trial/public/index.html
+++ b/examples/astra-mpp-trial/public/index.html
@@ -57,7 +57,7 @@
               <span class="payment-label">Unlock price</span>
               <strong id="payment">Loading policy…</strong>
             </div>
-            <button class="secondary" id="fund" type="button">Add $50 MACH</button>
+            <button class="secondary" id="fund" type="button">Add $5 MACH</button>
           </div>
           <button class="primary" id="submit" type="submit">Pay &amp; ask Astra</button>
         </form>

--- a/examples/astra-mpp-trial/src/client.ts
+++ b/examples/astra-mpp-trial/src/client.ts
@@ -5,7 +5,7 @@ import { tempo as tempoChain } from "viem/chains";
 import { MACH, TEMPO_CHAIN_ID, TIP20_CHANNEL_ESCROW, USDC_E } from "./policy";
 
 type AppConfiguration = Readonly<{
-  amount: "0" | "50";
+  amount: "0" | "0.1";
   chain_id: number;
   connect: Readonly<{
     api_url: string;
@@ -34,7 +34,7 @@ const CONNECT_RESOURCES = [
 ] as const;
 const MERCATOR_SETTLEMENT = "0xa295c42fbcc026a62304a7701f25b4c91799b0da" as const;
 const DEFAULT_ACCESS_KEY_LIMIT = 10_000_000n;
-const ASTRA_ACCESS_KEY_LIMIT = 50_000_000n;
+const ASTRA_ACCESS_KEY_LIMIT = 100_000n;
 const ACCESS_KEY_PERIOD = 86_400;
 
 const elements = {
@@ -71,7 +71,7 @@ async function initialize(): Promise<void> {
 
   elements.payment.textContent = configuration.amount === "0"
     ? "Local proof mode: your wallet signs, but no MACH moves."
-    : "$50 in MACH · one prompt · gas sponsored";
+    : "$0.10 in MACH · one prompt · gas sponsored";
   elements.connect.addEventListener("click", () => void connectAccount(storage));
   elements.logout.addEventListener("click", () => void disconnectAccount());
   elements.fund.addEventListener("click", () => void fundAccount());
@@ -124,7 +124,7 @@ function createAppClient(
 }
 
 function accessKeyPolicy(app: AppConfiguration) {
-  if (app.amount === "50") {
+  if (app.amount === "0.1") {
     if (!app.payment_enabled || !app.recipient) {
       throw new Error("The Astra trial payment recipient is not configured.");
     }
@@ -215,12 +215,12 @@ async function disconnectAccount(): Promise<void> {
 
 async function fundAccount(): Promise<void> {
   if (!connection || busy) return;
-  setBusy(true, "Opening the $50 MACH onramp…");
+  setBusy(true, "Opening the $5 MACH onramp…");
   try {
     await client.machineUsd.fund({
       accountAddress: connection.accountAddress,
       grantId: connection.grant.id,
-      usdAmountCents: 5_000,
+      usdAmountCents: 500,
     });
     elements.status.textContent = "MACH funded. Your one Astra prompt is ready.";
   } catch (error) {
@@ -240,7 +240,7 @@ async function submitPrompt(event: SubmitEvent): Promise<void> {
     showError(new Error("The trial payment or sponsor account is not configured."));
     return;
   }
-  setBusy(true, configuration.amount === "0" ? "Requesting wallet proof…" : "Authorizing 50 MACH…");
+  setBusy(true, configuration.amount === "0" ? "Requesting wallet proof…" : "Authorizing 0.1 MACH…");
   const requestKey = crypto.randomUUID();
   try {
     let response: Response;

--- a/examples/astra-mpp-trial/src/payment.ts
+++ b/examples/astra-mpp-trial/src/payment.ts
@@ -3,7 +3,7 @@ import { Mppx, Store, tempo } from "mppx/server";
 import { MACH, TEMPO_CHAIN_ID } from "./policy";
 
 export type PaymentConfiguration = Readonly<{
-  amount: "0" | "50";
+  amount: "0" | "0.1";
   recipient: `0x${string}`;
   secret: string;
   tempoApiKey?: string;

--- a/examples/astra-mpp-trial/src/policy.ts
+++ b/examples/astra-mpp-trial/src/policy.ts
@@ -30,9 +30,9 @@ export type TrialState = Readonly<{
   updatedAt: number;
 }>;
 
-export function paymentAmount(environment: string | undefined): "0" | "50" {
+export function paymentAmount(environment: string | undefined): "0" | "0.1" {
   const value = environment?.trim().toLowerCase();
-  return value === "development" || value === "local" || value === "test" ? "0" : "50";
+  return value === "development" || value === "local" || value === "test" ? "0" : "0.1";
 }
 
 export function reservePrompt(

--- a/examples/astra-mpp-trial/test/policy.test.ts
+++ b/examples/astra-mpp-trial/test/policy.test.ts
@@ -22,8 +22,8 @@ test("charges only a wallet proof outside production", () => {
   assert.equal(paymentAmount("development"), "0");
   assert.equal(paymentAmount("LOCAL"), "0");
   assert.equal(paymentAmount("test"), "0");
-  assert.equal(paymentAmount("production"), "50");
-  assert.equal(paymentAmount(undefined), "50");
+  assert.equal(paymentAmount("production"), "0.1");
+  assert.equal(paymentAmount(undefined), "0.1");
 });
 
 test("reserves one exact prompt and rejects every different claim", () => {

--- a/js/connect-api/src/astraTrialPolicy.mts
+++ b/js/connect-api/src/astraTrialPolicy.mts
@@ -1,6 +1,6 @@
 export const astraTrialAppId = "astra-one-shot";
 export const astraTrialAppOrigin = "https://nanocodex-astra-mpp-trial.gakonst.workers.dev";
-export const astraTrialMppLimit = 50_000_000n;
+export const astraTrialMppLimit = 100_000n;
 
 export function hasConsistentAstraTrialIdentity(appId: unknown, origin: unknown): boolean {
   const claimsIdentity = appId === astraTrialAppId || origin === astraTrialAppOrigin;

--- a/js/connect-api/test/astraTrialPolicy.test.mjs
+++ b/js/connect-api/test/astraTrialPolicy.test.mjs
@@ -22,7 +22,7 @@ function policy() {
 test("pins the registered Astra trial identity and one-shot amount", () => {
   assert.equal(astraTrialAppId, "astra-one-shot");
   assert.equal(astraTrialAppOrigin, "https://nanocodex-astra-mpp-trial.gakonst.workers.dev");
-  assert.equal(astraTrialMppLimit, 50_000_000n);
+  assert.equal(astraTrialMppLimit, 100_000n);
   assert.equal(hasConsistentAstraTrialIdentity(astraTrialAppId, astraTrialAppOrigin), true);
   assert.equal(hasConsistentAstraTrialIdentity("another-app", "https://another.example"), true);
   assert.equal(hasConsistentAstraTrialIdentity(astraTrialAppId, "https://another.example"), false);

--- a/js/connect-dialog/test/connectPolicy.test.mjs
+++ b/js/connect-dialog/test/connectPolicy.test.mjs
@@ -244,24 +244,24 @@ test("production Connect policy pins the API and registered embedding app", () =
   });
 });
 
-test("Astra consent exposes its exact 50 MACH recipient-bound authority", () => {
+test("Astra consent exposes its exact 0.1 MACH recipient-bound authority", () => {
   const token = "0x20c000000000000000000000f37de3740adec032";
   const recipient = "0x1234567890abcdef1234567890abcdef12345678";
-  assert.deepEqual(mppConsentDetails("astra-one-shot", token, 50_000_000n, [{
+  assert.deepEqual(mppConsentDetails("astra-one-shot", token, 100_000n, [{
     address: token,
     selector: "0x95777d59",
     recipients: [recipient],
-  }]), { maxPerRequest: 50_000_000n, recipient });
+  }]), { maxPerRequest: 100_000n, recipient });
   assert.deepEqual(mppConsentDetails("another-app", token, 10_000_000n, [{
     address: token,
     selector: "0x95777d59",
     recipients: [recipient],
   }]), { maxPerRequest: 250_000n, recipient });
-  assert.deepEqual(mppConsentDetails("astra-one-shot", token, 50_000_000n, [{
+  assert.deepEqual(mppConsentDetails("astra-one-shot", token, 100_000n, [{
     address: token,
     selector: "0xa9059cbb",
     recipients: [recipient],
-  }]), { maxPerRequest: 50_000_000n });
+  }]), { maxPerRequest: 100_000n });
 });
 
 test("only top-level popup dialogs admit unknown secure app origins", () => {

--- a/js/egress/src/broker.ts
+++ b/js/egress/src/broker.ts
@@ -1,7 +1,7 @@
 import { DurableObject } from "cloudflare:workers";
 import { Provider, ProviderRequest, secp256k1, Storage } from "accounts";
 import { http } from "viem";
-import { Actions } from "viem/tempo";
+import { Account as TempoAccount, Actions } from "viem/tempo";
 import { tempo } from "viem/tempo/chains";
 
 import {
@@ -1616,13 +1616,8 @@ async function createRootWallet(): Promise<RootWallet> {
   for (let attempt = 0; attempt < 8; attempt += 1) {
     const privateKey = randomRootPrivateKey();
     try {
-      const provider = rootWalletProvider({ privateKey, address: "0x0000000000000000000000000000000000000000", createdAt: Date.now() });
-      const result = await provider.request({
-        method: "wallet_connect",
-        params: [{ chainId: TEMPO_CHAIN_ID, capabilities: { method: "login" } }],
-      } as never) as { accounts?: readonly { address?: unknown }[] };
-      const address = result.accounts?.[0]?.address;
-      if (typeof address === "string" && ROOT_WALLET_ADDRESS.test(address)) {
+      const address = TempoAccount.fromSecp256k1(privateKey).address;
+      if (ROOT_WALLET_ADDRESS.test(address)) {
         return {
           privateKey,
           address: address.toLowerCase() as `0x${string}`,

--- a/js/managed/src/account-auth.ts
+++ b/js/managed/src/account-auth.ts
@@ -23,6 +23,7 @@ const OTP_RESEND_SECONDS = 60;
 const OTP_PHONE_REQUESTS_PER_HOUR = 5;
 const OTP_IP_REQUESTS_PER_HOUR = 20;
 const OTP_PROVIDER_TIMEOUT_MS = 10_000;
+const ACCOUNT_PROVISION_TIMEOUT_MS = 10_000;
 const MAX_WALLET_MUTATION_BODY_BYTES = 16 * 1024;
 const USER_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
@@ -618,10 +619,12 @@ async function verifySmsOtp(
   if (!isSmsIdentity(identity)) {
     return json({ error: "sms_identity_unavailable" }, { status: 503 });
   }
-  await ensureAccount(env, identity.userId, true);
   let wallet: AccountWalletMetadata;
   try {
-    wallet = await ensureAccountWallet(env, identity.userId);
+    [wallet] = await Promise.all([
+      ensureAccountWallet(env, identity.userId),
+      ensureAccount(env, identity.userId, true),
+    ]);
   } catch {
     await store.set(`challenge:${challengeId}`, challenge, {
       ttl: Math.max(1, challenge.expiresAt - now),
@@ -1254,26 +1257,34 @@ export async function ensureAccount(
   env: AccountAuthEnv,
   userId: string,
   persistent: boolean,
+  timeoutMs = ACCOUNT_PROVISION_TIMEOUT_MS,
 ): Promise<void> {
   if (!isUserId(userId)) {
     throw new Error("invalid account identity");
   }
-  const response = await env.NANOCODEX_USERS.getByName(userId).fetch(
+  const accountStub = env.NANOCODEX_USERS.getByName(userId);
+  const status = await fetchResponseWithDeadline(
+    accountStub,
     "https://user.internal/account",
     {
       method: "PUT",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ id: userId, persistent }),
     },
+    timeoutMs,
+    "account provisioning",
+    (response) => response.status,
   );
-  if (response.ok) {
-    await response.body?.cancel();
-    return;
-  }
-  const status = response.status;
-  await response.body?.cancel();
+  if (status >= 200 && status < 300) return;
   if (status === 409) {
-    const current = await readAccount(env, userId);
+    const current = await fetchResponseWithDeadline(
+      accountStub,
+      "https://user.internal/account",
+      {},
+      timeoutMs,
+      "account provisioning verification",
+      (response) => response.ok ? response.json<UserRecord>() : undefined,
+    );
     if (current?.id === userId && (current.persistent || !persistent)) return;
   }
   throw new Error("account provisioning failed");
@@ -1283,24 +1294,26 @@ export async function ensureAccount(
 export async function ensureAccountWallet(
   env: AccountAuthEnv,
   userId: string,
+  timeoutMs = ACCOUNT_PROVISION_TIMEOUT_MS,
 ): Promise<AccountWalletMetadata> {
   if (!isUserId(userId) || !env.NANOCODEX) throw new Error("wallet unavailable");
-  let response: Response;
   try {
-    response = await env.NANOCODEX.fetch(
+    return await fetchResponseWithDeadline(
+      env.NANOCODEX,
       `https://broker.internal/users/${encodeURIComponent(userId)}/wallet`,
       { method: "PUT" },
+      timeoutMs,
+      "account wallet provisioning",
+      async (response) => {
+        if (!response.ok) throw new Error("wallet unavailable");
+        const metadata = await response.json<unknown>().catch(() => undefined);
+        if (!isAccountWalletMetadata(metadata)) throw new Error("wallet unavailable");
+        return metadata;
+      },
     );
   } catch {
     throw new Error("wallet unavailable");
   }
-  if (!response.ok) {
-    await response.body?.cancel().catch(() => {});
-    throw new Error("wallet unavailable");
-  }
-  const metadata = await response.json<unknown>().catch(() => undefined);
-  if (!isAccountWalletMetadata(metadata)) throw new Error("wallet unavailable");
-  return metadata;
 }
 
 async function readAccountWallet(

--- a/js/managed/test/account-auth.test.ts
+++ b/js/managed/test/account-auth.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   authenticate,
   ensureAccount,
+  ensureAccountWallet,
   resolveChiefOfStaffPrincipal,
   routeAccountRequest,
   type AccountAuthEnv,
@@ -467,6 +468,15 @@ describe("SMS OTP authentication", () => {
 });
 
 describe("managed wallet bridge", () => {
+  it("bounds broker wallet provisioning so OTP verification cannot hang forever", async () => {
+    const local = portableEnv();
+    local.env.NANOCODEX = {
+      fetch: () => new Promise<Response>(() => {}),
+    } as unknown as Fetcher;
+
+    await expect(ensureAccountWallet(local.env, USER_ID, 1)).rejects.toThrow("wallet unavailable");
+  });
+
   it("includes the broker wallet address in OTP success and leaves a failed wallet provision retryable", async () => {
     const local = portableEnv();
     local.env.NANOCODEX_OTP_HMAC_KEY = "test-sms-otp-hmac-key-with-at-least-thirty-two-bytes";

--- a/js/nanocodex-connect-ui/src/AccountChooser.tsx
+++ b/js/nanocodex-connect-ui/src/AccountChooser.tsx
@@ -1,6 +1,8 @@
 import { useId, useState, type ReactNode } from "react";
 import { normalizeSmsPhone } from "./smsPhone.js";
 
+const OTP_REQUEST_TIMEOUT_MS = 25_000;
+
 export type StoredPasskey = Readonly<{
   address: `0x${string}`;
   credentialId: string;
@@ -74,6 +76,7 @@ export function AccountChooser({
         credentials: "include",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ phone: normalized }),
+        signal: AbortSignal.timeout(OTP_REQUEST_TIMEOUT_MS),
       });
       const body: unknown = await response.json().catch(() => undefined);
       if (!response.ok) throw new Error(otpError(body, "Couldn’t send the code."));
@@ -113,6 +116,7 @@ export function AccountChooser({
           code,
           phone: challenge.phone,
         }),
+        signal: AbortSignal.timeout(OTP_REQUEST_TIMEOUT_MS),
       });
       const body: unknown = await response.json().catch(() => undefined);
       if (!response.ok) throw new Error(otpError(body, "That code didn’t work."));
@@ -275,6 +279,9 @@ function otpError(value: unknown, fallback: string): string {
 }
 
 function errorMessage(value: unknown): string {
+  if (value instanceof DOMException && (value.name === "TimeoutError" || value.name === "AbortError")) {
+    return "The account service took too long to respond. Try again.";
+  }
   return value instanceof Error ? value.message : "The account service is unavailable.";
 }
 


### PR DESCRIPTION
## Summary
- derive managed Tempo wallet addresses locally and bound account/wallet provisioning
- time out stalled SMS requests in the shared Connect UI with a retryable error
- lower the isolated Astra one-shot demo charge and delegated MACH limit to 0.1 MACH

## Verification
- managed service: 303 tests, typecheck, and Worker/container dry-run
- egress wallet tests and Worker dry-run
- Connect UI, API, dialog, and playground builds/tests
- account app: 74 tests and typecheck
- Astra demo: typecheck, 9 tests, client build, and Worker dry-run