### PR TITLE
fix(wasm): prevent durability crashes above Worker memory offsets

### DIFF
--- a/js/nanocodex-vite/README.md
+++ b/js/nanocodex-vite/README.md
@@ -5,6 +5,13 @@ current Rust/WASM bindings when it runs from a source checkout, installs the
 browser compatibility aliases in page and nested Worker graphs, and exposes a
 same-origin ChatGPT subscription socket during local development.
 
+The WASM build normalizes wasm-bindgen byte views for all three JavaScript
+targets. Cloudflare's V8 `subarray` offset check can reject valid strings above
+the 128 MiB address boundary after WASM memory grows. Direct bounded views keep
+those transfers valid without changing the WASM ABI. The build validates the
+generated helper shapes, and changes to the normalization script invalidate
+the binding cache.
+
 ```js
 import { nanocodex } from "nanocodex-vite";
 import { defineConfig } from "vite";

--- a/js/nanocodex-vite/plugin.mjs
+++ b/js/nanocodex-vite/plugin.mjs
@@ -17,6 +17,8 @@ const LOCAL_SPONSORED_CHATGPT_USER_ID = "00000000-0000-4000-8000-000000000001";
 const buildScript = fileURLToPath(new URL("./scripts/build-js-package.sh", import.meta.url));
 const repositoryRoot = fileURLToPath(new URL("../../", import.meta.url));
 const rustBuildFiles = new Set([
+  buildScript,
+  fileURLToPath(new URL("./scripts/wasm-memory-views.mjs", import.meta.url)),
   resolve(repositoryRoot, "Cargo.lock"),
   resolve(repositoryRoot, "Cargo.toml"),
   resolve(repositoryRoot, ".cargo/config.toml"),

--- a/js/nanocodex-vite/scripts/build-js-package.sh
+++ b/js/nanocodex-vite/scripts/build-js-package.sh
@@ -84,6 +84,7 @@ fingerprint="$({
   wasm-bindgen --version
   printf 'build-mode=%s\n' "$build_mode"
   printf 'worker-bundler-v1-simd\n'
+  cksum < js/nanocodex-vite/scripts/wasm-memory-views.mjs
   if [[ "$build_mode" == release ]]; then
     "$binaryen" --version
   fi
@@ -121,6 +122,10 @@ wasm-bindgen "$wasm_artifact" \
 cmp "$worker_bindings/nanocodex_bg.wasm" js/nanocodex/pkg-web/nanocodex_bg.wasm
 cp "$worker_bindings/nanocodex_bg.js" js/nanocodex/pkg-web/nanocodex_bg.js
 cp "$worker_bindings/nanocodex.js" js/nanocodex/pkg-web/nanocodex_worker.js
+node js/nanocodex-vite/scripts/wasm-memory-views.mjs \
+  js/nanocodex/pkg-web/nanocodex.js \
+  js/nanocodex/pkg-web/nanocodex_bg.js \
+  js/nanocodex/pkg-node/nanocodex.js
 generated_wasm="js/nanocodex/pkg-web/nanocodex_bg.wasm"
 if [[ "$build_mode" == release ]]; then
   optimized_wasm="$generated_dir/nanocodex.wasm"

--- a/js/nanocodex-vite/scripts/wasm-memory-views.mjs
+++ b/js/nanocodex-vite/scripts/wasm-memory-views.mjs
@@ -1,0 +1,39 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** Normalize wasm-bindgen's byte views without changing the Rust/WASM ABI. */
+export function rewriteWasmMemoryViews(source) {
+  // V8 subarray() checks its begin offset against the embedder's maximum
+  // ArrayBuffer allocation (128 MiB on Cloudflare). WASM memory.grow can exceed
+  // that address, so even a tiny, valid string then throws RangeError. A direct
+  // view checks the requested length and the actual memory bounds instead.
+  const replacements = [
+    ["getUint8ArrayMemory0().subarray(ptr / 1, ptr / 1 + len)",
+      "new Uint8Array(wasm.memory.buffer, ptr, len)"],
+    ["getUint8ArrayMemory0().subarray(ptr, ptr + len)",
+      "new Uint8Array(wasm.memory.buffer, ptr, len)"],
+    ["getUint8ArrayMemory0().subarray(ptr, ptr + buf.length)",
+      "new Uint8Array(wasm.memory.buffer, ptr, buf.length)"],
+    ["getUint8ArrayMemory0().subarray(ptr + offset, ptr + len)",
+      "new Uint8Array(wasm.memory.buffer, ptr + offset, len - offset)"],
+  ];
+  for (const [before, after] of replacements) {
+    if (source.split(before).length !== 2) {
+      throw new Error(`unsupported wasm-bindgen memory view: expected exactly one ${before}`);
+    }
+    source = source.replace(before, after);
+  }
+  if (source.includes("getUint8ArrayMemory0().subarray(")) {
+    throw new Error("unsupported wasm-bindgen memory view remains");
+  }
+  return source;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const paths = process.argv.slice(2);
+  if (paths.length === 0) throw new Error("expected generated wasm-bindgen JavaScript paths");
+  // Validate all targets before writing any, so generator drift fails the build.
+  const outputs = await Promise.all(paths.map(async (path) => [path, rewriteWasmMemoryViews(await readFile(path, "utf8"))]));
+  await Promise.all(outputs.map(([path, source]) => writeFile(path, source)));
+}

--- a/js/nanocodex-vite/test/build-js-package.test.mjs
+++ b/js/nanocodex-vite/test/build-js-package.test.mjs
@@ -39,6 +39,11 @@ test("concurrent cold WASM package builds are serialized", async () => {
     for (const artifact of generatedArtifacts) {
       assert((await readFile(join(fixture.packageRoot, artifact))).length > 0, artifact);
     }
+    for (const artifact of ["pkg-web/nanocodex.js", "pkg-web/nanocodex_bg.js", "pkg-node/nanocodex.js"]) {
+      const glue = await readFile(join(fixture.packageRoot, artifact), "utf8");
+      assert.ok(glue.includes("new Uint8Array(wasm.memory.buffer, ptr, len)"), artifact);
+      assert.ok(!glue.includes("getUint8ArrayMemory0().subarray("), artifact);
+    }
   } finally {
     await fixture.close();
   }
@@ -59,6 +64,16 @@ test("an incomplete Node package cache regenerates bindings", async () => {
       NANOCODEX_WASM_LOCK_HELD: fixture.repository,
     });
     await assert.rejects(readFile(fixture.bindgenEvents), { code: "ENOENT" });
+
+    const viewScript = join(fixture.repository, "js/nanocodex-vite/scripts/wasm-memory-views.mjs");
+    await writeFile(viewScript, `${await readFile(viewScript, "utf8")}\n// Changed generator policy.\n`);
+    await runBuild(fixture, {
+      CACHE_VALID: "1",
+      NANOCODEX_WASM_BUILD_DELAY: "0",
+      NANOCODEX_WASM_LOCK_HELD: fixture.repository,
+    });
+    assert.deepEqual((await readFile(fixture.bindgenEvents, "utf8")).trim().split("\n"),
+      ["nodejs", "web", "bundler"], "memory-view changes must invalidate generated bindings");
 
     for (const artifact of ["pkg-node/nanocodex.d.ts", "pkg-node/package.json"]) {
       await Promise.all([
@@ -99,6 +114,7 @@ async function createBuildFixture() {
     mkdir(fakeBin, { recursive: true }),
   ]);
   await copyFile(sourceBuildScript, buildScript);
+  await copyFile(new URL("../scripts/wasm-memory-views.mjs", import.meta.url), join(scripts, "wasm-memory-views.mjs"));
   await chmod(buildScript, 0o755);
   await Promise.all([
     writeExecutable(join(fakeBin, "cargo"), `#!/bin/sh
@@ -125,13 +141,21 @@ while [ "$#" -gt 0 ]; do
 done
 mkdir -p "$output"
 printf 'fixture wasm\\n' > "$output/nanocodex_bg.wasm"
-printf 'fixture glue\\n' > "$output/nanocodex.js"
+cat > "$output/nanocodex.js" <<'GLUE'
+getUint8ArrayMemory0().subarray(ptr / 1, ptr / 1 + len);
+getUint8ArrayMemory0().subarray(ptr, ptr + len);
+getUint8ArrayMemory0().subarray(ptr, ptr + buf.length);
+getUint8ArrayMemory0().subarray(ptr + offset, ptr + len);
+GLUE
 printf 'fixture types\\n' > "$output/nanocodex.d.ts"
-printf 'fixture worker glue\\n' > "$output/nanocodex_bg.js"
+cp "$output/nanocodex.js" "$output/nanocodex_bg.js"
 printf '%s\\n' "$target" >> "$NANOCODEX_WASM_BINDGEN_EVENTS"
 `),
     writeExecutable(join(fakeBin, "node"), `#!/bin/sh
 case "$1" in
+  *wasm-memory-views.mjs)
+    exec '${process.execPath.replaceAll("'", "'\\''")}' "$@"
+    ;;
   *write-package-types.mjs)
     printf '{"type":"commonjs"}\\n' > js/nanocodex/pkg-node/package.json
     printf '{"type":"module"}\\n' > js/nanocodex/pkg-web/package.json

--- a/js/nanocodex-vite/test/wasm-memory-views.test.mjs
+++ b/js/nanocodex-vite/test/wasm-memory-views.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { runInNewContext } from "node:vm";
+import { test } from "node:test";
+import { rewriteWasmMemoryViews } from "../scripts/wasm-memory-views.mjs";
+
+const LIMIT = 128 * 1024 * 1024;
+
+for (const target of ["pkg-web/nanocodex.js", "pkg-web/nanocodex_bg.js", "pkg-node/nanocodex.js"]) {
+  test(`${target} transfers strings and bytes above the Worker subarray offset ceiling`, async () => {
+    const source = await readFile(new URL(`../../nanocodex/${target}`, import.meta.url), "utf8");
+    const memory = new WebAssembly.Memory({ initial: 1 });
+    memory.grow(2_304);
+    // Wrangler remote preview reproduces this V8 embedder limit. Local
+    // workerd/Node do not configure it, so apply that constraint in this realm.
+    class WorkerUint8Array extends Uint8Array {
+      subarray(begin, end) {
+        if (begin > LIMIT) throw new RangeError("Invalid array buffer length");
+        return super.subarray(begin, end);
+      }
+    }
+    assert.throws(() => new WorkerUint8Array(memory.buffer).subarray(LIMIT + 32, LIMIT + 33), RangeError);
+    let cursor = LIMIT + 32;
+    const malloc = (size) => { const ptr = cursor; cursor += Math.max(8, size); return ptr; };
+    const realloc = (ptr, oldSize, newSize) => {
+      const next = malloc(newSize);
+      new Uint8Array(memory.buffer, next, Math.min(oldSize, newSize))
+        .set(new Uint8Array(memory.buffer, ptr, Math.min(oldSize, newSize)));
+      return next;
+    };
+    const helpers = ["getArrayU8FromWasm0", "getStringFromWasm0", "getUint8ArrayMemory0", "decodeText", "passStringToWasm0"]
+      .map((name) => generatedFunction(source, name)).join("\n");
+    const transfer = runInNewContext(`
+      let cachedUint8ArrayMemory0 = null;
+      let cachedTextDecoder = new TextDecoder("utf-8", { ignoreBOM: true, fatal: true });
+      const cachedTextEncoder = new TextEncoder();
+      const MAX_SAFARI_DECODE_BYTES = 2146435072;
+      let numBytesDecoded = 0;
+      let WASM_VECTOR_LEN = 0;
+      ${helpers}
+      (value, useRealloc) => {
+        const ptr = passStringToWasm0(value, malloc, useRealloc ? realloc : undefined);
+        return { ptr, value: getStringFromWasm0(ptr, WASM_VECTOR_LEN), bytes: getArrayU8FromWasm0(ptr, WASM_VECTOR_LEN) };
+      }
+    `, { wasm: { memory }, Uint8Array: WorkerUint8Array, TextEncoder, TextDecoder, malloc, realloc });
+    for (const value of ["", "durability checkpoint", "ASCII then Ελληνικά 😀", "\uFEFFpreserve BOM", "\0embedded NUL"]) {
+      for (const useRealloc of [false, true]) {
+        const result = transfer(value, useRealloc);
+        assert.ok(result.ptr > LIMIT);
+        assert.equal(result.value, value);
+        assert.deepEqual([...result.bytes], [...new TextEncoder().encode(value)]);
+      }
+    }
+    // A grown memory detaches the prior cache. The next transfer must use the
+    // current backing buffer, including the ASCII prefix/realloc path.
+    memory.grow(1);
+    assert.equal(transfer("after growth 😀", true).value, "after growth 😀");
+  });
+}
+
+test("the build rejects an unknown wasm-bindgen memory-view ABI", () => {
+  assert.throws(() => rewriteWasmMemoryViews("unknown generated glue"), /unsupported wasm-bindgen memory view/);
+});
+
+function generatedFunction(source, name) {
+  const start = source.indexOf(`function ${name}(`);
+  assert.notEqual(start, -1, `${name} must be present in generated glue`);
+  const end = source.indexOf("\n}", start);
+  assert.notEqual(end, -1);
+  return source.slice(start, end + 2);
+}

--- a/js/nanocodex/test/durability-high-memory.test.mjs
+++ b/js/nanocodex/test/durability-high-memory.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import { gunzipSync } from "node:zlib";
+import { Agent, Subagents, Transport } from "../host/index.mjs";
+import { initializeBrowserEngine } from "../browser/engine.mjs";
+import { createMemoryDurabilityStore } from "../runtime/durability-store.mjs";
+
+class WaitingSocket extends EventTarget {
+  readyState = 1;
+  constructor() { super(); queueMicrotask(() => this.dispatchEvent(new Event("open"))); }
+  send() {}
+  close() { this.readyState = 3; }
+}
+
+test("durable subagent messaging survives a WASM heap beyond the Worker subarray ceiling", async () => {
+  const module = await readFile(new URL("../pkg-web/nanocodex_bg.wasm", import.meta.url));
+  const engine = await initializeBrowserEngine({ module });
+  // Reserve address space without filling it. This puts subsequent allocations
+  // above 128 MiB without launching a delegation storm or contacting a model.
+  const size = 144 * 1024 * 1024;
+  const padding = engine.__wbindgen_export(size, 1);
+  const nativeSubarray = Uint8Array.prototype.subarray;
+  const store = createMemoryDurabilityStore("high-memory-messaging");
+  const writes = [];
+  const durability = { ...store, replace(stateId, request) {
+    const result = store.replace(stateId, request);
+    if (result.status === "replaced") writes.push({ stateId, payload: request.payload });
+    return result;
+  } };
+  const options = { module, tools: [], durability, durabilityId: "high-memory-messaging",
+    transport: Transport.openAi({ apiKey: "fixture", WebSocketImpl: WaitingSocket }) };
+  let agent;
+  try {
+    // Cloudflare remote preview has this native V8 check. Node does not, so
+    // retain the real WASM/SDK/store and emulate only the embedder constraint.
+    Uint8Array.prototype.subarray = function(begin, end) {
+      if (begin > 128 * 1024 * 1024) throw new RangeError("Invalid array buffer length");
+      return nativeSubarray.call(this, begin, end);
+    };
+    assert.ok(engine.memory.buffer.byteLength > 128 * 1024 * 1024);
+    agent = await Agent.create(options);
+    const children = [];
+    for (const role of ["one", "two"]) children.push(await Subagents.spawn(agent, {
+      role, task: "Wait for directed checkpoint messages", outputSchema: { type: "object" },
+    }));
+    const initialWrites = writes.length;
+    for (let index = 0; index < 8; index++) {
+      const child = children[index % 2];
+      const result = await Subagents.send(agent, {
+        agentId: child.agent_id, priority: "urgent", purpose: "question", message: `Checkpoint Ελληνικά 😀 ${index}`,
+      });
+      assert.equal(result.to_agent_id, child.agent_id);
+    }
+    assert.ok(writes.length >= initialWrites + 8, "each message must reach the durable store");
+    const persisted = writes.slice(initialWrites).map(({ payload }) => payload.startsWith("nanocodex-durable-state-gzip-v1:")
+      ? gunzipSync(Buffer.from(payload.slice("nanocodex-durable-state-gzip-v1:".length), "base64")).toString("utf8")
+      : payload).join("\n");
+    assert.ok(persisted.includes("Checkpoint Ελληνικά 😀 7"));
+    assert.equal((await Subagents.list(agent)).agents.length, 2);
+    await agent.session.shutdown();
+    agent = await Agent.create(options);
+    const replacement = await Subagents.spawn(agent, {
+      role: "after-reopen", task: "Verify checkpointing after reopen", outputSchema: { type: "object" },
+    });
+    assert.equal((await Subagents.send(agent, {
+      agentId: replacement.agent_id, priority: "urgent", message: "Still durable after reopen 😀",
+    })).to_agent_id, replacement.agent_id);
+  } finally {
+    Uint8Array.prototype.subarray = nativeSubarray;
+    try { await agent?.session.shutdown(); }
+    finally { engine.__wbindgen_export5(padding, size, 1); }
+  }
+});


### PR DESCRIPTION
Urgent subagent messages and checkpoints could fail with `RangeError: Invalid array buffer length` after WASM memory grew past the Worker subarray offset ceiling. A real Cloudflare preview reproduced the failure on a valid 21-byte read above 128 MiB.

Normalize wasm-bindgen byte views in the existing Vite-owned build for web, Worker, and Node targets. Direct bounded views preserve the ABI and memory bounds. The build rejects unexpected generated helpers, invalidates the binding cache when the normalizer changes, and watches the build inputs.

Validation:
- Real SDK on Cloudflare remote preview: 153,681,920-byte WASM memory, two children, four urgent Unicode messages, eight successful durable writes.
- All 23 Vite/build tests and the full-SDK high-memory persistence/reopen regression pass in the isolated worktree.
- Earlier checks passed: 49 SDK runtime tests, type/package checks, real-workerd SQLite durability tests, the managed build graph, and 96 durable turns plus 432 cancellations.

Generated artifacts are excluded. The preview used synthetic data and no production bindings.
