### PR TITLE
feat(managed): add durable cron triggers and SDK controls

### DIFF
--- a/js/managed/package.json
+++ b/js/managed/package.json
@@ -24,6 +24,7 @@
     "accounts": "0.16.2",
     "agents": "0.22.0",
     "ai": "7.0.90",
+    "cron-parser": "5.6.0",
     "nanocodex": "workspace:*",
     "nanocodex-connect-protocol": "workspace:*",
     "nanocodex-tools": "workspace:*",

--- a/js/managed/src/cron-triggers.ts
+++ b/js/managed/src/cron-triggers.ts
@@ -1,0 +1,145 @@
+import { CronExpressionParser } from "cron-parser";
+
+export const CRON_TRIGGER_ID = /^[A-Za-z0-9_-]{1,64}$/;
+const MAX_TRIGGERS = 32;
+const encoder = new TextEncoder();
+
+export type CronTriggerConfig = {
+  cron: string;
+  timezone: string;
+  input: string;
+  enabled: boolean;
+};
+
+export type CronTriggerRow = {
+  id: string;
+  revision: string;
+  cron: string;
+  timezone: string;
+  input: string;
+  enabled: number;
+  authorization_json: string;
+  authorization_epoch: number;
+  request_hash: string;
+  next_run_at: number | null;
+  retry_at: number | null;
+  last_run_at: number | null;
+  last_turn_id: string | null;
+  last_skipped_at: number | null;
+  created_at: number;
+  updated_at: number;
+};
+
+export function nextCronRun(cron: string, timezone: string, after: number): number {
+  return CronExpressionParser.parse(cron, { tz: timezone, currentDate: after }).next().getTime();
+}
+
+export function parseCronTrigger(value: unknown, now: number): CronTriggerConfig {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("cron trigger must be an object");
+  }
+  const body = value as Record<string, unknown>;
+  if (Object.keys(body).some((key) => !["cron", "timezone", "input", "enabled"].includes(key))
+    || typeof body.cron !== "string" || body.cron.length > 256
+    || body.cron.trim().split(/\s+/).length !== 5
+    // Do not accept random H fields: every occurrence must be deterministic.
+    || /[^\d\s*,/\-A-Za-z]/.test(body.cron) || /H/i.test(body.cron.replace(/THU/gi, ""))
+    || typeof body.input !== "string" || body.input.trim().length === 0
+    || encoder.encode(body.input).byteLength > 64 * 1024
+    || (body.enabled !== undefined && typeof body.enabled !== "boolean")
+    || (body.timezone !== undefined && typeof body.timezone !== "string")) {
+    throw new Error("expected a five-field cron, a non-empty input (at most 64 KiB), optional timezone and enabled");
+  }
+  const timezone = body.timezone as string | undefined ?? "UTC";
+  if (timezone.length > 128) throw new Error("invalid timezone");
+  new Intl.DateTimeFormat("en", { timeZone: timezone });
+  const config = {
+    cron: body.cron.trim().replace(/\s+/g, " "), timezone,
+    input: body.input, enabled: body.enabled as boolean | undefined ?? true,
+  };
+  nextCronRun(config.cron, timezone, now);
+  return config;
+}
+
+export function cronTriggerView(row: CronTriggerRow) {
+  return {
+    id: row.id, cron: row.cron, timezone: row.timezone, input: row.input,
+    enabled: row.enabled === 1, next_run_at: row.next_run_at,
+    last_run_at: row.last_run_at, last_turn_id: row.last_turn_id,
+    last_skipped_at: row.last_skipped_at, created_at: row.created_at, updated_at: row.updated_at,
+  };
+}
+
+/** Session-owned schedules; dispatch advances this table in the turn-admission transaction. */
+export class CronTriggers {
+  constructor(private readonly storage: DurableObjectStorage) {
+    storage.sql.exec(`CREATE TABLE IF NOT EXISTS managed_cron_triggers (
+      id TEXT PRIMARY KEY, revision TEXT NOT NULL, cron TEXT NOT NULL,
+      timezone TEXT NOT NULL, input TEXT NOT NULL, enabled INTEGER NOT NULL,
+      authorization_json TEXT NOT NULL, authorization_epoch INTEGER NOT NULL,
+      request_hash TEXT NOT NULL, next_run_at INTEGER, retry_at INTEGER, last_run_at INTEGER,
+      last_turn_id TEXT, last_skipped_at INTEGER,
+      created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL
+    )`);
+  }
+
+  list(): CronTriggerRow[] {
+    return this.storage.sql.exec<CronTriggerRow>("SELECT * FROM managed_cron_triggers ORDER BY id").toArray();
+  }
+
+  get(id: string): CronTriggerRow | undefined {
+    return this.storage.sql.exec<CronTriggerRow>("SELECT * FROM managed_cron_triggers WHERE id = ?", id).toArray()[0];
+  }
+
+  put(id: string, config: CronTriggerConfig, authorization: string, epoch: number, hash: string, now: number): CronTriggerRow {
+    const previous = this.get(id);
+    if (!previous && this.list().length >= MAX_TRIGGERS) throw new Error("at most 32 cron triggers per agent");
+    if (previous && previous.cron === config.cron && previous.timezone === config.timezone
+      && previous.input === config.input && previous.enabled === Number(config.enabled)
+      && previous.authorization_json === authorization && previous.authorization_epoch === epoch) return previous;
+    const next = config.enabled ? nextCronRun(config.cron, config.timezone, now) : null;
+    this.storage.sql.exec(`INSERT INTO managed_cron_triggers (
+      id, revision, cron, timezone, input, enabled, authorization_json,
+      authorization_epoch, request_hash, next_run_at, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET revision = excluded.revision, cron = excluded.cron,
+      timezone = excluded.timezone, input = excluded.input, enabled = excluded.enabled,
+      authorization_json = excluded.authorization_json, authorization_epoch = excluded.authorization_epoch,
+      request_hash = excluded.request_hash, next_run_at = excluded.next_run_at, retry_at = NULL, updated_at = excluded.updated_at`,
+    id, crypto.randomUUID(), config.cron, config.timezone, config.input, Number(config.enabled),
+    authorization, epoch, hash, next, now, now);
+    return this.get(id)!;
+  }
+
+  delete(id: string): void {
+    this.storage.sql.exec("DELETE FROM managed_cron_triggers WHERE id = ?", id);
+  }
+
+  nextAlarm(): number | undefined {
+    return this.storage.sql.exec<{ next_run_at: number }>(
+      "SELECT MAX(next_run_at, COALESCE(retry_at, next_run_at)) AS next_run_at FROM managed_cron_triggers WHERE enabled = 1 ORDER BY next_run_at LIMIT 1",
+    ).toArray()[0]?.next_run_at;
+  }
+
+  due(now: number): CronTriggerRow[] {
+    return this.storage.sql.exec<CronTriggerRow>(
+      "SELECT * FROM managed_cron_triggers WHERE enabled = 1 AND next_run_at <= ? AND (retry_at IS NULL OR retry_at <= ?) ORDER BY next_run_at, id", now, now,
+    ).toArray();
+  }
+
+  retry(row: CronTriggerRow, retryAt: number): void {
+    this.storage.sql.exec("UPDATE managed_cron_triggers SET retry_at = ? WHERE id = ? AND revision = ? AND next_run_at = ?",
+      retryAt, row.id, row.revision, row.next_run_at);
+  }
+
+  /** Call synchronously in the same transaction that inserts the accepted turn. */
+  advance(row: CronTriggerRow, now: number, next: number, turnId?: string): boolean {
+    return this.storage.sql.exec(`UPDATE managed_cron_triggers SET next_run_at = ?, retry_at = NULL,
+      last_run_at = CASE WHEN ? IS NOT NULL THEN ? ELSE last_run_at END,
+      last_turn_id = COALESCE(?, last_turn_id),
+      last_skipped_at = CASE WHEN ? IS NULL THEN ? ELSE last_skipped_at END
+      WHERE id = ? AND revision = ? AND enabled = 1 AND next_run_at = ? RETURNING id`,
+    next, turnId ?? null, row.next_run_at, turnId ?? null, turnId ?? null, now,
+    row.id, row.revision, row.next_run_at).toArray().length === 1;
+  }
+}

--- a/js/managed/src/index.ts
+++ b/js/managed/src/index.ts
@@ -20,6 +20,7 @@ import { Agent as ManagedAgent } from "nanocodex/managed";
 import { imageGeneration, updatePlan, viewImage, web } from "nanocodex/tools";
 import { MAX_NAMESPACE_MOUNTS } from "nanocodex-tools";
 import { managedCodeEvaluator } from "./code-evaluator";
+import { CronTriggers, CRON_TRIGGER_ID, cronTriggerView, nextCronRun, parseCronTrigger } from "./cron-triggers";
 import {
   cloudflareSandboxTools,
   deleteCloudflareBrainWorkspace,
@@ -1907,6 +1908,28 @@ async function managedFetch(
         body: request.body,
       });
     }
+    if (resource === "triggers" || resource.startsWith("triggers/")) {
+      const triggerId = resource === "triggers" ? undefined : resource.slice("triggers/".length);
+      if (triggerId !== undefined && !CRON_TRIGGER_ID.test(triggerId)) {
+        return json({ error: "invalid_trigger_id" }, { status: 400 });
+      }
+      const allowed = triggerId === undefined ? ["GET"] : ["GET", "PUT", "DELETE"];
+      if (!allowed.includes(request.method)) return json({ error: "method_not_allowed" }, { status: 405 });
+      if (url.search !== "") return json({ error: "invalid_request" }, { status: 400 });
+      // Schedules are account-owned standing instructions, not ephemeral Connect grants.
+      if (principal.connectGrant || !principal.capabilities.includes(
+        request.method === "GET" ? "agents:read" : "agents:write",
+      ) || (request.method === "PUT" && !principal.capabilities.includes("tools:use"))) {
+        return json({ error: "forbidden" }, { status: 403 });
+      }
+      if (request.method !== "GET") {
+        const failure = requireSameOriginMutation(request, url, principal);
+        if (failure) return failure;
+      }
+      return stub.fetch(`https://session.internal/${resource}?${publicOrigin}`, {
+        method: request.method, headers: sessionHeaders, body: request.body,
+      });
+    }
     if (resource === "turns") {
       if (request.method !== "POST")
         return json({ error: "method_not_allowed" }, { status: 405 });
@@ -2442,6 +2465,7 @@ export class DurableAgentSession extends DurableComputerSession {
   readonly #namespaceMountRefreshTasks = new Map<string, Promise<void>>();
   #realtimeEventBuffer?: AgentEvent[];
   #realtimeRouteTail: Promise<void> = Promise.resolve();
+  readonly #cronTriggers: CronTriggers;
   #settingsMutationTail: Promise<void> = Promise.resolve();
   readonly #settingsRequests = new Set<Promise<Response>>();
   #recoveryTask?: Promise<void>;
@@ -2461,6 +2485,7 @@ export class DurableAgentSession extends DurableComputerSession {
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
+    this.#cronTriggers = new CronTriggers(ctx.storage);
     this.ctx.storage.sql.exec(`
       CREATE TABLE IF NOT EXISTS session_state (
         singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
@@ -2912,6 +2937,9 @@ export class DurableAgentSession extends DurableComputerSession {
       }
     }
     if (request.method === "POST" && url.pathname === "/durability/export") {
+      if (this.#cronTriggers.list().length > 0) {
+        return json({ error: "cron_triggers_present", message: "Delete cron triggers before exporting this agent; schedules are not portable yet." }, { status: 409 });
+      }
       if (this.#durabilityImportState === "pending") {
         return json({ error: "durability_import_pending" }, { status: 409 });
       }
@@ -3162,6 +3190,9 @@ export class DurableAgentSession extends DurableComputerSession {
         headers: { "cache-control": "no-store" },
       });
     }
+    if (url.pathname === "/triggers" || url.pathname.startsWith("/triggers/")) {
+      return this.#cronTriggerRequest(request, turnAuthorization);
+    }
     if (request.method === "PATCH" && url.pathname === "/settings") {
       return this.#trackSettingsPatch(request);
     }
@@ -3339,6 +3370,7 @@ export class DurableAgentSession extends DurableComputerSession {
       }
       return;
     }
+    await this.#fireCronTriggers();
     if (this.#eventArchive.needsSeal(this.#eventLog)) {
       // A failed alarm is retried by Durable Objects. This is the persistent
       // continuation for a seal that outlived or failed its originating turn.
@@ -4119,6 +4151,91 @@ export class DurableAgentSession extends DurableComputerSession {
       return json({ settings: await this.#applySettingsPatch(patch) });
     } catch (error) {
       return managedErrorResponse(error, "settings_update_failed");
+    }
+  }
+
+  async #cronTriggerRequest(request: Request, authorization: TurnAuthorization): Promise<Response> {
+    const session = this.#session();
+    if (!session || this.#deleted) return json({ error: "not_found" }, { status: 404 });
+    if (this.#deleting) return json({ error: "agent_deleting" }, { status: 409 });
+    if (session.runtime_profile !== "managed" || authorization.connectGrant) {
+      return json({ error: "forbidden" }, { status: 403 });
+    }
+    const path = new URL(request.url).pathname;
+    const id = path === "/triggers" ? undefined : path.slice("/triggers/".length);
+    if (id !== undefined && !CRON_TRIGGER_ID.test(id)) return json({ error: "invalid_trigger_id" }, { status: 400 });
+    if (request.method === "GET") {
+      if (id === undefined) return json({ data: this.#cronTriggers.list().map(cronTriggerView) });
+      const row = this.#cronTriggers.get(id);
+      return row ? json(cronTriggerView(row)) : json({ error: "not_found" }, { status: 404 });
+    }
+    if (id === undefined || !["PUT", "DELETE"].includes(request.method)) {
+      return json({ error: "method_not_allowed" }, { status: 405 });
+    }
+    if (request.method === "DELETE") {
+      this.#cronTriggers.delete(id);
+      await this.#scheduleNextAlarm();
+      return new Response(null, { status: 204 });
+    }
+    try {
+      const encoded = await readBoundedRequestText(request, 128 * 1024);
+      let config;
+      try { config = parseCronTrigger(JSON.parse(encoded), Date.now()); }
+      catch (error) { return json({ error: "invalid_trigger", message: errorMessage(error) }, { status: 400 }); }
+      const hash = await hashManagedInput(config.input);
+      this.#assertDurabilityAdmissionActive();
+      if (this.#deleting || this.#deleted) return json({ error: "agent_deleting" }, { status: 409 });
+      const exists = this.#cronTriggers.get(id) !== undefined;
+      if (!exists && this.#cronTriggers.list().length >= 32) return json({ error: "trigger_limit" }, { status: 429 });
+      const row = this.#cronTriggers.put(id, config, JSON.stringify(authorization), session.authorization_epoch, hash, Date.now());
+      await this.#scheduleNextAlarm();
+      return json(cronTriggerView(row), { status: exists ? 200 : 201 });
+    } catch (error) { return managedErrorResponse(error); }
+  }
+
+  async #fireCronTriggers(): Promise<void> {
+    if (this.#deleting || this.#deleted || this.#durabilityExported
+      || this.#durabilityImportState === "pending") return;
+    const session = this.#session();
+    if (!session || session.runtime_profile !== "managed") return;
+    const now = Date.now();
+    for (const trigger of this.#cronTriggers.due(now)) {
+      const next = nextCronRun(trigger.cron, trigger.timezone, now);
+      if (trigger.authorization_epoch !== session.authorization_epoch) {
+        this.#cronTriggers.delete(trigger.id);
+        continue;
+      }
+      if (this.#recoverableTurnCount() > 0 || this.#streamError) {
+        this.#cronTriggers.advance(trigger, now, next);
+        continue;
+      }
+      const id = `cron:${trigger.revision}:${trigger.next_run_at}`;
+      try {
+        await this.#submitManagedTurn(
+          id, trigger.input, trigger.request_hash, id, true,
+          parseTurnAuthorization(trigger.authorization_json),
+          () => {
+            // A pause, delete, edit, or interactive admission may win while
+            // archived receipt lookup yields. Fence and advance atomically.
+            if (this.#recoverableTurnCount() > 0) {
+              throw new ManagedRequestError(409, "cron_agent_busy", "agent became busy");
+            }
+            if (!this.#cronTriggers.advance(trigger, now, next, id)) {
+              throw new ManagedRequestError(409, "cron_trigger_changed", "trigger changed before admission");
+            }
+          },
+        );
+      } catch (error) {
+        if (error instanceof ManagedRequestError && error.code === "cron_trigger_changed") continue;
+        if (error instanceof ManagedRequestError && error.code === "cron_agent_busy") {
+          this.#cronTriggers.advance(trigger, now, next);
+          continue;
+        }
+        // Retain a wakeup beyond Cloudflare's bounded automatic alarm retries.
+        this.#cronTriggers.retry(trigger, Date.now() + MAX_RETRY_DELAY_MS);
+        await this.#scheduleNextAlarm();
+        throw error;
+      }
     }
   }
 
@@ -4931,6 +5048,7 @@ export class DurableAgentSession extends DurableComputerSession {
     requestKey: string | null,
     explicitId = true,
     authorization: TurnAuthorization = { capabilities: [] },
+    beforeAdmission?: () => void,
   ): Promise<ManagedTurnSubmission> {
     await this.#settingsMutationTail;
     if (this.#deleting || this.#deleted) {
@@ -5003,6 +5121,7 @@ export class DurableAgentSession extends DurableComputerSession {
       if (this.#deleting || !this.#sessionId()) {
         throw new ManagedRequestError(409, "agent_deleting", "the agent is being deleted");
       }
+      beforeAdmission?.();
       cancellationRequested = this.ctx.storage.sql.exec<{ turn_id: string }>(
         "SELECT turn_id FROM managed_turn_cancel_intents WHERE turn_id = ?",
         id,
@@ -5596,6 +5715,7 @@ export class DurableAgentSession extends DurableComputerSession {
     this.ctx.storage.transactionSync(() => {
       this.ctx.storage.sql.exec("DELETE FROM managed_turn_dispatch_chunks");
       this.ctx.storage.sql.exec("DELETE FROM managed_subagent_authorizations");
+      this.ctx.storage.sql.exec("DELETE FROM managed_cron_triggers");
       this.ctx.storage.sql.exec("DELETE FROM managed_turns");
       this.ctx.storage.sql.exec("DELETE FROM managed_turn_cancel_intents");
       this.ctx.storage.sql.exec("DELETE FROM history_projection_outbox");
@@ -8408,6 +8528,10 @@ export class DurableAgentSession extends DurableComputerSession {
     if (this.#deleting || !this.#sessionId()) return;
     const now = Date.now();
     const targets: number[] = [];
+    if (!this.#durabilityExported && this.#durabilityImportState !== "pending") {
+      const cronAlarm = this.#cronTriggers.nextAlarm();
+      if (cronAlarm !== undefined) targets.push(cronAlarm);
+    }
     if (this.#eventArchive.needsSeal(this.#eventLog)
       || this.#turnArchive.needsSeal()
       || this.#realtimeArchive.needsSeal()) {

--- a/js/managed/test/cron-triggers.test.ts
+++ b/js/managed/test/cron-triggers.test.ts
@@ -1,0 +1,216 @@
+import { env, runInDurableObject, runDurableObjectAlarm, createExecutionContext } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import worker, { type DurableAgentSession } from "../src/index";
+import type { Principal } from "../src/account-auth";
+import { CronTriggers, nextCronRun, parseCronTrigger } from "../src/cron-triggers";
+
+const now = Date.parse("2026-09-05T12:00:00Z");
+const config = { cron: "* * * * *", input: "Check the system" };
+const request = (id: string, body: unknown = config) => new Request(`https://session.internal/triggers/${id}`, {
+  method: "PUT", body: JSON.stringify(body),
+});
+const sessions = () => (env as unknown as {
+  NANOCODEX_SESSIONS: DurableObjectNamespace<DurableAgentSession>;
+}).NANOCODEX_SESSIONS;
+
+function initialize(state: DurableObjectState) {
+  state.storage.sql.exec(`INSERT INTO session_state (
+    singleton, session_id, owner_id, organization_id, team_id,
+    authorization_epoch, public_origin, runtime_profile, last_active
+  ) VALUES (1, ?, 'owner', 'org', 'team', 1, 'https://nanocodex.example', 'managed', ?)`,
+  crypto.randomUUID(), Date.now());
+}
+
+function retainBusyTurn(state: DurableObjectState) {
+  state.storage.sql.exec(`INSERT INTO managed_turns (
+    id, request_hash, input_json, authorization_json, state, accepted_cursor,
+    created_at, accepted_at, updated_at, retry_at
+  ) VALUES ('busy', 'hash', '"busy"', '{"capabilities":[]}', 'accepted', 1, ?, ?, ?, ?)`,
+  Date.now(), Date.now(), Date.now(), Date.now() + 60_000);
+}
+
+describe("cron policy", () => {
+  it("uses five fields, UTC by default, and skips to the next minute", () => {
+    expect(parseCronTrigger(config, now)).toEqual({ ...config, timezone: "UTC", enabled: true });
+    expect(nextCronRun("*/15 * * * *", "UTC", now + 1)).toBe(now + 15 * 60_000);
+    expect(nextCronRun("0 7 * * MON-FRI", "Europe/Athens", now)).toBe(Date.parse("2026-09-07T04:00:00Z"));
+    expect(nextCronRun("0 0 29 2 *", "UTC", now)).toBe(Date.parse("2028-02-29T00:00:00Z"));
+  });
+
+  it("keeps the local morning hour across both DST transitions", () => {
+    expect(nextCronRun("0 7 * * *", "Europe/Athens", Date.parse("2026-03-28T06:00:00Z")))
+      .toBe(Date.parse("2026-03-29T04:00:00Z"));
+    expect(nextCronRun("0 7 * * *", "Europe/Athens", Date.parse("2026-10-24T06:00:00Z")))
+      .toBe(Date.parse("2026-10-25T05:00:00Z"));
+  });
+
+  it.each([
+    { cron: "* * * * * *" }, { cron: "@daily" }, { cron: "H * * * *" },
+    { cron: "61 * * * *" }, { cron: "0 0 31 2 *" }, { timezone: "Mars/Olympus" },
+    { input: " " }, { input: "x".repeat(65_537) }, { enabled: "yes" }, { extra: true },
+  ])("rejects invalid or unbounded configuration %#", (patch) => {
+    expect(() => parseCronTrigger({ ...config, ...patch }, now)).toThrow();
+  });
+});
+
+describe("cron Durable Object protocol", () => {
+  it("persists an idle wakeup, idempotently replaces, pauses, resumes, and deletes", async () => {
+    const stub = sessions().getByName(crypto.randomUUID());
+    await runInDurableObject(stub, async (session, state) => {
+      initialize(state);
+      const created = await session.fetch(request("daily"));
+      expect(created.status).toBe(201);
+      const first = await created.json<{ next_run_at: number }>();
+      expect(await state.storage.getAlarm()).toBe(first.next_run_at);
+      const retried = await session.fetch(request("daily"));
+      expect(retried.status).toBe(200);
+      expect(await retried.json()).toEqual(first);
+      expect(JSON.stringify(first)).not.toMatch(/authorization|revision|request_hash/);
+      const paused = await session.fetch(request("daily", { ...config, enabled: false }));
+      expect(await paused.json()).toMatchObject({ enabled: false, next_run_at: null });
+      expect(await state.storage.getAlarm()).toBeNull();
+      await session.fetch(request("daily"));
+      expect(await state.storage.getAlarm()).not.toBeNull();
+      expect((await session.fetch(new Request("https://session.internal/durability/export", { method: "POST" }))).status).toBe(409);
+      for (let i = 0; i < 2; i++) {
+        expect((await session.fetch(new Request("https://session.internal/triggers/daily", { method: "DELETE" }))).status).toBe(204);
+      }
+      expect(await state.storage.getAlarm()).toBeNull();
+      const listed = await session.fetch(new Request("https://session.internal/triggers"));
+      expect(await listed.json()).toEqual({ data: [] });
+    });
+  });
+
+  it("coalesces missed ticks, admits one durable turn, and never duplicates an alarm", async () => {
+    const stub = sessions().getByName(crypto.randomUUID());
+    await runInDurableObject(stub, async (session, state) => {
+      initialize(state);
+      // Keep execution at the existing durable retry boundary. No model credentials are needed.
+      const runtimeEnv = (session as unknown as { env: Record<string, unknown> }).env;
+      Object.defineProperty(session, "env", { value: {
+        ...runtimeEnv, NANOCODEX_ACCOUNT_TOOLS: { getByName: () => {
+          throw Object.assign(new Error("fixture unavailable"), { code: "retryable" });
+        } },
+      } });
+      await session.fetch(request("daily"));
+      state.storage.sql.exec("UPDATE managed_cron_triggers SET next_run_at = ?", Date.now() - 86_400_000);
+    });
+    expect(await runDurableObjectAlarm(stub)).toBe(true);
+    await runInDurableObject(stub, async (session, state) => {
+      const row = new CronTriggers(state.storage).get("daily")!;
+      expect(row.last_turn_id).toMatch(/^cron:/);
+      expect(row.next_run_at).toBeGreaterThan(Date.now());
+      const receipt = await session.fetch(new Request(`https://session.internal/turns/${row.last_turn_id}`));
+      expect(receipt.status).toBe(200);
+      expect(await receipt.json()).toMatchObject({ turn_id: row.last_turn_id });
+      await session.alarm();
+      expect(state.storage.sql.exec<{ count: number }>("SELECT COUNT(*) AS count FROM managed_turns").one().count).toBe(1);
+      expect(new CronTriggers(state.storage).get("daily")!.last_turn_id).toBe(row.last_turn_id);
+    });
+  });
+
+  it("skips a busy agent without growing its inbox", async () => {
+    await runInDurableObject(sessions().getByName(crypto.randomUUID()), async (session, state) => {
+      initialize(state);
+      retainBusyTurn(state);
+      await session.fetch(request("daily"));
+      state.storage.sql.exec("UPDATE managed_cron_triggers SET next_run_at = ?", Date.now() - 1);
+      await session.alarm();
+      const row = new CronTriggers(state.storage).get("daily")!;
+      expect(row.last_turn_id).toBeNull();
+      expect(row.last_skipped_at).not.toBeNull();
+      expect(row.next_run_at).toBeGreaterThan(Date.now());
+      expect(state.storage.sql.exec<{ count: number }>("SELECT COUNT(*) AS count FROM managed_turns").one().count).toBe(1);
+    });
+  });
+
+  it("rolls back advancement with turn admission and fences edits, pause, and recreation", async () => {
+    await runInDurableObject(sessions().getByName(crypto.randomUUID()), async (session, state) => {
+      initialize(state);
+      const triggers = new CronTriggers(state.storage);
+      await session.fetch(request("daily"));
+      const original = triggers.get("daily")!;
+      expect(() => state.storage.transactionSync(() => {
+        expect(triggers.advance(original, Date.now(), Date.now() + 60_000, "turn")).toBe(true);
+        throw new Error("admission failed");
+      })).toThrow("admission failed");
+      expect(triggers.get("daily")).toEqual(original);
+      for (const replacement of [{ ...config, input: "new" }, { ...config, enabled: false }, config]) {
+        await session.fetch(request("daily", replacement));
+        expect(triggers.advance(original, Date.now(), Date.now() + 60_000, "stale")).toBe(false);
+      }
+      triggers.delete("daily");
+      await session.fetch(request("daily"));
+      expect(triggers.advance(original, Date.now(), Date.now() + 60_000, "stale")).toBe(false);
+    });
+  });
+
+  it("retains retry deadlines across reconstruction and clears them on replacement", async () => {
+    await runInDurableObject(sessions().getByName(crypto.randomUUID()), async (session, state) => {
+      initialize(state);
+      await session.fetch(request("daily"));
+      state.storage.sql.exec("UPDATE managed_cron_triggers SET next_run_at = ?", Date.now() - 60_000);
+      const triggers = new CronTriggers(state.storage);
+      const due = triggers.get("daily")!;
+      const retryAt = Date.now() + 60_000;
+      triggers.retry(due, retryAt);
+      const restored = new CronTriggers(state.storage);
+      expect(restored.nextAlarm()).toBe(retryAt);
+      expect(restored.due(Date.now())).toEqual([]);
+      expect(restored.due(retryAt)).toHaveLength(1);
+      await session.fetch(request("daily", { ...config, input: "replacement" }));
+      expect(restored.get("daily")!.retry_at).toBeNull();
+      restored.retry(due, retryAt + 60_000);
+      expect(restored.get("daily")!.retry_at).toBeNull();
+    });
+  });
+
+  it("enforces ownership assertions and the per-agent limit", async () => {
+    await runInDurableObject(sessions().getByName(crypto.randomUUID()), async (session, state) => {
+      initialize(state);
+      const wrongOwner = request("daily");
+      wrongOwner.headers.set("x-nanocodex-owner-id", "other");
+      expect((await session.fetch(wrongOwner)).status).toBe(404);
+      for (let index = 0; index < 32; index++) expect((await session.fetch(request(`t${index}`))).status).toBe(201);
+      expect((await session.fetch(request("overflow"))).status).toBe(429);
+      expect((await session.fetch(request("t0"))).status).toBe(200);
+      expect((await session.fetch(request("bad", { ...config, timezone: "invalid" }))).status).toBe(400);
+    });
+  });
+});
+
+
+describe("cron HTTP routes", () => {
+  it("applies capability, origin, and ownership checks before routing to the real session", async () => {
+    const id = "0198d3f0-8844-7000-8000-000000000001";
+    const owner = "11111111-1111-4111-8111-111111111111";
+    const org = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const team = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    const principal: Principal = {
+      kind: "api_key", userId: owner, organizationId: org, teamId: team,
+      role: "owner", subjectId: `user:${owner}`, credentialId: "test",
+      authorizationEpoch: 1, capabilities: ["agents:read", "agents:write", "tools:use"],
+    };
+    await runInDurableObject(sessions().getByName(id), async (_session, state) => {
+      initialize(state);
+      state.storage.sql.exec("UPDATE session_state SET session_id = ?, owner_id = ?, organization_id = ?, team_id = ?", id, owner, org, team);
+    });
+    const call = (method: string, actor = principal, origin?: string, suffix = "/daily") => worker.fetch(
+      new Request(`https://nanocodex.example/v1/agents/${id}/triggers${suffix}`, {
+        method, ...(method === "PUT" ? { body: JSON.stringify(config) } : {}),
+        headers: origin ? { origin } : {},
+      }), env as Parameters<typeof worker.fetch>[1], createExecutionContext(), actor,
+    );
+    expect((await call("PUT", { ...principal, capabilities: ["agents:write"] })).status).toBe(403);
+    expect((await call("GET", { ...principal, capabilities: ["agents:write"] })).status).toBe(403);
+    expect((await call("PUT", { ...principal, kind: "account_session" }, "https://evil.example")).status).toBe(403);
+    expect((await call("PUT", { ...principal, userId: "22222222-2222-4222-8222-222222222222" })).status).toBe(404);
+    expect((await call("PUT", { ...principal, connectGrant: { grantId: `0x${"a".repeat(64)}`, connectors: ["chatgpt"], mcpIds: [] } })).status).toBe(403);
+    expect((await call("PUT")).status).toBe(201);
+    expect(await (await call("GET")).json()).toMatchObject({ id: "daily", enabled: true });
+    expect((await call("GET", principal, undefined, "")).status).toBe(200);
+    expect((await call("POST")).status).toBe(405);
+    expect((await call("DELETE")).status).toBe(204);
+    expect((await call("GET")).status).toBe(404);
+  });
+});

--- a/js/managed/vitest.config.ts
+++ b/js/managed/vitest.config.ts
@@ -3,5 +3,9 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [cloudflareTest({ wrangler: { configPath: "./wrangler.test.jsonc" } })],
-  test: { include: ["test/**/*.test.ts"] },
+  test: {
+    include: ["test/**/*.test.ts"],
+    // Bundle cron-parser's CommonJS/Luxon boundary as Wrangler does in production.
+    deps: { optimizer: { ssr: { enabled: true, include: ["cron-parser"] } } },
+  },
 });

--- a/js/nanocodex/managed/Agent.d.mts
+++ b/js/nanocodex/managed/Agent.d.mts
@@ -295,6 +295,33 @@ export type Turn = Readonly<{
   result(options?: TurnResultOptions): Promise<TurnResult>;
 }>;
 
+export type CronTriggerConfig = Readonly<{
+  /** Five-field cron expression, with minute precision. */
+  cron: string;
+  /** IANA time zone. Defaults to UTC. */
+  timezone?: string | undefined;
+  /** Text prompt submitted for each occurrence, at most 64 KiB. */
+  input: string;
+  /** Defaults to true; false pauses future occurrences. */
+  enabled?: boolean | undefined;
+}>;
+
+export type CronTrigger = Readonly<{
+  id: string;
+  cron: string;
+  timezone: string;
+  input: string;
+  enabled: boolean;
+  /** Unix milliseconds; null while paused. */
+  next_run_at: number | null;
+  /** Scheduled time of the last accepted occurrence, in Unix milliseconds. */
+  last_run_at: number | null;
+  last_turn_id: string | null;
+  last_skipped_at: number | null;
+  created_at: number;
+  updated_at: number;
+}>;
+
 export type Agent = Readonly<{
   type: "managed";
   id: string;
@@ -304,6 +331,13 @@ export type Agent = Readonly<{
   settings: Readonly<{
     read(): Promise<CreateSettings>;
     update(patch: SettingsPatch): Promise<CreateSettings>;
+  }>;
+  triggers: Readonly<{
+    list(): Promise<readonly CronTrigger[]>;
+    get(id: string): Promise<CronTrigger>;
+    /** Create or replace an account-owned schedule using a stable id. */
+    put(id: string, config: CronTriggerConfig): Promise<CronTrigger>;
+    delete(id: string): Promise<void>;
   }>;
   /** Reverse-tool endpoint with cookie/bearer transport retained in a private closure. */
   toolsTarget(): import("../tools/Tools.mjs").AttachmentTarget;

--- a/js/nanocodex/managed/Agent.mjs
+++ b/js/nanocodex/managed/Agent.mjs
@@ -240,6 +240,18 @@ function agentHandle(client, id, summary) {
         body: managedSettingsPatch(patch),
       })).settings),
     }),
+    triggers: Object.freeze({
+      list: async () => {
+        const body = await client.json(`${agentPath(id)}/triggers`);
+        if (!body || !Array.isArray(body.data)) throw new ManagedError("invalid_response", "managed triggers are malformed");
+        return Object.freeze(body.data.map(managedCronTrigger));
+      },
+      get: async (triggerId) => managedCronTrigger(await client.json(cronTriggerPath(id, triggerId))),
+      put: async (triggerId, config) => managedCronTrigger(await client.json(cronTriggerPath(id, triggerId), {
+        method: "PUT", body: cronTriggerBody(config),
+      })),
+      delete: async (triggerId) => { await client.empty(cronTriggerPath(id, triggerId), { method: "DELETE" }); },
+    }),
     toolsTarget: () => client.toolsTarget(id),
     state: () => client.json(agentPath(id)),
     delete: async () => {
@@ -251,6 +263,44 @@ function agentHandle(client, id, summary) {
     voiceTransport: managedVoiceTransport(client, id),
   });
   return agent;
+}
+
+function cronTriggerPath(agentId, triggerId) {
+  if (typeof triggerId !== "string" || !/^[A-Za-z0-9_-]{1,64}$/.test(triggerId)) {
+    throw new TypeError("trigger id must be 1-64 letters, digits, underscores or hyphens");
+  }
+  return `${agentPath(agentId)}/triggers/${triggerId}`;
+}
+
+function cronTriggerBody(config) {
+  if (!config || typeof config !== "object" || Array.isArray(config)
+    || Object.keys(config).some((key) => !["cron", "timezone", "input", "enabled"].includes(key))
+    || typeof config.cron !== "string" || config.cron.length > 256
+    || config.cron.trim().split(/\s+/).length !== 5
+    || typeof config.input !== "string" || config.input.trim().length === 0
+    || UTF8.encode(config.input).byteLength > 64 * 1024
+    || (config.timezone !== undefined && typeof config.timezone !== "string")
+    || (config.enabled !== undefined && typeof config.enabled !== "boolean")) {
+    throw new TypeError("invalid cron trigger configuration");
+  }
+  return JSON.stringify(config);
+}
+
+function managedCronTrigger(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)
+    || typeof value.id !== "string" || !/^[A-Za-z0-9_-]{1,64}$/.test(value.id)
+    || typeof value.cron !== "string" || typeof value.timezone !== "string"
+    || typeof value.input !== "string" || typeof value.enabled !== "boolean"
+    || ![value.created_at, value.updated_at].every((n) => Number.isSafeInteger(n) && n >= 0)
+    || ![value.next_run_at, value.last_run_at, value.last_skipped_at].every((n) => n === null || (Number.isSafeInteger(n) && n >= 0))
+    || (value.last_turn_id !== null && (typeof value.last_turn_id !== "string" || !TURN_ID.test(value.last_turn_id)))) {
+    throw new ManagedError("invalid_response", "managed cron trigger is malformed");
+  }
+  return Object.freeze({
+    id: value.id, cron: value.cron, timezone: value.timezone, input: value.input, enabled: value.enabled,
+    next_run_at: value.next_run_at, last_run_at: value.last_run_at, last_turn_id: value.last_turn_id,
+    last_skipped_at: value.last_skipped_at, created_at: value.created_at, updated_at: value.updated_at,
+  });
 }
 
 function managedSettingsPatch(patch) {

--- a/js/nanocodex/managed/README.md
+++ b/js/nanocodex/managed/README.md
@@ -151,3 +151,66 @@ still verifies account ownership at the managed service boundary. Use
 
 The managed API never accepts model-provider credentials, egress bindings,
 runtime environment objects, credential grants, or arbitrary request headers.
+
+## Cron triggers
+
+Schedules belong to an existing managed agent and run without an open client.
+Use a stable trigger ID to create or replace a schedule idempotently:
+
+```js
+const agent = await Agent.get(agentId, { baseUrl, apiKey });
+const morning = {
+  cron: "0 7 * * MON-FRI",
+  timezone: "Europe/Athens",
+  input: "Review my running agents and summarize anything that needs attention.",
+};
+await agent.triggers.put("morning-review", morning);
+await agent.triggers.list();
+await agent.triggers.get("morning-review");
+await agent.triggers.put("morning-review", { ...morning, enabled: false }); // pause
+await agent.triggers.put("morning-review", morning); // resume
+await agent.triggers.delete("morning-review");
+```
+
+| Method | Route | Result |
+| --- | --- | --- |
+| GET | `/v1/agents/:agent/triggers` | `{ data: [...] }` |
+| GET | `/v1/agents/:agent/triggers/:id` | Trigger or 404 |
+| PUT | `/v1/agents/:agent/triggers/:id` | Create (201) or replace (200) |
+| DELETE | `/v1/agents/:agent/triggers/:id` | Idempotent deletion (204) |
+
+PUT takes `{ cron, input, timezone?, enabled? }`. Expressions have five fields
+(minute, hour, day of month, month, day of week), supporting numeric values,
+lists, ranges, steps, and month/day names. The time zone defaults to UTC and
+accepts IANA names. Local times follow daylight saving transitions. Seconds,
+macros, and random `H` fields are rejected. Inputs are text up to 64 KiB;
+there can be at most 32 triggers per agent. IDs use 1–64 letters, digits,
+underscores, or hyphens. PUT is a full replacement; an identical retry preserves
+the next occurrence. A changed configuration starts from the next matching time.
+
+Durable Object alarms wake the agent. Each occurrence enters the normal durable
+turn queue, with the schedule advance and turn acceptance committed atomically.
+Inspect `last_turn_id` through the normal turn and event APIs. Times in trigger
+responses are Unix milliseconds; `last_run_at` is the scheduled time of the last
+accepted occurrence, and `next_run_at` is null while paused.
+
+Missed ticks coalesce into one occurrence when idle. If the agent has unfinished
+work (including a prior scheduled run) or a failed event stream, the tick is
+skipped and recorded in `last_skipped_at`. Simultaneously due triggers are
+processed by scheduled time, then ID; the first admitted run makes the agent
+busy. This prevents an unbounded queue. Pausing or deleting fences future
+admissions; it does not cancel a turn already accepted. Resume does not backfill.
+
+Read requests require `agents:read`; writes require `agents:write`, and PUT also
+requires `tools:use`. The usual ownership and browser-origin checks apply.
+Triggers are account-owned standing instructions with the creator's capability
+scope, and persist after the creating API key or browser session ends. Connect
+grants and multiplayer rooms cannot create schedules. Delete the trigger to
+revoke its standing instruction. Provider credentials are resolved by the usual
+managed execution path and are never stored in trigger definitions or returned
+by these endpoints.
+
+Deleting an agent removes its triggers. Portable durability export currently
+returns `409 cron_triggers_present` while any trigger exists: list and delete
+triggers before transfer, then recreate them at the destination. This avoids
+silently dropping schedules or running the same schedule on two agents.

--- a/js/nanocodex/managed/index.d.mts
+++ b/js/nanocodex/managed/index.d.mts
@@ -2,6 +2,8 @@ export * as Agent from "./Agent.mjs";
 export { ManagedError } from "./ManagedError.mjs";
 export type {
   Agent as ManagedAgent,
+  CronTrigger as ManagedCronTrigger,
+  CronTriggerConfig as ManagedCronTriggerConfig,
   CreateOptions as ManagedCreateOptions,
   CreateSettings as ManagedCreateSettings,
   Event as ManagedEvent,

--- a/js/nanocodex/test/managed-cron.test.mjs
+++ b/js/nanocodex/test/managed-cron.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Agent, ManagedError } from "../managed/index.mjs";
+
+const agentId = "0198d3f0-8844-7000-8000-000000000001";
+const apiKey = `ncx_live_${"a".repeat(12)}_${"b".repeat(43)}`;
+const trigger = {
+  id: "morning", cron: "0 7 * * *", timezone: "Europe/Athens", input: "Daily summary",
+  enabled: true, next_run_at: 1_800_000, last_run_at: null, last_turn_id: null,
+  last_skipped_at: null, created_at: 1, updated_at: 1,
+};
+
+test("cron SDK routes CRUD through the authenticated agent and returns immutable views", async () => {
+  const calls = [];
+  const agent = Agent.open(agentId, { baseUrl: "https://managed.example", apiKey, fetch: async (input, init) => {
+    const request = new Request(input, init);
+    assert.equal(request.headers.get("authorization"), `Bearer ${apiKey}`);
+    assert.equal(request.credentials, "omit");
+    calls.push([request.method, new URL(request.url).pathname, request.method === "PUT" ? await request.json() : null]);
+    if (request.method === "DELETE") return new Response(null, { status: 204 });
+    if (request.url.endsWith("/triggers")) return Response.json({ data: [trigger] });
+    return Response.json({ ...trigger, authorization_json: "must not leak" });
+  } });
+  const config = { cron: trigger.cron, timezone: trigger.timezone, input: trigger.input };
+  const created = await agent.triggers.put("morning", config);
+  assert.deepEqual(created, trigger);
+  assert.ok(Object.isFrozen(created));
+  assert.deepEqual(await agent.triggers.get("morning"), trigger);
+  const listed = await agent.triggers.list();
+  assert.deepEqual(listed, [trigger]);
+  assert.ok(Object.isFrozen(listed));
+  assert.ok(Object.isFrozen(listed[0]));
+  await agent.triggers.put("morning", { ...config, enabled: false });
+  await agent.triggers.delete("morning");
+  assert.deepEqual(calls, [
+    ["PUT", `/v1/agents/${agentId}/triggers/morning`, config],
+    ["GET", `/v1/agents/${agentId}/triggers/morning`, null],
+    ["GET", `/v1/agents/${agentId}/triggers`, null],
+    ["PUT", `/v1/agents/${agentId}/triggers/morning`, { ...config, enabled: false }],
+    ["DELETE", `/v1/agents/${agentId}/triggers/morning`, null],
+  ]);
+});
+
+test("cron SDK rejects invalid ids and bodies before making a request", async () => {
+  const agent = Agent.open(agentId, { baseUrl: "https://managed.example", fetch: () => { throw new Error("unexpected request"); } });
+  for (const id of ["", "../turns", "a/b", "x".repeat(65)]) {
+    await assert.rejects(agent.triggers.get(id), TypeError);
+    await assert.rejects(agent.triggers.delete(id), TypeError);
+  }
+  for (const config of [{}, { cron: "* * * * * *", input: "text" },
+    { cron: "* * * * *", input: " " }, { cron: "* * * * *", input: "x".repeat(65_537) },
+    { cron: "* * * * *", input: "text", extra: true }]) {
+    await assert.rejects(agent.triggers.put("test", config), TypeError);
+  }
+});
+
+test("cron SDK rejects malformed responses and preserves API errors", async () => {
+  for (const body of [{}, { ...trigger, enabled: 1 }, { ...trigger, next_run_at: "tomorrow" },
+    { ...trigger, last_turn_id: undefined }]) {
+    const agent = Agent.open(agentId, { baseUrl: "https://managed.example", fetch: async () => Response.json(body) });
+    await assert.rejects(agent.triggers.get("morning"), (e) => e instanceof ManagedError && e.code === "invalid_response");
+  }
+  const agent = Agent.open(agentId, { baseUrl: "https://managed.example", fetch: async () => Response.json({ error: "forbidden" }, { status: 403 }) });
+  await assert.rejects(agent.triggers.list(), (e) => e instanceof ManagedError && e.status === 403);
+});

--- a/js/nanocodex/test/managed-types.test-d.mts
+++ b/js/nanocodex/test/managed-types.test-d.mts
@@ -44,6 +44,19 @@ async function checkManaged() {
     settings: { model: "gpt-6-astra", thinking: "high" },
   });
   const opened: ManagedAgent = Agent.open("0198d3f0-8844-7000-8000-000000000001");
+  const cron = await opened.triggers.put("morning", {
+    cron: "0 7 * * *", timezone: "Europe/Athens", input: "Daily summary",
+  });
+  const nextRun: number | null = cron.next_run_at;
+  await opened.triggers.put(cron.id, { cron: cron.cron, input: cron.input, enabled: false });
+  await opened.triggers.get(cron.id);
+  await opened.triggers.delete(cron.id);
+  const schedules: readonly import("nanocodex/managed").ManagedCronTrigger[] = await opened.triggers.list();
+  void nextRun; void schedules;
+  // @ts-expect-error cron triggers require an input.
+  await opened.triggers.put("missing", { cron: "* * * * *" });
+  // @ts-expect-error enabled is boolean.
+  await opened.triggers.put("bad", { cron: "* * * * *", input: "test", enabled: "yes" });
   const settings = await opened.settings.read();
   await opened.settings.update({ model: "gpt-6-astra" });
   await opened.settings.update({ thinking: settings.thinking, fastMode: true });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -411,6 +411,9 @@ importers:
       ai:
         specifier: 7.0.90
         version: 7.0.90(zod@4.5.4)
+      cron-parser:
+        specifier: 5.6.0
+        version: 5.6.0
       nanocodex:
         specifier: workspace:*
         version: link:../nanocodex
@@ -2935,6 +2938,10 @@ packages:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
     engines: {node: '>=0.8'}
 
+  cron-parser@5.6.0:
+    resolution: {integrity: sha512-6159NDv4eDOjXYDmMTkvUtaVcIrNZI779ydTMOfDdi9fSjhPqmySx0icCHX2+nOyXgNSw6sFCsgLKxYs/2KPuQ==}
+    engines: {node: '>=18'}
+
   cron-schedule@6.0.0:
     resolution: {integrity: sha512-BoZaseYGXOo5j5HUwTaegIog3JJbuH4BbrY9A1ArLjXpy+RWb3mV28F/9Gv1dDA7E2L8kngWva4NWisnLTyfgQ==}
     engines: {node: '>=20'}
@@ -3731,6 +3738,10 @@ packages:
     resolution: {integrity: sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -7292,6 +7303,10 @@ snapshots:
 
   crc-32@1.2.2: {}
 
+  cron-parser@5.6.0:
+    dependencies:
+      luxon: 3.7.2
+
   cron-schedule@6.0.0: {}
 
   cross-spawn@7.0.6:
@@ -8161,6 +8176,8 @@ snapshots:
   lucide-react@1.24.0(react@19.2.8):
     dependencies:
       react: 19.2.8
+
+  luxon@3.7.2: {}
 
   magic-string@0.30.21:
     dependencies:


### PR DESCRIPTION
Managed agents need recurring prompts that run without an open client. This adds account-owned cron triggers to the managed API and JavaScript SDK, using each session's existing Durable Object alarm and turn queue.

- Add GET/PUT/DELETE `/v1/agents/:agent/triggers/:id` and a list endpoint, with matching `agent.triggers` SDK methods.
- Support five-field cron expressions, IANA time zones, pause/resume, stable IDs, and occurrence metadata.
- Advance the schedule atomically with durable turn admission. Retain retry deadlines, fence edits/deletion, coalesce missed ticks, and skip busy agents to avoid a backlog.
- Preserve ownership, capability, and browser-origin checks. Connect grants and multiplayer schedules are excluded.

Schedules are account-owned standing instructions, retained after the creating credential ends. Portable export currently requires listing/deleting schedules first and recreating them at the destination. Limits are 32 triggers per agent and 64 KiB text input per trigger.

Validation: 26 Worker/protocol tests and 45 SDK tests passed; managed and SDK type checks, package validation, and Wrangler bundle dry-run passed. Container rollout was excluded from the dry-run because Docker is unavailable locally. No production model run was performed.

The published tree exactly matches the locally tested tree `5c801b984c0226d022179342a69722d952f868ab`.