### PR TITLE
feat(hands): watch live desktop and phone screens during agent tool use

### DIFF
--- a/bin/nanocodex/src/nanocodex2/main.rs
+++ b/bin/nanocodex/src/nanocodex2/main.rs
@@ -74,7 +74,7 @@ struct Cli {
 enum Command {
     /// Attach this machine's workspace to an existing managed agent.
     Attach(Attach),
-    /// Register one retained libkrun VM as a compute hand for the account.
+    /// Register a VM, desktop, or Android hand for the account.
     Hand(Hand),
     /// Serve a bounded pool of on-demand libkrun VM hands.
     Host(Host),
@@ -122,8 +122,26 @@ struct Hand {
     observability: HandObservabilityArgs,
 
     /// Writable raw ext4 image or development directory used as the retained VM root.
-    #[arg(long = "vm", visible_alias = "vm-rootfs", value_name = "ROOTFS")]
-    rootfs: PathBuf,
+    #[arg(
+        long = "vm",
+        visible_alias = "vm-rootfs",
+        value_name = "ROOTFS",
+        required_unless_present = "screen",
+        conflicts_with = "screen"
+    )]
+    rootfs: Option<PathBuf>,
+
+    /// Share the local desktop or one Android screen alongside local workspace tools.
+    #[arg(long, value_enum, conflicts_with = "rootfs")]
+    screen: Option<ScreenSource>,
+
+    /// Exact adb device serial for --screen android.
+    #[arg(long, required_if_eq("screen", "android"), requires = "screen")]
+    device: Option<String>,
+
+    /// Local tool workspace for a screen hand (defaults to configured workspace).
+    #[arg(long = "workspace", requires = "screen")]
+    local_workspace: Option<PathBuf>,
 
     /// Statically linked Linux guest executable used with a raw ext4 root.
     #[arg(long, value_name = "ELF", env = "NANOCODEX_VM_GUEST_RUNTIME")]
@@ -158,12 +176,28 @@ struct Hand {
     vm_no_network: bool,
 
     /// Stable account-local machine identifier.
-    #[arg(long, default_value = "vm")]
+    #[arg(
+        long,
+        default_value = "vm",
+        default_value_if("screen", "desktop", "desktop"),
+        default_value_if("screen", "android", "android")
+    )]
     machine_id: String,
 
     /// Human-readable name shown in accountInfo().machines.
-    #[arg(long, default_value = "Nanocodex VM")]
+    #[arg(
+        long,
+        default_value = "Nanocodex VM",
+        default_value_if("screen", "desktop", "Desktop"),
+        default_value_if("screen", "android", "Android")
+    )]
     machine_name: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum ScreenSource {
+    Desktop,
+    Android,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
@@ -414,7 +448,11 @@ async fn run(cli: Cli) -> Result<(), ManagedError> {
 }
 
 async fn launch_vm_hand(command: &Hand) -> Result<vm_hand::VmHand, ManagedError> {
-    let (root_kind, root_bytes) = match std::fs::metadata(&command.rootfs) {
+    let rootfs = command
+        .rootfs
+        .as_ref()
+        .ok_or_else(|| ManagedError::Configuration("VM root is required".into()))?;
+    let (root_kind, root_bytes) = match std::fs::metadata(rootfs) {
         Ok(metadata) if metadata.is_file() => ("file", metadata.len()),
         Ok(metadata) if metadata.is_dir() => ("directory", 0),
         Ok(_) => ("other", 0),
@@ -473,6 +511,9 @@ async fn launch_vm_hand(command: &Hand) -> Result<vm_hand::VmHand, ManagedError>
 }
 
 async fn serve_vm_hand(client: &ManagedClient, command: Hand) -> Result<(), ManagedError> {
+    if command.screen.is_some() {
+        return serve_screen_hand(client, command).await;
+    }
     let target = client.account_attachment_target()?;
     let hand = launch_vm_hand(&command).await?;
     drop(command);
@@ -517,6 +558,72 @@ async fn serve_vm_hand(client: &ManagedClient, command: Hand) -> Result<(), Mana
         (Err(error), Err(shutdown)) => Err(ManagedError::Configuration(format!(
             "{error}; VM shutdown also failed: {shutdown}"
         ))),
+    }
+}
+
+async fn serve_screen_hand(client: &ManagedClient, command: Hand) -> Result<(), ManagedError> {
+    use nanocodex_tools::attachment::{AttachmentMachine, ScreenObservation};
+    let error = |error: nanocodex_tools::attachment::AttachmentError| {
+        ManagedError::Configuration(error.to_string())
+    };
+    let source = match command.screen {
+        Some(ScreenSource::Desktop) if command.device.is_none() => {
+            ScreenObservation::desktop("Desktop")
+        }
+        Some(ScreenSource::Android) => {
+            ScreenObservation::android(command.device.unwrap_or_default(), "Android screen")
+        }
+        _ => {
+            return Err(ManagedError::Configuration(
+                "--device is only valid with --screen android".into(),
+            ));
+        }
+    }
+    .map_err(error)?;
+    let workspace = match command.local_workspace {
+        Some(path) => path,
+        None => HostConfig::load()
+            .map_err(|error| ManagedError::Configuration(error.to_string()))?
+            .workspace()
+            .to_path_buf(),
+    };
+    let workspace = workspace
+        .canonicalize()
+        .map_err(|error| ManagedError::Configuration(error.to_string()))?;
+    let machine = AttachmentMachine::new(
+        command.machine_id,
+        command.machine_name,
+        workspace.to_string_lossy(),
+        ["native", "filesystem", "process", "screen"],
+    )
+    .map_err(error)?;
+    let tools = Tools::builder()
+        .without_defaults()
+        .add(WorkspaceTools::new(&workspace))
+        .build()
+        .map_err(|error| ManagedError::Configuration(error.to_string()))?;
+    let (attachment, _events) = tools
+        .attach(client.account_attachment_target()?)
+        .metadata(AttachmentMetadata::machine(machine))
+        .observation(std::sync::Arc::new(source))
+        .start()
+        .map_err(error)?;
+    // Retain the handle during initialization so Ctrl-C also cancels connection attempts.
+    tokio::select! {
+        result = attachment.wait_until_ready() => result.map_err(error)?,
+        signal = tokio::signal::ctrl_c() => {
+            signal.map_err(|error| ManagedError::Configuration(error.to_string()))?;
+            return attachment.detach().await.map_err(error);
+        }
+    }
+    tracing::info!(target: "nanocodex2", "Screen hand ready; open Live view in an owned agent. Ctrl-C detaches.");
+    let closed = attachment.clone();
+    tokio::select! {
+        signal = tokio::signal::ctrl_c() => {
+            signal.map_err(|error| ManagedError::Configuration(error.to_string()))?;
+            attachment.detach().await.map_err(error)
+        }
+        result = closed.closed() => result.map_err(error),
     }
 }
 

--- a/bin/nanocodex/src/nanocodex2/main.rs
+++ b/bin/nanocodex/src/nanocodex2/main.rs
@@ -954,6 +954,45 @@ mod tests {
     use super::*;
 
     #[test]
+    fn screen_hand_requires_an_explicit_source_and_android_device() {
+        assert!(Cli::try_parse_from(["nanocodex2", "hand"]).is_err());
+        assert!(Cli::try_parse_from(["nanocodex2", "hand", "--screen", "android"]).is_err());
+        assert!(
+            Cli::try_parse_from([
+                "nanocodex2",
+                "hand",
+                "--screen",
+                "desktop",
+                "--vm",
+                "root.ext4"
+            ])
+            .is_err()
+        );
+        let cli = Cli::try_parse_from(["nanocodex2", "hand", "--screen", "desktop"]).unwrap();
+        let Some(Command::Hand(hand)) = cli.command else {
+            panic!("expected hand")
+        };
+        assert_eq!(hand.screen, Some(ScreenSource::Desktop));
+        assert!(hand.rootfs.is_none());
+        assert_eq!(hand.machine_id, "desktop");
+        let cli = Cli::try_parse_from([
+            "nanocodex2",
+            "hand",
+            "--screen",
+            "android",
+            "--device",
+            "SERIAL",
+        ])
+        .unwrap();
+        let Some(Command::Hand(hand)) = cli.command else {
+            panic!("expected hand")
+        };
+        assert_eq!(hand.device.as_deref(), Some("SERIAL"));
+        assert_eq!(hand.machine_id, "android");
+        assert!(Cli::try_parse_from(["nanocodex2", "hand", "--vm", "root.ext4"]).is_ok());
+    }
+
+    #[test]
     fn parses_attach_url_into_its_agent_id() {
         let cli = Cli::try_parse_from([
             "nanocodex2",

--- a/bin/nanocodex/src/nanocodex2/vm_hand.rs
+++ b/bin/nanocodex/src/nanocodex2/vm_hand.rs
@@ -30,7 +30,7 @@ pub(crate) struct VmHand {
 
 impl VmHand {
     pub(crate) async fn start(config: &Hand) -> Result<Self, ManagedError> {
-        Self::start_config(&VmHandConfig::from(config)).await
+        Self::start_config(&VmHandConfig::try_from(config)?).await
     }
 
     pub(crate) async fn start_config(config: &VmHandConfig) -> Result<Self, ManagedError> {

--- a/bin/nanocodex/src/nanocodex2/vm_hand_config.rs
+++ b/bin/nanocodex/src/nanocodex2/vm_hand_config.rs
@@ -18,10 +18,13 @@ pub(crate) struct VmHandConfig {
     pub(crate) machine_name: String,
 }
 
-impl From<&Hand> for VmHandConfig {
-    fn from(config: &Hand) -> Self {
-        Self {
-            rootfs: config.rootfs.clone(),
+impl TryFrom<&Hand> for VmHandConfig {
+    type Error = nanocodex_managed::ManagedError;
+    fn try_from(config: &Hand) -> Result<Self, Self::Error> {
+        Ok(Self {
+            rootfs: config.rootfs.clone().ok_or_else(|| {
+                nanocodex_managed::ManagedError::Configuration("VM root is required".into())
+            })?,
             vm_guest_runtime: config.vm_guest_runtime.clone(),
             vm_cache: config.vm_cache.clone(),
             vm_firmware: config.vm_firmware.clone(),
@@ -32,6 +35,6 @@ impl From<&Hand> for VmHandConfig {
             vm_no_network: config.vm_no_network,
             machine_id: config.machine_id.clone(),
             machine_name: config.machine_name.clone(),
-        }
+        })
     }
 }

--- a/bin/nanocodex/tests/nanocodex2_managed.rs
+++ b/bin/nanocodex/tests/nanocodex2_managed.rs
@@ -27,7 +27,7 @@ const CLOUD_TURN_ID: &str = "019fc927-b283-7a11-8445-1b9996ad2fb0";
 const PROCESS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 #[tokio::test]
-async fn hand_help_exposes_the_vm_and_machine_contract() {
+async fn hand_help_exposes_the_vm_screen_and_machine_contract() {
     let output = tokio::process::Command::new(env!("CARGO_BIN_EXE_nanocodex2"))
         .args(["hand", "--help"])
         .output()
@@ -36,12 +36,16 @@ async fn hand_help_exposes_the_vm_and_machine_contract() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(
-        stdout.contains("Usage: nanocodex2 hand [OPTIONS] --vm <ROOTFS>"),
+        stdout.contains("Usage: nanocodex2 hand [OPTIONS]\n"),
         "{stdout}"
     );
     assert!(!stdout.contains("AGENT_ID"), "{stdout}");
     for expected in [
         "--vm <ROOTFS>",
+        "--screen <SCREEN>",
+        "--device <DEVICE>",
+        "--workspace <LOCAL_WORKSPACE>",
+        "[possible values: desktop, android]",
         "--vm-guest-runtime <ELF>",
         "--vm-workspace <PATH>",
         "--vm-cpus <COUNT>",

--- a/crates/nanocodex-tools/Cargo.toml
+++ b/crates/nanocodex-tools/Cargo.toml
@@ -20,6 +20,8 @@ rustdoc-args = ["-D", "warnings"]
 [features]
 default = ["native"]
 attachment = [
+    "dep:base64",
+    "dep:tempfile",
     "dep:async-trait",
     "dep:futures-util",
     "dep:http",
@@ -83,6 +85,7 @@ schemars = { workspace = true, optional = true }
 sha1 = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "process", "rt", "sync", "time"], optional = true }
 tokio-util = { workspace = true, optional = true }
+tempfile = { workspace = true, optional = true }
 tokio-tungstenite = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }

--- a/crates/nanocodex-tools/README.md
+++ b/crates/nanocodex-tools/README.md
@@ -239,3 +239,44 @@ deliberately restoring proxy-safe credential markers to tool subprocesses.
 - [`workspace_runtime`] contains the retained canonical workspace-tool runtime
   used by process companions.
 - [`image`] contains prompt-image preparation and tool-output normalization.
+
+### Live screen observations
+
+Attach an opt-in screen provider alongside the native hand's tools:
+
+```rust,ignore
+use std::sync::Arc;
+use nanocodex_tools::attachment::{AttachmentMetadata, ScreenObservation};
+
+let (attachment, events) = tools.attach(target)
+    .metadata(AttachmentMetadata::machine(machine))
+    .observation(Arc::new(ScreenObservation::desktop("Desktop")?))
+    .connect().await?;
+```
+
+`ScreenObservation::android(serial, name)` captures an explicit adb device. Both
+providers require FFmpeg; desktop acquisition uses macOS screencapture, X11,
+Windows gdigrab, or grim on supported Wayland compositors. Grant the necessary
+OS screen-recording/device permissions to the hand process.
+
+Custom browser, phone, or VM adapters implement `ObservationProvider`; capture
+futures must release resources on drop. Providers describe 1–8 screens on one
+named machine and only run for authorized viewer requests. Each capture has a
+five-second deadline and a 180 KB JPEG/PNG limit. Frames never enter durable tool
+receipts or agent history. Cancellation, detach, and connection loss abort
+capture without replaying it into another connection.
+
+With the configured managed origin and `NANOCODEX_API_KEY`:
+
+```sh
+nanocodex2 hand --screen desktop --machine-id laptop --workspace /path/to/work
+nanocodex2 hand --screen android --device SERIAL --machine-id phone --workspace /path/to/work
+```
+
+Open **Live view** in any owned agent's web terminal. Screen hands attach native
+workspace tools from the selected directory, so agent actions and capture run
+on the same host. Android tools can invoke adb against the same explicit serial.
+Existing `hand --vm ROOTFS` behavior is preserved. VM mode and host screen mode
+are exclusive: host capture does not represent the guest display. Built-in iOS
+and graphical VM capture adapters are not included; custom providers can supply
+those surfaces through the same protocol.

--- a/crates/nanocodex-tools/src/attachment/driver.rs
+++ b/crates/nanocodex-tools/src/attachment/driver.rs
@@ -1,3 +1,6 @@
+use super::{
+    OBSERVATION_TIMEOUT, ObservationProvider, ObservationSurface, observation::ObservationResult,
+};
 use std::{
     collections::{HashMap, VecDeque},
     sync::Arc,
@@ -42,6 +45,8 @@ pub(crate) struct Config {
     pub(crate) authorization: Box<str>,
     pub(crate) tools: Value,
     pub(crate) metadata: Option<AttachmentMetadata>,
+    pub(crate) observation: Option<Arc<dyn ObservationProvider>>,
+    pub(crate) observation_surfaces: Vec<ObservationSurface>,
 }
 
 pub(crate) enum Command {
@@ -456,6 +461,8 @@ where
         &mut socket,
         &ExecutorFrame::Catalog {
             tools: &config.tools,
+            observation_surfaces: (!config.observation_surfaces.is_empty())
+                .then_some(config.observation_surfaces.as_slice()),
             machines: config
                 .metadata
                 .as_ref()
@@ -503,6 +510,8 @@ where
     heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     let mut pong_timeout = Box::pin(tokio::time::sleep(PONG_TIMEOUT));
     let mut awaiting_pong: Option<String> = None;
+    let mut captures = tokio::task::JoinSet::new();
+    let mut capture_request: Option<String> = None;
     let mut detaching = false;
     let mut draining = false;
 
@@ -522,6 +531,8 @@ where
                 if let Err(error) = send(&mut socket, &ExecutorFrame::Drain {}).await {
                     break ConnectionEnd::DetachFailed(error);
                 }
+                captures.abort_all();
+                capture_request = None;
                 detaching = true;
             }
             _ = &mut pong_timeout, if awaiting_pong.is_some() => {
@@ -539,6 +550,16 @@ where
                 }
                 awaiting_pong = Some(nonce);
                 pong_timeout.as_mut().reset(tokio::time::Instant::now() + PONG_TIMEOUT);
+            }
+            captured = captures.join_next(), if !captures.is_empty() => {
+                if let Some(Ok((request_id, result))) = captured {
+                    if capture_request.as_ref() == Some(&request_id) && !detaching {
+                        capture_request = None;
+                        if let Err(error) = send(&mut socket, &ExecutorFrame::Observation { request_id: &request_id, result: &result }).await {
+                            break ConnectionEnd::Failed(error);
+                        }
+                    }
+                }
             }
             completion = completed_rx.recv() => if let Some(Completion::Result { call_id, outcome, observed }) = completion {
                 let Some(call) = in_flight.remove(&call_id) else { continue };
@@ -558,6 +579,29 @@ where
                     Err(end) => break end,
                 };
                 match frame {
+                    RemoteFrame::ObserveCancel { request_id } => {
+                        if capture_request.as_ref() == Some(&request_id) {
+                            captures.abort_all();
+                            capture_request = None;
+                        }
+                    }
+                    RemoteFrame::Observe { request_id, surface_id } => {
+                        if detaching || !captures.is_empty() || !config.observation_surfaces.iter().any(|s| s.id() == surface_id) {
+                            if let Err(error) = send(&mut socket, &ExecutorFrame::Observation { request_id: &request_id, result: &ObservationResult::unavailable() }).await {
+                                break ConnectionEnd::Failed(error);
+                            }
+                            continue;
+                        }
+                        let Some(provider) = config.observation.clone() else { continue };
+                        capture_request = Some(request_id.clone());
+                        captures.spawn(async move {
+                            let result = match tokio::time::timeout(OBSERVATION_TIMEOUT, provider.capture(&surface_id)).await {
+                                Ok(Ok(frame)) => ObservationResult::Frame { frame },
+                                _ => ObservationResult::unavailable(),
+                            };
+                            (request_id, result)
+                        });
+                    }
                     RemoteFrame::Call { session_id, call_id, model, name, input, output_token_budget, output_byte_budget, deadline_at } => {
                         if draining { break ConnectionEnd::Rejected("call received after drain barrier".into()); }
                         let identity = CallIdentity { session_id:session_id.into(), call_id:call_id.clone().into(), model:model.into(), name:name.clone().into(), input:input.clone(), output_token_budget, output_byte_budget, deadline_at };
@@ -644,6 +688,8 @@ where
     } else {
         end
     };
+
+    captures.shutdown().await;
 
     if !matches!(end, ConnectionEnd::Detached) {
         for call in pending {

--- a/crates/nanocodex-tools/src/attachment/driver.rs
+++ b/crates/nanocodex-tools/src/attachment/driver.rs
@@ -552,12 +552,11 @@ where
                 pong_timeout.as_mut().reset(tokio::time::Instant::now() + PONG_TIMEOUT);
             }
             captured = captures.join_next(), if !captures.is_empty() => {
-                if let Some(Ok((request_id, result))) = captured {
-                    if capture_request.as_ref() == Some(&request_id) && !detaching {
-                        capture_request = None;
-                        if let Err(error) = send(&mut socket, &ExecutorFrame::Observation { request_id: &request_id, result: &result }).await {
-                            break ConnectionEnd::Failed(error);
-                        }
+                if let Some(Ok((request_id, result))) = captured
+                    && capture_request.as_ref() == Some(&request_id) && !detaching {
+                    capture_request = None;
+                    if let Err(error) = send(&mut socket, &ExecutorFrame::Observation { request_id: &request_id, result: &result }).await {
+                        break ConnectionEnd::Failed(error);
                     }
                 }
             }

--- a/crates/nanocodex-tools/src/attachment/mod.rs
+++ b/crates/nanocodex-tools/src/attachment/mod.rs
@@ -4,7 +4,14 @@
 //! account, placement, and endpoint discovery remain the caller's responsibility.
 
 mod driver;
+mod observation;
 mod protocol;
+mod screen;
+pub use observation::{
+    MAX_OBSERVATION_IMAGE_BYTES, OBSERVATION_TIMEOUT, ObservationFrame, ObservationImageFormat,
+    ObservationKind, ObservationProvider, ObservationSurface,
+};
+pub use screen::ScreenObservation;
 
 use std::{collections::HashSet, fmt, sync::Arc};
 use tokio::sync::{mpsc, watch};
@@ -261,6 +268,7 @@ pub struct AttachmentConnector {
     tools: Tools,
     target: AttachmentTarget,
     metadata: Option<AttachmentMetadata>,
+    observation: Option<Arc<dyn ObservationProvider>>,
 }
 
 impl Tools {
@@ -271,6 +279,7 @@ impl Tools {
             tools: self,
             target,
             metadata: None,
+            observation: None,
         }
     }
 }
@@ -283,6 +292,13 @@ impl AttachmentConnector {
         self
     }
 
+    /// Enables opt-in live viewing for this exact machine attachment.
+    #[must_use]
+    pub fn observation(mut self, provider: Arc<dyn ObservationProvider>) -> Self {
+        self.observation = Some(provider);
+        self
+    }
+
     /// Validates the recipe and starts its complete lifecycle in the background.
     ///
     /// # Errors
@@ -291,6 +307,27 @@ impl AttachmentConnector {
     /// attached catalog. Discovery and transport failures are reported through
     /// the returned handle while its driver initializes and reconnects.
     pub fn start(self) -> Result<(Attachment, AttachmentEvents), AttachmentError> {
+        let observation_surfaces = match &self.observation {
+            None => Vec::new(),
+            Some(provider) => {
+                let surfaces = provider.surfaces();
+                let unique: HashSet<_> = surfaces.iter().map(ObservationSurface::id).collect();
+                if self
+                    .metadata
+                    .as_ref()
+                    .and_then(AttachmentMetadata::attached_machine)
+                    .is_none()
+                    || surfaces.is_empty()
+                    || surfaces.len() > 8
+                    || unique.len() != surfaces.len()
+                {
+                    return Err(AttachmentError::Catalog(
+                        "observation requires one machine and 1-8 unique surfaces".into(),
+                    ));
+                }
+                surfaces.to_vec()
+            }
+        };
         install_default_rustls_crypto_provider();
         let prepared = PreparedTools::prepare(&self.tools)?;
         let (command_tx, command_rx) = mpsc::channel(8);
@@ -302,6 +339,8 @@ impl AttachmentConnector {
             prepared,
             self.target,
             self.metadata,
+            self.observation,
+            observation_surfaces,
             command_rx,
             event_tx,
             status_tx,
@@ -335,6 +374,8 @@ async fn initialize_and_run(
     prepared: PreparedTools,
     target: AttachmentTarget,
     metadata: Option<AttachmentMetadata>,
+    observation: Option<Arc<dyn ObservationProvider>>,
+    observation_surfaces: Vec<ObservationSurface>,
     mut command_rx: mpsc::Receiver<driver::Command>,
     event_tx: mpsc::Sender<AttachmentEvent>,
     status_tx: watch::Sender<AttachmentStatus>,
@@ -380,6 +421,8 @@ async fn initialize_and_run(
             authorization: format!("Bearer {}", target.bearer).into(),
             tools,
             metadata,
+            observation,
+            observation_surfaces,
         })
     })();
     let config = match config {
@@ -467,7 +510,11 @@ impl Attachment {
         }
     }
 
-    async fn wait_until_ready(&self) -> Result<(), AttachmentError> {
+    /// Waits for catalog acknowledgement while the caller retains cancellation ownership.
+    ///
+    /// # Errors
+    /// Returns the terminal initialization or transport error if readiness fails.
+    pub async fn wait_until_ready(&self) -> Result<(), AttachmentError> {
         let mut status = self.status.clone();
         loop {
             let current = status.borrow().clone();

--- a/crates/nanocodex-tools/src/attachment/mod.rs
+++ b/crates/nanocodex-tools/src/attachment/mod.rs
@@ -338,9 +338,11 @@ impl AttachmentConnector {
         tokio::spawn(initialize_and_run(
             prepared,
             self.target,
-            self.metadata,
-            self.observation,
-            observation_surfaces,
+            ObservationConfig {
+                metadata: self.metadata,
+                provider: self.observation,
+                surfaces: observation_surfaces,
+            },
             command_rx,
             event_tx,
             status_tx,
@@ -370,12 +372,16 @@ impl AttachmentConnector {
     }
 }
 
+struct ObservationConfig {
+    metadata: Option<AttachmentMetadata>,
+    provider: Option<Arc<dyn ObservationProvider>>,
+    surfaces: Vec<ObservationSurface>,
+}
+
 async fn initialize_and_run(
     prepared: PreparedTools,
     target: AttachmentTarget,
-    metadata: Option<AttachmentMetadata>,
-    observation: Option<Arc<dyn ObservationProvider>>,
-    observation_surfaces: Vec<ObservationSurface>,
+    config: ObservationConfig,
     mut command_rx: mpsc::Receiver<driver::Command>,
     event_tx: mpsc::Sender<AttachmentEvent>,
     status_tx: watch::Sender<AttachmentStatus>,
@@ -420,9 +426,9 @@ async fn initialize_and_run(
             endpoint: target.endpoint,
             authorization: format!("Bearer {}", target.bearer).into(),
             tools,
-            metadata,
-            observation,
-            observation_surfaces,
+            metadata: config.metadata,
+            observation: config.provider,
+            observation_surfaces: config.surfaces,
         })
     })();
     let config = match config {

--- a/crates/nanocodex-tools/src/attachment/observation.rs
+++ b/crates/nanocodex-tools/src/attachment/observation.rs
@@ -1,0 +1,135 @@
+//! Demand-driven screen observations, independent of durable tool execution.
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use serde::Serialize;
+
+use super::{AttachmentError, valid_safe_identifier};
+
+/// Maximum decoded image size accepted by every attachment implementation.
+pub const MAX_OBSERVATION_IMAGE_BYTES: usize = 180_000;
+/// Capture deadline shared with the managed observation broker.
+pub const OBSERVATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Physical or virtual screen represented by a hand.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservationKind {
+    /// Host desktop.
+    Desktop,
+    /// Browser viewport.
+    Browser,
+    /// Phone display.
+    Phone,
+}
+
+/// Immutable, non-secret screen description.
+#[derive(Clone, Debug, Serialize)]
+pub struct ObservationSurface {
+    id: String,
+    name: String,
+    kind: ObservationKind,
+}
+
+impl ObservationSurface {
+    /// Creates a bounded screen description.
+    ///
+    /// # Errors
+    /// Rejects invalid identifiers and empty or oversized names.
+    pub fn new(
+        id: impl Into<String>,
+        name: impl Into<String>,
+        kind: ObservationKind,
+    ) -> Result<Self, AttachmentError> {
+        let id = id.into();
+        let name = name.into();
+        if !valid_safe_identifier(&id, 128) || name.trim().is_empty() || name.len() > 128 {
+            return Err(AttachmentError::Catalog(
+                "invalid observation surface".into(),
+            ));
+        }
+        Ok(Self { id, name, kind })
+    }
+
+    /// Stable screen identifier within this attachment.
+    #[must_use]
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+}
+
+/// Supported inert image formats; no URLs, SVG, or executable content.
+#[derive(Clone, Copy, Debug, Serialize)]
+pub enum ObservationImageFormat {
+    /// JPEG image.
+    #[serde(rename = "image/jpeg")]
+    Jpeg,
+    /// PNG image.
+    #[serde(rename = "image/png")]
+    Png,
+}
+
+/// One bounded image captured in response to a viewer request.
+#[derive(Debug, Serialize)]
+pub struct ObservationFrame {
+    captured_at: u64,
+    width: u32,
+    height: u32,
+    mime_type: ObservationImageFormat,
+    data: String,
+}
+
+impl ObservationFrame {
+    /// Encodes an image for the cross-language observation protocol.
+    ///
+    /// # Errors
+    /// Rejects oversized or empty images, dimensions, and non-JavaScript timestamps.
+    pub fn new(
+        captured_at: u64,
+        width: u32,
+        height: u32,
+        format: ObservationImageFormat,
+        bytes: &[u8],
+    ) -> Result<Self, AttachmentError> {
+        if captured_at > 9_007_199_254_740_991
+            || !(1..=8192).contains(&width)
+            || !(1..=8192).contains(&height)
+            || bytes.is_empty()
+            || bytes.len() > MAX_OBSERVATION_IMAGE_BYTES
+        {
+            return Err(AttachmentError::Catalog("invalid observation frame".into()));
+        }
+        Ok(Self {
+            captured_at,
+            width,
+            height,
+            mime_type: format,
+            data: STANDARD.encode(bytes),
+        })
+    }
+}
+
+/// Application-owned capture capability. Capture futures must be cancellation
+/// safe: dropping one must stop capture and release its resources. The driver
+/// permits one capture at a time and drops it on timeout, cancellation, or detach.
+#[async_trait::async_trait]
+pub trait ObservationProvider: Send + Sync + 'static {
+    /// Descriptors snapshotted once when the attachment starts (1–8 unique IDs).
+    fn surfaces(&self) -> &[ObservationSurface];
+    /// Captures the requested surface. Errors are redacted before transmission.
+    async fn capture(&self, surface_id: &str) -> Result<ObservationFrame, AttachmentError>;
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub(crate) enum ObservationResult {
+    Frame { frame: ObservationFrame },
+    Unavailable { message: &'static str },
+}
+
+impl ObservationResult {
+    pub(crate) const fn unavailable() -> Self {
+        Self::Unavailable {
+            message: "Screen capture unavailable",
+        }
+    }
+}

--- a/crates/nanocodex-tools/src/attachment/protocol.rs
+++ b/crates/nanocodex-tools/src/attachment/protocol.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::AttachmentMachine;
+use super::{AttachmentMachine, ObservationSurface, observation::ObservationResult};
 
 pub(crate) const MAX_FRAME_BYTES: usize = 256 * 1024;
 pub(crate) const MAX_OUTPUT_BYTES: u64 = 128 * 1024;
@@ -21,6 +21,12 @@ pub(crate) enum ExecutorFrame<'a> {
         machines: Option<&'a [AttachmentMachine]>,
         #[serde(skip_serializing_if = "Option::is_none")]
         attachment_id: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        observation_surfaces: Option<&'a [ObservationSurface]>,
+    },
+    Observation {
+        request_id: &'a str,
+        result: &'a ObservationResult,
     },
     Result {
         call_id: &'a str,
@@ -35,6 +41,13 @@ pub(crate) enum ExecutorFrame<'a> {
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub(crate) enum RemoteFrame {
+    Observe {
+        request_id: String,
+        surface_id: String,
+    },
+    ObserveCancel {
+        request_id: String,
+    },
     Ready {},
     Call {
         session_id: String,
@@ -61,6 +74,8 @@ pub(crate) enum RemoteFrame {
 impl RemoteFrame {
     pub(crate) const fn kind(&self) -> &'static str {
         match self {
+            Self::Observe { .. } => "observe",
+            Self::ObserveCancel { .. } => "observe_cancel",
             Self::Ready {} => "ready",
             Self::Call { .. } => "call",
             Self::Cancel { .. } => "cancel",
@@ -81,6 +96,23 @@ impl RemoteFrame {
 
     fn validate(&self) -> Result<(), &'static str> {
         match self {
+            Self::Observe {
+                request_id,
+                surface_id,
+            } => {
+                if valid_identifier(request_id) && valid_identifier(surface_id) {
+                    Ok(())
+                } else {
+                    Err("invalid observation identity")
+                }
+            }
+            Self::ObserveCancel { request_id } => {
+                if valid_identifier(request_id) {
+                    Ok(())
+                } else {
+                    Err("invalid observation identity")
+                }
+            }
             Self::Ready {} | Self::Draining {} => Ok(()),
             Self::Call {
                 session_id,

--- a/crates/nanocodex-tools/src/attachment/screen.rs
+++ b/crates/nanocodex-tools/src/attachment/screen.rs
@@ -1,0 +1,205 @@
+//! Native capture commands stay local; no capture command or device is supplied by viewers.
+use super::{
+    AttachmentError, MAX_OBSERVATION_IMAGE_BYTES, ObservationFrame, ObservationImageFormat,
+    ObservationKind, ObservationProvider, ObservationSurface,
+};
+use std::{
+    process::Stdio,
+    time::{SystemTime, UNIX_EPOCH},
+};
+use tokio::{io::AsyncReadExt as _, process::Command};
+
+/// Native desktop or explicitly selected Android capture provider.
+/// Requires FFmpeg, plus screencapture (macOS), grim (Wayland), or adb (Android).
+pub struct ScreenObservation {
+    surfaces: [ObservationSurface; 1],
+    device: Option<String>,
+}
+
+impl ScreenObservation {
+    /// Shares this process's desktop. OS screen-recording permission is required.
+    ///
+    /// # Errors
+    /// Rejects invalid display names. Capture errors are reported per request.
+    pub fn desktop(name: impl Into<String>) -> Result<Self, AttachmentError> {
+        Ok(Self {
+            surfaces: [ObservationSurface::new(
+                "screen",
+                name,
+                ObservationKind::Desktop,
+            )?],
+            device: None,
+        })
+    }
+
+    /// Shares exactly one Android device, identified by its adb serial.
+    ///
+    /// # Errors
+    /// Rejects empty, option-like, or oversized serials and invalid display names.
+    pub fn android(
+        device: impl Into<String>,
+        name: impl Into<String>,
+    ) -> Result<Self, AttachmentError> {
+        let device = device.into();
+        if device.is_empty()
+            || device.starts_with('-')
+            || device.len() > 256
+            || device.contains('\0')
+        {
+            return Err(failure());
+        }
+        Ok(Self {
+            surfaces: [ObservationSurface::new(
+                "screen",
+                name,
+                ObservationKind::Phone,
+            )?],
+            device: Some(device),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl ObservationProvider for ScreenObservation {
+    fn surfaces(&self) -> &[ObservationSurface] {
+        &self.surfaces
+    }
+
+    async fn capture(&self, surface_id: &str) -> Result<ObservationFrame, AttachmentError> {
+        if surface_id != "screen" {
+            return Err(failure());
+        }
+        let directory = tempfile::tempdir().map_err(|_| failure())?;
+        let raw = directory.path().join("raw.png");
+        let mut ffmpeg = Command::new("ffmpeg");
+        ffmpeg.args(["-nostdin", "-loglevel", "error"]);
+        if let Some(device) = &self.device {
+            let bytes = output(
+                Command::new("adb").args(["-s", device, "exec-out", "screencap", "-p"]),
+                32 * 1024 * 1024,
+            )
+            .await?;
+            tokio::fs::write(&raw, bytes).await.map_err(|_| failure())?;
+            ffmpeg.arg("-i").arg(&raw);
+        } else if cfg!(target_os = "macos") {
+            output(
+                Command::new("screencapture")
+                    .args(["-x", "-t", "png"])
+                    .arg(&raw),
+                1024,
+            )
+            .await?;
+            ffmpeg.arg("-i").arg(&raw);
+        } else if cfg!(target_os = "windows") {
+            ffmpeg.args(["-f", "gdigrab", "-i", "desktop"]);
+        } else if std::env::var_os("WAYLAND_DISPLAY").is_some() {
+            output(Command::new("grim").arg(&raw), 1024).await?;
+            ffmpeg.arg("-i").arg(&raw);
+        } else if let Some(display) = std::env::var_os("DISPLAY") {
+            ffmpeg.args(["-f", "x11grab", "-i"]).arg(display);
+        } else {
+            return Err(failure());
+        }
+        ffmpeg.args([
+            "-frames:v",
+            "1",
+            "-vf",
+            "scale=960:960:force_original_aspect_ratio=decrease",
+            "-q:v",
+            "8",
+            "-f",
+            "image2pipe",
+            "-vcodec",
+            "mjpeg",
+            "pipe:1",
+        ]);
+        let bytes = output(&mut ffmpeg, MAX_OBSERVATION_IMAGE_BYTES).await?;
+        let (width, height) = jpeg_dimensions(&bytes).ok_or_else(failure)?;
+        let captured_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|_| failure())?
+            .as_millis();
+        ObservationFrame::new(
+            u64::try_from(captured_at).map_err(|_| failure())?,
+            width,
+            height,
+            ObservationImageFormat::Jpeg,
+            &bytes,
+        )
+    }
+}
+
+async fn output(command: &mut Command, limit: usize) -> Result<Vec<u8>, AttachmentError> {
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true);
+    let mut child = command.spawn().map_err(|_| failure())?;
+    let mut stdout = child
+        .stdout
+        .take()
+        .ok_or_else(failure)?
+        .take(limit as u64 + 1);
+    let mut bytes = Vec::new();
+    // The outer attachment timeout drops this future and kills the process.
+    stdout
+        .read_to_end(&mut bytes)
+        .await
+        .map_err(|_| failure())?;
+    if bytes.len() > limit {
+        return Err(failure());
+    }
+    if !child.wait().await.map_err(|_| failure())?.success() {
+        return Err(failure());
+    }
+    Ok(bytes)
+}
+
+fn jpeg_dimensions(bytes: &[u8]) -> Option<(u32, u32)> {
+    if !bytes.starts_with(&[0xff, 0xd8]) {
+        return None;
+    }
+    let mut offset = 2;
+    while offset + 9 < bytes.len() {
+        if bytes[offset] != 0xff {
+            return None;
+        }
+        let length = usize::from(u16::from_be_bytes([bytes[offset + 2], bytes[offset + 3]]));
+        if length < 2 {
+            return None;
+        }
+        if matches!(bytes[offset + 1], 0xc0..=0xc2) {
+            let height = u16::from_be_bytes([bytes[offset + 5], bytes[offset + 6]]);
+            let width = u16::from_be_bytes([bytes[offset + 7], bytes[offset + 8]]);
+            return Some((u32::from(width), u32::from(height)));
+        }
+        offset += length + 2;
+    }
+    None
+}
+
+fn failure() -> AttachmentError {
+    AttachmentError::Transport("Screen capture unavailable".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[ignore = "requires a real desktop display and FFmpeg"]
+    async fn capture_live_desktop() {
+        let source = ScreenObservation::desktop("Desktop").unwrap();
+        let frame =
+            tokio::time::timeout(super::super::OBSERVATION_TIMEOUT, source.capture("screen"))
+                .await
+                .unwrap()
+                .unwrap();
+        let value = serde_json::to_value(frame).unwrap();
+        assert_eq!(value["mime_type"], "image/jpeg");
+        assert!(value["width"].as_u64().unwrap() <= 960);
+        assert!(value["height"].as_u64().unwrap() <= 960);
+        assert!(!value["data"].as_str().unwrap().is_empty());
+    }
+}

--- a/crates/nanocodex-tools/src/attachment/tests.rs
+++ b/crates/nanocodex-tools/src/attachment/tests.rs
@@ -442,3 +442,124 @@ fn machine_metadata(id: &str, workspace: &str) -> AttachmentMetadata {
         .unwrap(),
     )
 }
+
+struct TestObservation {
+    surfaces: [ObservationSurface; 1],
+    started: tokio::sync::Notify,
+    stopped: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+}
+
+struct CaptureGuard(std::sync::Arc<std::sync::atomic::AtomicUsize>);
+impl Drop for CaptureGuard {
+    fn drop(&mut self) {
+        self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+#[async_trait]
+impl ObservationProvider for TestObservation {
+    fn surfaces(&self) -> &[ObservationSurface] {
+        &self.surfaces
+    }
+    async fn capture(&self, _surface_id: &str) -> Result<ObservationFrame, AttachmentError> {
+        let _guard = CaptureGuard(self.stopped.clone());
+        self.started.notify_one();
+        std::future::pending().await
+    }
+}
+
+#[tokio::test]
+async fn observation_capture_cancellation_does_not_block_tool_calls_or_drain() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    let source = Arc::new(TestObservation {
+        surfaces: [ObservationSurface::new("screen", "Desktop", ObservationKind::Desktop).unwrap()],
+        started: tokio::sync::Notify::new(),
+        stopped: Arc::new(AtomicUsize::new(0)),
+    });
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let endpoint = format!("ws://{}/tools", listener.local_addr().unwrap());
+    let (complete_tx, complete_rx) = tokio::sync::oneshot::channel();
+    let observed = source.clone();
+    let server = tokio::spawn(async move {
+        let mut socket = accept(&listener).await;
+        let catalog = recv_json(&mut socket).await;
+        assert_eq!(
+            catalog["observation_surfaces"],
+            json!([{"id":"screen","name":"Desktop","kind":"desktop"}])
+        );
+        send_json(&mut socket, json!({"type":"ready"})).await;
+        assert_eq!(observed.stopped.load(Ordering::SeqCst), 0);
+        send_json(
+            &mut socket,
+            json!({"type":"observe","request_id":"view-1","surface_id":"screen"}),
+        )
+        .await;
+        observed.started.notified().await;
+        send_json(&mut socket, call("call-1", "echo")).await;
+        let result = recv_json(&mut socket).await;
+        assert_eq!(result["type"], "result");
+        assert_eq!(result["outcome"]["status"], "completed");
+        send_json(&mut socket, json!({"type":"ack","call_id":"call-1"})).await;
+        send_json(
+            &mut socket,
+            json!({"type":"observe","request_id":"view-2","surface_id":"screen"}),
+        )
+        .await;
+        let busy = recv_json(&mut socket).await;
+        assert_eq!(busy["result"]["status"], "unavailable");
+        send_json(
+            &mut socket,
+            json!({"type":"observe_cancel","request_id":"view-1"}),
+        )
+        .await;
+        send_json(&mut socket, call("call-2", "echo")).await;
+        assert_eq!(recv_json(&mut socket).await["call_id"], "call-2");
+        send_json(&mut socket, json!({"type":"ack","call_id":"call-2"})).await;
+        assert_eq!(observed.stopped.load(Ordering::SeqCst), 1);
+        let _ = complete_tx.send(());
+        assert_eq!(recv_json(&mut socket).await, json!({"type":"drain"}));
+        send_json(&mut socket, json!({"type":"draining"})).await;
+    });
+    let tools = Tools::builder()
+        .without_defaults()
+        .tool(EchoTool)
+        .build()
+        .unwrap();
+    let (attachment, _) = tools
+        .attach(AttachmentTarget::new(endpoint, "bearer").unwrap())
+        .metadata(machine_metadata("observed", "/work"))
+        .observation(source)
+        .connect()
+        .await
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(3), complete_rx)
+        .await
+        .unwrap()
+        .unwrap();
+    attachment.detach().await.unwrap();
+    server.await.unwrap();
+}
+
+#[test]
+fn observation_bounds_match_the_javascript_contract() {
+    assert!(ObservationSurface::new("bad/id", "Screen", ObservationKind::Phone).is_err());
+    assert!(ObservationSurface::new("screen", "é".repeat(65), ObservationKind::Phone).is_err());
+    assert!(ObservationFrame::new(1, 0, 1, ObservationImageFormat::Png, &[1]).is_err());
+    assert!(
+        ObservationFrame::new(1, 1, 1, ObservationImageFormat::Png, &vec![0; 180_001]).is_err()
+    );
+    let frame = ObservationFrame::new(1, 1, 1, ObservationImageFormat::Png, &[0, 0, 0]).unwrap();
+    assert_eq!(
+        serde_json::to_value(frame).unwrap(),
+        json!({"captured_at":1,"width":1,"height":1,"mime_type":"image/png","data":"AAAA"})
+    );
+    assert!(
+        protocol::RemoteFrame::parse(
+            r#"{"type":"observe","request_id":"r","surface_id":"screen","command":"evil"}"#
+        )
+        .is_err()
+    );
+    assert!(
+        protocol::RemoteFrame::parse(r#"{"type":"observe_cancel","request_id":"bad/id"}"#).is_err()
+    );
+}

--- a/js/account/src/AgentTerminal.tsx
+++ b/js/account/src/AgentTerminal.tsx
@@ -1,3 +1,4 @@
+import { HandLiveView } from "./HandLiveView";
 import {
   memo,
   type ReactNode,
@@ -322,7 +323,7 @@ export const ManagedAgentTerminal = memo(function ManagedAgentTerminal({
       onStateChange={onStateChange}
       retryAgent={retryAgent}
       voice={voiceEnabled}
-      controls={({ agentReady }) => (
+      controls={({ agentReady }) => (<>
         <TerminalSettingsControls
           agentReady={agentReady && settingsReady}
           modelLocked={conversationStarted}
@@ -336,7 +337,8 @@ export const ManagedAgentTerminal = memo(function ManagedAgentTerminal({
           })}
           onThinking={(thinking) => updateManagedSettings({ thinking })}
         />
-      )}
+        <HandLiveView key={agentId} agent={managed} />
+      </>)}
       accessory={({ agentReady, submit }) => browserHand ? (
         <ArtifactDock
           agentReady={agentReady}

--- a/js/account/src/HandLiveView.css
+++ b/js/account/src/HandLiveView.css
@@ -1,0 +1,10 @@
+.hand-live-view { position: fixed; right: 16px; bottom: calc(84px + env(safe-area-inset-bottom)); z-index: 100; width: min(640px, calc(100vw - 32px)); max-height: calc(100dvh - 116px); overflow: auto; box-sizing: border-box; padding: 16px; background: var(--surface, #191c22); color: var(--text, #eee); border: 1px solid #68708066; border-radius: 16px; box-shadow: 0 16px 60px #0005; font: 14px/1.5 system-ui, sans-serif; }
+.hand-live-toolbar { display: flex; gap: 8px; align-items: center; margin-bottom: 12px; }
+.hand-live-toolbar strong { flex: 1; }
+.hand-live-view button, .hand-live-view select { font: inherit; color: inherit; background: transparent; border: 1px solid #68708088; border-radius: 8px; padding: 6px 10px; cursor: pointer; }
+.hand-live-view label { display: flex; align-items: center; gap: 12px; }
+.hand-live-view select { flex: 1; min-width: 0; }
+.hand-live-view option { color: #111; }
+.hand-live-screen { display: flex; justify-content: center; align-items: center; min-height: 180px; background: #080a0e; color: #bfc6d2; border-radius: 8px; margin: 12px 0 8px; overflow: hidden; }
+.hand-live-screen img { display: block; width: 100%; height: auto; max-height: min(60dvh, 640px); object-fit: contain; }
+.hand-live-view small { opacity: .75; }

--- a/js/account/src/HandLiveView.tsx
+++ b/js/account/src/HandLiveView.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { Monitor } from "lucide-react";
+import type { ManagedAgent, ManagedHandSurface, ManagedHandFrame } from "nanocodex/managed";
+import "./HandLiveView.css";
+
+const surfaceKey = (surface: ManagedHandSurface) => `${surface.source}:${surface.machine_id}:${surface.id}`;
+
+export function HandLiveView({ agent }: { agent: ManagedAgent }) {
+  const [open, setOpen] = useState(false);
+  const [paused, setPaused] = useState(false);
+  const [visible, setVisible] = useState(document.visibilityState === "visible");
+  const [surfaces, setSurfaces] = useState<readonly ManagedHandSurface[]>([]);
+  const [selected, setSelected] = useState("");
+  const [frame, setFrame] = useState<ManagedHandFrame>();
+  const [status, setStatus] = useState("Connecting…");
+  const [attempt, setAttempt] = useState(0);
+  const surface = surfaces.find((candidate) => surfaceKey(candidate) === selected) ?? surfaces[0];
+
+  useEffect(() => {
+    const visibility = () => setVisible(document.visibilityState === "visible");
+    const escape = (event: KeyboardEvent) => { if (event.key === "Escape") setOpen(false); };
+    document.addEventListener("visibilitychange", visibility);
+    document.addEventListener("keydown", escape);
+    return () => { document.removeEventListener("visibilitychange", visibility); document.removeEventListener("keydown", escape); };
+  }, []);
+  useEffect(() => {
+    if (!open || !visible) return;
+    const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout>;
+    const refresh = async () => {
+      try {
+        const next = await agent.hands.list({ signal: controller.signal });
+        if (!controller.signal.aborted) setSurfaces(next);
+      } catch {
+        if (!controller.signal.aborted) { setSurfaces([]); setStatus("Hands unavailable"); }
+      } finally {
+        if (!controller.signal.aborted) timer = setTimeout(refresh, 3_000);
+      }
+    };
+    void refresh();
+    return () => { controller.abort(); clearTimeout(timer); };
+  }, [agent, open, visible]);
+  useEffect(() => {
+    setFrame(undefined);
+    if (!open || paused || !visible || !surface) return;
+    const controller = new AbortController();
+    let retry: ReturnType<typeof setTimeout>;
+    setStatus("Connecting…");
+    void (async () => {
+      try {
+        for await (const result of agent.hands.frames(surface, { signal: controller.signal })) {
+          if (controller.signal.aborted) break;
+          setFrame(result.status === "frame" ? result.frame : undefined);
+          setStatus(result.status === "frame" ? "Live" : result.message);
+        }
+      } catch {
+        if (!controller.signal.aborted) {
+          setFrame(undefined); setStatus("Reconnecting…");
+          retry = setTimeout(() => setAttempt((value) => value + 1), 1_000);
+        }
+      }
+    })();
+    return () => { controller.abort(); clearTimeout(retry); };
+  }, [agent, open, paused, visible, surface?.id, surface?.source, surface?.route_token, attempt]);
+
+  return <>
+    <button type="button" aria-label="Live view" title="Live view" aria-expanded={open} onClick={() => setOpen(!open)}><Monitor size={18} /></button>
+    {open && createPortal(<section className="hand-live-view" aria-label="Hand live view">
+      <div className="hand-live-toolbar">
+        <strong>Live view</strong>
+        <button type="button" onClick={() => setPaused(!paused)}>{paused ? "Resume" : "Pause"}</button>
+        <button type="button" aria-label="Close live view" onClick={() => setOpen(false)}>Close</button>
+      </div>
+      {surfaces.length > 0 && <label>Screen<select aria-label="Screen" value={surface ? surfaceKey(surface) : ""} onChange={(event) => setSelected(event.target.value)}>
+        {surfaces.map((entry) => <option key={surfaceKey(entry)} value={surfaceKey(entry)}>{entry.machine_name} · {entry.name}</option>)}
+      </select></label>}
+      <div className="hand-live-screen">
+        {frame && !paused && visible ? <img alt={surface?.name ?? "Hand screen"} width={frame.width} height={frame.height}
+          src={`data:${frame.mime_type};base64,${frame.data}`} onError={() => { setFrame(undefined); setStatus("Invalid screen image"); }} />
+          : <p>{paused ? "Paused" : !visible ? "Paused while hidden" : !surface ? "No screens connected" : status}</p>}
+      </div>
+      <small role="status">{paused ? "Paused" : !surface ? "No screens connected" : status}{frame && !paused ? ` · ${new Date(frame.captured_at).toLocaleTimeString()}` : ""}</small>
+    </section>, document.body)}
+  </>;
+}

--- a/js/managed/src/account-hosted-tools.ts
+++ b/js/managed/src/account-hosted-tools.ts
@@ -1,3 +1,4 @@
+import { handObservationResponse } from "./hand-observation";
 import { DurableObject } from "cloudflare:workers";
 import {
   HOSTED_TOOLS_PRE_ADMISSION_UNAVAILABLE,
@@ -96,6 +97,13 @@ export class AccountHostedTools extends DurableObject<AccountHostedToolsEnv> {
         return Response.json({ error: "not_found" }, { status: 404 });
       }
       return this.#broker.upgrade(ownerId);
+    }
+    if (request.method === "GET" && (url.pathname === "/hands" || url.pathname === "/hands/frame")) {
+      const ownerId = request.headers.get(OWNER_ASSERTION);
+      if (!isUserId(ownerId) || !await this.#owns(ownerId)) {
+        return Response.json({ error: "not_found" }, { status: 404, headers: { "cache-control": "no-store" } });
+      }
+      return handObservationResponse(this.#broker, request);
     }
     if (request.method === "POST" && url.pathname === "/snapshot") {
       const ownerId = await ownerFromBody(request);

--- a/js/managed/src/hand-observation.ts
+++ b/js/managed/src/hand-observation.ts
@@ -1,0 +1,48 @@
+import { HandObservationError, type HostedToolsBrokerCore, type HostedObservationSurface } from "nanocodex-tools/hosted";
+
+const headers = { "cache-control": "no-store", "x-content-type-options": "nosniff" };
+const json = (body: unknown, status = 200) => Response.json(body, { status, headers });
+
+/** Called only after the owning service has authorized the account. */
+export async function handObservationResponse(broker: HostedToolsBrokerCore, request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  if (request.method !== "GET") return json({ error: "method_not_allowed" }, 405);
+  if (url.pathname === "/hands" && !url.search) return json({ surfaces: broker.observationSurfaces() });
+  const route = url.searchParams.get("route_token");
+  const surface = url.searchParams.get("surface_id");
+  if (url.pathname !== "/hands/frame" || [...url.searchParams].length !== 2
+    || url.searchParams.getAll("route_token").length !== 1 || url.searchParams.getAll("surface_id").length !== 1
+    || !route || route.length > 256 || !surface || surface.length > 128) return json({ error: "invalid_request" }, 400);
+  try { return json(await broker.observe(route, surface, request.signal)); }
+  catch (error) {
+    if (!(error instanceof HandObservationError)) throw error;
+    return Response.json({ error: `observation_${error.code}` }, {
+      status: error.code === "busy" ? 429 : error.code === "timeout" ? 504 : 409,
+      headers: { ...headers, ...(error.code === "busy" ? { "retry-after": "1" } : {}) },
+    });
+  }
+}
+
+export async function sessionHandObservationResponse(options: {
+  broker: HostedToolsBrokerCore; account: Fetcher; ownerId: string; request: Request;
+}): Promise<Response> {
+  const { broker, account, ownerId, request } = options;
+  const url = new URL(request.url);
+  const accountRequest = () => account.fetch(`https://account-tools.internal${url.pathname}${url.search}`, {
+    headers: { "x-nanocodex-owner-id": ownerId }, signal: request.signal,
+  });
+  if (url.pathname === "/hands" && !url.search) {
+    const response = await accountRequest();
+    if (!response.ok && response.status !== 404) return response;
+    const accountSurfaces = response.ok ? (await response.json<{ surfaces: HostedObservationSurface[] }>()).surfaces : [];
+    return json({ surfaces: [
+      ...broker.observationSurfaces().map((surface) => ({ ...surface, source: "agent" })),
+      ...accountSurfaces.map((surface) => ({ ...surface, source: "account" })),
+    ] });
+  }
+  const source = url.searchParams.get("source");
+  if (url.pathname !== "/hands/frame" || url.searchParams.getAll("source").length !== 1
+    || (source !== "agent" && source !== "account")) return json({ error: "invalid_request" }, 400);
+  url.searchParams.delete("source");
+  return source === "account" ? accountRequest() : handObservationResponse(broker, new Request(url, { signal: request.signal }));
+}

--- a/js/managed/src/index.ts
+++ b/js/managed/src/index.ts
@@ -1,3 +1,4 @@
+import { sessionHandObservationResponse } from "./hand-observation";
 import { DurableObject, WorkerEntrypoint } from "cloudflare:workers";
 import {
   getWorkspace,
@@ -1799,6 +1800,14 @@ async function managedFetch(
     sessionHeaders.delete("x-nanocodex-vm-renewal");
     forwardPrincipalAssertions(sessionHeaders, principal);
     const publicOrigin = `public_origin=${encodeURIComponent(url.origin)}`;
+    if (resource === "hands" || resource === "hands/frame") {
+      if (request.method !== "GET") return json({ error: "method_not_allowed" }, { status: 405 });
+      if (principal.connectGrant || !principal.capabilities.includes("agents:read")
+        || !principal.capabilities.includes("tools:use")) return json({ error: "forbidden" }, { status: 403 });
+      return stub.fetch(`https://session.internal/${resource}${url.search}`, {
+        headers: sessionHeaders, signal: request.signal,
+      });
+    }
     if (resource === "vm-host") {
       if (url.search !== "") return json({ error: "invalid_request" }, { status: 400 });
       if (request.method !== "GET" || request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
@@ -3002,6 +3011,13 @@ export class DurableAgentSession extends DurableComputerSession {
         ?? "VM host control lease ended";
       this.#hostedTools.revokeRoute(routeId, reason.slice(0, 256));
       return new Response(null, { status: 204 });
+    }
+    if (request.method === "GET" && (url.pathname === "/hands" || url.pathname === "/hands/frame")) {
+      if (ownerAssertion === null || this.#deleting || this.#deleted) return json({ error: "not_found" }, { status: 404 });
+      if (turnAuthorization.connectGrant || !turnAuthorization.capabilities.includes("agents:read")
+        || !turnAuthorization.capabilities.includes("tools:use")) return json({ error: "forbidden" }, { status: 403 });
+      return sessionHandObservationResponse({ broker: this.#hostedTools, request, ownerId: ownerAssertion,
+        account: this.env.NANOCODEX_ACCOUNT_TOOLS.getByName(ownerAssertion) });
     }
     if (request.method === "GET" && url.pathname === "/tool-host") {
       if (ownerAssertion === null) return json({ error: "not_found" }, { status: 404 });

--- a/js/managed/test/account-hosted-tools.test.ts
+++ b/js/managed/test/account-hosted-tools.test.ts
@@ -448,3 +448,40 @@ function machineEntry() {
     timeout_ms: 30_000,
   };
 }
+
+it("serves live observations through an account-owned Worker socket with isolation and drain fencing", async () => {
+  const namespace = (env as unknown as { NANOCODEX_ACCOUNT_TOOLS: DurableObjectNamespace<AccountHostedTools> }).NANOCODEX_ACCOUNT_TOOLS;
+  const stub = namespace.getByName(ACCOUNT_A);
+  const headers = { "x-nanocodex-owner-id": ACCOUNT_A };
+  const upgraded = await stub.fetch("https://account-tools.internal/tool-host", { headers: { ...headers, upgrade: "websocket" } });
+  const socket = upgraded.webSocket!;
+  socket.accept();
+  const ready = nextFrame(socket);
+  socket.send(JSON.stringify({ type: "catalog", attachment_id: "observed", tools: [machineEntry()],
+    machines: [{ id: "observed", name: "Observed desktop", workspace: "/work", capabilities: ["screen"] }],
+    observation_surfaces: [{ id: "screen", name: "Desktop", kind: "desktop" }] }));
+  await expect(ready).resolves.toEqual({ type: "ready" });
+  const listed = await stub.fetch("https://account-tools.internal/hands", { headers });
+  expect(listed.headers.get("cache-control")).toBe("no-store");
+  const body = await listed.json<{ surfaces: { route_token: string }[] }>();
+  const query = new URLSearchParams({ route_token: body.surfaces[0]!.route_token, surface_id: "screen" });
+  const url = `https://account-tools.internal/hands/frame?${query}`;
+  expect((await stub.fetch(url, { headers: { "x-nanocodex-owner-id": ACCOUNT_B } })).status).toBe(404);
+  expect((await stub.fetch(url)).status).toBe(404);
+  expect((await stub.fetch(`${url}&surface_id=other`, { headers })).status).toBe(400);
+  const request = nextFrame(socket);
+  const capture = stub.fetch(url, { headers });
+  const frame = await request;
+  expect(frame).toMatchObject({ type: "observe", surface_id: "screen" });
+  const result = { status: "frame", frame: { captured_at: 123, width: 1, height: 1, mime_type: "image/png", data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl6iAAAAABJRU5ErkJggg==" } };
+  socket.send(JSON.stringify({ type: "observation", request_id: frame.request_id, result }));
+  const response = await capture;
+  expect(response.status).toBe(200);
+  expect(response.headers.get("cache-control")).toBe("no-store");
+  expect(await response.json()).toEqual(result);
+  const draining = nextFrame(socket);
+  socket.send(JSON.stringify({ type: "drain" }));
+  await expect(draining).resolves.toEqual({ type: "draining" });
+  expect((await stub.fetch(url, { headers })).status).toBe(409);
+  socket.close(1000, "test complete");
+});

--- a/js/managed/test/hosted-tools-broker.test.ts
+++ b/js/managed/test/hosted-tools-broker.test.ts
@@ -1332,3 +1332,92 @@ function result(callId: string, output: string): string {
     },
   });
 }
+
+const screenCatalog = {
+  type: "catalog", attachment_id: "screen-host", tools: [entry()],
+  machines: [{ id: "screen-host", name: "Screen host", workspace: "/work", capabilities: ["screen"] }],
+  observation_surfaces: [{ id: "screen", name: "Screen", kind: "desktop" }],
+};
+const observation = { status: "frame", frame: { captured_at: 123, width: 1, height: 1, mime_type: "image/png", data: "AAAA" } };
+
+describe("hand observation protocol", () => {
+  it("fences generations, bounds requests and keeps frames out of durable receipts", async () => {
+    let now = NOW;
+    const fixture = createFixture(undefined, { now: () => now });
+    const host = fixture.socket();
+    await fixture.broker.message(host.webSocket, JSON.stringify(screenCatalog));
+    const [screen] = fixture.broker.observationSurfaces();
+    const result = fixture.broker.observe(screen!.route_token, "screen");
+    await expect(fixture.broker.observe(screen!.route_token, "screen")).rejects.toMatchObject({ code: "busy" });
+    const request = host.sent.at(-1)!;
+    expect(request).toMatchObject({ type: "observe", surface_id: "screen" });
+    await fixture.broker.message(host.webSocket, JSON.stringify({ type: "observation", request_id: request.request_id, result: observation }));
+    await expect(result).resolves.toEqual(observation);
+    expect(fixture.persistence.call(String(request.request_id))).toBeUndefined();
+    now += 250;
+    const interrupted = fixture.broker.observe(screen!.route_token, "screen");
+    const rejected = expect(interrupted).rejects.toMatchObject({ code: "unavailable" });
+    const replacement = fixture.socket();
+    await fixture.broker.message(replacement.webSocket, JSON.stringify(screenCatalog));
+    await rejected;
+    await expect(fixture.broker.observe(screen!.route_token, "screen")).rejects.toMatchObject({ code: "unavailable" });
+    expect(fixture.broker.observationSurfaces()[0]!.route_token).not.toBe(screen!.route_token);
+  });
+
+  it("cancels viewers without retiring the hand, and removes draining screens", async () => {
+    let now = NOW;
+    const fixture = createFixture(undefined, { now: () => now });
+    const host = fixture.socket();
+    await fixture.broker.message(host.webSocket, JSON.stringify(screenCatalog));
+    const [screen] = fixture.broker.observationSurfaces();
+    const controller = new AbortController();
+    const result = fixture.broker.observe(screen!.route_token, "screen", controller.signal);
+    controller.abort();
+    await expect(result).rejects.toMatchObject({ code: "aborted" });
+    expect(host.sent.at(-1)).toMatchObject({ type: "observe_cancel" });
+    expect(fixture.broker.provider().definitions()).toHaveLength(1);
+    expect(host.closed).toBeUndefined();
+    now += 250;
+    const pending = fixture.broker.observe(screen!.route_token, "screen");
+    const rejected = expect(pending).rejects.toMatchObject({ code: "unavailable" });
+    await fixture.broker.message(host.webSocket, JSON.stringify({ type: "drain" }));
+    await rejected;
+    expect(fixture.broker.observationSurfaces()).toEqual([]);
+  });
+
+  it("keeps an existing hand when candidate socket metadata cannot be serialized", async () => {
+    const fixture = createFixture();
+    const host = fixture.socket();
+    await fixture.broker.message(host.webSocket, JSON.stringify(screenCatalog));
+    const before = fixture.broker.observationSurfaces();
+    const candidate = fixture.socket();
+    const original = candidate.serializeAttachment.bind(candidate);
+    candidate.serializeAttachment = (value: unknown) => {
+      if ((value as { observationSurfaces?: unknown }).observationSurfaces) throw new Error("attachment too large");
+      original(value);
+    };
+    await fixture.broker.message(candidate.webSocket, JSON.stringify(screenCatalog));
+    expect(fixture.broker.observationSurfaces()).toEqual(before);
+    expect(host.closed).toBeUndefined();
+    expect(candidate.sent).not.toContainEqual({ type: "ready" });
+  });
+});
+
+it("times out a stalled observation and ignores its late frame without fencing tool routing", async () => {
+  vi.useFakeTimers();
+  try {
+    const fixture = createFixture();
+    const host = fixture.socket();
+    await fixture.broker.message(host.webSocket, JSON.stringify(screenCatalog));
+    const [screen] = fixture.broker.observationSurfaces();
+    const pending = fixture.broker.observe(screen!.route_token, "screen");
+    const request = host.sent.at(-1)!;
+    const rejected = expect(pending).rejects.toMatchObject({ code: "timeout" });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await rejected;
+    expect(host.sent.at(-1)).toMatchObject({ type: "observe_cancel", request_id: request.request_id });
+    await fixture.broker.message(host.webSocket, JSON.stringify({ type: "observation", request_id: request.request_id, result: observation }));
+    expect(fixture.broker.observationSurfaces()).toHaveLength(1);
+    expect(host.closed).toBeUndefined();
+  } finally { vi.useRealTimers(); }
+});

--- a/js/managed/test/hosted-tools-protocol.test.ts
+++ b/js/managed/test/hosted-tools-protocol.test.ts
@@ -186,3 +186,16 @@ describe("hosted tools socket protocol", () => {
     }))).toThrow("id equals attachment_id");
   });
 });
+
+it("validates observation direction, metadata and image bounds", () => {
+  const observe = { type: "observe", request_id: "request:1", surface_id: "screen" };
+  expect(parseHostedToolsManagedFrame(JSON.stringify(observe))).toEqual(observe);
+  expect(() => parseHostedToolsHostFrame(JSON.stringify(observe))).toThrow();
+  expect(() => parseHostedToolsManagedFrame(JSON.stringify({ ...observe, surface_id: "bad/id" }))).toThrow();
+  expect(() => parseHostedToolsHostFrame(JSON.stringify({ type: "catalog", tools: [], observation_surfaces: [{ id: "screen", name: "Screen", kind: "desktop" }] }))).toThrow();
+  const observation = { type: "observation", request_id: "request:1", result: { status: "frame", frame: { captured_at: 1, width: 1, height: 1, mime_type: "image/jpeg", data: "AAAA" } } };
+  expect(parseHostedToolsHostFrame(JSON.stringify(observation))).toEqual(observation);
+  expect(() => parseHostedToolsManagedFrame(JSON.stringify(observation))).toThrow();
+  observation.result.frame.data = "a".repeat(240004);
+  expect(() => parseHostedToolsHostFrame(JSON.stringify(observation))).toThrow();
+});

--- a/js/nanocodex-tools/README.md
+++ b/js/nanocodex-tools/README.md
@@ -18,3 +18,68 @@ JS-only host capabilities; `nanocodex-tools` never imports `nanocodex`.
 Cloudflare Workers may supply Durable Object persistence and WebSocket
 registries to the hosted-tools core, but Cloudflare bindings, account authority,
 Connect grants, and storage schemas remain owned by those Workers.
+
+### Live hand screens
+
+In the web agent terminal, open **Live view**, select a screen, and watch as
+hand tools run. Pause, close, or hide the tab to stop capture. Landscape and
+portrait images retain their aspect ratios. Viewing is read-only; agent actions
+continue through the hand's tools.
+
+JavaScript hosts opt in with an observation provider:
+
+```js
+import { createTools } from "nanocodex/tools";
+import { createScreenObservation } from "nanocodex-tools/observation/node";
+
+const tools = await createTools({
+  attachmentId: "desktop",
+  machines: [{ id: "desktop", name: "My desktop", workspace: process.cwd(), capabilities: ["screen"] }],
+  tools: myComputerUseTools,
+  observation: createScreenObservation({ source: "desktop" }),
+});
+await tools.attach(agent.toolsTarget()).connect();
+```
+
+For Android use `{ source: "android", device: "SERIAL" }`. Both providers require
+FFmpeg. Desktop acquisition uses macOS `screencapture`, Linux X11, Windows
+`gdigrab`, or `grim` on supported Wayland compositors. Android uses
+`adb -s SERIAL exec-out screencap -p`. Grant screen-recording permission to the
+host on macOS, and authorize the explicit Android device in adb.
+
+Browser or other device adapters can implement
+`{ surfaces, capture({ surfaceId, signal }) }`. Surface descriptors have `id`,
+`name`, and `kind` (`desktop`, `browser`, or `phone`). Capture returns
+`{ captured_at, width, height, mime_type, data }` with base64 JPEG or PNG data.
+Honor abort signals and capture the actual surface controlled by the hand.
+iOS and graphical VM displays require custom providers; built-in adapters for
+those platforms are not included.
+
+The managed SDK exposes the same capability:
+
+```js
+const [screen] = await agent.hands.list();
+if (screen) {
+  for await (const result of agent.hands.frames(screen, { signal })) {
+    if (result.status === "frame") renderFrame(result.frame);
+  }
+}
+```
+
+Breaking iteration stops demand; abort the signal to interrupt an outstanding
+request. After a reconnect, list again for the new route token. Pending requests
+never move to a replacement hand.
+
+Endpoints: `GET /v1/agents/:id/hands` and
+`GET /v1/agents/:id/hands/frame?source=agent|account&route_token=...&surface_id=...`.
+Both require the owning account with `agents:read` and `tools:use`. Connect grants
+cannot enumerate or view screens. Route tokens select connections and are not
+authorization credentials. Responses disable caching.
+
+This is a live screenshot feed (up to four frames/second), without audio or
+recording. Capture is limited to one request per hand every 250 ms, one capture
+in flight, and a five-second deadline. Images are at most 180 KB; built-in
+providers fit them inside 960×960. No capture runs without viewer demand. Frames
+and capture requests never enter durable tool receipts, agent history, or replay
+logs. Errors are redacted before transmission. Detaching, draining, replacing,
+or revoking a hand cancels its observations independently of tool receipts.

--- a/js/nanocodex-tools/package.json
+++ b/js/nanocodex-tools/package.json
@@ -71,6 +71,14 @@
     "./workspace": {
       "types": "./tools/workspace.d.mts",
       "import": "./tools/workspace.mjs"
+    },
+    "./observation": {
+      "types": "./tools/observation.d.mts",
+      "import": "./tools/observation.mjs"
+    },
+    "./observation/node": {
+      "types": "./tools/observation-node.d.mts",
+      "import": "./tools/observation-node.mjs"
     }
   },
   "files": [

--- a/js/nanocodex-tools/src/hosted/broker-core.ts
+++ b/js/nanocodex-tools/src/hosted/broker-core.ts
@@ -1,3 +1,4 @@
+import { OBSERVATION_TIMEOUT_MS, OBSERVATION_INTERVAL_MS, type ObservationSurface, type ObservationResult } from "../../tools/observation.mjs";
 import {
   HOSTED_TOOL_CALL_TIMEOUT_MS,
   HOSTED_TOOLS_LEASE_MS,
@@ -48,6 +49,13 @@ const encoder = new TextEncoder();
 export const HOSTED_TOOLS_PRE_ADMISSION_UNAVAILABLE = Symbol.for(
   "nanocodex.tool.preDispatchUnavailable",
 );
+
+export type HostedObservationSurface = ObservationSurface & Readonly<{
+  machine_id: string; machine_name: string; route_token: string;
+}>;
+export class HandObservationError extends Error {
+  constructor(readonly code: "unavailable" | "busy" | "timeout" | "aborted") { super(`Hand observation ${code}`); }
+}
 
 export type HostedToolsCallState =
   | "admitted"
@@ -101,6 +109,7 @@ type HostedToolsSocketAttachment = {
   active?: true;
   draining?: true;
   machines?: readonly HostedMachine[];
+  observationSurfaces?: readonly ObservationSurface[];
 };
 
 type PendingCall = {
@@ -263,6 +272,8 @@ export type HostedToolsLeasedAttachmentRenewal = Readonly<{
 /** Owns one reverse-tool attachment over an injected socket and durable ledger. */
 export class HostedToolsBrokerCore {
   readonly #provider: HostedToolsDynamicProvider;
+  readonly #observations = new Map<string, { socket: HostedToolsSocket; finish(result: ObservationResult | HandObservationError): void }>();
+  readonly #lastObservation = new WeakMap<HostedToolsSocket, number>();
   readonly #pending = new Map<string, PendingCall>();
   readonly #now: () => number;
   readonly #randomUUID: () => string;
@@ -281,6 +292,61 @@ export class HostedToolsBrokerCore {
     | undefined;
   #catalogValidator: HostedToolsCatalogValidator | undefined;
   #nextCandidateGeneration: number;
+
+  /** Live metadata only: frames and capture requests never enter durable tool receipts. */
+  observationSurfaces(): HostedObservationSurface[] {
+    return this.#observationBindings().map(({ surface }) => surface);
+  }
+
+  #observationBindings(): { socket: HostedToolsSocket; surface: HostedObservationSurface }[] {
+    return this.#persistence.states().flatMap((state) => {
+      const socket = this.#liveRoutingSocketForState(state);
+      const attachment = socket && this.#attachment(socket);
+      const machine = attachment?.machines?.[0];
+      if (!socket || !attachment || attachment.connectGrantId !== undefined || !machine) return [];
+      return (attachment.observationSurfaces ?? []).map((surface) => ({ socket, surface: {
+        ...surface, machine_id: machine.id, machine_name: machine.name,
+        route_token: `${state.lease_id}:${state.generation}`,
+      } }));
+    });
+  }
+
+  async observe(routeToken: string, surfaceId: string, signal?: AbortSignal): Promise<ObservationResult> {
+    if (signal?.aborted) throw new HandObservationError("aborted");
+    const binding = this.#observationBindings().find(({ surface }) => surface.route_token === routeToken && surface.id === surfaceId);
+    if (!binding) throw new HandObservationError("unavailable");
+    const { socket } = binding;
+    if (this.#observations.size >= 32 || [...this.#observations.values()].some((p) => p.socket === socket)
+      || this.#now() - (this.#lastObservation.get(socket) ?? -Infinity) < OBSERVATION_INTERVAL_MS) throw new HandObservationError("busy");
+    this.#lastObservation.set(socket, this.#now());
+    const requestId = this.#randomUUID();
+    return new Promise((resolve, reject) => {
+      const finish = (result: ObservationResult | HandObservationError) => {
+        if (!this.#observations.delete(requestId)) return;
+        clearTimeout(timer);
+        signal?.removeEventListener("abort", aborted);
+        if (result instanceof HandObservationError) reject(result); else resolve(result);
+      };
+      const cancel = (code: "timeout" | "aborted") => {
+        try { this.#send(socket, { type: "observe_cancel", request_id: requestId }); } catch { /* Connection may already be closed. */ }
+        finish(new HandObservationError(code));
+      };
+      const aborted = () => cancel("aborted");
+      const timer = setTimeout(() => cancel("timeout"), OBSERVATION_TIMEOUT_MS);
+      this.#observations.set(requestId, { socket, finish });
+      signal?.addEventListener("abort", aborted, { once: true });
+      try { this.#send(socket, { type: "observe", request_id: requestId, surface_id: surfaceId }); }
+      catch { finish(new HandObservationError("unavailable")); }
+    });
+  }
+
+  #cancelObservations(socket: HostedToolsSocket): void {
+    for (const [requestId, pending] of this.#observations) {
+      if (pending.socket !== socket) continue;
+      try { this.#send(socket, { type: "observe_cancel", request_id: requestId }); } catch { /* Closed socket. */ }
+      pending.finish(new HandObservationError("unavailable"));
+    }
+  }
 
   constructor(
     readonly context: HostedToolsBrokerCoreContext,
@@ -591,7 +657,11 @@ export class HostedToolsBrokerCore {
     if (frame.type === "catalog") await this.#publishCatalog(socket, frame);
     else if (frame.type === "ping") await this.#heartbeat(socket, frame);
     else if (frame.type === "drain") this.#drain(socket);
-    else this.#completeResult(socket, frame);
+    else if (frame.type === "observation") {
+      this.#activeAttachment(socket);
+      const pending = this.#observations.get(frame.request_id);
+      if (pending?.socket === socket) pending.finish(frame.result);
+    } else this.#completeResult(socket, frame);
   }
 
   #activeAttachment(socket: HostedToolsSocket): HostedToolsSocketAttachment {
@@ -825,6 +895,15 @@ export class HostedToolsBrokerCore {
     }
     const now = this.#now();
     const replaced = state.lease_id ? state : undefined;
+    this.context.writeAttachment(
+      socket,
+      {
+        ...candidate,
+        active: true,
+        ...(frame.observation_surfaces === undefined ? {} : { observationSurfaces: frame.observation_surfaces }),
+        ...(frame.machines === undefined ? {} : { machines: frame.machines }),
+      } satisfies HostedToolsSocketAttachment,
+    );
     // A failed ready send must leave the previous attachment routable.
     this.#send(socket, { type: "ready" });
     this.#persistence.transaction(() => {
@@ -855,14 +934,7 @@ export class HostedToolsBrokerCore {
         closeSocket(existing, 1008, "Hosted Tools attachment replaced");
       }
     }
-    this.context.writeAttachment(
-      socket,
-      {
-        ...candidate,
-        active: true,
-        ...(frame.machines === undefined ? {} : { machines: frame.machines }),
-      } satisfies HostedToolsSocketAttachment,
-    );
+
     this.#notifyCatalogChanged();
   }
 
@@ -872,6 +944,7 @@ export class HostedToolsBrokerCore {
       throw new HostedToolsProtocolError("already_draining", "socket is already draining");
     }
     const state = this.#persistence.state(attachment.routeId!)!;
+    this.#cancelObservations(socket);
     // Visibility is removed before the peer is told that draining began.
     this.#persistence.clearCatalog(state.lease_id!, state.generation);
     this.context.writeAttachment(
@@ -1288,6 +1361,10 @@ export class HostedToolsBrokerCore {
   }
 
   #resolveGeneration(leaseId: string, generation: number, outcome: HostedToolCallOutcome): void {
+    for (const socket of this.context.sockets()) {
+      const attachment = this.#attachment(socket);
+      if (attachment?.leaseId === leaseId && attachment.generation === generation) this.#cancelObservations(socket);
+    }
     for (const [callId, pending] of this.#pending) {
       if (pending.leaseId !== leaseId || pending.generation !== generation) continue;
       this.#takePending(callId)?.resolve(outcome);

--- a/js/nanocodex-tools/src/hosted/protocol.ts
+++ b/js/nanocodex-tools/src/hosted/protocol.ts
@@ -1,3 +1,4 @@
+import { normalizeObservationSurfaces, normalizeObservationResult, observationId, type ObservationSurface, type ObservationResult } from "../../tools/observation.mjs";
 import {
   normalizeHostedMachines,
   type HostedMachine,
@@ -81,11 +82,13 @@ export type HostedToolCallOutcome =
   | { status: "cancelled"; message: string };
 
 export type HostedToolsHostFrame =
+  | { type: "observation"; request_id: string; result: ObservationResult }
   | {
       type: "catalog";
       tools: HostedToolCatalogEntry[];
       machines?: HostedMachine[];
       attachment_id?: string;
+      observation_surfaces?: readonly ObservationSurface[];
     }
   | {
       type: "result";
@@ -99,6 +102,8 @@ export type HostedToolsHostFrame =
   | { type: "drain" };
 
 export type HostedToolsManagedFrame =
+  | { type: "observe"; request_id: string; surface_id: string }
+  | { type: "observe_cancel"; request_id: string }
   | { type: "ready" }
   | {
       type: "call";
@@ -127,8 +132,8 @@ export type HostedToolsManagedFrame =
 
 export type HostedToolsFrame = HostedToolsHostFrame | HostedToolsManagedFrame;
 
-const HOST_FRAME_TYPES = new Set(["catalog", "result", "ping", "drain"]);
-const MANAGED_FRAME_TYPES = new Set(["ready", "call", "cancel", "ack", "pong", "draining"]);
+const HOST_FRAME_TYPES = new Set(["catalog", "result", "ping", "drain", "observation"]);
+const MANAGED_FRAME_TYPES = new Set(["ready", "call", "cancel", "ack", "pong", "draining", "observe", "observe_cancel"]);
 
 export function parseHostedToolsHostFrame(encoded: string): HostedToolsHostFrame {
   const frame = parseHostedToolsFrame(encoded);
@@ -167,6 +172,15 @@ export function parseHostedToolsFrame(encoded: string): HostedToolsFrame {
   }
   const frame = objectValue(value, "Hosted Tools frame");
   switch (frame.type) {
+    case "observation":
+      exactKeys(frame, ["type", "request_id", "result"]);
+      return { type: "observation", request_id: observationId(frame.request_id), result: normalizeObservationResult(frame.result) };
+    case "observe":
+      exactKeys(frame, ["type", "request_id", "surface_id"]);
+      return { type: "observe", request_id: observationId(frame.request_id), surface_id: observationId(frame.surface_id) };
+    case "observe_cancel":
+      exactKeys(frame, ["type", "request_id"]);
+      return { type: "observe_cancel", request_id: observationId(frame.request_id) };
     case "catalog":
       return parseCatalog(frame);
     case "result":
@@ -198,7 +212,7 @@ export function parseHostedToolsFrame(encoded: string): HostedToolsFrame {
 function parseCatalog(
   frame: Record<string, unknown>,
 ): Extract<HostedToolsHostFrame, { type: "catalog" }> {
-  exactKeys(frame, ["type", "tools", "machines", "attachment_id"]);
+  exactKeys(frame, ["type", "tools", "machines", "attachment_id", "observation_surfaces"]);
   if (!Array.isArray(frame.tools) || frame.tools.length > MAX_HOSTED_TOOL_CATALOG_ENTRIES) {
     throw new HostedToolsProtocolError(
       "invalid_catalog",
@@ -207,6 +221,8 @@ function parseCatalog(
   }
   const tools = frame.tools.map((entry, index) => catalogEntry(entry, index));
   const machines = machineCatalog(frame.machines);
+  const surfaces = frame.observation_surfaces === undefined ? undefined : normalizeObservationSurfaces(frame.observation_surfaces);
+  if (surfaces && machines?.length !== 1) throw new HostedToolsProtocolError("invalid_catalog", "observation requires one machine");
   const attachmentId = frame.attachment_id === undefined
     ? undefined
     : sourceIdentifier(frame.attachment_id, "attachment_id");
@@ -238,6 +254,7 @@ function parseCatalog(
     tools,
     ...(machines === undefined ? {} : { machines }),
     ...(attachmentId === undefined ? {} : { attachment_id: attachmentId }),
+    ...(surfaces === undefined ? {} : { observation_surfaces: surfaces }),
   };
 }
 

--- a/js/nanocodex-tools/tools/attachment.mjs
+++ b/js/nanocodex-tools/tools/attachment.mjs
@@ -1,3 +1,4 @@
+import { normalizeObservationProvider, normalizeObservationFrame, OBSERVATION_TIMEOUT_MS } from "./observation.mjs";
 import { toolRouterRuntime } from "../runtime/tool-router.mjs";
 import { utf8ByteLength } from "../runtime/utf8.mjs";
 import { hostedCatalog } from "./hostedCatalog.mjs";
@@ -33,6 +34,7 @@ export function createAttachment(owner, target, options = {}) {
   validateAttachmentOptions(target, options);
   const machines = normalizeHostedMachines(options.machines);
   const attachmentId = options.attachmentId;
+  options = { ...options, observation: normalizeObservationProvider(options.observation, machines) };
   if (machines.length > 0 && attachmentId !== machines[0].id) {
     throw new TypeError("a machine attachment requires one machine whose id equals attachmentId");
   }
@@ -86,6 +88,7 @@ function createClient(endpoint, transport, options, admission, machines, attachm
     catalog: hostedCatalog(admission.catalog(options.provider ?? "javascript")),
     machines,
     attachmentId,
+    observation: undefined,
     calls: new Map(),
     receipts: new Map(),
     heartbeat: undefined,
@@ -113,6 +116,7 @@ function createClient(endpoint, transport, options, admission, machines, attachm
     close() {
       if (state.stopped) return closed;
       state.stopped = true;
+      state.observation?.controller.abort();
       clearTimeout(state.reconnectTimer);
       state.reconnectTimer = undefined;
       const socket = state.socket;
@@ -219,9 +223,35 @@ function createClient(endpoint, transport, options, admission, machines, attachm
     send(socket, {
       type: "catalog",
       tools: state.catalog,
+      ...(options.observation === undefined ? {} : { observation_surfaces: options.observation.surfaces }),
       ...(state.machines.length === 0 ? {} : { machines: state.machines }),
       ...(state.attachmentId === undefined ? {} : { attachment_id: state.attachmentId }),
     });
+  }
+
+  async function captureObservation(frame, socket) {
+    const reply = (result) => {
+      if (state.socket === socket && !state.stopped && !state.draining) {
+        try { send(socket, { type: "observation", request_id: frame.request_id, result }); }
+        catch (error) { transportFailure(socket, error); }
+      }
+    };
+    if (state.observation || !options.observation?.surfaces.some((s) => s.id === frame.surface_id)) {
+      reply({ status: "unavailable", message: "Screen capture unavailable" });
+      return;
+    }
+    const capture = { requestId: frame.request_id, controller: new AbortController() };
+    state.observation = capture;
+    const timer = setTimeout(() => capture.controller.abort(), OBSERVATION_TIMEOUT_MS);
+    try {
+      const image = await options.observation.capture({ surfaceId: frame.surface_id, signal: capture.controller.signal });
+      if (!capture.controller.signal.aborted) reply({ status: "frame", frame: normalizeObservationFrame(image) });
+    } catch {
+      if (!capture.controller.signal.aborted) reply({ status: "unavailable", message: "Screen capture unavailable" });
+    } finally {
+      clearTimeout(timer);
+      if (state.observation === capture) state.observation = undefined;
+    }
   }
 
   async function handleFrame(encoded, socket) {
@@ -236,6 +266,13 @@ function createClient(endpoint, transport, options, admission, machines, attachm
         state.handshakeTimer = undefined;
         startHeartbeat(socket);
         if (!state.readySettled) { state.readySettled = true; resolveReady(publicClient); }
+        break;
+      case "observe":
+        if (!state.readyReceived || state.draining) throw new Error("observe outside routing-ready socket");
+        void captureObservation(frame, socket);
+        break;
+      case "observe_cancel":
+        if (state.observation?.requestId === frame.request_id) state.observation.controller.abort();
         break;
       case "call":
         if (!state.readyReceived || state.drainAcknowledged) throw new Error("call received outside a routing-ready socket");
@@ -481,7 +518,7 @@ async function openSocket(endpoint, transport) {
 
 function validateAttachmentOptions(target, options) {
   if (!options || typeof options !== "object" || Array.isArray(options)) throw new TypeError("tool attachment options must be an object");
-  const allowed = new Set(["provider", "reconnect", "reconnectDelayMs", "heartbeatMs", "handshakeTimeoutMs", "drainTimeoutMs", "machines", "attachmentId"]);
+  const allowed = new Set(["provider", "reconnect", "reconnectDelayMs", "heartbeatMs", "handshakeTimeoutMs", "drainTimeoutMs", "machines", "attachmentId", "observation"]);
   for (const name of Object.keys(options)) if (!allowed.has(name)) throw new TypeError(`unsupported tool attachment option: ${name}`);
   if (options.provider !== undefined && (typeof options.provider !== "string" || !options.provider.trim())) throw new TypeError("tool attachment provider must be a non-empty string");
   if (options.reconnect !== undefined && typeof options.reconnect !== "boolean") throw new TypeError("tool attachment reconnect must be boolean");
@@ -542,6 +579,9 @@ function parseFrame(encoded) {
     if (positiveInteger(frame.output_token_budget, "output_token_budget") > 1_000_000) throw new Error("output_token_budget exceeds protocol bound");
     if (positiveInteger(frame.output_byte_budget, "output_byte_budget") > 128 * 1024) throw new Error("output_byte_budget exceeds protocol bound");
     positiveInteger(frame.deadline_at, "deadline_at");
+  } else if (frame.type === "observe" || frame.type === "observe_cancel") {
+    requiredIdentifier(frame.request_id, "request_id");
+    if (frame.type === "observe") requiredIdentifier(frame.surface_id, "surface_id");
   } else if (frame.type === "cancel" || frame.type === "ack") requiredIdentifier(frame.call_id, "call_id");
   else if (frame.type === "pong") {
     if (typeof frame.nonce !== "string" || !frame.nonce || utf8ByteLength(frame.nonce) > 128) throw new Error("invalid pong nonce");
@@ -555,6 +595,7 @@ function clearTimers(state) {
   state.pendingNonce = undefined;
 }
 function abortGeneration(state, reason) {
+  state.observation?.controller.abort(reason);
   for (const call of state.calls.values()) call.controller.abort(reason);
   state.calls.clear(); state.receipts.clear(); state.pendingNonce = undefined;
 }
@@ -595,6 +636,8 @@ function randomNonce() {
 
 const DO_KEYS = Object.freeze({
   ready: ["type"],
+  observe: ["type", "request_id", "surface_id"],
+  observe_cancel: ["type", "request_id"],
   call: ["type", "session_id", "call_id", "model", "name", "input", "output_token_budget", "output_byte_budget", "deadline_at"],
   cancel: ["type", "call_id"],
   ack: ["type", "call_id"],

--- a/js/nanocodex-tools/tools/observation-node.d.mts
+++ b/js/nanocodex-tools/tools/observation-node.d.mts
@@ -1,0 +1,2 @@
+import type { ObservationProvider } from "./observation.mjs";
+export function createScreenObservation(options?: { source?: "desktop"; name?: string } | { source: "android"; device: string; name?: string }): ObservationProvider;

--- a/js/nanocodex-tools/tools/observation-node.mjs
+++ b/js/nanocodex-tools/tools/observation-node.mjs
@@ -1,0 +1,60 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { mkdtemp, readFile, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { normalizeObservationFrame } from "./observation.mjs";
+
+const execute = promisify(execFile);
+
+/** Explicitly shares the local desktop or one named Android device with owned viewers. */
+export function createScreenObservation({ source = "desktop", device, name = source === "android" ? "Android screen" : "Desktop" } = {}) {
+  if (!["desktop", "android"].includes(source)) throw new TypeError("unsupported screen source");
+  if (source === "android" && (typeof device !== "string" || !device || device.startsWith("-") || device.length > 256 || device.includes("\0"))) throw new TypeError("Android capture requires an explicit device serial");
+  return Object.freeze({
+    surfaces: Object.freeze([Object.freeze({ id: "screen", name, kind: source === "android" ? "phone" : "desktop" })]),
+    async capture({ surfaceId, signal }) {
+      if (surfaceId !== "screen") throw new Error("unknown screen");
+      signal.throwIfAborted();
+      const directory = await mkdtemp(join(tmpdir(), "nanocodex-screen-"));
+      const raw = join(directory, "raw.png");
+      const output = join(directory, "frame.jpg");
+      const run = (command, args, maxBuffer = 64 * 1024) => execute(command, args, { signal, timeout: 4_000, maxBuffer, encoding: "buffer", windowsHide: true });
+      try {
+        let input;
+        if (source === "android") {
+          const { stdout } = await run("adb", ["-s", device, "exec-out", "screencap", "-p"], 32 * 1024 * 1024);
+          await writeFile(raw, stdout, { mode: 0o600 });
+          input = ["-i", raw];
+        } else if (process.platform === "darwin") {
+          await run("screencapture", ["-x", "-t", "png", raw]);
+          input = ["-i", raw];
+        } else if (process.platform === "win32") {
+          input = ["-f", "gdigrab", "-i", "desktop"];
+        } else if (process.env.WAYLAND_DISPLAY) {
+          await run("grim", [raw]);
+          input = ["-i", raw];
+        } else if (process.env.DISPLAY) {
+          input = ["-f", "x11grab", "-i", process.env.DISPLAY];
+        } else throw new Error("No desktop display available");
+        await run("ffmpeg", ["-nostdin", "-loglevel", "error", ...input, "-frames:v", "1", "-vf", "scale=960:960:force_original_aspect_ratio=decrease", "-q:v", "8", "-y", output]);
+        const bytes = await readFile(output);
+        const [width, height] = jpegSize(bytes);
+        return normalizeObservationFrame({ captured_at: Date.now(), width, height, mime_type: "image/jpeg", data: bytes.toString("base64") });
+      } finally { await rm(directory, { recursive: true, force: true }); }
+    },
+  });
+}
+
+function jpegSize(bytes) {
+  if (bytes[0] !== 0xff || bytes[1] !== 0xd8) throw new Error("invalid JPEG");
+  for (let offset = 2; offset + 9 < bytes.length;) {
+    if (bytes[offset] !== 0xff) break;
+    const marker = bytes[offset + 1];
+    const length = bytes.readUInt16BE(offset + 2);
+    if (length < 2) break;
+    if ([0xc0, 0xc1, 0xc2].includes(marker)) return [bytes.readUInt16BE(offset + 7), bytes.readUInt16BE(offset + 5)];
+    offset += length + 2;
+  }
+  throw new Error("missing JPEG dimensions");
+}

--- a/js/nanocodex-tools/tools/observation.d.mts
+++ b/js/nanocodex-tools/tools/observation.d.mts
@@ -1,0 +1,12 @@
+export type ObservationSurface = Readonly<{ id: string; name: string; kind: "desktop" | "browser" | "phone" }>;
+export type ObservationFrame = Readonly<{ captured_at: number; width: number; height: number; mime_type: "image/jpeg" | "image/png"; data: string }>;
+export type ObservationResult = Readonly<{ status: "frame"; frame: ObservationFrame } | { status: "unavailable"; message: string }>;
+export type ObservationProvider = Readonly<{ surfaces: readonly ObservationSurface[]; capture(request: { surfaceId: string; signal: AbortSignal }): Promise<ObservationFrame> }>;
+export const MAX_OBSERVATION_IMAGE_BYTES: number;
+export const OBSERVATION_TIMEOUT_MS: number;
+export const OBSERVATION_INTERVAL_MS: number;
+export function observationId(value: unknown): string;
+export function normalizeObservationSurfaces(value: unknown): readonly ObservationSurface[];
+export function normalizeObservationProvider(value: ObservationProvider | undefined, machines: readonly unknown[]): ObservationProvider | undefined;
+export function normalizeObservationFrame(value: unknown): ObservationFrame;
+export function normalizeObservationResult(value: unknown): ObservationResult;

--- a/js/nanocodex-tools/tools/observation.mjs
+++ b/js/nanocodex-tools/tools/observation.mjs
@@ -1,0 +1,53 @@
+export const MAX_OBSERVATION_IMAGE_BYTES = 180_000;
+export const OBSERVATION_TIMEOUT_MS = 5_000;
+export const OBSERVATION_INTERVAL_MS = 250;
+
+export function observationId(value) {
+  if (typeof value !== "string" || !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(value)) {
+    throw new TypeError("invalid observation identifier");
+  }
+  return value;
+}
+function keys(value, allowed) {
+  if (!value || typeof value !== "object" || Array.isArray(value)
+    || Object.keys(value).some((key) => !allowed.includes(key))) throw new TypeError("invalid observation fields");
+}
+export function normalizeObservationSurfaces(value) {
+  if (!Array.isArray(value) || value.length < 1 || value.length > 8) throw new TypeError("expected 1-8 observation surfaces");
+  const ids = new Set();
+  return Object.freeze(value.map((surface) => {
+    keys(surface, ["id", "name", "kind"]);
+    const id = observationId(surface.id);
+    if (ids.has(id) || typeof surface.name !== "string" || !surface.name.trim()
+      || new TextEncoder().encode(surface.name).length > 128
+      || !["desktop", "browser", "phone"].includes(surface.kind)) throw new TypeError("invalid observation surface");
+    ids.add(id);
+    return Object.freeze({ id, name: surface.name, kind: surface.kind });
+  }));
+}
+export function normalizeObservationProvider(provider, machines) {
+  if (provider === undefined) return undefined;
+  if (machines.length !== 1 || typeof provider?.capture !== "function") throw new TypeError("observation requires one machine and a capture function");
+  return Object.freeze({ surfaces: normalizeObservationSurfaces(provider.surfaces), capture: provider.capture.bind(provider) });
+}
+export function normalizeObservationFrame(frame) {
+  keys(frame, ["captured_at", "width", "height", "mime_type", "data"]);
+  if (!Number.isSafeInteger(frame.captured_at) || frame.captured_at < 0
+    || ![frame.width, frame.height].every((n) => Number.isInteger(n) && n >= 1 && n <= 8192)
+    || !["image/jpeg", "image/png"].includes(frame.mime_type)
+    || typeof frame.data !== "string" || frame.data.length === 0
+    || frame.data.length > MAX_OBSERVATION_IMAGE_BYTES * 4 / 3
+    || !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(frame.data)) {
+    throw new TypeError("invalid observation frame");
+  }
+  return Object.freeze({ ...frame });
+}
+export function normalizeObservationResult(result) {
+  if (result?.status === "frame") {
+    keys(result, ["status", "frame"]);
+    return Object.freeze({ status: "frame", frame: normalizeObservationFrame(result.frame) });
+  }
+  keys(result, ["status", "message"]);
+  if (result.status !== "unavailable" || typeof result.message !== "string" || result.message.length > 256) throw new TypeError("invalid observation result");
+  return Object.freeze({ status: "unavailable", message: result.message });
+}

--- a/js/nanocodex/managed/Agent.d.mts
+++ b/js/nanocodex/managed/Agent.d.mts
@@ -1,3 +1,4 @@
+import type { ManagedHands } from "./Hands.mjs";
 import type { Model, PromptInput, ReasoningMode, Thinking, TurnUsage } from "../types.mjs";
 import type { AgentId } from "../runtime/subagents.mjs";
 
@@ -306,6 +307,7 @@ export type Agent = Readonly<{
     update(patch: SettingsPatch): Promise<CreateSettings>;
   }>;
   /** Reverse-tool endpoint with cookie/bearer transport retained in a private closure. */
+  readonly hands: ManagedHands;
   toolsTarget(): import("../tools/Tools.mjs").AttachmentTarget;
   events: Readonly<{
     page(options?: EventHistoryOptions): Promise<EventHistoryPage>;

--- a/js/nanocodex/managed/Agent.mjs
+++ b/js/nanocodex/managed/Agent.mjs
@@ -1,3 +1,4 @@
+import { managedHands } from "./Hands.mjs";
 import { ManagedError } from "./ManagedError.mjs";
 import { registerManagedAgent } from "./internal.mjs";
 
@@ -240,6 +241,7 @@ function agentHandle(client, id, summary) {
         body: managedSettingsPatch(patch),
       })).settings),
     }),
+    hands: managedHands(client, agentPath(id)),
     toolsTarget: () => client.toolsTarget(id),
     state: () => client.json(agentPath(id)),
     delete: async () => {

--- a/js/nanocodex/managed/Hands.d.mts
+++ b/js/nanocodex/managed/Hands.d.mts
@@ -1,0 +1,10 @@
+import type { ObservationSurface, ObservationFrame, ObservationResult } from "nanocodex-tools/observation";
+export type ManagedHandFrame = ObservationFrame;
+export type ManagedHandSurface = ObservationSurface & Readonly<{
+  source: "agent" | "account"; machine_id: string; machine_name: string; route_token: string;
+}>;
+export type ManagedHands = Readonly<{
+  list(options?: { signal?: AbortSignal }): Promise<readonly ManagedHandSurface[]>;
+  frames(surface: ManagedHandSurface, options?: { signal?: AbortSignal; intervalMs?: number }): AsyncGenerator<ObservationResult>;
+}>;
+export function managedHands(client: { json(path: string, options?: { signal?: AbortSignal }): Promise<unknown> }, path: string): ManagedHands;

--- a/js/nanocodex/managed/Hands.mjs
+++ b/js/nanocodex/managed/Hands.mjs
@@ -1,0 +1,44 @@
+import { normalizeObservationSurfaces, normalizeObservationResult, observationId, OBSERVATION_INTERVAL_MS } from "nanocodex-tools/observation";
+
+function surfaceMetadata(surface) {
+  observationId(surface?.id);
+  if (!["agent", "account"].includes(surface.source) || typeof surface.route_token !== "string"
+    || !surface.route_token || surface.route_token.length > 256) throw new TypeError("invalid managed hand surface");
+  return surface;
+}
+export function managedHands(client, path) {
+  return Object.freeze({
+    async list({ signal } = {}) {
+      const body = await client.json(`${path}/hands`, { signal });
+      if (!Array.isArray(body?.surfaces)) throw new TypeError("invalid managed hand surfaces");
+      return Object.freeze(body.surfaces.map((surface) => {
+        surfaceMetadata(surface);
+        const [description] = normalizeObservationSurfaces([{ id: surface.id, name: surface.name, kind: surface.kind }]);
+        if (typeof surface.machine_id !== "string" || typeof surface.machine_name !== "string") throw new TypeError("invalid hand machine");
+        return Object.freeze({ ...description, source: surface.source, route_token: surface.route_token,
+          machine_id: surface.machine_id, machine_name: surface.machine_name });
+      }));
+    },
+    async *frames(surface, { signal, intervalMs = OBSERVATION_INTERVAL_MS } = {}) {
+      surfaceMetadata(surface);
+      if (!Number.isInteger(intervalMs) || intervalMs < OBSERVATION_INTERVAL_MS || intervalMs > 60_000) throw new TypeError("invalid observation interval");
+      const query = new URLSearchParams({ source: surface.source, surface_id: surface.id, route_token: surface.route_token });
+      while (!signal?.aborted) {
+        const timeout = AbortSignal.timeout(10_000);
+        const requestSignal = signal ? AbortSignal.any([signal, timeout]) : timeout;
+        const result = normalizeObservationResult(await client.json(`${path}/hands/frame?${query}`, { signal: requestSignal }));
+        signal?.throwIfAborted();
+        yield result;
+        await pause(intervalMs, signal);
+      }
+    },
+  });
+}
+function pause(ms, signal) {
+  if (signal?.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const done = () => { clearTimeout(timer); signal?.removeEventListener("abort", done); resolve(); };
+    const timer = setTimeout(done, ms);
+    signal?.addEventListener("abort", done, { once: true });
+  });
+}

--- a/js/nanocodex/managed/index.d.mts
+++ b/js/nanocodex/managed/index.d.mts
@@ -16,3 +16,4 @@ export type {
   Turn as ManagedTurn,
   TurnResult as ManagedTurnResult,
 } from "./Agent.mjs";
+export type { ManagedHands, ManagedHandSurface, ManagedHandFrame } from "./Hands.mjs";

--- a/js/nanocodex/test/attachment.test.mjs
+++ b/js/nanocodex/test/attachment.test.mjs
@@ -655,3 +655,42 @@ async function waitForTimer(predicate) {
   }
   throw new Error("timer condition did not become true");
 }
+
+test("observation is demand-driven, concurrent with tools, and cancelled on detach", async () => {
+  const socket = new FakeSocket();
+  let captureSignal;
+  let finishCapture;
+  let captures = 0;
+  const tools = await createTools({
+    attachmentId: "desktop",
+    machines: [{ id: "desktop", name: "Desktop", workspace: "/work", capabilities: ["screen"] }],
+    observation: {
+      surfaces: [{ id: "screen", name: "Screen", kind: "desktop" }],
+      capture: ({ signal }) => { captures++; captureSignal = signal; return new Promise((resolve) => { finishCapture = resolve; }); },
+    },
+    tools: { echo: { description: "Echo", handler: () => "ok" } },
+  });
+  const connector = tools.attach(reverseTarget(async () => socket));
+  const connecting = connector.connect();
+  await waitFor(() => socket.frames().length > 0);
+  assert.equal(socket.frames()[0].observation_surfaces[0].id, "screen");
+  socket.receive({ type: "ready" });
+  const client = await connecting;
+  assert.equal(captures, 0);
+  socket.receive({ type: "observe", request_id: "view-1", surface_id: "screen" });
+  await waitFor(() => captures === 1);
+  socket.receive(callFrame({}));
+  await waitFor(() => lastFrame(socket, "result"));
+  socket.receive({ type: "ack", call_id: "call:1" });
+  socket.receive({ type: "observe", request_id: "view-2", surface_id: "screen" });
+  await waitFor(() => lastFrame(socket, "observation"));
+  assert.equal(lastFrame(socket, "observation").result.status, "unavailable");
+  const closing = client.close();
+  assert.equal(captureSignal.aborted, true);
+  finishCapture({ captured_at: 1, width: 1, height: 1, mime_type: "image/png", data: "AAAA" });
+  await tick();
+  assert.equal(socket.frames().some((f) => f.type === "observation" && f.request_id === "view-1"), false);
+  socket.receive({ type: "draining" });
+  await closing;
+  await tools.close();
+});

--- a/js/nanocodex/test/managed-hands.test.mjs
+++ b/js/nanocodex/test/managed-hands.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { open } from "../managed/Agent.mjs";
+import { normalizeObservationFrame, normalizeObservationSurfaces } from "nanocodex-tools/observation";
+
+const surface = { id: "screen", name: "Screen", kind: "desktop", source: "account", machine_id: "laptop", machine_name: "Laptop", route_token: "lease:1" };
+const frame = { captured_at: 123, width: 1, height: 1, mime_type: "image/png", data: "AAAA" };
+const options = { baseUrl: "https://managed.test", apiKey: `ncx_live_${"a".repeat(12)}_${"b".repeat(43)}` };
+const id = "11111111-1111-7111-8111-111111111111";
+
+test("public SDK requests exact hand scope/generation and stops on consumer break", async () => {
+  const requests = [];
+  const agent = open(id, { ...options, fetch: async (url, init) => {
+    requests.push({ url: new URL(url), init });
+    return Response.json(new URL(url).pathname.endsWith("/hands") ? { surfaces: [surface] } : { status: "frame", frame });
+  } });
+  const [screen] = await agent.hands.list();
+  for await (const result of agent.hands.frames(screen)) { assert.deepEqual(result.frame, frame); break; }
+  assert.equal(requests.length, 2);
+  assert.equal(requests[1].url.searchParams.get("source"), "account");
+  assert.equal(requests[1].url.searchParams.get("route_token"), "lease:1");
+  assert.equal(requests[1].url.searchParams.has("api_key"), false);
+  assert.match(new Headers(requests[1].init.headers).get("authorization"), /^Bearer /);
+});
+
+test("viewer abort interrupts an outstanding frame and stale routes do not switch", async () => {
+  const controller = new AbortController();
+  let calls = 0;
+  const agent = open(id, { ...options, fetch: async (_url, init) => {
+    calls++;
+    controller.abort();
+    init.signal.throwIfAborted();
+  } });
+  await assert.rejects(agent.hands.frames(surface, { signal: controller.signal }).next());
+  assert.equal(calls, 1);
+  const stale = open(id, { ...options, fetch: async () => { calls++; return Response.json({ error: "observation_unavailable" }, { status: 409 }); } });
+  await assert.rejects(stale.hands.frames(surface).next());
+  assert.equal(calls, 2);
+});
+
+test("screen protocol bounds dimensions, formats, payloads and identities", () => {
+  assert.deepEqual(normalizeObservationFrame(frame), frame);
+  for (const invalid of [{ width: 0 }, { height: 9000 }, { mime_type: "image/svg+xml" }, { data: "https://example.test/x.png" }, { data: "a".repeat(240004) }, { data: "A===" }, { extra: true }]) {
+    assert.throws(() => normalizeObservationFrame({ ...frame, ...invalid }));
+  }
+  assert.throws(() => normalizeObservationSurfaces([{ id: "bad/id", name: "Screen", kind: "desktop" }]));
+  assert.throws(() => normalizeObservationSurfaces(Array(9).fill({ id: "x", name: "X", kind: "phone" })));
+});

--- a/js/nanocodex/test/managed-types.test-d.mts
+++ b/js/nanocodex/test/managed-types.test-d.mts
@@ -44,6 +44,13 @@ async function checkManaged() {
     settings: { model: "gpt-6-astra", thinking: "high" },
   });
   const opened: ManagedAgent = Agent.open("0198d3f0-8844-7000-8000-000000000001");
+  const [screen] = await opened.hands.list();
+  if (screen) {
+    for await (const result of opened.hands.frames(screen, { signal: new AbortController().signal })) {
+      if (result.status === "frame") { const width: number = result.frame.width; void width; }
+      break;
+    }
+  }
   const settings = await opened.settings.read();
   await opened.settings.update({ model: "gpt-6-astra" });
   await opened.settings.update({ thinking: settings.thinking, fastMode: true });

--- a/js/nanocodex/tools/Tools.d.mts
+++ b/js/nanocodex/tools/Tools.d.mts
@@ -1,3 +1,4 @@
+import type { ObservationProvider } from "nanocodex-tools/observation";
 import type { McpServers, NamedTool, ToolMap } from "../types.mjs";
 import type { Workspace } from "../runtime/workspace.mjs";
 import type { HostedMachine } from "./hostedCatalog.mjs";
@@ -46,6 +47,8 @@ export function createTools(options?: {
   tools?: ToolMap | readonly NamedTool[];
   /** Stable safe ASCII identifier (at most 123 bytes) for this independent attachment. */
   attachmentId?: string;
+  /** Optional live screen capture, requested only while a viewer is watching. */
+  observation?: ObservationProvider;
   /** Sole non-secret machine published by this host; its id must equal attachmentId. */
   machines?: readonly HostedMachine[];
   /** Portable workspace handle; React Native supplies one via createWorkspace({ backend }). */

--- a/js/nanocodex/tools/Tools.mjs
+++ b/js/nanocodex/tools/Tools.mjs
@@ -1,3 +1,4 @@
+import { normalizeObservationProvider } from "nanocodex-tools/observation";
 import { resolveTools } from "../runtime/tool-configuration.mjs";
 import { tools as workspaceTools } from "../runtime/workspace.mjs";
 import {
@@ -20,6 +21,7 @@ export async function createTools(options = {}) {
   validateOptions(options);
   const machines = normalizeHostedMachines(options.machines);
   const attachmentId = options.attachmentId;
+  const observation = normalizeObservationProvider(options.observation, machines);
   if (machines.length > 0 && attachmentId !== machines[0].id) {
     throw new TypeError("createTools machine attachment requires one machine whose id equals attachmentId");
   }
@@ -81,7 +83,7 @@ export async function createTools(options = {}) {
     attach(target) {
       if (closed) throw new Error("Tools runtime is closed");
       if (arguments.length !== 1) throw new TypeError("Tools.attach accepts only a target");
-      const attachment = createAttachment(owner, target, { machines, attachmentId });
+      const attachment = createAttachment(owner, target, { machines, attachmentId, observation });
       attachments.add(attachment);
       void attachment.closed().then(() => attachments.delete(attachment));
       return attachment;
@@ -120,7 +122,7 @@ function validateOptions(options) {
   if (!options || typeof options !== "object" || Array.isArray(options)) {
     throw new TypeError("createTools options must be an object");
   }
-  const allowed = new Set(["tools", "workspace", "workspaceOptions", "mcp", "mcpOptions", "machines", "attachmentId"]);
+  const allowed = new Set(["tools", "workspace", "workspaceOptions", "mcp", "mcpOptions", "machines", "attachmentId", "observation"]);
   for (const name of Object.keys(options)) {
     if (!allowed.has(name)) throw new TypeError(`unsupported createTools option: ${name}`);
   }


### PR DESCRIPTION
Adds live screen viewing for hands so owners can see the system while an agent uses its tools.

- Adds opt-in observation providers to JavaScript and native Rust attachments, using the existing outbound socket and exact connection generation.
- Adds authenticated agent/account screen discovery and frame requests, managed SDK `agent.hands.list()` / `frames()`, and a terminal Live view panel with screen selection, pause/resume, timestamps, and reconnect handling.
- Adds `nanocodex2 hand --screen desktop` and `--screen android --device SERIAL`, plus Node capture providers. Screen hands attach local workspace tools; existing VM mode remains separate from host desktop capture.
- Bounds images, concurrency, pacing, and deadlines; cancels on detach/replacement/revocation; keeps frames out of durable receipts and agent history. Connect grants cannot view account screens.

Verified locally:

- 53 Worker/protocol tests, including an actual Durable Object WebSocket → frame request → screenshot response, cross-account denial, drain/replacement fencing, timeout/cancellation, and failed candidate metadata publication.
- 33 JavaScript attachment, managed SDK, and package tests.
- 16 native attachment tests plus the native CLI screen-mode contract test.
- Native Rust desktop capture test executed successfully against Xvfb with real FFmpeg. Node desktop capture also succeeded: a 1280×800 X11 display produced a 960×600 JPEG (7,221 bytes).
- JavaScript/WASM package builds; account, managed service, and SDK typechecks; native CLI check; Rust formatting and Clippy for nanocodex-tools and nanocodex2-bin with warnings denied.

CI is running on 405cb4e7ba57be7c64f572a960cd4817b38c7bc2. The earlier native lint findings are fixed in that commit.

Draft because the authenticated browser/device journey remains unverified: the canonical local stack cannot start with this environment's incomplete ChatGPT development login. Physical macOS/Windows/Android capture is not verified here. This is a live screenshot feed up to four frames/second, without audio/video recording. iOS and graphical VM screens need application-owned capture providers.