### PR TITLE
fix(managed): run brain tools without provisioning hands

### DIFF
--- a/js/managed/README.md
+++ b/js/managed/README.md
@@ -32,7 +32,24 @@ storage ownership.
 - `GET /v1/agents/:id/capacity` requires `agents:read` for that agent and returns
   storage byte counts, hot receipt counts, and archive counts without loading
   the runtime or returning conversation contents.
-- Managed agents begin with no sandbox hand. The provider-neutral `mount` model
+- Managed agents execute bounded Just Bash in durable `/brain` without a hand.
+  `exec_command` defaults there; `/brain` and `.` also select the brain. Its R2
+  prefix is shared with the native hand mounts, and listings refresh between
+  commands. Text/file processing, HTTP, and supported Git/GitHub commands run
+  here; native binaries, package installs, builds, and process sessions need a
+  hand. The agent reuses a suitable attached hand or mounts one when needed.
+  Known native work such as `cargo test` can go directly to a hand; an
+  unsupported brain capability can also trigger that choice after a probe.
+  `exec_command` always honors its selected cwd; the agent owns the fallback.
+  Brain execution requires `tools:use`, with connector authority taken
+  from the exact calling root or subagent.
+  Shell HTTP response bodies are bounded at 16 MiB.
+  Oversized responses fail with a request to narrow the result. Connect grants
+  cannot use Vault-backed shell requests or SSH identities.
+  The shared task tree admits at most eight active subagents, including nested
+  delegation. The existing WASM admission policy enforces this ceiling before
+  creating children; a failed tool does not justify recursively delegating it.
+  The provider-neutral `mount` model
   tool provisions and attaches named execution hands on demand. `cf_sandbox`
   names the built-in Cloudflare Sandbox factory (`cloudflare` remains a legacy
   input alias); any other provider value is the exact name of a connected VM

--- a/js/managed/package.json
+++ b/js/managed/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.19.0",
     "@cloudflare/workers-types": "^5.20260730.1",
+    "@types/node": "^22.20.1",
     "typescript": "5.9.3",
     "vitest": "^4.0.18",
     "wrangler": "4.127.1",

--- a/js/managed/src/brain-workspace.ts
+++ b/js/managed/src/brain-workspace.ts
@@ -1,0 +1,146 @@
+import { resolveNamespaceCwd, type Workspace, type WorkspaceEntry } from "nanocodex-tools";
+
+const ROOT = "/brain";
+const MAX_FILE_BYTES = 64 * 1024 * 1024;
+const MAX_ENTRIES = 20_000;
+
+/** The same prefix that Sandbox mounts at /brain; no copy or hand is needed. */
+export function createBrainWorkspace(bucket: R2Bucket, resourceId: string): Workspace {
+  if (!/^[A-Za-z0-9._:-]{1,256}$/.test(resourceId)) {
+    throw new TypeError("brain workspace has an invalid resource id");
+  }
+  const prefix = `brains/${resourceId}/`;
+  const resolve = (path: string): string => {
+    const absolute = resolveNamespaceCwd(ROOT, path);
+    if (absolute !== ROOT && !absolute.startsWith(`${ROOT}/`)) {
+      throw error("EPERM", "workspace path must stay within /brain");
+    }
+    return absolute;
+  };
+  const key = (path: string): string => `${prefix}${path.slice(ROOT.length + 1)}`;
+  const stat = async (path: string): Promise<"file" | "directory" | undefined> => {
+    if (path === ROOT) return "directory";
+    if (await bucket.head(key(path))) return "file";
+    const page = await bucket.list({ prefix: `${key(path)}/`, limit: 1 });
+    return page.objects.length ? "directory" : undefined;
+  };
+  const ancestors = async (path: string): Promise<void> => {
+    let current = ROOT;
+    for (const segment of path.slice(ROOT.length + 1).split("/").slice(0, -1)) {
+      current += `/${segment}`;
+      if (await bucket.head(key(current))) throw error("ENOTDIR", `${current} is not a directory`);
+    }
+  };
+  const mkdir = async (path: string): Promise<void> => {
+    const absolute = resolve(path);
+    if (absolute === ROOT) return;
+    await ancestors(absolute);
+    if (await stat(absolute) === "file") throw error("EEXIST", `${absolute} is a file`);
+    // Keep empty ancestors after their last child is removed. Trailing-slash
+    // markers are also understood by the native s3fs mount.
+    let current = ROOT;
+    for (const segment of absolute.slice(ROOT.length + 1).split("/")) {
+      current += `/${segment}`;
+      if (!await bucket.head(`${key(current)}/`)) await bucket.put(`${key(current)}/`, new Uint8Array(), {
+        httpMetadata: { contentType: "application/x-directory" },
+      });
+    }
+  };
+  const list: Workspace["list"] = async (path = ".", options = {}) => {
+    const absolute = resolve(path);
+    await ancestors(absolute);
+    const kind = await stat(absolute);
+    if (kind !== "directory") throw error(kind === "file" ? "ENOTDIR" : "ENOENT", `${absolute} is not a directory`);
+    const maximum = options.maxEntries ?? MAX_ENTRIES;
+    if (!Number.isSafeInteger(maximum) || maximum < 1 || maximum > MAX_ENTRIES) {
+      throw new RangeError(`workspace listing limit must be between 1 and ${MAX_ENTRIES}`);
+    }
+    const entries = new Map<string, WorkspaceEntry>();
+    const directoryPrefix = absolute === ROOT ? prefix : `${key(absolute)}/`;
+    let cursor: string | undefined;
+    do {
+      const page = await bucket.list({
+        prefix: directoryPrefix,
+        ...(options.recursive ? {} : { delimiter: "/" }),
+        limit: Math.min(1_000, maximum + 1),
+        cursor,
+      });
+      const add = (objectKey: string, kind: "file" | "directory", object?: R2Object) => {
+        const relative = objectKey.slice(prefix.length).replace(/\/$/, "");
+        const candidate = `${ROOT}/${relative}`;
+        if (!relative || candidate === absolute) return;
+        // Reject foreign/noncanonical native names instead of aliasing them.
+        if (resolve(candidate) !== candidate) throw error("EINVAL", "noncanonical brain workspace entry");
+        entries.set(candidate, {
+          path: candidate, kind,
+          ...(object === undefined ? {} : { size: object.size, modifiedAt: object.uploaded.getTime() }),
+        });
+        if (options.recursive) {
+          let parent = candidate.slice(0, candidate.lastIndexOf("/"));
+          while (parent !== absolute && parent.startsWith(`${absolute}/`)) {
+            if (!entries.has(parent)) entries.set(parent, { path: parent, kind: "directory" });
+            parent = parent.slice(0, parent.lastIndexOf("/"));
+          }
+        }
+        if (entries.size > maximum) throw new RangeError(`workspace listing exceeds ${maximum} entries`);
+      };
+      for (const object of page.objects) add(object.key, object.key.endsWith("/") ? "directory" : "file", object);
+      for (const directory of page.delimitedPrefixes) add(directory, "directory");
+      cursor = page.truncated ? page.cursor : undefined;
+    } while (cursor !== undefined);
+    return [...entries.values()].sort((a, b) => a.path < b.path ? -1 : a.path > b.path ? 1 : 0);
+  };
+  return Object.freeze({
+    root: ROOT,
+    list,
+    mkdir,
+    async readFile(path) {
+      const absolute = resolve(path);
+      if (absolute === ROOT) throw error("EISDIR", "cannot read the workspace root as a file");
+      await ancestors(absolute);
+      const object = await bucket.get(key(absolute));
+      if (!object) {
+        if (await stat(absolute) === "directory") throw error("EISDIR", `${absolute} is a directory`);
+        throw error("ENOENT", `brain workspace file not found: ${absolute}`);
+      }
+      if (object.size > MAX_FILE_BYTES) {
+        await object.body.cancel();
+        throw new RangeError("workspace file exceeds the 64 MiB read bound");
+      }
+      return new Uint8Array(await object.arrayBuffer());
+    },
+    async writeFile(path, contents) {
+      const absolute = resolve(path);
+      if (absolute === ROOT || await stat(absolute) === "directory") {
+        throw error("EISDIR", `${absolute} is a directory`);
+      }
+      const bytes = typeof contents === "string" ? new TextEncoder().encode(contents)
+        : contents instanceof ArrayBuffer ? new Uint8Array(contents)
+        : new Uint8Array(contents.buffer, contents.byteOffset, contents.byteLength);
+      if (bytes.byteLength > MAX_FILE_BYTES) throw new RangeError("workspace file exceeds the 64 MiB write bound");
+      await ancestors(absolute);
+      await mkdir(absolute.slice(0, absolute.lastIndexOf("/")));
+      await bucket.put(key(absolute), bytes);
+    },
+    async remove(path, options = {}) {
+      const absolute = resolve(path);
+      if (absolute === ROOT) throw error("EPERM", "cannot remove the workspace root");
+      await ancestors(absolute);
+      const kind = await stat(absolute);
+      if (kind === undefined) throw error("ENOENT", `${absolute} does not exist`);
+      if (kind === "file") {
+        await bucket.delete(key(absolute));
+        return;
+      }
+      const entries = await list(absolute, { recursive: true, maxEntries: MAX_ENTRIES });
+      if (!options.recursive && entries.length) throw error("ENOTEMPTY", `${absolute} is not empty`);
+      const keys = entries.map((entry) => `${key(entry.path)}${entry.kind === "directory" ? "/" : ""}`);
+      keys.push(`${key(absolute)}/`);
+      for (let offset = 0; offset < keys.length; offset += 1_000) await bucket.delete(keys.slice(offset, offset + 1_000));
+    },
+  } satisfies Workspace);
+}
+
+function error(code: string, message: string): Error {
+  return Object.assign(new Error(message), { code });
+}

--- a/js/managed/src/computer-runtime.ts
+++ b/js/managed/src/computer-runtime.ts
@@ -3,12 +3,16 @@ import {
   createWorkspaceFilesystem,
   type ComputerRuntime,
   type ShellFetch,
+  type Workspace,
   type WorkspaceStorageClient,
 } from "nanocodex-tools";
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { ToolContext } from "nanocodex";
 
 import { createCloudflareSshCommand } from "./cloudflare-ssh";
 import {
   handleManagedEgress,
+  VAULT_ID_HEADER,
   type ManagedEgressConnectorAccess,
   type ManagedEgressConnectorId,
 } from "./managed-egress";
@@ -17,6 +21,8 @@ type DisposableComputerWorkspace = WorkspaceStorageClient & Readonly<{
   [Symbol.dispose](): void;
 }>;
 
+const MAX_SHELL_RESPONSE_BYTES = 16 * 1024 * 1024;
+
 export type ManagedComputerRuntime = ComputerRuntime & Readonly<{
   dispose(): void;
 }>;
@@ -24,31 +30,40 @@ export type ManagedComputerRuntime = ComputerRuntime & Readonly<{
 /** Wires managed persistence, egress, and SSH policy into the generic JS tools. */
 export async function createManagedComputerRuntime(options: Readonly<{
   computer: DisposableComputerWorkspace;
+  filesystem?: Workspace;
   connectorAllowed?: (
     connector: ManagedEgressConnectorId,
     connectionId?: string,
+    context?: ToolContext,
   ) => ManagedEgressConnectorAccess;
   egress: Fetcher;
-  sshIdentityAllowed?: (reference: string) => boolean;
+  sshIdentityAllowed?: (reference: string, context?: ToolContext) => boolean;
+  vaultAllowed?: (context?: ToolContext) => boolean;
   subject?: string;
   sshPassword?: (reference: string) => Promise<string>;
 }>): Promise<ManagedComputerRuntime> {
   let disposed = false;
+  const lifetime = new AbortController();
+  const calls = new AsyncLocalStorage<ToolContext>();
   const dispose = () => {
     if (disposed) return;
     disposed = true;
+    lifetime.abort(new Error("managed computer runtime is disposed"));
     options.computer[Symbol.dispose]();
   };
 
   try {
-    const filesystem = await createWorkspaceFilesystem(options.computer);
+    const filesystem = options.filesystem ?? await createWorkspaceFilesystem(options.computer);
     const fetch = createManagedShellFetch(
       options.egress,
       options.subject,
-      options.connectorAllowed,
+      options.connectorAllowed === undefined ? undefined
+        : (connector, connectionId) => options.connectorAllowed!(connector, connectionId, calls.getStore()),
+      () => options.vaultAllowed?.(calls.getStore()) ?? true,
     );
     const runtime = await createComputerRuntime({
       filesystem,
+      refreshFilesystemBeforeExec: options.filesystem !== undefined,
       fetch,
       networkMode: options.subject === undefined
         ? "public-http-only"
@@ -61,7 +76,7 @@ export async function createManagedComputerRuntime(options: Readonly<{
           ...(options.sshPassword === undefined ? {} : { resolvePassword: options.sshPassword }),
           ...(options.sshIdentityAllowed === undefined
             ? {}
-            : { sshIdentityAllowed: options.sshIdentityAllowed }),
+            : { sshIdentityAllowed: (reference: string) => options.sshIdentityAllowed!(reference, calls.getStore()) }),
           ...(options.subject === undefined ? {} : { subject: options.subject }),
         }),
       }],
@@ -69,7 +84,14 @@ export async function createManagedComputerRuntime(options: Readonly<{
     return Object.freeze({
       ...runtime,
       dispose,
-      tool: Object.freeze({ ...runtime.tool, dispose }),
+      tool: Object.freeze({
+        ...runtime.tool, dispose,
+        handler: (input: unknown, context: ToolContext) => {
+          if (disposed) throw new Error("managed computer runtime is disposed");
+          const scoped = { ...context, signal: AbortSignal.any([context.signal, lifetime.signal]) };
+          return calls.run(scoped, () => runtime.tool.handler(input, scoped));
+        },
+      }),
     });
   } catch (error) {
     dispose();
@@ -84,6 +106,7 @@ function createManagedShellFetch(
     connector: ManagedEgressConnectorId,
     connectionId?: string,
   ) => ManagedEgressConnectorAccess,
+  vaultAllowed: () => boolean = () => true,
 ): ShellFetch {
   return async (url, options = {}) => {
     const method = (options.method ?? "GET").toUpperCase();
@@ -95,6 +118,9 @@ function createManagedShellFetch(
         : { body: options.body }),
       signal: options.signal,
     });
+    if (request.headers.has(VAULT_ID_HEADER) && !vaultAllowed()) {
+      throw new Error("the current authorization cannot use Vault items");
+    }
     const response = await handleManagedEgress(request, binding, subject, connectorAllowed);
     const headers: Record<string, string> = Object.create(null) as Record<string, string>;
     response.headers.forEach((value, name) => { headers[name] = value; });
@@ -102,8 +128,42 @@ function createManagedShellFetch(
       status: response.status,
       statusText: response.statusText,
       headers,
-      body: new Uint8Array(await response.arrayBuffer()),
+      body: await readShellResponse(response, options.signal),
       url: response.url || request.url,
     };
   };
+}
+
+async function readShellResponse(response: Response, signal?: AbortSignal): Promise<Uint8Array> {
+  if (Number(response.headers.get("content-length")) > MAX_SHELL_RESPONSE_BYTES) {
+    await response.body?.cancel();
+    throw new RangeError("brain HTTP response exceeds 16 MiB; request a smaller response or use a hand");
+  }
+  if (response.body === null) return new Uint8Array();
+  const reader = response.body.getReader();
+  const abort = () => { void reader.cancel(signal?.reason).catch(() => {}); };
+  signal?.addEventListener("abort", abort, { once: true });
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    for (;;) {
+      signal?.throwIfAborted();
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > MAX_SHELL_RESPONSE_BYTES) throw new RangeError("brain HTTP response exceeds 16 MiB; request a smaller response or use a hand");
+      chunks.push(value);
+    }
+    signal?.throwIfAborted();
+  } catch (error) {
+    try { await reader.cancel(); } catch { /* Preserve the read failure. */ }
+    throw error;
+  } finally {
+    signal?.removeEventListener("abort", abort);
+    reader.releaseLock();
+  }
+  const body = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) { body.set(chunk, offset); offset += chunk.byteLength; }
+  return body;
 }

--- a/js/managed/src/index.ts
+++ b/js/managed/src/index.ts
@@ -18,7 +18,8 @@ import type {
 import { Agent as CloudflareAgent } from "nanocodex/cloudflare";
 import { Agent as ManagedAgent } from "nanocodex/managed";
 import { imageGeneration, updatePlan, viewImage, web } from "nanocodex/tools";
-import { MAX_NAMESPACE_MOUNTS } from "nanocodex-tools";
+import { createWorkspaceFilesystem, MAX_NAMESPACE_MOUNTS } from "nanocodex-tools";
+import { createBrainWorkspace } from "./brain-workspace";
 import { managedCodeEvaluator } from "./code-evaluator";
 import { CronTriggers, CRON_TRIGGER_ID, cronTriggerView, nextCronRun, parseCronTrigger, type CronTriggerConfig } from "./cron-triggers";
 import { createCronTool } from "./cron-tool";
@@ -34,6 +35,7 @@ import {
 } from "./sandbox-tools";
 import {
   createNamespaceExecutionRuntime,
+  isBrainExecution,
   machineMountRoot,
   type MachineToolResolver,
   type NamespaceMachine,
@@ -800,6 +802,7 @@ const SANDBOX_HAND_CAPABILITIES = Object.freeze([
   "servers",
 ]);
 const MAX_MANAGED_MOUNTS = 16;
+export const MANAGED_SUBAGENT_MAX_CONCURRENCY = 8;
 
 const json = (body: unknown, init: ResponseInit = {}) => Response.json(body, {
   ...init,
@@ -1086,9 +1089,7 @@ export function createSharedBrainReadWorkspace(
     readFile: async (path: string): Promise<Uint8Array> => {
       const key = sharedBrainObjectKey(resourceId, path);
       if (key === undefined) return fallback.readFile(path);
-      const object = await bucket.get(key);
-      if (object === null) throw new Error(`brain workspace file not found: ${path}`);
-      return new Uint8Array(await object.arrayBuffer());
+      return createBrainWorkspace(bucket, resourceId).readFile(path);
     },
   });
 }
@@ -2254,12 +2255,14 @@ export function createManagedNamespaceTools(
   machines: (context: ToolContext) => readonly NamespaceMachine[] = () => [],
   resolveMachineTool: MachineToolResolver = () => undefined,
   prepareNamespace: (context: ToolContext) => Promise<void> = async () => {},
+  brain?: Readonly<{ tool: NamedTool; allowed(context: ToolContext): boolean }>,
 ): NamedTool[] {
   return createManagedNamespaceRuntime(
     canUseExecutionNamespace,
     machines,
     resolveMachineTool,
     prepareNamespace,
+    brain,
   ).tools;
 }
 
@@ -2268,15 +2271,17 @@ function createManagedNamespaceRuntime(
   machines: (context: ToolContext) => readonly NamespaceMachine[] = () => [],
   resolveMachineTool: MachineToolResolver = () => undefined,
   prepareNamespace: (context: ToolContext) => Promise<void> = async () => {},
+  brain?: Readonly<{ tool: NamedTool; allowed(context: ToolContext): boolean }>,
 ): Readonly<{ tools: NamedTool[]; capture(context: ToolContext): Promise<void> }> {
   const runtime = createNamespaceExecutionRuntime(
     machines,
     resolveMachineTool,
+    brain?.tool,
   );
   const captured = new Set<string>();
   const preparations = new Map<string, Promise<void>>();
   const cellKey = (context: ToolContext): string => (
-    `${context.sessionId}\u0000${context.parentCallId}`
+    `${context.sessionId}\u0000${context.parentCallId || context.callId}`
   );
   const capture = async (context: ToolContext): Promise<void> => {
     const key = cellKey(context);
@@ -2308,6 +2313,13 @@ function createManagedNamespaceRuntime(
     name,
     ...tool,
     handler: async (input, context) => {
+      context.signal.throwIfAborted();
+      if (name === "exec_command" && brain !== undefined && isBrainExecution(input)) {
+        if (!brain.allowed(context)) {
+          throw new ManagedRequestError(403, "namespace_forbidden", "the current authorization cannot use brain tools");
+        }
+        return tool.handler(input, context);
+      }
       if (!canUseExecutionNamespace(context)) {
         throw new ManagedRequestError(
           403,
@@ -2326,6 +2338,7 @@ function createManagedNamespaceRuntime(
       captured.clear();
       preparations.clear();
       tool.dispose?.();
+      if (name === "exec_command") brain?.tool.dispose?.();
     },
   } satisfies NamedTool));
   return Object.freeze({ tools, capture });
@@ -6317,17 +6330,26 @@ export class DurableAgentSession extends DurableComputerSession {
     // fail closed without a subject, while ordinary public HTTP remains usable.
     const computer = await createManagedComputerRuntime({
       computer: workspace,
+      ...(multiplayer ? {} : { filesystem: createBrainWorkspace(this.env.NANOCODEX_WORKSPACES, session.session_id) }),
       egress: this.env.NANOCODEX,
       ...(multiplayer ? {} : { subject: this.ctx.id.toString() }),
-      connectorAllowed: (connector, connectionId) => (
-        this.#activeTurnConnectorAllowed(connector, connectionId)
+      connectorAllowed: (connector, connectionId, context) => (
+        this.#toolConnectorAllowed(connector, connectionId, context)
       ),
-      sshIdentityAllowed: (reference) => this.#activeTurnSshIdentityAllowed(reference),
+      vaultAllowed: (context) => context !== undefined
+        && this.#hasFullAccountAuthority(this.#authorizationForToolContext(context)),
+      sshIdentityAllowed: (_reference, context) => context !== undefined
+        && this.#hasFullAccountAuthority(this.#authorizationForToolContext(context)),
     });
     const sharedBrainWorkspace = createSharedBrainReadWorkspace(
       this.env.NANOCODEX_WORKSPACES,
       session.session_id,
-      computer.filesystem,
+      { readFile: async (path: string) => {
+        if (multiplayer || !path.startsWith("/")) return computer.filesystem.readFile(path);
+        // Retain explicit legacy /workspace image paths without opening that
+        // filesystem during ordinary brain-only startup or relative reads.
+        return (await createWorkspaceFilesystem(workspace)).readFile(path);
+      } },
     );
     const computerRuntimeMs = performance.now() - phaseStartedAt;
     const currentAccountInfo = async (context: ToolContext) => {
@@ -6453,6 +6475,10 @@ export class DurableAgentSession extends DurableComputerSession {
       (context) => this.#refreshMountedHostMounts(
         this.#authorizationForToolContext(context),
       ),
+      {
+        tool: computer.tool,
+        allowed: (context) => this.#authorizationForToolContext(context)?.capabilities.includes("tools:use") === true,
+      },
     );
     const cloudTools: NamedTool[] = [
       ...(browserRuntime?.tools ?? []),
@@ -6513,8 +6539,8 @@ export class DurableAgentSession extends DurableComputerSession {
         parameters: { type: "object", additionalProperties: false },
         handler: async (_input: unknown, context: ToolContext) => ({
           runtime: "cloudflare-durable-object",
-          shell: multiplayer ? computer.descriptor.shell : "unavailable",
-          shell_network: multiplayer ? computer.descriptor.network.mode : "unavailable",
+          shell: computer.descriptor.shell,
+          shell_network: computer.descriptor.network.mode,
           namespace: multiplayer ? { status: "disabled" } : {
             status: "cwd-placement",
             default_cwd: "/brain",
@@ -6534,9 +6560,10 @@ export class DurableAgentSession extends DurableComputerSession {
             },
           },
           workspace: computer.descriptor.cwd,
-          commands: multiplayer ? computer.descriptor.commands : [],
-          custom_commands: multiplayer ? computer.descriptor.customCommands : [],
+          commands: computer.descriptor.commands,
+          custom_commands: computer.descriptor.customCommands,
           limits: computer.descriptor.limits,
+          subagent_max_concurrency: MANAGED_SUBAGENT_MAX_CONCURRENCY,
           pty: multiplayer ? computer.descriptor.pty : false,
           sessions: multiplayer ? computer.descriptor.sessions : false,
           sandbox_escalation: false,
@@ -6584,9 +6611,11 @@ export class DurableAgentSession extends DurableComputerSession {
             "No process sandbox is attached. Bounded Just Bash is the complete local execution boundary.",
           ].join("\n\n")
           : [
-            "You are the durable Nanocodex brain running on Cloudflare Workers. The brain does not execute shell commands. /brain is durable shared scratch mounted read-write in every Cloudflare hand; it never contains credentials or control-plane authority.",
-            "The agent starts without a sandbox hand. When a task such as cloning a repository, building code, or running tests needs native Linux execution, infer that need and call mount with provider cf_sandbox and a useful stable name. Use another provider only when the user supplied its exact connected VM factory name. Do not ask the user to request a routine sandbox mount. mount provisions and attaches the hand before it returns.",
-            "Hands appear as logical top-level paths returned by mount or listed in accountInfo().machines. exec_command has its standard shape: set workdir to the exact hand mount or a path beneath it; the root of that cwd selects where the process runs. The default /brain cwd is not executable. write_stdin remains pinned to the hand that created its session. There is no environment or host argument.",
+            "You are the durable Nanocodex brain running on Cloudflare Workers. Use Code Mode, tools, and bounded Just Bash in /brain first. /brain is durable shared scratch mounted read-write in every Cloudflare hand; it never contains credentials or control-plane authority.",
+            computer.instructions,
+            "The agent starts without a sandbox hand. File work, text processing, HTTP, supported Git/GitHub commands, and JavaScript computation in Code Mode need no hand. When the task needs native binaries, package installation, builds, tests, a server, or a process session, reuse a suitable attached hand from accountInfo or mount output; otherwise call mount with provider cf_sandbox and a useful stable name. A known native command such as cargo test should go directly to a suitable hand. If a brain command reveals an unsupported binary or runtime capability, select or mount a hand and continue there, checking for partial effects before retrying. A compiler error or failing test on a hand should be investigated there. Use another provider only when the user supplied its exact connected VM factory name. Do not ask the user to request a routine sandbox mount. mount provisions and attaches the hand before it returns.",
+            `Subagents share your tools and permissions. Delegate bounded independent work; spawning another researcher does not repair an unavailable tool. The entire task tree may have at most ${MANAGED_SUBAGENT_MAX_CONCURRENCY} active subagents. When capacity is full, continue your assigned work with the available brain tools.`,
+            "Hands appear as logical top-level paths returned by mount or listed in accountInfo().machines. exec_command defaults to /brain; omit workdir or use /brain for Just Bash. For native execution, set workdir to the exact hand mount or a path beneath it. The root of that cwd selects where the process runs. write_stdin remains pinned to the hand that created its session. There is no environment or host argument.",
             "A Code Mode cell captures its mount mapping. Commands in Promise.all may run concurrently on different cwd roots, and subagents use the same cwd rule independently. A disconnect or reconnect never retargets an admitted command or session.",
             "Cloudflare sandbox hands are separate retained workspaces mounted into each other's native filesystem namespaces. A process may write its executing hand through /workspace or that hand's logical mount path, read peer hand paths without mutating them, and read or write /brain using ordinary filesystem syscalls. The trees are mounted, never copied or synchronized. Connected user hands and future providers remain placement-only until their provider advertises a conforming native namespace adapter, so native_cross_mounts remains false globally while runtimeInfo.cloudflare_native_cross_mounts is true.",
             "The browser_execute tool is the managed remote browser. Reuse its retained session when continuity matters. Never inspect, return, or persist cookies, authorization material, CDP connection URLs, provider URLs, or Live View URLs. If a login, MFA, CAPTCHA, or other human-only gate appears, stop and ask the user to complete it outside the model-visible browser tool; do not bypass or evade the gate.",
@@ -6602,9 +6631,10 @@ export class DurableAgentSession extends DurableComputerSession {
           ].join("\n\n"),
         tools: preparedTools ?? cloudTools,
       };
-      if (hostedRuntime !== undefined) {
-        Object.defineProperty(agentOptions, internalRuntime, { value: hostedRuntime });
-      }
+      Object.defineProperty(agentOptions, internalRuntime, { value: {
+        ...hostedRuntime,
+        subagentMaxConcurrency: MANAGED_SUBAGENT_MAX_CONCURRENCY,
+      } });
       Object.defineProperty(agentOptions, internalConfiguration, { value: this.#settings() });
       phaseStartedAt = performance.now();
       agent = await CloudflareAgent.create(this, agentOptions);
@@ -7442,11 +7472,12 @@ export class DurableAgentSession extends DurableComputerSession {
       .sort((left, right) => left.id.localeCompare(right.id));
   }
 
-  #activeTurnConnectorAllowed(
+  #toolConnectorAllowed(
     connector: ManagedEgressConnectorId,
     connectionId?: string,
+    context?: ToolContext,
   ): boolean | string {
-    const authorization = this.#activeTurnAuthorization();
+    const authorization = context === undefined ? undefined : this.#authorizationForToolContext(context);
     if (authorization === undefined) return false;
     const grant = authorization.connectGrant;
     if (grant === undefined) return true;
@@ -7461,12 +7492,6 @@ export class DurableAgentSession extends DurableComputerSession {
     return authorization !== undefined
       && (authorization.connectGrant === undefined
         || authorization.connectGrant.mcpIds.includes(connectionId));
-  }
-
-  #activeTurnSshIdentityAllowed(_reference: string): boolean {
-    // Full account turns may use account identities. Connect grants fail closed
-    // until signed resources can enumerate exact SSH identity references.
-    return this.#hasFullAccountAuthority();
   }
 
   #hostedToolAllowed(

--- a/js/managed/src/namespace-tools.ts
+++ b/js/managed/src/namespace-tools.ts
@@ -5,6 +5,7 @@ import {
   EXEC_COMMAND_PARAMETERS,
   EXECUTION_OUTPUT_SCHEMA,
   namespaceMountRoot,
+  resolveNamespaceCwd,
   PREVIEW_OUTPUT_SCHEMA,
   routeNamespaceCwd,
   WRITE_STDIN_PARAMETERS,
@@ -17,7 +18,7 @@ import {
 const TOOL_RESULT = Symbol.for("nanocodex.toolResult");
 const DEFAULT_CWD = "/brain";
 
-type RoutedTool = Readonly<{
+export type RoutedTool = Readonly<{
   handler(input: unknown, context: ToolContext): unknown | Promise<unknown>;
 }>;
 
@@ -67,11 +68,13 @@ export type NamespaceExecutionRuntime = Readonly<{
 export function createNamespaceExecutionRuntime(
   machines: (context: ToolContext) => readonly NamespaceMachine[],
   resolveMachineTool: MachineToolResolver = () => undefined,
+  brainExec?: RoutedTool,
 ): NamespaceExecutionRuntime {
   const brain = Object.freeze({
     mountId: "mount:brain",
     root: "/brain",
-    workspace: "/workspace",
+    workspace: "/brain",
+    exec: brainExec,
   }) satisfies MountedHand;
   const cells = new Map<string, CellBinding>();
   const sessions = new Map<number, ProcessBinding>();
@@ -103,17 +106,20 @@ export function createNamespaceExecutionRuntime(
 
   const tools: ToolMap = {
     exec_command: {
-      description: "Run a command on the hand that owns the root of workdir. workdir is a logical namespace path returned by mount or listed by accountInfo, such as /repo-test/repo or /laptop/repo. No execution hand is attached by default.",
+      description: "Run a command in durable /brain using bounded Just Bash by default. Use an explicit hand workdir returned by mount or accountInfo only for native binaries, builds, or process sessions. No execution hand is attached by default.",
       parameters: EXEC_COMMAND_PARAMETERS,
       outputSchema: EXECUTION_OUTPUT_SCHEMA,
       supportsParallelToolCalls: true,
       handler: async (input, context) => {
         const value = record(input);
         const workdir = optionalString(value.workdir, "workdir");
-        if (workdir === undefined) {
-          throw new Error(
-            "exec_command.workdir must select an attached hand; call mount when native execution is needed",
-          );
+        if (brainExec !== undefined && isBrainExecution(value)) {
+          // Brain calls must remain independent of hand discovery/readiness,
+          // and do not need to retain a per-cell native mount lease.
+          return brainExec.handler({
+            ...without(value, "workdir"),
+            workdir: resolveNamespaceCwd(DEFAULT_CWD, workdir),
+          }, context);
         }
         const binding = cell(context);
         const route = routeNamespaceCwd(binding.scope, workdir);
@@ -215,6 +221,12 @@ export function createNamespaceExecutionTools(
 }
 
 export const machineMountRoot = namespaceMountRoot;
+
+export function isBrainExecution(input: unknown): boolean {
+  const value = record(input);
+  const cwd = resolveNamespaceCwd(DEFAULT_CWD, optionalString(value.workdir, "workdir"));
+  return cwd === DEFAULT_CWD || cwd.startsWith(`${DEFAULT_CWD}/`);
+}
 
 function createCellBinding(
   brain: MountedHand,

--- a/js/managed/test/brain-workspace.test.ts
+++ b/js/managed/test/brain-workspace.test.ts
@@ -1,0 +1,179 @@
+import { env } from "cloudflare:test";
+import { describe, expect, it, vi } from "vitest";
+import type { ToolContext } from "nanocodex";
+import { viewImage } from "nanocodex/tools";
+import type { WorkspaceStorageClient } from "nanocodex-tools";
+import { createBrainWorkspace } from "../src/brain-workspace";
+import { createManagedComputerRuntime } from "../src/computer-runtime";
+import { createManagedNamespaceTools, createSharedBrainReadWorkspace } from "../src/index";
+
+const bucket = (env as unknown as { NANOCODEX_HISTORY: R2Bucket }).NANOCODEX_HISTORY;
+const context = (sessionId = "root"): ToolContext => ({
+  sessionId, callId: crypto.randomUUID(), parentCallId: "", model: "test",
+  signal: new AbortController().signal,
+});
+const computer = () => ({
+  get fs(): WorkspaceStorageClient["fs"] { throw new Error("brain must not open a computer filesystem"); },
+  [Symbol.dispose]: vi.fn(),
+});
+
+describe("durable brain without hands", () => {
+  it("fences the retained R2 handle after disposal", async () => {
+    const workspace = createBrainWorkspace(bucket, crypto.randomUUID());
+    const runtime = await createManagedComputerRuntime({
+      computer: computer(), filesystem: workspace, egress: { fetch: vi.fn() } as unknown as Fetcher,
+    });
+    runtime.dispose();
+    expect(() => runtime.tool.handler({ cmd: "echo stale > stale" }, context())).toThrow("runtime is disposed");
+    expect(await workspace.list()).toEqual([]);
+  });
+
+  it("cancels a stalled HTTP body when its tool call is aborted", async () => {
+    let started!: () => void;
+    const requestStarted = new Promise<void>((resolve) => { started = resolve; });
+    const cancel = vi.fn();
+    const runtime = await createManagedComputerRuntime({
+      computer: computer(), filesystem: createBrainWorkspace(bucket, crypto.randomUUID()),
+      subject: "s".repeat(43), connectorAllowed: () => true,
+      egress: { async fetch() {
+        started();
+        return new Response(new ReadableStream<Uint8Array>({ cancel }));
+      } } as unknown as Fetcher,
+    });
+    try {
+      const controller = new AbortController();
+      const pending = runtime.tool.handler({ cmd: "gh api user" }, { ...context(), signal: controller.signal });
+      await requestStarted;
+      controller.abort(new Error("caller cancelled"));
+      await expect(pending).resolves.toMatchObject({ exit_code: 124 });
+      expect(cancel).toHaveBeenCalledOnce();
+    } finally { runtime.dispose(); }
+  });
+
+  it("cancels oversized chunked HTTP responses before buffering them in full", async () => {
+    let chunks = 0;
+    const cancel = vi.fn();
+    const runtime = await createManagedComputerRuntime({
+      computer: computer(), filesystem: createBrainWorkspace(bucket, crypto.randomUUID()),
+      subject: "s".repeat(43), connectorAllowed: () => true,
+      egress: { async fetch() {
+        return new Response(new ReadableStream<Uint8Array>({
+          pull(controller) { chunks++; controller.enqueue(new Uint8Array(1024 * 1024)); }, cancel,
+        }));
+      } } as unknown as Fetcher,
+    });
+    try {
+      await expect(runtime.tool.handler({ cmd: "gh api user" }, context()))
+        .resolves.toMatchObject({ exit_code: 1, output: expect.stringContaining("exceeds 16 MiB") });
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(chunks).toBeLessThanOrEqual(18);
+      await expect(runtime.tool.handler({ cmd: "echo still-working" }, context()))
+        .resolves.toMatchObject({ exit_code: 0, output: "still-working\n" });
+    } finally { runtime.dispose(); }
+  });
+
+  it("executes default, dot, and /brain cwd; reopens files; sees native R2 changes", async () => {
+    const id = crypto.randomUUID();
+    const filesystem = createBrainWorkspace(bucket, id);
+    const runtime = await createManagedComputerRuntime({
+      computer: computer(), filesystem, egress: { fetch: vi.fn() } as unknown as Fetcher,
+    });
+    const prepareHand = vi.fn(async () => { throw new Error("hand unavailable"); });
+    const listHands = vi.fn(() => { throw new Error("hand discovery unavailable"); });
+    const resolveHand = vi.fn();
+    const tools = createManagedNamespaceTools(() => false, listHands, resolveHand, prepareHand, {
+      tool: runtime.tool, allowed: () => true,
+    });
+    const exec = tools.find((tool) => tool.name === "exec_command")!;
+    try {
+      const denied = createManagedNamespaceTools(() => false, () => [], resolveHand, prepareHand, {
+        tool: runtime.tool, allowed: () => false,
+      }).find((tool) => tool.name === "exec_command")!;
+      await expect(denied.handler({ cmd: "echo denied > denied" }, context()))
+        .rejects.toThrow("cannot use brain tools");
+      expect(await filesystem.list()).toEqual([]);
+      for (const workdir of [undefined, ".", "/brain"]) {
+        await expect(exec.handler({ cmd: "pwd && echo no && true", workdir }, context()))
+          .resolves.toMatchObject({ exit_code: 0, output: "/brain\nno\n" });
+      }
+      await expect(exec.handler({ cmd: "mkdir -p notes && printf 'persistent\\n' > notes/result" }, context()))
+        .resolves.toMatchObject({ exit_code: 0 });
+      expect(await (await bucket.get(`brains/${id}/notes/result`))!.text()).toBe("persistent\n");
+      await expect(exec.handler({ cmd: "printf iVBORw0KGgo= | base64 -d > notes/pixel.png" }, context()))
+        .resolves.toMatchObject({ exit_code: 0 });
+      const image = viewImage({ workspace: createSharedBrainReadWorkspace(bucket, id, filesystem) });
+      for (const path of ["notes/pixel.png", "/brain/notes/pixel.png"]) {
+        await expect(image.handler({ path }, context())).resolves.toMatchObject({
+          output: [{ type: "input_image", image_url: "data:image/png;base64,iVBORw0KGgo=" }],
+        });
+      }
+      await bucket.put(`brains/${id}/notes/native`, "written by a hand\n");
+      await bucket.delete(`brains/${id}/notes/result`);
+      await expect(exec.handler({ cmd: "cat native && test ! -e result", workdir: "notes" }, context()))
+        .resolves.toMatchObject({ exit_code: 0, output: "written by a hand\n" });
+      await expect(exec.handler({ cmd: "pwd", workdir: "/brain/../hand" }, context()))
+        .rejects.toThrow("cannot use execution hands");
+      expect(prepareHand).not.toHaveBeenCalled();
+      expect(listHands).not.toHaveBeenCalled();
+      expect(resolveHand).not.toHaveBeenCalled();
+      const reopened = await createManagedComputerRuntime({
+        computer: computer(), filesystem: createBrainWorkspace(bucket, id),
+        egress: { fetch: vi.fn() } as unknown as Fetcher,
+      });
+      try {
+        await expect(reopened.tool.handler({ cmd: "cat notes/native" }, context()))
+          .resolves.toMatchObject({ exit_code: 0, output: "written by a hand\n" });
+      } finally { reopened.dispose(); }
+    } finally { runtime.dispose(); }
+  });
+
+  it("preserves empty directories and fences paths, file ancestors, bounds, and other agents", async () => {
+    const id = crypto.randomUUID();
+    const workspace = createBrainWorkspace(bucket, id);
+    const other = createBrainWorkspace(bucket, crypto.randomUUID());
+    await workspace.writeFile("a/b/file", "hello");
+    await workspace.remove("a/b/file");
+    expect(await workspace.list("a", { recursive: true })).toMatchObject([{ path: "/brain/a/b", kind: "directory" }]);
+    await workspace.writeFile("a/b/file", "hello");
+    await expect(workspace.remove("a")).rejects.toMatchObject({ code: "ENOTEMPTY" });
+    await expect(workspace.list(".", { recursive: true, maxEntries: 2 })).rejects.toThrow("exceeds 2 entries");
+    await expect(other.readFile("a/b/file")).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(workspace.writeFile("../outside", "no")).rejects.toMatchObject({ code: "EPERM" });
+    await expect(workspace.writeFile("a/b/file/child", "no")).rejects.toMatchObject({ code: "ENOTDIR" });
+    await expect(workspace.writeFile("a", "no")).rejects.toMatchObject({ code: "EISDIR" });
+    await workspace.remove("a", { recursive: true });
+    expect(await workspace.list()).toEqual([]);
+    expect((await bucket.list({ prefix: `brains/${id}/` })).objects).toEqual([]);
+  });
+
+  it("keeps queued connector calls scoped to the calling agent and never exposes gateway headers", async () => {
+    const seen: Request[] = [];
+    const allowed = vi.fn((_connector, _connection, call?: ToolContext) => call?.sessionId === "allowed");
+    const runtime = await createManagedComputerRuntime({
+      computer: computer(), filesystem: createBrainWorkspace(bucket, crypto.randomUUID()),
+      subject: "s".repeat(43), connectorAllowed: allowed,
+      vaultAllowed: () => false,
+      egress: { async fetch(request: Request) {
+        seen.push(request);
+        return Response.json({ login: "fixture" }, { headers: { "x-nanocodex-subject": "private-subject" } });
+      } } as unknown as Fetcher,
+    });
+    try {
+      const [permitted, denied] = await Promise.all([
+        runtime.tool.handler({ cmd: "gh auth status" }, context("allowed")),
+        runtime.tool.handler({ cmd: "gh auth status" }, context("denied")),
+      ]);
+      expect(permitted).toMatchObject({ exit_code: 0, output: expect.stringContaining("fixture") });
+      expect(denied).toMatchObject({ exit_code: 1, output: expect.stringContaining("connector_forbidden") });
+      expect(seen).toHaveLength(1);
+      expect(allowed.mock.calls.map((call) => call[2]?.sessionId)).toEqual(["allowed", "denied"]);
+      expect(JSON.stringify([permitted, denied])).not.toMatch(/private-subject|NANOCODEX_PROVIDER_CREDENTIAL/);
+      await expect(runtime.tool.handler({
+        cmd: `curl -sS -H 'x-nanocodex-vault-id: ${"v".repeat(22)}' https://example.com`,
+      }, context("allowed"))).resolves.toMatchObject({
+        output: expect.stringContaining("cannot use Vault items"),
+      });
+      expect(seen).toHaveLength(1);
+    } finally { runtime.dispose(); }
+  });
+});

--- a/js/managed/test/durability-runtime.test.ts
+++ b/js/managed/test/durability-runtime.test.ts
@@ -1,0 +1,92 @@
+import { env, runInDurableObject } from "cloudflare:test";
+import { expect, it } from "vitest";
+import { Agent } from "nanocodex/cloudflare";
+import { Subagents } from "nanocodex/host";
+import { createTools } from "nanocodex/tools";
+import { MANAGED_SUBAGENT_MAX_CONCURRENCY } from "../src/index";
+
+it("bounds a delegation storm with prepared tools and keeps checkpointed messaging usable", async () => {
+  const namespace = (env as unknown as { NANOCODEX_MEMORY: DurableObjectNamespace }).NANOCODEX_MEMORY;
+  await runInDurableObject(namespace.getByName(crypto.randomUUID()), async (_instance, ctx) => {
+    const owner = { ctx, env: { NANOCODEX: { async fetch() {
+      return {
+        status: 101, headers: new Headers(),
+        webSocket: { addEventListener() {}, accept() {}, send() {}, close() {} },
+      };
+    } } } };
+    const tools = await createTools({ tools: [] });
+    const options = { tools, eventPersistence: "caller" as const };
+    Object.defineProperty(options, Symbol.for("nanocodex.cloudflare.internalRuntime"), { value: {
+      subagentMaxConcurrency: MANAGED_SUBAGENT_MAX_CONCURRENCY,
+    } });
+    const agent = await Agent.create(owner, options);
+    try {
+      const attempts = await Promise.allSettled(Array.from({ length: 104 }, (_, index) => Subagents.spawn(agent, {
+        role: `researcher-${index}`, task: "Research fixture without further delegation", outputSchema: { type: "object" },
+      })));
+      expect(attempts.filter((attempt) => attempt.status === "fulfilled")).toHaveLength(MANAGED_SUBAGENT_MAX_CONCURRENCY);
+      const rejected = attempts.filter((attempt) => attempt.status === "rejected");
+      expect(rejected).toHaveLength(104 - MANAGED_SUBAGENT_MAX_CONCURRENCY);
+      for (const attempt of rejected) expect(String(attempt.reason)).toContain("sub-agent concurrency limit of 8");
+      const directory = await Subagents.list(agent);
+      expect(directory.agents).toHaveLength(MANAGED_SUBAGENT_MAX_CONCURRENCY);
+      await expect(Subagents.send(agent, {
+        agentId: directory.agents[0]!.agent_id, priority: "urgent", purpose: "question", message: "Still available?",
+      })).resolves.toMatchObject({ to_agent_id: directory.agents[0]!.agent_id });
+    } finally { await agent.session.shutdown(); }
+  });
+}, 30_000);
+
+it("retains interrupted children and bounds new delegation after Worker SQLite reconstruction", async () => {
+  const namespace = (env as unknown as { NANOCODEX_MEMORY: DurableObjectNamespace }).NANOCODEX_MEMORY;
+  await runInDurableObject(namespace.getByName(crypto.randomUUID()), async (_instance, ctx) => {
+    // Transport stays open without making provider calls, so both children
+    // remain active while directed messages are durably admitted.
+    const owner = { ctx, env: { NANOCODEX: { async fetch() {
+      return {
+        status: 101, headers: new Headers(),
+        webSocket: { addEventListener() {}, accept() {}, send() {}, close() {} },
+      };
+    } } } };
+    const agent = await Agent.create(owner, { eventPersistence: "caller" });
+    let reopened: Awaited<ReturnType<typeof Agent.create>> | undefined;
+    try {
+      const children = await Promise.all(["one", "two"].map((role) => Subagents.spawn(agent, {
+        role, task: `Research fixture ${role}`, outputSchema: { type: "object" },
+      })));
+      for (let index = 0; index < 12; index++) {
+        await expect(Subagents.send(agent, {
+          agentId: children[index % 2]!.agent_id, priority: "urgent", purpose: "question",
+          message: `Verified URLs? Ελληνικά 😀 ${index}`,
+        })).resolves.toMatchObject({ to_agent_id: children[index % 2]!.agent_id });
+      }
+      expect((await Subagents.list(agent)).agents).toHaveLength(2);
+      // A new context over retained storage models an evicted DO. Explicit
+      // session.shutdown closes children, so it is not a restart simulation.
+      const restoredOptions = { eventPersistence: "caller" as const };
+      Object.defineProperty(restoredOptions, Symbol.for("nanocodex.cloudflare.internalRuntime"), {
+        value: { subagentMaxConcurrency: 1 },
+      });
+      reopened = await Agent.create({ ...owner, ctx: {
+        id: ctx.id, storage: ctx.storage,
+        acceptWebSocket: ctx.acceptWebSocket.bind(ctx), getWebSockets: ctx.getWebSockets.bind(ctx),
+      } }, restoredOptions);
+      agent.dispose();
+      const restoredChildren = (await Subagents.list(reopened, { includeCompleted: true })).agents;
+      expect(restoredChildren).toHaveLength(2);
+      expect(restoredChildren.map(({ agent_id }) => agent_id).sort()).toEqual(children.map(({ agent_id }) => agent_id).sort());
+      for (const child of restoredChildren) expect(child.status).toEqual({ state: "interrupted" });
+      // Reconstruction preserves logical children, not their running harnesses.
+      // Fresh work must still obey the replacement host's concurrency policy.
+      const fresh = await Subagents.spawn(reopened, {
+        role: "replacement", task: "Continue research after restart", outputSchema: { type: "object" },
+      });
+      await expect(Subagents.spawn(reopened, {
+        role: "excess", task: "Exceed the replacement host limit", outputSchema: { type: "object" },
+      })).rejects.toThrow("sub-agent concurrency limit of 1");
+      await expect(Subagents.send(reopened, {
+        agentId: fresh.agent_id, priority: "urgent", message: "Still available after reconstruction?",
+      })).resolves.toMatchObject({ to_agent_id: fresh.agent_id });
+    } finally { await (reopened ?? agent).session.shutdown(); }
+  });
+}, 30_000);

--- a/js/managed/test/namespace-tools.test.ts
+++ b/js/managed/test/namespace-tools.test.ts
@@ -26,7 +26,7 @@ describe("cwd-root namespace execution", () => {
     const tools = createRuntimeNamespaceExecutionTools(() => []);
 
     await expect(tools.exec_command!.handler({ cmd: "pwd" }, context()))
-      .rejects.toThrow("call mount when native execution is needed");
+      .rejects.toThrow("namespace cwd /brain lacks process.exec");
   });
 
   it("keeps canonical schemas and routes an explicit logical cwd to a sandbox hand", async () => {

--- a/js/managed/tsconfig.json
+++ b/js/managed/tsconfig.json
@@ -8,7 +8,7 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "ES2024",
-    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers/types"]
+    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers/types", "node"]
   },
   "include": ["src/**/*.ts", "test/**/*.ts"]
 }

--- a/js/nanocodex-tools/src/runtime.ts
+++ b/js/nanocodex-tools/src/runtime.ts
@@ -15,6 +15,7 @@ export type ComputerCommandContext = Readonly<{
 export type ComputerRuntimeOptions = Readonly<{
   filesystem: Workspace;
   fetch: ShellFetch;
+  refreshFilesystemBeforeExec?: boolean | undefined;
   networkMode: string;
   maxEntries?: number | undefined;
   maxOutputTokens?: number | undefined;
@@ -48,6 +49,7 @@ export async function createComputerRuntime(
   const additional = options.commands?.({ fetch: options.fetch, filesystem }) ?? [];
   const shell = await justBash({
     filesystem: options.filesystem,
+    refreshFilesystemBeforeExec: options.refreshFilesystemBeforeExec,
     maxEntries: options.maxEntries ?? DEFAULT_MAX_ENTRIES,
     maxOutputTokens: options.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS,
     fetch: options.fetch,

--- a/js/nanocodex-tools/src/shell.ts
+++ b/js/nanocodex-tools/src/shell.ts
@@ -21,7 +21,7 @@ export type ShellFetch = (
   options?: ShellFetchOptions,
 ) => Promise<ShellFetchResult>;
 
-type CommandContext = Readonly<{ cwd?: unknown }>;
+type CommandContext = Readonly<{ cwd?: unknown; signal?: AbortSignal }>;
 type CommandResult = Readonly<{
   stdout: string;
   stderr: string;
@@ -46,9 +46,14 @@ export function createGhCommand(
     name: "gh",
     trusted: true,
     async execute(args: string[], context: CommandContext = {}) {
+      const request: ShellFetch = (url, options) => {
+        context.signal?.throwIfAborted();
+        return fetch(url, { ...options, signal: context.signal });
+      };
       try {
+        context.signal?.throwIfAborted();
         if (args[0] === "auth" && args[1] === "status") {
-          const user = await github(fetch, "/user");
+          const user = await github(request, "/user");
           return ok(`Logged in to github.com as ${text(user, "login")} through the connected account.\n`);
         }
         if (args[0] === "api") {
@@ -66,7 +71,7 @@ export function createGhCommand(
             for (const [name, value] of Object.entries(fields)) target.searchParams.set(name, value);
             path = `${target.pathname}${target.search}`;
           }
-          return ok(`${JSON.stringify(await github(fetch, path, {
+          return ok(`${JSON.stringify(await github(request, path, {
             method,
             ...(hasFields && method !== "GET" && method !== "HEAD"
               ? { body: JSON.stringify(fields) }
@@ -78,7 +83,7 @@ export function createGhCommand(
             ?? args.slice(2).find((value) => !value.startsWith("-"));
           requireRepository(repository, "gh repo view requires OWNER/REPO");
           const repo = requireRecord(
-            await github(fetch, `/repos/${repository}`),
+            await github(request, `/repos/${repository}`),
             "repository",
           );
           return ok([
@@ -95,7 +100,7 @@ export function createGhCommand(
         if (args[0] === "repo" && args[1] === "list") {
           const owner = positional(args.slice(2), ["--limit", "-L"]);
           const perPage = limit(option(args.slice(2), "--limit", "-L"));
-          const repositories = await github(fetch, `/user/repos?${new URLSearchParams({
+          const repositories = await github(request, `/user/repos?${new URLSearchParams({
             affiliation: "owner,collaborator,organization_member",
             per_page: "100",
             sort: "updated",
@@ -119,7 +124,7 @@ export function createGhCommand(
         if (args[0] === "pr" && args[1] === "list") {
           const repository = option(args.slice(2), "--repo", "-R");
           requireRepository(repository, "gh pr list requires --repo OWNER/REPO");
-          const pulls = await github(fetch, `/repos/${repository}/pulls?${new URLSearchParams({
+          const pulls = await github(request, `/repos/${repository}/pulls?${new URLSearchParams({
             state: "open",
             per_page: String(limit(option(args.slice(2), "--limit", "-L"))),
           })}`);
@@ -164,6 +169,7 @@ function ghRepoCloneArguments(args: string[]): string[] {
   const repository = commandArgs[0];
   requireRepository(repository, "gh repo clone requires OWNER/REPO");
   return [
+    "clone",
     ...gitArgs,
     `https://github.com/${repository}.git`,
     ...(commandArgs[1] === undefined ? [] : [commandArgs[1]]),
@@ -178,13 +184,13 @@ export function createGitCommand(
   return {
     name: "git",
     trusted: true,
-    async execute(args: string[], context: { cwd?: unknown } = {}) {
+    async execute(args: string[], context: CommandContext = {}) {
       try {
+        const mounted = commandWorkspace(workspace(), context.signal);
         const command = args[0];
         if (command === "clone") {
-          return ok(await cloneRepository(fetch, workspace(), args.slice(1), context.cwd));
+          return ok(await cloneRepository(fetch, mounted, args.slice(1), context));
         }
-        const mounted = workspace();
         const dir = await gitDirectory(mounted, context.cwd);
         const fs = workspaceFs(mounted);
         if (command === "status") {
@@ -276,10 +282,11 @@ async function cloneRepository(
   fetch: ShellFetch,
   workspace: Workspace,
   args: string[],
-  cwd: unknown,
+  context: CommandContext,
 ): Promise<string> {
+  const { cwd, signal } = context;
   const depthValue = option(args, "--depth", "-") ?? joinedOption(args, "--depth");
-  const depth = depthValue === undefined ? 1 : positiveInteger(depthValue, "--depth");
+  const depth = depthValue === undefined ? undefined : positiveInteger(depthValue, "--depth");
   const branch = option(args, "--branch", "-b") ?? joinedOption(args, "--branch");
   const positionals = gitPositionals(args);
   const remote = positionals[0];
@@ -306,12 +313,10 @@ async function cloneRepository(
   try {
     await git.clone({
       fs: workspaceFs(workspace),
-      http: managedGitHttp(fetch),
+      http: managedGitHttp(fetch, signal),
       dir,
       url: `https://github.com/${repository}.git`,
-      depth,
-      noTags: true,
-      singleBranch: true,
+      ...(depth === undefined ? {} : { depth, singleBranch: true }),
       ...(branch === undefined ? {} : { ref: branch }),
     });
   } catch (error) {
@@ -323,9 +328,10 @@ async function cloneRepository(
   return `Cloning into '${destination}'...\n`;
 }
 
-function managedGitHttp(fetch: ShellFetch): HttpClient {
+function managedGitHttp(fetch: ShellFetch, signal?: AbortSignal): HttpClient {
   return {
     async request(request: GitHttpRequest) {
+      signal?.throwIfAborted();
       const body = request.body === undefined
         ? undefined
         : await collectGitBody(request.body);
@@ -333,7 +339,7 @@ function managedGitHttp(fetch: ShellFetch): HttpClient {
         method: request.method,
         headers: request.headers,
         body,
-        ...(request.signal instanceof AbortSignal ? { signal: request.signal } : {}),
+        signal: signal ?? (request.signal instanceof AbortSignal ? request.signal : undefined),
       });
       return {
         url: response.url,
@@ -396,6 +402,17 @@ function workspaceFs(workspace: Workspace) {
     chmod: async (path: string) => { await requiredWorkspaceEntry(workspace, resolve(path)); },
   };
   return { promises };
+}
+
+function commandWorkspace(workspace: Workspace, signal?: AbortSignal): Workspace {
+  return {
+    root: workspace.root,
+    list: (...args) => { signal?.throwIfAborted(); return workspace.list(...args); },
+    readFile: (...args) => { signal?.throwIfAborted(); return workspace.readFile(...args); },
+    writeFile: (...args) => { signal?.throwIfAborted(); return workspace.writeFile(...args); },
+    mkdir: (...args) => { signal?.throwIfAborted(); return workspace.mkdir(...args); },
+    remove: (...args) => { signal?.throwIfAborted(); return workspace.remove(...args); },
+  };
 }
 
 function gitWorkspacePath(workspace: Workspace, path: string): string {

--- a/js/nanocodex-tools/tools/bash.d.mts
+++ b/js/nanocodex-tools/tools/bash.d.mts
@@ -75,6 +75,8 @@ export type JustBashDescriptor = Readonly<{
 export function justBash(options: {
   /** Caller-owned durable workspace. See `JustBashRuntime.filesystem` for mutation ownership. */
   filesystem: Workspace;
+  /** Refresh metadata before each serialized command when another writer shares the storage. */
+  refreshFilesystemBeforeExec?: boolean | undefined;
   executionTimeoutMs?: number | undefined;
   maxEntries?: number | undefined;
   maxOutputTokens?: number | undefined;

--- a/js/nanocodex-tools/tools/bash.mjs
+++ b/js/nanocodex-tools/tools/bash.mjs
@@ -48,6 +48,14 @@ export async function justBash(options) {
         ? undefined
         : "restricted-http"),
     customCommands: options.customCommands,
+    aroundExecute: options.refreshFilesystemBeforeExec
+      ? async ({ execute, signal }) => {
+        signal.throwIfAborted();
+        await shellFilesystem.open();
+        signal.throwIfAborted();
+        return execute();
+      }
+      : undefined,
     executionTimeoutMs,
     defaultMaxOutputTokens: maxOutputTokens,
     maxOutputTokens,
@@ -281,8 +289,10 @@ class WorkspaceShellFileSystem {
   }
 
   async open() {
-    this.#entries.set(this.#root, directoryEntry());
     const entries = await this.#source.list(".", { recursive: true, maxEntries: this.#maxEntries });
+    this.#entries.clear();
+    this.#sortedPaths = undefined;
+    this.#entries.set(this.#root, directoryEntry());
     for (const entry of entries) {
       const path = resolvePath(this.#root, this.#root, entry.path);
       this.#addParents(path);
@@ -443,6 +453,9 @@ class WorkspaceShellFileSystem {
     const source = resolvePath(this.#root, this.#root, sourcePath);
     const destination = resolvePath(this.#root, this.#root, destinationPath);
     const entry = this.#require(source);
+    if (source === destination || (entry.kind === "directory" && destination.startsWith(`${source}/`))) {
+      throw fsError("EINVAL", "cannot copy a path onto itself or into its own subtree");
+    }
     if (entry.kind === "directory") {
       if (!options.recursive) throw fsError("EISDIR", "copying a directory requires recursive mode");
       await this.mkdir(destination, { recursive: true });

--- a/js/nanocodex/browser/InlineAgent.mjs
+++ b/js/nanocodex/browser/InlineAgent.mjs
@@ -78,7 +78,20 @@ export async function create(options = {}) {
     WebSocketImpl,
     createWebSocket,
   } = resolveResponsesTransport(transport ?? defaultHostManagedTransport());
-  const { tools: hostTools, subagents: subagentConfig } = resolveTools(tools);
+  const { tools: hostTools, subagents: configuredSubagents } = resolveTools(tools);
+  const subagentMaxConcurrency = internalRuntime?.subagentMaxConcurrency;
+  if (subagentMaxConcurrency !== undefined
+    && (!Number.isSafeInteger(subagentMaxConcurrency) || subagentMaxConcurrency < 1)) {
+    throw new TypeError("host subagentMaxConcurrency must be a positive safe integer");
+  }
+  // Hosted runtimes own the resource ceiling, including when their tools are
+  // a prepared router rather than a named-tool array. A caller's lower cap wins.
+  const subagentConfig = configuredSubagents === undefined || subagentMaxConcurrency === undefined
+    ? configuredSubagents
+    : {
+      ...configuredSubagents,
+      max_concurrency: Math.min(configuredSubagents.max_concurrency ?? subagentMaxConcurrency, subagentMaxConcurrency),
+    };
   if (filesystem && workspace !== undefined && workspace !== filesystem.root) {
     throw new TypeError("workspace must match filesystem.root when both are provided");
   }

--- a/js/nanocodex/cloudflare/Agent.mjs
+++ b/js/nanocodex/cloudflare/Agent.mjs
@@ -371,6 +371,7 @@ async function createOwned(module, resolved, options, hostAgent, lifecycle) {
       codeEvaluator: internalRuntime?.codeEvaluator,
       [Symbol.for("nanocodex.browser.internalRuntime")]: {
         toolProviders: internalRuntime?.toolProviders,
+        subagentMaxConcurrency: internalRuntime?.subagentMaxConcurrency,
         subagentSessions,
         [CLOUDFLARE_SESSION_RESERVATION]: sessionReservation,
       },

--- a/js/nanocodex/runtime/subagents.d.mts
+++ b/js/nanocodex/runtime/subagents.d.mts
@@ -1,5 +1,8 @@
 import type { DefaultAgent, Thinking } from "../types.mjs";
 
+// Adapter-specific extend() signatures do not change subagent ownership.
+type SubagentOwner = Omit<DefaultAgent, "extend">;
+
 declare const subagentToolBrand: unique symbol;
 
 /** Opaque selector for the Rust-owned subagent tool set. */
@@ -86,19 +89,19 @@ export type MessageReceipt = Readonly<{
 /** Returns a spreadable Rust-backed tool extension for an Agent's tools array. */
 export function create(options?: Options): Subagents;
 /** Directly invokes the canonical Rust spawn_agent handler. */
-export function spawn(agent: DefaultAgent, options: SpawnOptions): Promise<SpawnReport>;
+export function spawn(agent: SubagentOwner, options: SpawnOptions): Promise<SpawnReport>;
 /** Atomically reserves and starts an ordered batch of canonical Rust subagents. */
 export function spawnMany(
-  agent: DefaultAgent,
+  agent: SubagentOwner,
   options: readonly BatchSpawnOptions[],
 ): Promise<readonly SpawnReport[]>;
 /** Directly invokes the canonical Rust wait_agent handler. */
-export function wait(agent: DefaultAgent, options: WaitOptions): Promise<WaitReport>;
+export function wait(agent: SubagentOwner, options: WaitOptions): Promise<WaitReport>;
 /** Directly invokes the canonical Rust list_agents handler. */
-export function list(agent: DefaultAgent, options?: DirectoryOptions): Promise<DirectoryReport>;
+export function list(agent: SubagentOwner, options?: DirectoryOptions): Promise<DirectoryReport>;
 /** Directly invokes the canonical Rust send_agent_message handler. */
-export function send(agent: DefaultAgent, options: SendOptions): Promise<MessageReceipt>;
+export function send(agent: SubagentOwner, options: SendOptions): Promise<MessageReceipt>;
 /** Directly invokes the canonical Rust interrupt_agent handler. */
-export function interrupt(agent: DefaultAgent, agentId: AgentId): Promise<LifecycleReport>;
+export function interrupt(agent: SubagentOwner, agentId: AgentId): Promise<LifecycleReport>;
 /** Directly invokes the canonical Rust close_agent handler. */
-export function close(agent: DefaultAgent, agentId: AgentId): Promise<LifecycleReport>;
+export function close(agent: SubagentOwner, agentId: AgentId): Promise<LifecycleReport>;

--- a/js/nanocodex/test/bash.test.mjs
+++ b/js/nanocodex/test/bash.test.mjs
@@ -71,6 +71,16 @@ test("the returned filesystem is the authoritative bounded mutation handle", asy
   );
 });
 
+test("copying a directory into itself fails without losing its contents", async () => {
+  const runtime = await justBash({ filesystem: memoryWorkspace() });
+  await runtime.tool.handler({ cmd: "mkdir data && echo keep > data/file" }, context());
+  for (const command of ["cp -r data data/child", "mv data data/child"]) {
+    const result = await runtime.tool.handler({ cmd: command }, context());
+    assert.notEqual(result.exit_code, 0);
+    assert.equal(new TextDecoder().decode(await runtime.filesystem.readFile("data/file")), "keep\n");
+  }
+});
+
 test("workspace paths cannot escape the mounted root", async () => {
   const source = memoryWorkspace();
   const runtime = await justBash({ filesystem: source });

--- a/js/nanocodex/test/cloudflare-agent.test.mjs
+++ b/js/nanocodex/test/cloudflare-agent.test.mjs
@@ -292,6 +292,12 @@ test("Cloudflare Agent owns credentials, transport, and durability options", asy
     /subagent lifecycle hook must be a function/,
   );
   await assert.rejects(
+    create(module, durableOwner(new MemoryStorage()), {
+      [Symbol.for("nanocodex.cloudflare.internalRuntime")]: { subagentMaxConcurrency: 0 },
+    }),
+    /subagentMaxConcurrency must be a positive safe integer/,
+  );
+  await assert.rejects(
     create(module, { env: { NANOCODEX: egressBinding() } }),
     /requires owner\.ctx/,
   );

--- a/js/nanocodex/test/repository-workspace.test.mjs
+++ b/js/nanocodex/test/repository-workspace.test.mjs
@@ -8,6 +8,48 @@ import test from "node:test";
 
 import * as NodeWorkspace from "../node/workspace.mjs";
 import { materializeRepositoryWorkspace } from "../tools/repository-workspace.mjs";
+import { createComputerRuntime } from "nanocodex-tools";
+
+test("Just Bash gh clone creates a usable repository with the requested history", async () => {
+  const fixture = await gitFixture();
+  const destination = await mkdtemp(join(tmpdir(), "nanocodex-shell-clone-"));
+  try {
+    const runtime = await createComputerRuntime({
+      filesystem: await NodeWorkspace.open({ path: destination }),
+      networkMode: "test",
+      fetch: async (url, options) => {
+        const target = new URL(url);
+        assert.equal(target.origin, "https://github.com");
+        assert.ok(options.signal instanceof AbortSignal);
+        const response = await fetch(`${fixture.url}/git/${fixture.head}${target.pathname.slice("/fixture/repo.git".length)}${target.search}`, options);
+        return {
+          status: response.status, statusText: response.statusText,
+          headers: Object.fromEntries(response.headers),
+          body: new Uint8Array(await response.arrayBuffer()), url,
+        };
+      },
+    });
+    const call = { signal: new AbortController().signal, sessionId: "fixture" };
+    const cloned = await runtime.tool.handler({
+      cmd: "gh repo clone fixture/repo /workspace/source && cd source && git log --oneline && git status --porcelain",
+    }, call);
+    assert.equal(cloned.exit_code, 0, cloned.output);
+    assert.match(cloned.output, /Cloning into 'source'/);
+    assert.match(cloned.output, /second/);
+    assert.match(cloned.output, /seed/);
+    assert.equal(await readFile(join(destination, "source/README.md"), "utf8"), "immutable\n");
+    assert.equal(await git(["rev-list", "--count", "HEAD"], join(destination, "source")), "2\n");
+    assert.equal(await git(["tag"], join(destination, "source")), "v1\n");
+    const shallow = await runtime.tool.handler({
+      cmd: "gh repo clone fixture/repo shallow -- --depth 1",
+    }, call);
+    assert.equal(shallow.exit_code, 0, shallow.output);
+    assert.equal(await git(["rev-list", "--count", "HEAD"], join(destination, "shallow")), "1\n");
+  } finally {
+    await fixture.close();
+    await rm(destination, { recursive: true, force: true });
+  }
+});
 
 test("materializes once, reopens without network, and preserves retained work", async () => {
   const fixture = await gitFixture();
@@ -107,6 +149,8 @@ async function gitFixture() {
   await writeFile(join(source, "README.md"), "immutable\n");
   await git(["add", "README.md"], source);
   await git(["commit", "-q", "-m", "seed"], source);
+  await git(["tag", "v1"], source);
+  await git(["commit", "-q", "--allow-empty", "-m", "second"], source);
   const head = (await git(["rev-parse", "HEAD"], source)).trim();
   await git(["clone", "-q", "--bare", source, join(repositories, "seed.git")], directory);
 

--- a/js/nanocodex/test/types.test-d.mts
+++ b/js/nanocodex/test/types.test-d.mts
@@ -263,6 +263,12 @@ async function check() {
   cloudflareAgent.turn.prompt({ input: "hello" });
   cloudflareAgent.events.connect(new Request("https://agent.internal/events"));
   const extendedCloudflareAgent = cloudflareAgent.extend(() => ({ application: true as const }));
+  const managedChild = await Subagents.spawn(cloudflareAgent, {
+    role: "researcher", task: "Inspect the brain", outputSchema: { type: "object" },
+  });
+  await Subagents.send(extendedCloudflareAgent, {
+    agentId: managedChild.agent_id, priority: "urgent", message: "Report status",
+  });
   extendedCloudflareAgent.events.connect(new Request("https://agent.internal/events"));
   const cloudflareApplication: true = extendedCloudflareAgent.application;
   void cloudflareApplication;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -513,6 +513,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^5.20260730.1
         version: 5.20260831.1
+      '@types/node':
+        specifier: ^22.20.1
+        version: 22.20.1
       typescript:
         specifier: 5.9.3
         version: 5.9.3


### PR DESCRIPTION
Managed `exec_command` rejected basic commands in `/brain` and required an execution hand even for `pwd`, file work, and HTTP. The captured failure then spiraled into 104 nested subagents.

Run bounded Just Bash in the durable R2 brain workspace by default. Omitted cwd, `.`, `/brain`, and relative brain paths need no hand discovery or native lease. Native commands use an explicit attached or newly mounted hand; the agent owns that choice and checks partial effects before retrying.

Also fixes the related boundaries:
- Reuse the native hands' existing R2 prefix, refresh metadata between commands, preserve empty directories, bound files/listings, and resolve brain images.
- Carry the exact calling agent's connector authority through queued commands; fence Vault/SSH access, cancellation, disposed runtimes, and oversized HTTP responses.
- Fix GitHub clone dispatch/history, abort Git requests, and reject recursive self-copy/move.
- Admit at most eight active subagents across the managed task tree, including prepared tool routers. Generic SDK defaults stay unchanged; Cloudflare subagent types accept extended handles.

Validation on the isolated branch: 65 Worker tests, 35 SDK runtime tests, managed/SDK type checks, and package validation passed. The Worker tests use real local R2/SQLite, exercise checkpointed messaging and reconstruction, and verify brain commands work when hand discovery throws. The full managed build and durability performance checks passed during the investigation.

The WASM checkpoint crash itself is fixed separately in #279. No Apple/desktop, startup/memory, cron, or hand-bootstrap changes are included. A live mounted-hand and two-turn browser reload journey remain unverified; CI completion is not a merge prerequisite for this change.
