### PR TITLE
fix(account): include the browser hand in managed startup context

### DIFF
--- a/js/account/src/AgentTerminal.tsx
+++ b/js/account/src/AgentTerminal.tsx
@@ -245,6 +245,7 @@ export const ManagedAgentTerminal = memo(function ManagedAgentTerminal({
   const [settingsReady, setSettingsReady] = useState(false);
   const [conversationStarted, setConversationStarted] = useState(true);
   const [browserHand, setBrowserHand] = useState<Awaited<ReturnType<typeof attachManagedBrowserHand>>>();
+  const [browserHandSettledFor, setBrowserHandSettledFor] = useState<typeof managed>();
   const [browserHandAttempt, setBrowserHandAttempt] = useState(0);
   useEffect(() => {
     const controller = new AbortController();
@@ -272,6 +273,8 @@ export const ManagedAgentTerminal = memo(function ManagedAgentTerminal({
       if (controller.signal.aborted) return;
       console.warn("nanocodex:browser_hand_attach_failed", { error: errorMessage(error) });
       reconnect();
+    }).finally(() => {
+      if (!controller.signal.aborted) setBrowserHandSettledFor(managed);
     });
     return () => {
       controller.abort();
@@ -306,9 +309,13 @@ export const ManagedAgentTerminal = memo(function ManagedAgentTerminal({
     const updated = await managed.settings.update(patch);
     setSettings(updated);
   }, [managed]);
+  // Keep the first prompt queued while this page's hand is still attaching,
+  // so the host can include it in the initial environment snapshot. A failed
+  // optional hand does not block the managed brain or subsequent reconnects.
+  const startupReady = browserHandSettledFor === managed || (settingsReady && conversationStarted);
   return (
     <AgentTerminalView
-      agent={agent}
+      agent={startupReady ? agent : undefined}
       agentError={undefined}
       inactiveMessage={({ agentError, agentStatus }) => inactiveTerminalMessage({
         agentError,


### PR DESCRIPTION
A fresh hosted conversation could submit its first prompt while the page’s browser hand was still attaching. The managed startup snapshot then correctly saw no connected hands, even though the hand appeared a few seconds later.

Keep the terminal’s existing first-prompt queue active until the initial hand attachment settles. Existing conversations can resume immediately after their state loads, and an unavailable optional hand does not block the managed brain. The server still performs account, history, and memory bootstrap before the first model request.

Hosted evidence: reproduced the missing-hand race on Astra, then confirmed the same startup developer context included the hand’s name, mount, and capabilities when attachment completed before submission. Both runs had no initial model tool calls. Validation: the full account-app Turbo build (including typecheck and documentation checks) passed, and all 74 existing app tests passed. Hosted verification passed after deployment: a cold browser page held readiness until the hand attached, then Astra answered its first prompt with the new hand’s name, logical mount, and capabilities and no tool calls. After reload, a second turn retained the original account, hand, session-search, and memory context. No application console errors were observed.
