### PR TITLE
fix(agent): recover sessions after invalid discovery schemas

### DIFF
--- a/crates/nanocodex-agent/src/model/run/state.rs
+++ b/crates/nanocodex-agent/src/model/run/state.rs
@@ -208,6 +208,10 @@ impl ConversationState {
         self.managed.replace_rejected_images()
     }
 
+    pub(super) fn remove_tool_definition(&mut self, definition: &Value) -> usize {
+        self.managed.remove_tool_definition(definition)
+    }
+
     pub(super) fn commit_tail(&mut self) {
         self.managed.commit_tail();
     }

--- a/crates/nanocodex-agent/src/model/run/turn.rs
+++ b/crates/nanocodex-agent/src/model/run/turn.rs
@@ -274,6 +274,12 @@ where
                         }) {
                             session.conversation.replace_rejected_images();
                         }
+                        if let Some(definition) = error
+                            .responses_error()
+                            .and_then(ResponsesError::invalid_tool_schema)
+                        {
+                            session.conversation.remove_tool_definition(definition);
+                        }
                         session.conversation.commit_interrupted();
                         session.preserve_inherited_delta = false;
                     }

--- a/crates/nanocodex-agent/tests/it/model/recovery/mod.rs
+++ b/crates/nanocodex-agent/tests/it/model/recovery/mod.rs
@@ -5,4 +5,5 @@ mod durable_provider;
 mod failures;
 mod normalization;
 mod reconnect;
+mod tool_schema;
 mod transport;

--- a/crates/nanocodex-agent/tests/it/model/recovery/tool_schema.rs
+++ b/crates/nanocodex-agent/tests/it/model/recovery/tool_schema.rs
@@ -1,0 +1,239 @@
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+use nanocodex_tools::{
+    Tool, ToolContext, ToolDefinition, ToolInput, ToolOutput, ToolResult, contract::async_trait,
+};
+
+use super::*;
+
+struct CatalogSearch {
+    corrected: Arc<AtomicBool>,
+    calls: Arc<AtomicU32>,
+}
+
+fn lookup_definition(corrected: bool) -> Value {
+    json!({
+        "type": "function",
+        "name": "lookup",
+        "strict": true,
+        "parameters": {
+            "type": "object",
+            "properties": { "limit": { "type": ["integer", "null"] } },
+            "required": if corrected { vec!["limit"] } else { vec![] },
+            "additionalProperties": false
+        }
+    })
+}
+
+fn sibling_definition() -> Value {
+    json!({
+        "type": "function",
+        "name": "list_keys",
+        "parameters": { "type": "object", "properties": {} }
+    })
+}
+
+#[async_trait]
+impl Tool for CatalogSearch {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::tool_search(
+            "client",
+            "Find lookup tools.",
+            json!({
+                "type": "object",
+                "properties": { "query": { "type": "string" } },
+                "required": ["query"],
+                "additionalProperties": false
+            }),
+        )
+    }
+
+    async fn execute(&self, _input: ToolInput, _context: ToolContext<'_>) -> ToolResult {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        Ok(ToolOutput::json(&json!([
+            lookup_definition(self.corrected.load(Ordering::Relaxed)),
+            sibling_definition()
+        ])))
+    }
+}
+
+#[tokio::test]
+async fn invalid_tool_schema_is_removed_before_durable_resume() -> Result<()> {
+    assert_schema_recovery(false).await
+}
+
+#[tokio::test]
+async fn invalid_tool_schema_uses_the_request_after_checkpoint_loss() -> Result<()> {
+    assert_schema_recovery(true).await
+}
+
+async fn assert_schema_recovery(lose_checkpoint: bool) -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let endpoint = format!("ws://{}", listener.local_addr()?);
+    let server =
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await?;
+            let mut socket = accept_async(stream).await?;
+            assert_eq!(next_json(&mut socket).await?["generate"], false);
+            send_warmup(&mut socket, "resp-warmup").await?;
+            let _generation = next_json(&mut socket).await?;
+            send_json(
+                &mut socket,
+                completed_response("resp-search", &[search_call("search-old")]),
+            )
+            .await?;
+
+            let mut request = next_json(&mut socket).await?;
+            assert_eq!(request["input"][0]["type"], "tool_search_output");
+            assert_eq!(request["previous_response_id"], "resp-search");
+            if lose_checkpoint {
+                send_json(
+                    &mut socket,
+                    json!({
+                        "type": "error",
+                        "error": { "code": "previous_response_not_found" }
+                    }),
+                )
+                .await?;
+                request = next_json(&mut socket).await?;
+                assert!(request.get("previous_response_id").is_none());
+            }
+            let input = request["input"].as_array().unwrap();
+            let index = input
+                .iter()
+                .position(|item| item["type"] == "tool_search_output")
+                .unwrap();
+            assert_eq!(index > 0, lose_checkpoint);
+            assert_eq!(input[index]["tools"][0], lookup_definition(false));
+            let mut expected_output = input[index].clone();
+            expected_output["tools"] = json!([sibling_definition()]);
+            send_json(
+                &mut socket,
+                json!({
+                    "type": "error",
+                    "status": 400,
+                    "error": {
+                        "type": "invalid_request_error",
+                        "code": "invalid_function_parameters",
+                        "param": format!("input[{index}].tools[0].parameters"),
+                        "message": "The required array must include limit."
+                    }
+                }),
+            )
+            .await?;
+
+            // The rejected turn must finish without another request on this socket.
+            let next = timeout(std::time::Duration::from_secs(5), socket.next()).await?;
+            assert!(!matches!(next, Some(Ok(Message::Text(_)))));
+            let (stream, _) = listener.accept().await?;
+            let mut socket = accept_async(stream).await?;
+            let replay = next_json(&mut socket).await?;
+            assert!(replay.get("previous_response_id").is_none());
+            let history = replay["input"].as_array().unwrap();
+            assert!(replay.to_string().contains("find a lookup tool"));
+            assert!(replay.to_string().contains("use the corrected catalog"));
+            assert!(history.iter().any(|item| {
+                item["type"] == "tool_search_call" && item["call_id"] == "search-old"
+            }));
+            assert_eq!(
+                history
+                    .iter()
+                    .find(|item| item["type"] == "tool_search_output"),
+                Some(&expected_output)
+            );
+            send_json(
+                &mut socket,
+                completed_response("resp-rediscovery", &[search_call("search-new")]),
+            )
+            .await?;
+            let corrected = next_json(&mut socket).await?;
+            assert_eq!(corrected["input"][0]["call_id"], "search-new");
+            assert_eq!(
+                corrected["input"][0]["tools"],
+                json!([lookup_definition(true), sibling_definition()])
+            );
+            send_final(&mut socket, "resp-final").await
+        });
+
+    let workspace = tempfile::tempdir()?;
+    let rollout_home = tempfile::tempdir()?;
+    let corrected = Arc::new(AtomicBool::new(false));
+    let calls = Arc::new(AtomicU32::new(0));
+    let tools = || {
+        Tools::builder()
+            .without_defaults()
+            .tool(CatalogSearch {
+                corrected: Arc::clone(&corrected),
+                calls: Arc::clone(&calls),
+            })
+            .build()
+    };
+    let openai = || OpenAi::builder("test-key").websocket_url(&endpoint).build();
+    let (agent, events) = Nanocodex::builder(openai()?)
+        .thinking(Thinking::Low)
+        .workspace(workspace.path())
+        .session_id(test_session_id())
+        .tools(tools()?)
+        .rollout(RolloutConfig::new(rollout_home.path()))
+        .build()?;
+    drop(events);
+    let error = agent
+        .prompt("find a lookup tool")
+        .await?
+        .await
+        .expect_err("invalid discovery must fail the original turn");
+    assert!(error.to_string().contains("invalid_function_parameters"));
+    assert!(
+        error
+            .to_string()
+            .contains("The required array must include limit.")
+    );
+    assert_eq!(calls.load(Ordering::Relaxed), 1);
+    agent.shutdown().await?;
+    drop(agent);
+
+    let durable = RolloutConfig::new(rollout_home.path()).load_session(TEST_SESSION_ID)?;
+    let snapshot = serde_json::to_value(durable.snapshot())?;
+    let discovery = snapshot["history"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|item| item["type"] == "tool_search_output")
+        .unwrap();
+    assert_eq!(discovery["tools"], json!([sibling_definition()]));
+
+    corrected.store(true, Ordering::Relaxed);
+    let (thread_id, snapshot, rollout) = durable.into_parts();
+    let (agent, events) = Nanocodex::builder(openai()?)
+        .thinking(Thinking::Low)
+        .session_id(thread_id.parse()?)
+        .resume(snapshot)
+        .tools(tools()?)
+        .rollout(rollout)
+        .build()?;
+    drop(events);
+    assert_eq!(
+        agent
+            .prompt("use the corrected catalog")
+            .await?
+            .await?
+            .final_message(),
+        "done"
+    );
+    assert_eq!(calls.load(Ordering::Relaxed), 2);
+    agent.shutdown().await?;
+    drop(agent);
+    timeout(std::time::Duration::from_secs(5), server)
+        .await
+        .map_err(|_| eyre!("mock Responses server did not finish"))???;
+    Ok(())
+}
+
+fn search_call(call_id: &str) -> Value {
+    json!({
+        "type": "tool_search_call",
+        "call_id": call_id,
+        "execution": "client",
+        "arguments": { "query": "lookup" }
+    })
+}

--- a/crates/nanocodex-oai-api/src/session/context.rs
+++ b/crates/nanocodex-oai-api/src/session/context.rs
@@ -145,6 +145,28 @@ impl ContextManager {
         replaced
     }
 
+    pub fn remove_tool_definition(&mut self, definition: &serde_json::Value) -> usize {
+        let mut removed = 0;
+        let mut items = self.flattened_items();
+        for item in &mut items {
+            if let ResponseItem::ToolSearchOutput { tools, .. } = item {
+                tools.retain_mut(|tool| {
+                    let mut value = tool.as_value().clone();
+                    let before = removed;
+                    let retain = retain_tool_definition(&mut value, definition, &mut removed);
+                    if retain && removed != before {
+                        *tool = value.into();
+                    }
+                    retain
+                });
+            }
+        }
+        if removed > 0 {
+            self.replace_and_recompute(items, &[]);
+        }
+        removed
+    }
+
     pub fn replace_and_recompute(&mut self, mut items: Vec<ResponseItem>, prefix: &[ResponseItem]) {
         assign_missing_response_item_ids(&mut items);
         self.items.replace(items);
@@ -412,6 +434,31 @@ pub fn responses_lite_request_prefix(
     );
     instructions_item.set_id(Some(instructions_id));
     Ok([tools_item, instructions_item])
+}
+
+// Only namespace children are definitions. Never walk arbitrary JSON Schema
+// properties that happen to be named `tools`.
+fn retain_tool_definition(
+    tool: &mut serde_json::Value,
+    rejected: &serde_json::Value,
+    removed: &mut usize,
+) -> bool {
+    if tool == rejected {
+        *removed += 1;
+        return false;
+    }
+    if tool["type"] == "namespace"
+        && let Some(children) = tool
+            .get_mut("tools")
+            .and_then(serde_json::Value::as_array_mut)
+    {
+        let before = *removed;
+        children.retain_mut(|child| retain_tool_definition(child, rejected, removed));
+        if *removed != before && children.is_empty() {
+            return false;
+        }
+    }
+    true
 }
 
 fn new_response_item_id(prefix: &str) -> ResponseItemId {

--- a/crates/nanocodex-oai-api/src/session/state.rs
+++ b/crates/nanocodex-oai-api/src/session/state.rs
@@ -299,6 +299,18 @@ impl ManagedSessionState {
         self.context.replace_rejected_images()
     }
 
+    /// Removes exact matches from discovery metadata while retaining transcript items.
+    /// A changed history must be replayed without its old provider continuation.
+    #[doc(hidden)]
+    pub fn remove_tool_definition(&mut self, definition: &serde_json::Value) -> usize {
+        let removed = self.context.remove_tool_definition(definition);
+        if removed > 0 {
+            self.reset_for_full_request();
+            self.history_revision = self.history_revision.saturating_add(1);
+        }
+        removed
+    }
+
     /// Commits the active tail without changing continuation state.
     ///
     /// The agent uses this only when publishing a safe in-turn fork boundary.
@@ -352,7 +364,75 @@ pub enum ManagedSessionStateError {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::{ManagedSessionState, ManagedSessionStateError};
+
+    #[test]
+    fn removing_a_tool_definition_preserves_transcript_and_corrected_schemas() {
+        let rejected = json!({
+            "type": "function", "name": "lookup", "parameters": {
+                "type": "object", "properties": { "limit": { "type": "integer" } },
+                "required": []
+            }
+        });
+        let mut corrected = rejected.clone();
+        corrected["parameters"]["required"] = json!(["limit"]);
+        let sibling = json!({
+            "type": "function", "name": "other",
+            "parameters": { "type": "object", "tools": [rejected] }
+        });
+        let mut state = ManagedSessionState::new(
+            serde_json::from_value(json!([
+                { "type": "message", "role": "user", "content": [] },
+                { "type": "tool_search_call", "id": "tsc-original", "call_id": "search",
+                    "execution": "client", "arguments": { "query": "lookup" } },
+                { "type": "tool_search_output", "id": "tso-original", "call_id": "search",
+                    "status": "completed", "execution": "client", "tools": [
+                        rejected, corrected, sibling,
+                        { "type": "namespace", "name": "keep", "description": "Keep metadata",
+                            "tools": [rejected, corrected] },
+                        { "type": "namespace", "name": "prune", "tools": [
+                            { "type": "namespace", "name": "nested", "tools": [rejected] }
+                        ]}
+                    ] },
+                { "type": "function_call", "call_id": "completed", "name": "other",
+                    "arguments": "{}" },
+            { "type": "function_call_output", "call_id": "completed", "output": "already done" },
+            { "type": "tool_search_call", "call_id": "duplicate", "execution": "client",
+                "arguments": { "query": "lookup" } },
+            { "type": "tool_search_output", "call_id": "duplicate", "execution": "client",
+                "status": "completed", "tools": [rejected] }
+            ]))
+            .unwrap(),
+        );
+        state.set_previous_response_id("resp-before");
+        state.commit().unwrap();
+        let mut expected = serde_json::to_value(state.flattened_history()).unwrap();
+        expected[2]["tools"] = json!([
+            corrected, sibling,
+            { "type": "namespace", "name": "keep", "description": "Keep metadata",
+                "tools": [corrected] }
+        ]);
+
+        expected[6]["tools"] = json!([]);
+        assert_eq!(state.remove_tool_definition(&rejected), 4);
+        assert_eq!(
+            serde_json::to_value(state.flattened_history()).unwrap(),
+            expected
+        );
+        assert_eq!(state.previous_response_id(), None);
+        assert_eq!(state.delta_start(), 0);
+        assert_eq!(state.history_revision(), 1);
+        assert!(!state.prompt_history_with_repair().1);
+
+        state.set_previous_response_id("resp-after");
+        state.commit().unwrap();
+        assert_eq!(state.remove_tool_definition(&rejected), 0);
+        assert_eq!(state.previous_response_id(), Some("resp-after"));
+        assert_eq!(state.delta_start(), state.history_len());
+        assert_eq!(state.history_revision(), 1);
+    }
 
     #[test]
     fn empty_response_id_cannot_commit_an_incremental_checkpoint() {

--- a/crates/nanocodex-oai-api/src/tower/service.rs
+++ b/crates/nanocodex-oai-api/src/tower/service.rs
@@ -298,7 +298,10 @@ impl ResponsesService {
             self.run_websocket(&mut guard, request, started_at).await
         } else {
             https::run(self, &mut guard, request, started_at).await
-        };
+        }
+        // Resolve provider indices before retry policy can change the input
+        // from an incremental delta to full replay (or back again).
+        .map_err(|error| error.with_request_input(request));
         guard.complete();
         drop(guard);
         tracing::Span::current().record(

--- a/crates/nanocodex-oai-api/src/tower/service_error.rs
+++ b/crates/nanocodex-oai-api/src/tower/service_error.rs
@@ -91,6 +91,17 @@ impl ResponsesServiceError {
         self
     }
 
+    pub(crate) fn with_request_input(self, request: &crate::ResponsesAttempt) -> Self {
+        match self.source {
+            ResponsesServiceErrorSource::Responses(source) => Self::responses(
+                source.with_request_input(request.input_items()),
+                self.phase,
+                self.connection_generation,
+            ),
+            _ => self,
+        }
+    }
+
     /// Returns a stable low-cardinality error class.
     #[must_use]
     pub const fn error_class(&self) -> &'static str {
@@ -157,9 +168,9 @@ impl From<ResponsesError> for ResponsesServiceError {
             ResponsesError::HttpRequest { .. } | ResponsesError::InvalidSseUtf8 { .. } => {
                 FailurePhase::Receive
             }
-            ResponsesError::Api { .. } | ResponsesError::ContextWindowExceeded { .. } => {
-                FailurePhase::Api
-            }
+            ResponsesError::Api { .. }
+            | ResponsesError::ContextWindowExceeded { .. }
+            | ResponsesError::InvalidToolSchema { .. } => FailurePhase::Api,
             ResponsesError::HttpRejected { .. } => FailurePhase::Api,
             ResponsesError::HostUnavailable
             | ResponsesError::HandshakeTimeout { .. }

--- a/crates/nanocodex-oai-api/src/transport/api_error.rs
+++ b/crates/nanocodex-oai-api/src/transport/api_error.rs
@@ -43,6 +43,39 @@ pub(super) fn api_error_has_code(event: &str, expected: &str) -> bool {
     event.code() == Some(expected)
 }
 
+/// Resolves only structured paths into discovered function parameters.
+pub(super) fn invalid_tool_schema_path(event: &str) -> Option<Vec<usize>> {
+    let event: ApiErrorEnvelope = serde_json::from_str(event).ok()?;
+    let (code, param) = if event.code.is_some() {
+        (event.code.as_deref(), event.param.as_deref())
+    } else {
+        let error = event.error()?;
+        (error.code.as_deref(), error.param.as_deref())
+    };
+    if code != Some("invalid_function_parameters") {
+        return None;
+    }
+    let (input, mut rest) = path_index(param?.strip_prefix("input[")?)?;
+    let mut indices = vec![input];
+    while let Some(suffix) = rest.strip_prefix(".tools[") {
+        let (index, suffix) = path_index(suffix)?;
+        indices.push(index);
+        rest = suffix;
+    }
+    let suffix = rest.strip_prefix(".parameters")?;
+    (indices.len() >= 2
+        && (suffix.is_empty() || suffix.starts_with('.') || suffix.starts_with('[')))
+    .then_some(indices)
+}
+
+fn path_index(path: &str) -> Option<(usize, &str)> {
+    let (index, rest) = path.split_once(']')?;
+    if index.is_empty() || !index.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    Some((index.parse().ok()?, rest))
+}
+
 pub(super) fn api_error_is_checkpoint_missing(event: &str) -> bool {
     let Ok(event) = serde_json::from_str::<ApiErrorEnvelope>(event) else {
         return false;
@@ -88,6 +121,8 @@ struct ApiErrorEnvelope {
     #[serde(default)]
     code: Option<Box<str>>,
     #[serde(default)]
+    param: Option<Box<str>>,
+    #[serde(default)]
     error: Option<ApiErrorDetail>,
     #[serde(default)]
     response: Option<ApiErrorResponse>,
@@ -121,6 +156,8 @@ struct ApiErrorDetail {
     kind: Option<Box<str>>,
     #[serde(default)]
     code: Option<Box<str>>,
+    #[serde(default)]
+    param: Option<Box<str>>,
     #[serde(default)]
     message: Option<Box<str>>,
     #[serde(default)]

--- a/crates/nanocodex-oai-api/src/transport/error.rs
+++ b/crates/nanocodex-oai-api/src/transport/error.rs
@@ -1,6 +1,9 @@
 use std::time::Duration;
 
-use super::api_error::{api_error_has_code, api_error_is_checkpoint_missing, retryable_api_error};
+use super::api_error::{
+    api_error_has_code, api_error_is_checkpoint_missing, invalid_tool_schema_path,
+    retryable_api_error,
+};
 
 /// Errors produced by the standard `OpenAI` Responses transports.
 ///
@@ -133,6 +136,15 @@ pub enum ResponsesError {
         /// Complete retained provider event.
         event: String,
     },
+    /// The provider identified an invalid function schema in discovery history.
+    #[error("{source}")]
+    InvalidToolSchema {
+        /// Original provider failure, including its complete error detail.
+        #[source]
+        source: Box<Self>,
+        /// Exact discovered definition selected by the provider's parameter path.
+        definition: Box<serde_json::Value>,
+    },
     /// Sending or reading an HTTPS request failed.
     #[error("Responses HTTPS request failed: {detail}")]
     HttpRequest {
@@ -247,6 +259,7 @@ impl ResponsesError {
             Self::Api { .. } => "api",
             Self::ContextWindowExceeded { .. } => "context_window_exceeded",
             Self::InvalidImageRequest { .. } => "invalid_image_request",
+            Self::InvalidToolSchema { .. } => "invalid_tool_schema",
             Self::HttpRequest { timeout: true, .. } => "https_timeout",
             Self::HttpRequest { .. } => "https_transport",
             Self::HttpRejected { body, .. }
@@ -271,6 +284,59 @@ impl ResponsesError {
     #[must_use]
     pub const fn is_context_window_exceeded(&self) -> bool {
         matches!(self, Self::ContextWindowExceeded { .. })
+    }
+
+    /// Returns the rejected discovery definition identified on the failed request.
+    #[must_use]
+    pub fn invalid_tool_schema(&self) -> Option<&serde_json::Value> {
+        match self {
+            Self::InvalidToolSchema { definition, .. } => Some(definition),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn with_request_input<'a>(
+        self,
+        mut input: impl Iterator<Item = &'a crate::ResponseItem>,
+    ) -> Self {
+        let event = match &self {
+            Self::Api { event } => event,
+            Self::HttpRejected {
+                status: 400, body, ..
+            } => body,
+            _ => return self,
+        };
+        let Some(indices) = invalid_tool_schema_path(event) else {
+            return self;
+        };
+        let Some(crate::ResponseItem::ToolSearchOutput { tools, .. }) = input.nth(indices[0])
+        else {
+            return self;
+        };
+        let Some(tool) = tools.get(indices[1]) else {
+            return self;
+        };
+        let mut definition = tool.as_value();
+        for index in &indices[2..] {
+            if definition["type"] != "namespace" {
+                return self;
+            }
+            let Some(child) = definition
+                .get("tools")
+                .and_then(serde_json::Value::as_array)
+                .and_then(|tools| tools.get(*index))
+            else {
+                return self;
+            };
+            definition = child;
+        }
+        if definition["type"] != "function" || !definition["parameters"].is_object() {
+            return self;
+        }
+        Self::InvalidToolSchema {
+            source: Box::new(self),
+            definition: Box::new(definition.clone()),
+        }
     }
 
     /// Returns whether Astra's misalignment monitor stopped the conversation.
@@ -307,8 +373,140 @@ pub struct RetryAdvice {
 mod tests {
     use std::time::Duration;
 
+    use serde_json::json;
+
     use super::ResponsesError;
     use crate::transport::api_error::retryable_api_error;
+
+    #[test]
+    fn invalid_tool_schema_resolves_discovery_paths_and_preserves_provider_errors() {
+        let definition = json!({
+            "type": "function", "name": "lookup", "parameters": { "type": "object" }
+        });
+        let input: Vec<crate::ResponseItem> = serde_json::from_value(json!([
+            { "type": "message", "role": "user", "content": [] },
+            {
+                "type": "tool_search_output", "call_id": "search", "status": "completed",
+                "execution": "client", "tools": [definition, {
+                    "type": "namespace", "name": "outer", "tools": [{
+                        "type": "namespace", "name": "inner", "tools": [definition]
+                    }]
+                }]
+            }
+        ]))
+        .unwrap();
+
+        for param in [
+            "input[1].tools[0].parameters",
+            "input[1].tools[0].parameters.required",
+            "input[1].tools[1].tools[0].tools[0].parameters.properties.limit",
+        ] {
+            let detail = json!({
+                "code": "invalid_function_parameters", "param": param,
+                "message": "Invalid lookup schema."
+            });
+            for event in [
+                json!({ "type": "error", "error": detail }),
+                json!({ "type": "response.failed", "response": { "error": detail } }),
+                json!({
+                    "type": "error", "code": "invalid_function_parameters",
+                    "param": param, "message": "Invalid lookup schema."
+                }),
+            ] {
+                for error in [
+                    ResponsesError::Api {
+                        event: event.to_string(),
+                    },
+                    ResponsesError::HttpRejected {
+                        status: 400,
+                        body: event.to_string(),
+                        retry_after: None,
+                    },
+                ] {
+                    let original = error.to_string();
+                    let error = error.with_request_input(input.iter());
+                    assert_eq!(error.invalid_tool_schema(), Some(&definition), "{param}");
+                    assert_eq!(error.to_string(), original);
+                    assert_eq!(error.class(), "invalid_tool_schema");
+                    assert!(error.retry_advice().is_none());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn invalid_tool_schema_leaves_unrelated_or_ambiguous_failures_unchanged() {
+        let input: Vec<crate::ResponseItem> = serde_json::from_value(json!([
+            { "type": "message", "role": "user", "content": [] },
+            {
+                "type": "tool_search_output", "call_id": "search", "status": "completed",
+                "execution": "client", "tools": [
+                    { "type": "function", "name": "lookup", "parameters": {} },
+                    { "type": "namespace", "name": "empty", "tools": [] },
+                    { "type": "custom", "name": "edit" }
+                ]
+            }
+        ]))
+        .unwrap();
+        for param in [
+            "tools[0].parameters",
+            "input[0].tools[0].parameters",
+            "input[9].tools[0].parameters",
+            "input[1].tools[9].parameters",
+            "input[1].tools[1].parameters",
+            "input[1].tools[2].parameters",
+            "input[1].tools[0].tools[0].parameters",
+            "input[1].tools[0].name",
+            "input[1].tools[0].parameters_extra",
+            "input[-1].tools[0].parameters",
+            "input[+1].tools[0].parameters",
+            "input[9999999999999999999999999].tools[0].parameters",
+            "input[1].tools[].parameters",
+            "input[1].parameters",
+            "",
+        ] {
+            let error = ResponsesError::Api {
+                event: json!({ "error": {
+                    "code": "invalid_function_parameters", "param": param
+                }})
+                .to_string(),
+            }
+            .with_request_input(input.iter());
+            assert!(matches!(error, ResponsesError::Api { .. }), "{param}");
+        }
+        for event in [
+            json!({ "error": {
+                "code": "invalid_function_parameters", "param": null,
+                "message": "input[1].tools[0].parameters"
+            }}),
+            json!({ "error": {
+                "code": "invalid_request_error", "param": "input[1].tools[0].parameters",
+                "message": "invalid_function_parameters"
+            }}),
+            json!({ "code": "invalid_function_parameters", "error": {
+                "code": "invalid_request_error", "param": "input[1].tools[0].parameters"
+            }}),
+        ] {
+            let error = ResponsesError::Api {
+                event: event.to_string(),
+            }
+            .with_request_input(input.iter());
+            assert!(matches!(error, ResponsesError::Api { .. }));
+        }
+        let error = ResponsesError::HttpRejected {
+            status: 500,
+            body: json!({ "error": {
+                "code": "invalid_function_parameters", "param": "input[1].tools[0].parameters"
+            }})
+            .to_string(),
+            retry_after: None,
+        }
+        .with_request_input(input.iter());
+        assert!(matches!(
+            error,
+            ResponsesError::HttpRejected { status: 500, .. }
+        ));
+    }
 
     #[test]
     fn handshake_rejection_retains_provider_retry_delay() {

--- a/crates/nanocodex-oai-api/tests/it/https.rs
+++ b/crates/nanocodex-oai-api/tests/it/https.rs
@@ -1,5 +1,9 @@
 use eyre::{Result, eyre};
-use nanocodex_oai_api::{OpenAi, transport::ResponsesTransport};
+use nanocodex_oai_api::{
+    OpenAi,
+    session::ResponseInput,
+    transport::{ResponsesError, ResponsesTransport},
+};
 use serde_json::{Value, json};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -8,6 +12,92 @@ use tokio::{
 };
 
 const TURN_STATE_HEADER: &str = "x-codex-turn-state";
+
+#[tokio::test]
+async fn https_invalid_tool_schema_identifies_the_failed_request_definition() -> Result<()> {
+    let definition = json!({
+        "type": "function", "name": "lookup", "strict": true,
+        "parameters": {
+            "type": "object", "properties": { "limit": { "type": "integer" } },
+            "required": [], "additionalProperties": false
+        }
+    });
+    for streamed_error in [false, true] {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let api_base_url = format!("http://{}", listener.local_addr()?);
+        let server = tokio::spawn(async move {
+            let mut request = read_http_json(&listener).await?;
+            let index = request.body["input"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .position(|item| item["type"] == "tool_search_output")
+                .unwrap();
+            let error = json!({
+                "code": "invalid_function_parameters",
+                "param": format!("input[{index}].tools[0].parameters"),
+                "message": "The required array must include limit."
+            });
+            if streamed_error {
+                send_http_events(
+                    request.stream,
+                    None,
+                    [json!({
+                        "type": "response.failed", "response": { "error": error }
+                    })],
+                )
+                .await?;
+            } else {
+                let body = json!({ "error": error }).to_string();
+                request
+                    .stream
+                    .write_all(
+                        format!(
+                            "HTTP/1.1 400 Bad Request\r\ncontent-type: application/json\r\n\
+                     content-length: {}\r\nconnection: close\r\n\r\n{body}",
+                            body.len()
+                        )
+                        .as_bytes(),
+                    )
+                    .await?;
+                request.stream.shutdown().await?;
+            }
+            Result::<()>::Ok(())
+        });
+        let openai = OpenAi::builder("test-key")
+            .transport(ResponsesTransport::Https)
+            .api_base_url(api_base_url)
+            .build()?;
+        let mut session = openai.instructions("Use discovered tools.").build()?;
+        let items: Vec<nanocodex_oai_api::responses::ResponseItem> =
+            serde_json::from_value(json!([
+                { "type": "tool_search_call", "call_id": "search", "execution": "client",
+                    "arguments": { "query": "lookup" } },
+                { "type": "tool_search_output", "call_id": "search", "execution": "client",
+                    "status": "completed", "tools": [definition] }
+            ]))?;
+        let error = session
+            .turn()
+            .create(ResponseInput::items(items))
+            .await
+            .expect_err("the provider must reject the invalid schema");
+        assert_eq!(
+            error
+                .responses_error()
+                .and_then(ResponsesError::invalid_tool_schema),
+            Some(&definition)
+        );
+        assert!(
+            error
+                .to_string()
+                .contains("The required array must include limit.")
+        );
+        timeout(std::time::Duration::from_secs(5), server)
+            .await
+            .map_err(|_| eyre!("mock HTTPS schema server did not finish"))???;
+    }
+    Ok(())
+}
 
 #[tokio::test]
 async fn https_turn_state_is_scoped_to_one_logical_turn_and_survives_retry() -> Result<()> {


### PR DESCRIPTION
Fixes #273.

A rejected schema in `tool_search_output` survives failed-turn checkpointing, so later turns keep replaying it even after the live catalog is corrected. This change removes the rejected discovery definition before checkpointing, allowing subsequent turns to discover the corrected tool.

## Changes

- `nanocodex-oai-api` transport: Resolve `invalid_function_parameters` paths against the exact failed physical request, including full replay after provider checkpoint loss. Carry the identified definition in `InvalidToolSchema`, preserving the original provider error.
- `nanocodex-oai-api` session state: Remove exact definition matches from discovery outputs and namespace children. Preserve transcript items, search identities, completed results, and unrelated or corrected definitions. Clear provider continuation and increment the history revision so persistence records the replacement.
- `nanocodex-agent`: Apply the repair at the existing failed-turn checkpoint boundary. The original turn still fails; tools and failed turns are not automatically retried.

Recovery requires a structured path identifying a discovered function schema. Configured top-level tools and errors without a usable path remain unchanged.

## Tests

- WebSocket rejection, durable checkpointing, shutdown/reload, repaired replay, and corrected rediscovery—with both incremental requests and full replay after checkpoint loss.
- HTTP 400 and SSE `response.failed` errors through the standard transport.
- Structured error envelopes, nested namespaces, invalid or unrelated paths, original error preservation, and non-retryable classification.
- Duplicate-definition removal, empty discovery outputs, transcript preservation, continuation invalidation, and history revision changes.