### PR TITLE
fix(managed): broker connected execution and remove artificial workload limits

### DIFF
--- a/js/connect-api/src/connectorPolicy.mts
+++ b/js/connect-api/src/connectorPolicy.mts
@@ -73,7 +73,8 @@ export function connectorProvider(value: unknown): OAuthConnectorProvider | unde
 }
 
 export function connectorCapabilityForUrl(url: URL): RoutableConnectorCapability | undefined {
-  if (url.origin === "https://api.github.com") return "github";
+  if (url.origin === "https://api.github.com" || (url.origin === "https://github.com"
+    && /^\/[A-Za-z0-9_-]+\/[A-Za-z0-9_.-]+\/(?:info\/refs|git-upload-pack|git-receive-pack)$/.test(url.pathname))) return "github";
   if (url.origin === "https://gmail.googleapis.com") return "gmail";
   if (url.origin === "https://www.googleapis.com"
     && /^(?:\/drive\/v3|\/upload\/drive\/v3)(?:\/|$)/.test(url.pathname)) return "gdrive";

--- a/js/connect-api/src/index.ts
+++ b/js/connect-api/src/index.ts
@@ -243,14 +243,9 @@ const ACCOUNT_LINK_TTL = 5 * 60;
 const REGISTERED_APP_ID = "atlas-workspace";
 const MAX_BROKER_BODY_BYTES = 16 * 1024;
 const MAX_BROKER_CREDENTIALS_BODY_BYTES = 256 * 1024;
-const MAX_CONNECTOR_REQUEST_BODY_BYTES = 256 * 1024;
-const MAX_CONNECTOR_RESPONSE_BODY_BYTES = 1024 * 1024;
 const MAX_AGENT_TOOL_BODY_BYTES = 20 * 1024 * 1024;
-const MAX_PUBLIC_EGRESS_BODY_BYTES = 256 * 1024;
-const MAX_PUBLIC_EGRESS_RESPONSE_BYTES = 1024 * 1024;
 const MAX_MANAGED_MEMORY_REQUEST_BYTES = 16 * 1024;
 const MAX_MANAGED_MEMORY_RESPONSE_BYTES = 1024 * 1024;
-const MAX_PINNED_RUNTIME_RESPONSE_BYTES = 32 * 1024 * 1024;
 const MAX_ACCOUNT_AUTHORIZATIONS = 64;
 const MAX_DEVICE_REGISTER_BYTES = 64 * 1024;
 const MAX_CONNECTION_REQUEST_BYTES = 128 * 1024;
@@ -266,6 +261,7 @@ const CONNECTOR_REQUEST_HEADERS = new Set([
   "accept",
   "content-range",
   "content-type",
+  "git-protocol",
   "if-match",
   "if-modified-since",
   "if-none-match",
@@ -288,17 +284,16 @@ const FORBIDDEN_CONNECTOR_HEADERS = /^(?:authorization|cookie|forwarded|host|ori
 const PRIVATE_EGRESS_HEADER = /(?:^|[-_])(?:auth(?:orization)?|cookie|credential|password|proxy|secret|token|api[-_]?key)(?:$|[-_]|\d)/i;
 const FORBIDDEN_EGRESS_HEADERS = new Set([
   "connection", "host", "origin", "proxy-connection", "referer", "te", "trailer",
-  "transfer-encoding", "upgrade", "x-nanocodex-subject", "x-nanocodex-vault-id",
+  "transfer-encoding", "upgrade", "x-nanocodex-subject", "x-nanocodex-vault-id", "x-nanocodex-target-url",
 ]);
 const BLOCKED_EGRESS_RESPONSE_HEADERS = new Set([
   "clear-site-data", "connection", "content-encoding", "content-length", "keep-alive", "nel", "proxy-authenticate",
   "proxy-authorization", "refresh", "report-to", "set-cookie", "set-cookie2",
-  "trailer", "transfer-encoding", "upgrade", "x-nanocodex-subject",
+  "trailer", "transfer-encoding", "upgrade", "x-nanocodex-subject", "x-nanocodex-target-url",
 ]);
 const PRIVATE_HOST_SUFFIXES = [
   ".internal", ".invalid", ".local", ".localhost", ".test", ".home.arpa",
 ];
-const PUBLIC_REDIRECTS = new Set([301, 302, 303, 307, 308]);
 
 type ConnectorState = Readonly<{
   accountAddress?: `0x${string}`;
@@ -3270,7 +3265,7 @@ async function grantBrowserEgress(request: Request, env: Env, grant: GrantRecord
   if (grant.expiresAt <= Math.floor(Date.now() / 1000)) {
     throw new ApiFailure(409, "grant_expired", "The grant has expired.");
   }
-  const value = await boundedJson(request, MAX_PUBLIC_EGRESS_BODY_BYTES, "browser egress");
+  const value = await boundedJson(request, Infinity, "browser egress");
   const targetValue = value.url;
   const threadId = value.thread_id;
   if (typeof targetValue !== "string" || typeof threadId !== "string"
@@ -3309,16 +3304,16 @@ async function grantBrowserEgress(request: Request, env: Env, grant: GrantRecord
     }));
   }
   if (connector) {
-    const result = await grantConnectorRequest(env, grant, connector, {
+    return grantConnectorRequest(env, grant, connector, {
       path: `${target.pathname}${target.search}`,
       method: value.method,
       headers: value.headers,
       body: value.body,
+      body_base64: value.body_base64,
       connection_id: value.connection_id,
-    });
-    return new Response(result.body, { status: result.status, headers: result.headers });
+    }, target, request.signal);
   }
-  return publicBrowserEgress(target, value, request.signal);
+  return publicBrowserEgress(env, grant, target, value, request.signal);
 }
 
 function connectorForUrl(url: URL): RoutableConnectorCapability | undefined {
@@ -3326,73 +3321,51 @@ function connectorForUrl(url: URL): RoutableConnectorCapability | undefined {
 }
 
 async function publicBrowserEgress(
+  env: Env,
+  grant: GrantRecord,
   target: URL,
   value: Record<string, unknown>,
   signal: AbortSignal,
 ): Promise<Response> {
-  let url = publicEgressUrl(target);
-  let method = typeof value.method === "string" ? value.method.toUpperCase() : "GET";
+  const url = publicEgressUrl(target);
+  const method = typeof value.method === "string" ? value.method.toUpperCase() : "GET";
   if (!CONNECTOR_METHODS.has(method)) {
     throw new ApiFailure(403, "egress_method_denied", "The browser egress method is denied.");
   }
+  if (!EGRESS_SUBJECT.test(grant.egressSubject)) {
+    throw new ApiFailure(403, "invalid_grant_binding", "The grant's broker binding is invalid.");
+  }
   const headers = publicEgressHeaders(value.headers);
-  const bodyValue = value.body;
-  if (bodyValue !== undefined && typeof bodyValue !== "string") {
-    throw new ApiFailure(400, "invalid_egress_body", "The browser egress body must be a string.");
-  }
-  let body: string | undefined = bodyValue;
-  if (body !== undefined && (method === "GET" || method === "HEAD")) {
-    throw new ApiFailure(400, "invalid_egress_body", "GET and HEAD egress requests cannot have a body.");
-  }
-  for (let redirects = 0; ; redirects += 1) {
-    if (redirects > 5) {
-      throw new ApiFailure(502, "too_many_redirects", "The public request redirected too many times.");
-    }
-    const outgoingHeaders = new Headers(headers);
-    if (method === "GET" || method === "HEAD") {
-      outgoingHeaders.delete("content-length");
-      outgoingHeaders.delete("content-type");
-      body = undefined;
-    }
-    const upstream = await fetch(url, {
-      method,
-      headers: outgoingHeaders,
-      ...(body === undefined ? {} : { body }),
-      redirect: "manual",
-      signal,
-    });
-    if (PUBLIC_REDIRECTS.has(upstream.status)) {
-      const location = upstream.headers.get("location");
-      await upstream.body?.cancel();
-      if (!location) throw new ApiFailure(502, "invalid_redirect", "The public request returned an invalid redirect.");
-      url = publicEgressUrl(new URL(location, url));
-      if (connectorForUrl(url)) {
-        throw new ApiFailure(502, "redirect_to_connector_denied", "Public requests cannot redirect into a connected account.");
-      }
-      if (upstream.status === 303
-        || ((upstream.status === 301 || upstream.status === 302) && method === "POST")) {
-        method = "GET";
-        body = undefined;
-      }
-      continue;
-    }
-    const responseBody = await boundedResponseBytes(upstream, publicEgressResponseLimit(url));
-    return new Response(responseBody, {
-      status: upstream.status,
-      statusText: upstream.statusText,
-      headers: projectedPublicHeaders(upstream.headers),
-    });
-  }
+  const body = browserEgressBody(value, method);
+  headers.set("x-nanocodex-subject", grant.egressSubject);
+  headers.set("x-nanocodex-target-url", url.href);
+  const upstream = await env.EGRESS.fetch(new Request("https://public-egress.internal/v1/request", {
+    method,
+    headers,
+    ...(body === undefined ? {} : { body }),
+    redirect: "manual",
+    signal,
+  }));
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: projectedPublicHeaders(upstream.headers),
+  });
 }
 
-function publicEgressResponseLimit(url: URL): number {
-  if (url.origin === "https://cdn.jsdelivr.net" && (
-    url.pathname.startsWith("/pyodide/v314.0.5/full/")
-    || url.pathname.startsWith("/npm/wasm-clang@0.0.1/bin/")
-  )) {
-    return MAX_PINNED_RUNTIME_RESPONSE_BYTES;
+function browserEgressBody(value: Record<string, unknown>, method: string): string | Uint8Array<ArrayBuffer> | undefined {
+  if ((value.body !== undefined && typeof value.body !== "string")
+    || (value.body !== undefined && value.body_base64 !== undefined)
+    || (value.body_base64 !== undefined && (typeof value.body_base64 !== "string"
+      || !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value.body_base64)))) {
+    throw new ApiFailure(400, "invalid_egress_body", "The browser egress body must be text or base64 bytes.");
   }
-  return MAX_PUBLIC_EGRESS_RESPONSE_BYTES;
+  if ((value.body !== undefined || value.body_base64 !== undefined) && (method === "GET" || method === "HEAD")) {
+    throw new ApiFailure(400, "invalid_egress_body", "GET and HEAD egress requests cannot have a body.");
+  }
+  return typeof value.body_base64 === "string"
+    ? Uint8Array.from(atob(value.body_base64), (character) => character.charCodeAt(0))
+    : value.body as string | undefined;
 }
 
 function publicEgressUrl(url: URL): URL {
@@ -5131,7 +5104,9 @@ async function grantConnectorRequest(
   grant: GrantRecord,
   connector: RoutableConnectorCapability,
   value: Record<string, unknown>,
-): Promise<{ status: number; headers: Record<string, string>; body: string }> {
+  browserTarget: URL,
+  signal: AbortSignal,
+): Promise<Response> {
   if (grant.status !== "active") {
     throw new ApiFailure(409, "grant_inactive", "The grant is not active.");
   }
@@ -5149,7 +5124,15 @@ async function grantConnectorRequest(
   if (!CONNECTOR_METHODS.has(method)) {
     throw new ApiFailure(400, "invalid_connector_method", "The connector request method is not allowed.");
   }
-  const target = connectorTarget(connector, value.path);
+  let target = connectorTarget(connector, value.path);
+  publicEgressUrl(browserTarget);
+  if (browserTarget.href !== target.href) {
+    if (connector !== "github" || browserTarget.origin !== "https://github.com"
+      || connectorForUrl(browserTarget) !== connector) {
+      throw new ApiFailure(403, "connector_destination_denied", "The connector destination is not allowed.");
+    }
+    target = browserTarget;
+  }
   const headers = connectorHeaders(value.headers);
   try {
     applyConnectorConnectionSelector(
@@ -5165,30 +5148,22 @@ async function grantConnectorRequest(
   }
   headers.set("authorization", PROVIDER_CREDENTIAL_PLACEHOLDER);
   headers.set("x-nanocodex-subject", grant.egressSubject);
-  const body = value.body;
-  if (body !== undefined && typeof body !== "string") {
-    throw new ApiFailure(400, "invalid_connector_body", "The connector request body must be a string.");
-  }
-  if (typeof body === "string" && new TextEncoder().encode(body).byteLength > MAX_CONNECTOR_REQUEST_BODY_BYTES) {
-    throw new ApiFailure(413, "connector_body_too_large", "Connector request bodies are limited to 256 KiB.");
-  }
-  if (body !== undefined && (method === "GET" || method === "HEAD")) {
-    throw new ApiFailure(400, "invalid_connector_body", "GET and HEAD connector requests cannot have a body.");
-  }
+  const body = browserEgressBody(value, method);
 
   const response = await env.EGRESS.fetch(new Request(target, {
     method,
     headers,
     ...(body === undefined ? {} : { body }),
+    redirect: "manual",
+    signal,
   }));
-  const responseBody = await boundedResponseText(response, MAX_CONNECTOR_RESPONSE_BODY_BYTES);
-  const responseHeaders: Record<string, string> = {};
+  const responseHeaders = new Headers();
   for (const [name, headerValue] of response.headers) {
     if (CONNECTOR_RESPONSE_HEADERS.has(name.toLowerCase()) && headerValue.length <= 4_096) {
-      responseHeaders[name.toLowerCase()] = headerValue;
+      responseHeaders.set(name, headerValue);
     }
   }
-  return { status: response.status, headers: responseHeaders, body: responseBody };
+  return new Response(response.body, { status: response.status, headers: responseHeaders });
 }
 
 async function grantMcpRequest(
@@ -5215,10 +5190,7 @@ async function grantMcpRequest(
     const value = request.headers.get(name);
     if (value && value.length <= 4_096) headers.set(name, value);
   }
-  let body: ArrayBuffer | undefined;
-  if (request.method !== "GET" && request.method !== "HEAD" && request.body) {
-    body = await boundedRequestBytes(request, MAX_CONNECTOR_REQUEST_BODY_BYTES);
-  }
+  const body = request.method === "GET" || request.method === "HEAD" ? undefined : request.body;
   const upstream = await env.EGRESS.fetch(new Request(
     `https://mcp.internal/v1/connections/${connectionId}`,
     {

--- a/js/connect-api/test/connectorWorker.test.mjs
+++ b/js/connect-api/test/connectorWorker.test.mjs
@@ -26,6 +26,7 @@ test("Worker connector execution fences and forwards the exact approved identity
   const worker = (await import(new URL(`file://${path.join(outdir, "index.js")}`))).default;
   let grant = activeGrant({ gmail: [alpha, bravo] });
   const forwarded = [];
+  let reply = () => new Response("ok", { status: 200 });
   const env = {
     CONNECT_STATE: {
       idFromName: (name) => name,
@@ -36,7 +37,7 @@ test("Worker connector execution fences and forwards the exact approved identity
     },
     EGRESS: { fetch: async (request) => {
       forwarded.push(request);
-      return new Response("ok", { status: 200 });
+      return reply();
     } },
   };
   const context = { waitUntil() {} };
@@ -61,6 +62,61 @@ test("Worker connector execution fences and forwards the exact approved identity
   const legacyExpansion = await worker.fetch(egressRequest(alpha), env, context);
   assert.equal(legacyExpansion.status, 403);
   assert.equal((await legacyExpansion.json()).error.code, "connector_connection_not_granted");
+
+  grant = { ...activeGrant({ github: [alpha] }), capabilities: ["github"] };
+  const bytes = Uint8Array.from({ length: 300 * 1024 }, (_, index) => index % 256);
+  const largeSize = 17 * 1024 * 1024 + 123;
+  reply = () => {
+    let remaining = largeSize;
+    return new Response(new ReadableStream({
+      pull(controller) {
+        if (!remaining) { controller.close(); return; }
+        const size = Math.min(remaining, 64 * 1024);
+        controller.enqueue(new Uint8Array(size).fill(255));
+        remaining -= size;
+      },
+    }), { headers: { "content-type": "application/x-git-upload-pack-result" } });
+  };
+  const cloned = await worker.fetch(egressRequest(undefined, {
+    url: "https://github.com/fixture/large.git/git-upload-pack",
+    method: "POST",
+    headers: { "content-type": "application/x-git-upload-pack-request", "git-protocol": "version=2" },
+    body_base64: Buffer.from(bytes).toString("base64"),
+  }), env, context);
+  assert.equal(cloned.status, 200);
+  const git = forwarded.at(-1);
+  assert.equal(git.url, "https://github.com/fixture/large.git/git-upload-pack");
+  assert.equal(git.headers.get("x-nanocodex-subject"), grant.egressSubject);
+  assert.equal(git.headers.get("x-nanocodex-connector-connection"), alpha);
+  assert.equal(git.headers.get("git-protocol"), "version=2");
+  assert.deepEqual(new Uint8Array(await git.arrayBuffer()), bytes);
+  const downloaded = new Uint8Array(await cloned.arrayBuffer());
+  assert.equal(downloaded.byteLength, largeSize);
+  assert(downloaded.every((byte) => byte === 255));
+
+  reply = () => new Response("public");
+  const publicResponse = await worker.fetch(egressRequest(undefined, {
+    url: "https://example.com/archive", method: "POST", body_base64: "AP+A/g==",
+  }), env, context);
+  assert.equal(await publicResponse.text(), "public");
+  const publicRequest = forwarded.at(-1);
+  assert.equal(publicRequest.url, "https://public-egress.internal/v1/request");
+  assert.equal(publicRequest.headers.get("x-nanocodex-target-url"), "https://example.com/archive");
+  assert.equal(publicRequest.headers.get("x-nanocodex-subject"), grant.egressSubject);
+  assert.equal(publicRequest.headers.get("authorization"), null);
+  assert.deepEqual([...new Uint8Array(await publicRequest.arrayBuffer())], [0, 255, 128, 254]);
+
+  const before = forwarded.length;
+  const spoofed = await worker.fetch(egressRequest(undefined, {
+    url: "https://example.com", headers: { "x-nanocodex-target-url": "https://api.github.com/user" },
+  }), env, context);
+  assert.equal(spoofed.status, 403);
+  const outsideGrant = await worker.fetch(egressRequest(bravo, {
+    url: "https://github.com/fixture/large.git/info/refs?service=git-upload-pack",
+  }), env, context);
+  assert.equal(outsideGrant.status, 403);
+  assert.equal(forwarded.length, before);
+
 });
 
 function activeGrant(connectorConnections) {
@@ -82,7 +138,7 @@ function activeGrant(connectorConnections) {
   };
 }
 
-function egressRequest(connectionId) {
+function egressRequest(connectionId, fields = {}) {
   return new Request("https://nanocodex-connect-api.gakonst.workers.dev/v1/egress", {
     method: "POST",
     headers: {
@@ -95,6 +151,7 @@ function egressRequest(connectionId) {
       url: "https://gmail.googleapis.com/gmail/v1/users/me/messages",
       thread_id: "123e4567-e89b-42d3-a456-426614174000",
       ...(connectionId === undefined ? {} : { connection_id: connectionId }),
+      ...fields,
     }),
   });
 }

--- a/js/egress/src/connector-broker.ts
+++ b/js/egress/src/connector-broker.ts
@@ -1,4 +1,5 @@
 import { DurableObject } from "cloudflare:workers";
+import { credentialFilteringBody } from "./credential-stream";
 
 import {
   CredentialVault,
@@ -50,9 +51,7 @@ const PENDING_TTL_MS = 10 * 60_000;
 const MAX_BODY_BYTES = 8 * 1024;
 const MAX_PROVIDER_RESPONSE_BYTES = 64 * 1024;
 const MAX_CONNECTOR_URL_BYTES = 8 * 1024;
-const MAX_CONNECTOR_RESPONSE_BYTES = 8 * 1024 * 1024;
 const MAX_SLACK_REQUEST_BYTES = 1024 * 1024;
-const CONNECTOR_TIMEOUT_MS = 20_000;
 const EXPIRY_SKEW_MS = 30_000;
 const REVOCATION_RETRY_BASE_MS = 30_000;
 const REVOCATION_RETRY_MAX_MS = 60 * 60_000;
@@ -69,6 +68,12 @@ type ProviderRule = Readonly<{
 }>;
 
 const PROVIDER_RULES: readonly ProviderRule[] = [
+  {
+    id: "github",
+    provider: "github",
+    origin: "https://github.com",
+    paths: [/^\/[A-Za-z0-9_-]+\/[A-Za-z0-9_.-]+\/(?:info\/refs|git-upload-pack|git-receive-pack)$/],
+  },
   {
     id: "github",
     provider: "github",
@@ -385,12 +390,20 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
     if (selectedConnectionId !== null && !CONNECTION_ID.test(selectedConnectionId)) {
       throw new ConnectorFailure(400, "connector_connection_invalid");
     }
-    const selected = await this.#usableConnector(
-      provider,
-      selectedConnectionId ?? undefined,
-    );
-    const connector = selected.connector;
-    const headers = connectorRequestHeaders(request.headers, provider.id, connector.accessToken);
+    let selected: { connectionId: string; connector: StoredConnector } | undefined;
+    try {
+      selected = await this.#usableConnector(provider, selectedConnectionId ?? undefined);
+    } catch (error) {
+      // Public Git remains usable before an account connects GitHub. Never
+      // fall back when an exact connection was selected or has expired.
+      if (provider.origin !== "https://github.com" || selectedConnectionId !== null
+        || !(error instanceof ConnectorFailure) || error.code !== "connector_not_connected") throw error;
+    }
+    const connector = selected?.connector;
+    const headers = connectorRequestHeaders(request.headers, provider.id, connector?.accessToken);
+    if (provider.origin === "https://github.com" && connector) {
+      headers.set("authorization", `Basic ${btoa(`x-access-token:${connector.accessToken}`)}`);
+    }
     const requestBody = provider.provider === "slack"
       ? await slackRequestBody(request)
       : request.body;
@@ -405,12 +418,12 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
         redirect: "manual",
       }), {
         redirect: "manual",
-        signal: AbortSignal.timeout(CONNECTOR_TIMEOUT_MS),
+        signal: request.signal,
       });
     } catch {
       throw new ConnectorFailure(503, "connector_provider_unavailable");
     }
-    if (upstream.status === 401) {
+    if (upstream.status === 401 && selected) {
       await upstream.body?.cancel();
       delete this.#connections(provider.provider)[selected.connectionId];
       await this.#persist();
@@ -420,20 +433,26 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
       await upstream.body?.cancel();
       throw new ConnectorFailure(502, "connector_redirect_blocked");
     }
-    let body: Uint8Array | null;
+    let body: ReadableStream<Uint8Array> | null;
     if (request.method === "HEAD" || !responseBodyPermitted(upstream.status)) {
       await upstream.body?.cancel();
       body = null;
     } else {
-      body = await readBoundedBytes(upstream, MAX_CONNECTOR_RESPONSE_BYTES);
+      body = upstream.body;
     }
-    if (body && containsCredential(body, connector)) {
-      throw new ConnectorFailure(502, "credential_projection_blocked");
+    const credentials = connector ? [connector.accessToken, connector.refreshToken,
+      headers.get("authorization")?.split(" ", 2)[1]]
+      .filter((value): value is string => Boolean(value)) : [];
+    const responseHeaders = connectorResponseHeaders(upstream.headers);
+    for (const value of responseHeaders.values()) {
+      if (credentials.some((credential) => value.includes(credential))) {
+        await body?.cancel();
+        throw new ConnectorFailure(502, "credential_projection_blocked");
+      }
     }
-    return new Response(body, {
+    return new Response(body && credentials.length ? credentialFilteringBody(body, credentials) : body, {
       status: upstream.status,
-      statusText: upstream.statusText,
-      headers: connectorResponseHeaders(upstream.headers),
+      headers: responseHeaders,
     });
   }
 
@@ -1277,12 +1296,12 @@ async function slackRequestBody(request: Request): Promise<string | null> {
 function connectorRequestHeaders(
   caller: Headers,
   id: ConnectorId,
-  accessToken: string,
+  accessToken: string | undefined,
 ): Headers {
   const headers = new Headers({
     accept: boundedCallerHeader(caller, "accept") ?? "application/json",
-    authorization: `Bearer ${accessToken}`,
   });
+  if (accessToken !== undefined) headers.set("authorization", `Bearer ${accessToken}`);
   for (const name of [
     "content-range",
     "content-type",
@@ -1290,6 +1309,7 @@ function connectorRequestHeaders(
     "if-none-match",
     "if-modified-since",
     "if-unmodified-since",
+    "git-protocol",
   ])
     if (caller.has(name)) headers.set(name, boundedCallerHeader(caller, name)!);
   if (id === "github") {
@@ -1328,44 +1348,6 @@ function connectorResponseHeaders(upstream: Headers): Headers {
   return headers;
 }
 
-async function readBoundedBytes(response: Response, limit: number): Promise<Uint8Array> {
-  const declared = response.headers.get("content-length");
-  if (declared !== null) {
-    const size = Number(declared);
-    if (!/^(?:0|[1-9][0-9]*)$/.test(declared) || !Number.isSafeInteger(size) || size > limit) {
-      await response.body?.cancel();
-      throw new ConnectorFailure(502, "connector_response_too_large");
-    }
-  }
-  if (!response.body) return new Uint8Array();
-  const reader = response.body.getReader();
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      total += value.byteLength;
-      if (total > limit) {
-        await reader.cancel();
-        throw new ConnectorFailure(502, "connector_response_too_large");
-      }
-      chunks.push(value);
-    }
-  } finally { reader.releaseLock(); }
-  const body = new Uint8Array(total);
-  let offset = 0;
-  for (const chunk of chunks) { body.set(chunk, offset); offset += chunk.byteLength; }
-  return body;
-}
-
-function containsCredential(body: Uint8Array, connector: StoredConnector): boolean {
-  const credentials = [connector.accessToken, connector.refreshToken].filter(
-    (value): value is string => Boolean(value),
-  );
-  const decoded = new TextDecoder().decode(body);
-  return credentials.some((credential) => decoded.includes(credential));
-}
 
 function validRedirectUri(value: string, env: ConnectorBrokerEnv): boolean {
   try {

--- a/js/egress/src/credential-stream.ts
+++ b/js/egress/src/credential-stream.ts
@@ -1,0 +1,72 @@
+/** Streams provider bytes while retaining enough overlap to fence reflected credentials. */
+export function credentialFilteringBody(
+  body: ReadableStream<Uint8Array>,
+  credentials: string[],
+): ReadableStream<Uint8Array> {
+  const patterns = credentials.map((value) => new TextEncoder().encode(value));
+  const hold = Math.max(0, ...patterns.map((pattern) => pattern.byteLength - 1));
+  const reader = body.getReader();
+  let tail = new Uint8Array();
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            if (containsPattern(tail, patterns)) {
+              controller.error(new Error("credential_projection_blocked"));
+            } else {
+              if (tail.byteLength > 0) controller.enqueue(tail);
+              controller.close();
+            }
+            reader.releaseLock();
+            return;
+          }
+          const combined = concatenate(tail, value);
+          if (containsPattern(combined, patterns)) {
+            await reader.cancel().catch(() => {});
+            reader.releaseLock();
+            controller.error(new Error("credential_projection_blocked"));
+            return;
+          }
+          const emitLength = Math.max(0, combined.byteLength - hold);
+          tail = combined.slice(emitLength);
+          if (emitLength > 0) {
+            controller.enqueue(combined.slice(0, emitLength));
+            return;
+          }
+        }
+      } catch (error) {
+        await reader.cancel(error).catch(() => {});
+        reader.releaseLock();
+        controller.error(error);
+      }
+    },
+    async cancel(reason) {
+      await reader.cancel(reason).catch(() => {});
+      reader.releaseLock();
+    },
+  });
+}
+
+function concatenate(left: Uint8Array, right: Uint8Array): Uint8Array {
+  const result = new Uint8Array(left.byteLength + right.byteLength);
+  result.set(left);
+  result.set(right, left.byteLength);
+  return result;
+}
+
+function containsPattern(value: Uint8Array, patterns: Uint8Array[]): boolean {
+  return patterns.some((pattern) => indexOfBytes(value, pattern) !== -1);
+}
+
+function indexOfBytes(value: Uint8Array, pattern: Uint8Array): number {
+  if (pattern.byteLength === 0 || pattern.byteLength > value.byteLength) return -1;
+  outer: for (let index = 0; index <= value.byteLength - pattern.byteLength; index += 1) {
+    for (let offset = 0; offset < pattern.byteLength; offset += 1) {
+      if (value[index + offset] !== pattern[offset]) continue outer;
+    }
+    return index;
+  }
+  return -1;
+}

--- a/js/egress/src/egress.ts
+++ b/js/egress/src/egress.ts
@@ -122,6 +122,11 @@ type VaultEgressEnvelope = Readonly<{
 const CONNECTOR_OPERATIONS: readonly ConnectorOperation[] = [
   {
     id: "github",
+    origin: "https://github.com",
+    paths: [/^\/[A-Za-z0-9_-]+\/[A-Za-z0-9_.-]+\/(?:info\/refs|git-upload-pack|git-receive-pack)$/],
+  },
+  {
+    id: "github",
     origin: "https://api.github.com",
     paths: [/^\//],
   },
@@ -300,6 +305,10 @@ export async function handleEgress(
   let url: URL;
   try { url = new URL(request.url); } catch { return jsonError(400, "invalid_url"); }
   if (url.username || url.password || url.hash) return jsonError(403, "destination_denied");
+
+  if (url.origin === "https://public-egress.internal" && url.pathname === "/v1/request" && !url.search) {
+    return handlePublicEgress(request, env, upstreamFetch);
+  }
 
   if (url.protocol === "https:" && url.hostname === "vault-egress.internal" && !url.port
     && url.pathname === "/v1/request" && !url.search) {
@@ -658,6 +667,69 @@ function vaultTemplatePlaceholders(template: string): Set<VaultPlaceholder> {
     throw new EgressFailure(400, "invalid_vault_placeholder");
   }
   return placeholders;
+}
+
+/** Public traffic takes the same service binding as credentialed traffic. */
+async function handlePublicEgress(
+  request: Request,
+  env: EgressEnv,
+  upstreamFetch: typeof fetch,
+): Promise<Response> {
+  if (!VAULT_EGRESS_METHODS.has(request.method)) return jsonError(403, "method_denied");
+  const subject = request.headers.get(SUBJECT_HEADER);
+  if (subject !== null) {
+    if (!SUBJECT.test(subject)) return jsonError(403, "agent_subject_required");
+    try { await resolveSubject(env, subject); }
+    catch (error) { const problem = egressFailure(error); return jsonError(problem.status, problem.code); }
+  }
+  let target: URL;
+  try { target = vaultEgressTarget(new URL(request.headers.get("x-nanocodex-target-url") ?? "")); }
+  catch { return jsonError(403, "destination_denied"); }
+  const headers = new Headers(request.headers);
+  headers.delete(SUBJECT_HEADER);
+  headers.delete("x-nanocodex-target-url");
+  for (const name of headers.keys()) {
+    if (VAULT_PRIVATE_HEADER.test(name) || VAULT_FORBIDDEN_HEADERS.has(name)
+      || name.startsWith("x-nanocodex-")) return jsonError(403, "credential_header_denied");
+  }
+  let method = request.method;
+  let body = request.body;
+  const visited = new Set<string>();
+  for (;;) {
+    const key = `${method} ${target.href}`;
+    if (visited.has(key)) return jsonError(502, "redirect_cycle");
+    visited.add(key);
+    let response: Response;
+    try {
+      response = await upstreamFetch(new Request(target, {
+        method,
+        headers,
+        ...(method === "GET" || method === "HEAD" || !body ? {} : { body }),
+        signal: request.signal,
+        redirect: "manual",
+      }));
+    } catch { return jsonError(request.signal.aborted ? 499 : 502, "upstream_unavailable"); }
+    if (![301, 302, 303, 307, 308].includes(response.status)) return sanitizeUpstreamResponse(response);
+    const location = response.headers.get("location");
+    try {
+      if (!location) throw new Error("missing redirect");
+      target = vaultEgressTarget(new URL(location, target));
+    } catch {
+      await response.body?.cancel();
+      return jsonError(502, "redirect_denied");
+    }
+    if (response.status === 303 || ((response.status === 301 || response.status === 302) && method === "POST")) {
+      method = "GET";
+      body = null;
+      headers.delete("content-type");
+      headers.delete("content-length");
+    } else if (body) {
+      // The upload has already streamed. Leave replay to the client's native
+      // redirect handling instead of buffering every upload speculatively.
+      return sanitizeUpstreamResponse(response);
+    }
+    await response.body?.cancel();
+  }
 }
 
 function vaultEgressTarget(url: URL): URL {

--- a/js/egress/src/mcp-connection-owner.ts
+++ b/js/egress/src/mcp-connection-owner.ts
@@ -1,3 +1,4 @@
+import { credentialFilteringBody } from "./credential-stream";
 import { DurableObject } from "cloudflare:workers";
 
 import {
@@ -840,49 +841,6 @@ function authorizationCredentials(authorization: StoredAuthorization): string[] 
     .filter((value): value is string => Boolean(value));
 }
 
-function credentialFilteringBody(
-  body: ReadableStream<Uint8Array>,
-  credentials: string[],
-): ReadableStream<Uint8Array> {
-  const patterns = credentials.map((value) => new TextEncoder().encode(value));
-  const hold = Math.max(0, ...patterns.map((pattern) => pattern.byteLength - 1));
-  const reader = body.getReader();
-  let tail = new Uint8Array();
-  return new ReadableStream<Uint8Array>({
-    async pull(controller) {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) {
-          if (containsPattern(tail, patterns)) {
-            controller.error(new Error("credential_projection_blocked"));
-          } else {
-            if (tail.byteLength > 0) controller.enqueue(tail);
-            controller.close();
-          }
-          reader.releaseLock();
-          return;
-        }
-        const combined = concatenate(tail, value);
-        if (containsPattern(combined, patterns)) {
-          await reader.cancel().catch(() => {});
-          reader.releaseLock();
-          controller.error(new Error("credential_projection_blocked"));
-          return;
-        }
-        const emitLength = Math.max(0, combined.byteLength - hold);
-        tail = combined.slice(emitLength);
-        if (emitLength > 0) {
-          controller.enqueue(combined.slice(0, emitLength));
-          return;
-        }
-      }
-    },
-    async cancel(reason) {
-      await reader.cancel(reason).catch(() => {});
-      reader.releaseLock();
-    },
-  });
-}
 
 function captureReplayBody(body: ReadableStream<Uint8Array> | null): {
   stream: ReadableStream<Uint8Array> | null;
@@ -1130,20 +1088,6 @@ function concatenate(left: Uint8Array, right: Uint8Array): Uint8Array {
   return result;
 }
 
-function containsPattern(value: Uint8Array, patterns: Uint8Array[]): boolean {
-  return patterns.some((pattern) => indexOfBytes(value, pattern) !== -1);
-}
-
-function indexOfBytes(value: Uint8Array, pattern: Uint8Array): number {
-  if (pattern.byteLength === 0 || pattern.byteLength > value.byteLength) return -1;
-  outer: for (let index = 0; index <= value.byteLength - pattern.byteLength; index += 1) {
-    for (let offset = 0; offset < pattern.byteLength; offset += 1) {
-      if (value[index + offset] !== pattern[offset]) continue outer;
-    }
-    return index;
-  }
-  return -1;
-}
 
 async function readJson(request: Request, limit: number): Promise<Record<string, unknown> | undefined> {
   try {

--- a/js/egress/test/connector-connections.test.ts
+++ b/js/egress/test/connector-connections.test.ts
@@ -22,6 +22,38 @@ const workerEnv = env as unknown as EgressEnv;
 const redirectUri = "https://nanocodex.test/v1/connectors/callback";
 
 describe("provider-neutral connector identities", () => {
+  it("streams authenticated Git packs beyond 16 MiB and fences a disconnected connection", async () => {
+    const user = "large-git-egress";
+    const subject = "L".repeat(43);
+    const connection = await connect(user, "github", "github-code");
+    await bindSubject(subject, user);
+    const headers = {
+      authorization: "Bearer NANOCODEX_PROVIDER_CREDENTIAL",
+      "x-nanocodex-subject": subject,
+      "x-nanocodex-connector-connection": connection,
+    };
+    const metadata = await (await SELF.fetch("https://api.github.com/repos/fixture/large", { headers })).json() as { head: string };
+    const refs = await SELF.fetch("https://github.com/fixture/large.git/info/refs?service=git-upload-pack", { headers });
+    expect(refs.status).toBe(200);
+    expect(await refs.text()).toContain(metadata.head);
+    const want = `want ${metadata.head} side-band-64k ofs-delta\n`;
+    const body = `${(want.length + 4).toString(16).padStart(4, "0")}${want}00000009done\n`;
+    const response = await SELF.fetch("https://github.com/fixture/large.git/git-upload-pack", {
+      method: "POST", headers: { ...headers, "content-type": "application/x-git-upload-pack-request" }, body,
+    });
+    expect(response.status).toBe(200);
+    const reader = response.body!.getReader();
+    let bytes = 0;
+    for (;;) { const part = await reader.read(); if (part.done) break; bytes += part.value.byteLength; }
+    expect(bytes).toBeGreaterThan(16 * 1024 * 1024);
+    expect((await SELF.fetch(`https://broker.test/users/${user}/connectors/github/connections/${connection}`, {
+      method: "DELETE",
+    })).status).toBe(204);
+    const revoked = await SELF.fetch("https://github.com/fixture/large.git/info/refs?service=git-upload-pack", { headers });
+    expect(revoked.status).toBe(404);
+    expect(await revoked.json()).toEqual({ error: "connector_connection_not_found" });
+  }, 60_000);
+
   it("requests the full Google Workspace catalog while decoding partial consent", () => {
     const authorization = buildGoogleAuthorizationUrl({
       clientId: "client", redirectUri, state: "state", codeChallenge: "A".repeat(43),
@@ -282,7 +314,7 @@ type PublicConnection = {
 };
 type PublicStatus = Record<string, { connected: boolean; connections: PublicConnection[] }>;
 
-async function connect(user: string, provider: "google" | "slack", code: string): Promise<string> {
+async function connect(user: string, provider: "github" | "google" | "slack", code: string): Promise<string> {
   const started = await control(`/users/${user}/connectors/${provider}`, "POST", {
     redirect_uri: redirectUri,
     return_to: `/agent?provider=${provider}`,

--- a/js/egress/test/public-egress.test.ts
+++ b/js/egress/test/public-egress.test.ts
@@ -1,0 +1,61 @@
+import { env } from "cloudflare:workers";
+import { SELF } from "cloudflare:test";
+import { expect, it, vi } from "vitest";
+import { handleEgress, type EgressEnv } from "../src/egress";
+
+const workerEnv = env as unknown as EgressEnv;
+
+it("brokers public traffic without projecting account authority or imposing a redirect quota", async () => {
+  const subject = "P".repeat(43);
+  expect((await SELF.fetch(`https://broker.internal/subjects/${subject}`, {
+    method: "PUT", headers: { "content-type": "application/json" },
+    body: JSON.stringify({ user_id: "public-egress-owner" }),
+  })).status).toBe(200);
+  const requests: Request[] = [];
+  const upstream = vi.fn(async (input: RequestInfo | URL) => {
+    const request = input as Request;
+    requests.push(request);
+    expect(request.headers.get("x-nanocodex-subject")).toBeNull();
+    expect(request.headers.get("x-nanocodex-target-url")).toBeNull();
+    expect(request.headers.get("authorization")).toBeNull();
+    const step = Number(new URL(request.url).searchParams.get("step"));
+    return step < 7
+      ? new Response(null, { status: 302, headers: { location: `/users/private?step=${step + 1}` } })
+      : new Response("public result");
+  });
+  const response = await handleEgress(publicRequest("https://example.com/users/private", subject),
+    workerEnv, undefined, upstream as typeof fetch);
+  expect(await response.text()).toBe("public result");
+  expect(requests).toHaveLength(8);
+
+  await SELF.fetch(`https://broker.internal/subjects/${subject}`, {
+    method: "DELETE", headers: { "content-type": "application/json" },
+    body: JSON.stringify({ user_id: "public-egress-owner" }),
+  });
+  expect((await handleEgress(publicRequest("https://example.com", subject),
+    workerEnv, undefined, upstream as typeof fetch)).status).not.toBe(200);
+  expect(requests).toHaveLength(8);
+});
+
+it("rejects private destinations, credential headers, and redirect escapes before forwarding", async () => {
+  const upstream = vi.fn(async () => new Response("must not fetch"));
+  for (const target of ["http://127.0.0.1/", "https://broker.internal/users/private", "https://api.github.com/user"]) {
+    expect((await handleEgress(publicRequest(target), workerEnv, undefined, upstream as typeof fetch)).status).toBe(403);
+  }
+  const credentialed = publicRequest("https://example.com");
+  credentialed.headers.set("authorization", "Bearer caller-secret");
+  expect((await handleEgress(credentialed, workerEnv, undefined, upstream as typeof fetch)).status).toBe(403);
+  expect(upstream).not.toHaveBeenCalled();
+  for (const location of ["http://127.0.0.1/", "https://api.github.com/user", "https://broker.internal/users/private"]) {
+    const redirect = vi.fn(async () => new Response(null, { status: 302, headers: { location } }));
+    expect((await handleEgress(publicRequest("https://example.com"), workerEnv, undefined, redirect as typeof fetch)).status).toBe(502);
+    expect(redirect).toHaveBeenCalledTimes(1);
+  }
+});
+
+function publicRequest(target: string, subject?: string): Request {
+  return new Request("https://public-egress.internal/v1/request", { headers: {
+    "x-nanocodex-target-url": target,
+    ...(subject ? { "x-nanocodex-subject": subject } : {}),
+  } });
+}

--- a/js/egress/vitest.config.ts
+++ b/js/egress/vitest.config.ts
@@ -1,3 +1,4 @@
+import { gitProvider } from "../test-fixtures/git-provider.mjs";
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
 import { defineConfig } from "vitest/config";
 
@@ -97,6 +98,8 @@ export default defineConfig({
           durableObjects: { CHATGPT_EGRESS: "ChatGptEgress" },
         }],
         outboundService: async (request) => {
+          const gitResponse = await gitProvider(request);
+          if (gitResponse) return gitResponse;
           const url = new URL(request.url);
           if (request.method === "POST" && url.hostname === "slack.com"
             && url.pathname === "/api/oauth.v2.access") {

--- a/js/managed/README.md
+++ b/js/managed/README.md
@@ -32,7 +32,7 @@ storage ownership.
 - `GET /v1/agents/:id/capacity` requires `agents:read` for that agent and returns
   storage byte counts, hot receipt counts, and archive counts without loading
   the runtime or returning conversation contents.
-- Managed agents execute bounded Just Bash in durable `/brain` without a hand.
+- Managed agents execute Just Bash in durable `/brain` without a hand.
   `exec_command` defaults there; `/brain` and `.` also select the brain. Its R2
   prefix is shared with the native hand mounts, and listings refresh between
   commands. Text/file processing, HTTP, and supported Git/GitHub commands run
@@ -43,12 +43,15 @@ storage ownership.
   `exec_command` always honors its selected cwd; the agent owns the fallback.
   Brain execution requires `tools:use`, with connector authority taken
   from the exact calling root or subagent.
-  Shell HTTP response bodies are bounded at 16 MiB.
-  Oversized responses fail with a request to narrow the result. Connect grants
-  cannot use Vault-backed shell requests or SSH identities.
-  The shared task tree admits at most eight active subagents, including nested
-  delegation. The existing WASM admission policy enforces this ceiling before
-  creating children; a failed tool does not justify recursively delegating it.
+  Shell and Git transfers stream through the account's egress broker without an
+  application byte ceiling. Browser runtime and Cloudflare Sandbox HTTP traffic
+  use the same broker; native `gh` receives a public marker so authentication is
+  injected only at the provider boundary. Exact Connect identities and revocation
+  apply to both GitHub API calls and Git smart HTTP. Connect grants cannot use
+  Vault-backed shell requests or SSH identities.
+  Shell execution, workspace traversal, and subagent admission have no implicit
+  application quota; caller-specified limits, cancellation, and platform capacity
+  still apply.
   The provider-neutral `mount` model
   tool provisions and attaches named execution hands on demand. `cf_sandbox`
   names the built-in Cloudflare Sandbox factory (`cloudflare` remains a legacy

--- a/js/managed/src/brain-workspace.ts
+++ b/js/managed/src/brain-workspace.ts
@@ -1,8 +1,6 @@
 import { resolveNamespaceCwd, type Workspace, type WorkspaceEntry } from "nanocodex-tools";
 
 const ROOT = "/brain";
-const MAX_FILE_BYTES = 64 * 1024 * 1024;
-const MAX_ENTRIES = 20_000;
 
 /** The same prefix that Sandbox mounts at /brain; no copy or hand is needed. */
 export function createBrainWorkspace(bucket: R2Bucket, resourceId: string): Workspace {
@@ -51,9 +49,9 @@ export function createBrainWorkspace(bucket: R2Bucket, resourceId: string): Work
     await ancestors(absolute);
     const kind = await stat(absolute);
     if (kind !== "directory") throw error(kind === "file" ? "ENOTDIR" : "ENOENT", `${absolute} is not a directory`);
-    const maximum = options.maxEntries ?? MAX_ENTRIES;
-    if (!Number.isSafeInteger(maximum) || maximum < 1 || maximum > MAX_ENTRIES) {
-      throw new RangeError(`workspace listing limit must be between 1 and ${MAX_ENTRIES}`);
+    const maximum = options.maxEntries ?? Infinity;
+    if (options.maxEntries !== undefined && (!Number.isSafeInteger(maximum) || maximum < 1)) {
+      throw new RangeError("workspace listing limit must be a positive integer");
     }
     const entries = new Map<string, WorkspaceEntry>();
     const directoryPrefix = absolute === ROOT ? prefix : `${key(absolute)}/`;
@@ -103,10 +101,6 @@ export function createBrainWorkspace(bucket: R2Bucket, resourceId: string): Work
         if (await stat(absolute) === "directory") throw error("EISDIR", `${absolute} is a directory`);
         throw error("ENOENT", `brain workspace file not found: ${absolute}`);
       }
-      if (object.size > MAX_FILE_BYTES) {
-        await object.body.cancel();
-        throw new RangeError("workspace file exceeds the 64 MiB read bound");
-      }
       return new Uint8Array(await object.arrayBuffer());
     },
     async writeFile(path, contents) {
@@ -117,7 +111,6 @@ export function createBrainWorkspace(bucket: R2Bucket, resourceId: string): Work
       const bytes = typeof contents === "string" ? new TextEncoder().encode(contents)
         : contents instanceof ArrayBuffer ? new Uint8Array(contents)
         : new Uint8Array(contents.buffer, contents.byteOffset, contents.byteLength);
-      if (bytes.byteLength > MAX_FILE_BYTES) throw new RangeError("workspace file exceeds the 64 MiB write bound");
       await ancestors(absolute);
       await mkdir(absolute.slice(0, absolute.lastIndexOf("/")));
       await bucket.put(key(absolute), bytes);
@@ -132,7 +125,7 @@ export function createBrainWorkspace(bucket: R2Bucket, resourceId: string): Work
         await bucket.delete(key(absolute));
         return;
       }
-      const entries = await list(absolute, { recursive: true, maxEntries: MAX_ENTRIES });
+      const entries = await list(absolute, { recursive: true });
       if (!options.recursive && entries.length) throw error("ENOTEMPTY", `${absolute} is not empty`);
       const keys = entries.map((entry) => `${key(entry.path)}${entry.kind === "directory" ? "/" : ""}`);
       keys.push(`${key(absolute)}/`);

--- a/js/managed/src/browser-egress.ts
+++ b/js/managed/src/browser-egress.ts
@@ -12,7 +12,7 @@ type BrowserEgressEnv = AccountAuthEnv & { NANOCODEX: Fetcher };
 
 const THREAD_ID = /^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/;
 const METHODS = new Set(["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]);
-const ENVELOPE_FIELDS = new Set(["thread_id", "url", "method", "headers", "body"]);
+const ENVELOPE_FIELDS = new Set(["thread_id", "url", "method", "headers", "body", "body_base64"]);
 const PRINCIPAL_HEADERS = new Set([
   "authorization",
   "cookie",
@@ -26,6 +26,7 @@ type EgressEnvelope = Readonly<{
   method?: string;
   headers?: Record<string, string>;
   body?: string;
+  body_base64?: string;
 }>;
 
 /** One credential-free, destination-policy-owned egress capability for browser runtimes. */
@@ -55,7 +56,7 @@ export async function routeBrowserEgress(
   if (!envelope) return json({ error: "invalid_request" }, 400);
   const method = (envelope.method ?? "GET").toUpperCase();
   if (!METHODS.has(method)) return json({ error: "method_denied" }, 403);
-  if ((method === "GET" || method === "HEAD") && envelope.body !== undefined) {
+  if ((method === "GET" || method === "HEAD") && (envelope.body !== undefined || envelope.body_base64 !== undefined)) {
     return json({ error: "body_denied" }, 400);
   }
   const headers = decodeHeaders(envelope.headers);
@@ -65,12 +66,14 @@ export async function routeBrowserEgress(
   try { destination = new URL(envelope.url); } catch { return json({ error: "invalid_url" }, 400); }
   let target: Request;
   try {
+    const body = envelope.body_base64 === undefined ? envelope.body
+      : Uint8Array.from(atob(envelope.body_base64), (character) => character.charCodeAt(0));
     target = new Request(destination, {
       method,
       headers,
-      ...(method === "GET" || method === "HEAD" || envelope.body === undefined
+      ...(method === "GET" || method === "HEAD" || body === undefined
         ? {}
-        : { body: envelope.body }),
+        : { body }),
       redirect: "manual",
       signal: request.signal,
     });
@@ -114,6 +117,9 @@ async function readEnvelope(request: Request): Promise<EgressEnvelope | undefine
     || typeof value.url !== "string"
     || (value.method !== undefined && typeof value.method !== "string")
     || (value.body !== undefined && typeof value.body !== "string")
+    || (value.body !== undefined && value.body_base64 !== undefined)
+    || (value.body_base64 !== undefined && (typeof value.body_base64 !== "string"
+      || !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value.body_base64)))
     || (value.headers !== undefined && !isRecord(value.headers))) return undefined;
   return value as EgressEnvelope;
 }

--- a/js/managed/src/computer-runtime.ts
+++ b/js/managed/src/computer-runtime.ts
@@ -21,8 +21,6 @@ type DisposableComputerWorkspace = WorkspaceStorageClient & Readonly<{
   [Symbol.dispose](): void;
 }>;
 
-const MAX_SHELL_RESPONSE_BYTES = 16 * 1024 * 1024;
-
 export type ManagedComputerRuntime = ComputerRuntime & Readonly<{
   dispose(): void;
 }>;
@@ -108,7 +106,7 @@ function createManagedShellFetch(
   ) => ManagedEgressConnectorAccess,
   vaultAllowed: () => boolean = () => true,
 ): ShellFetch {
-  return async (url, options = {}) => {
+  const stream: NonNullable<ShellFetch["stream"]> = async (url, options = {}) => {
     const method = (options.method ?? "GET").toUpperCase();
     const request = new Request(url, {
       method,
@@ -128,42 +126,41 @@ function createManagedShellFetch(
       status: response.status,
       statusText: response.statusText,
       headers,
-      body: await readShellResponse(response, options.signal),
+      body: shellResponseChunks(response, options.signal),
       url: response.url || request.url,
     };
   };
+  return Object.assign(async (url: string, options: Parameters<ShellFetch>[1] = {}) => {
+    const response = await stream(url, options);
+    const chunks: Uint8Array[] = [];
+    let size = 0;
+    for await (const chunk of response.body) { chunks.push(chunk); size += chunk.byteLength; }
+    const body = new Uint8Array(size);
+    let offset = 0;
+    for (const chunk of chunks) { body.set(chunk, offset); offset += chunk.byteLength; }
+    return { ...response, body };
+  }, { stream });
 }
 
-async function readShellResponse(response: Response, signal?: AbortSignal): Promise<Uint8Array> {
-  if (Number(response.headers.get("content-length")) > MAX_SHELL_RESPONSE_BYTES) {
-    await response.body?.cancel();
-    throw new RangeError("brain HTTP response exceeds 16 MiB; request a smaller response or use a hand");
-  }
-  if (response.body === null) return new Uint8Array();
+async function* shellResponseChunks(response: Response, signal?: AbortSignal): AsyncIterable<Uint8Array> {
+  if (response.body === null) { signal?.throwIfAborted(); return; }
   const reader = response.body.getReader();
   const abort = () => { void reader.cancel(signal?.reason).catch(() => {}); };
   signal?.addEventListener("abort", abort, { once: true });
-  const chunks: Uint8Array[] = [];
-  let size = 0;
+  let complete = false;
   try {
     for (;;) {
       signal?.throwIfAborted();
       const { done, value } = await reader.read();
-      if (done) break;
-      size += value.byteLength;
-      if (size > MAX_SHELL_RESPONSE_BYTES) throw new RangeError("brain HTTP response exceeds 16 MiB; request a smaller response or use a hand");
-      chunks.push(value);
+      if (done) { complete = true; break; }
+      yield value;
     }
     signal?.throwIfAborted();
-  } catch (error) {
-    try { await reader.cancel(); } catch { /* Preserve the read failure. */ }
-    throw error;
   } finally {
+    if (!complete) {
+      try { await reader.cancel(signal?.reason); } catch { /* Preserve the read failure. */ }
+    }
     signal?.removeEventListener("abort", abort);
     reader.releaseLock();
   }
-  const body = new Uint8Array(size);
-  let offset = 0;
-  for (const chunk of chunks) { body.set(chunk, offset); offset += chunk.byteLength; }
-  return body;
 }

--- a/js/managed/src/index.ts
+++ b/js/managed/src/index.ts
@@ -18,7 +18,7 @@ import type {
 import { Agent as CloudflareAgent } from "nanocodex/cloudflare";
 import { Agent as ManagedAgent } from "nanocodex/managed";
 import { imageGeneration, updatePlan, viewImage, web } from "nanocodex/tools";
-import { createWorkspaceFilesystem, MAX_NAMESPACE_MOUNTS } from "nanocodex-tools";
+import { createWorkspaceFilesystem } from "nanocodex-tools";
 import { createBrainWorkspace } from "./brain-workspace";
 import { managedCodeEvaluator } from "./code-evaluator";
 import { CronTriggers, CRON_TRIGGER_ID, cronTriggerView, nextCronRun, parseCronTrigger, type CronTriggerConfig } from "./cron-triggers";
@@ -269,12 +269,10 @@ export { ApiKeyRecord, NonceStorage, Organization, UserAccount } from "./account
 
 const MAX_CLIENT_MESSAGE_BYTES = 1024 * 1024;
 const MAX_PRE_ADMISSION_CANCELLATIONS = 64;
-const MAX_CLIENT_CONNECTIONS = 64;
 const MAX_REQUEST_BODY_BYTES = 1024 * 1024;
 const MAX_REALTIME_REQUEST_BYTES = 64 * 1024;
 const MAX_REALTIME_CONTEXT_BYTES = 1024 * 1024;
 const DISPATCH_INPUT_CHUNK_CODE_UNITS = 256_000;
-const MAX_PENDING_REALTIME_OPERATIONS = 32;
 const MAX_RETRY_DELAY_MS = 60_000;
 const MAX_IMPORT_BATCHES_PER_CREATE = 4;
 const UUID =
@@ -801,8 +799,8 @@ const SANDBOX_HAND_CAPABILITIES = Object.freeze([
   "processes",
   "servers",
 ]);
-const MAX_MANAGED_MOUNTS = 16;
-export const MANAGED_SUBAGENT_MAX_CONCURRENCY = 8;
+// One alias per peer bucket is required by the Sandbox SDK mount protocol.
+const CLOUDFLARE_NAMESPACE_BINDING_COUNT = 16;
 
 const json = (body: unknown, init: ResponseInit = {}) => Response.json(body, {
   ...init,
@@ -3669,9 +3667,6 @@ export class DurableAgentSession extends DurableComputerSession {
       && !authorization.connectGrant.connectors.includes("chatgpt")) {
       return json({ error: "connector_forbidden" }, { status: 403 });
     }
-    if (this.ctx.getWebSockets("client").length >= MAX_CLIENT_CONNECTIONS) {
-      return new Response("Session client limit reached", { status: 429 });
-    }
     const latestCursor = this.#eventArchive.latestCursor(this.#eventLog);
     const cursor = requestedCursor === null || requestedCursor === "latest"
       ? latestCursor
@@ -4243,9 +4238,6 @@ export class DurableAgentSession extends DurableComputerSession {
       || previous.authorization_epoch !== session.authorization_epoch)) {
       throw new ManagedRequestError(409, "trigger_exists", "cron trigger id already exists with different settings or authorization; choose a new id");
     }
-    if (!previous && this.#cronTriggers.list().length >= 32) {
-      throw new ManagedRequestError(429, "trigger_limit", "at most 32 cron triggers per agent");
-    }
     const row = this.#cronTriggers.put(id, config, encodedAuthorization, session.authorization_epoch, hash, Date.now());
     await this.#scheduleNextAlarm();
     return { trigger: cronTriggerView(row, session.session_id), exists: previous !== undefined };
@@ -4727,17 +4719,6 @@ export class DurableAgentSession extends DurableComputerSession {
         "realtime operation is pending and will not be replayed",
       );
     }
-    const pendingOperations = this.ctx.storage.sql.exec<{ count: number }>(
-      "SELECT COUNT(*) AS count FROM managed_realtime_operations WHERE state = 'pending' AND blocked = 0",
-    ).one().count;
-    if (pendingOperations >= MAX_PENDING_REALTIME_OPERATIONS) {
-      throw new ManagedRequestError(
-        429,
-        "realtime_queue_full",
-        `at most ${MAX_PENDING_REALTIME_OPERATIONS} realtime operations may be pending`,
-      );
-    }
-
     const now = Date.now();
     this.ctx.storage.transactionSync(() => {
       this.#assertDurabilityAdmissionActive();
@@ -6455,6 +6436,7 @@ export class DurableAgentSession extends DurableComputerSession {
             undefined,
             () => this.#cloudflareNamespaceMounts("mounted"),
             { resourceId: session.session_id },
+            this.ctx.id.toString(),
           );
           sandboxToolsByMount.set(mount.id, tools);
         }
@@ -6563,7 +6545,6 @@ export class DurableAgentSession extends DurableComputerSession {
           commands: computer.descriptor.commands,
           custom_commands: computer.descriptor.customCommands,
           limits: computer.descriptor.limits,
-          subagent_max_concurrency: MANAGED_SUBAGENT_MAX_CONCURRENCY,
           pty: multiplayer ? computer.descriptor.pty : false,
           sessions: multiplayer ? computer.descriptor.sessions : false,
           sandbox_escalation: false,
@@ -6611,10 +6592,10 @@ export class DurableAgentSession extends DurableComputerSession {
             "No process sandbox is attached. Bounded Just Bash is the complete local execution boundary.",
           ].join("\n\n")
           : [
-            "You are the durable Nanocodex brain running on Cloudflare Workers. Use Code Mode, tools, and bounded Just Bash in /brain first. /brain is durable shared scratch mounted read-write in every Cloudflare hand; it never contains credentials or control-plane authority.",
+            "You are the durable Nanocodex brain running on Cloudflare Workers. Use Code Mode, tools, and Just Bash in /brain first. /brain is durable shared scratch mounted read-write in every Cloudflare hand; it never contains credentials or control-plane authority.",
             computer.instructions,
             "The agent starts without a sandbox hand. File work, text processing, HTTP, supported Git/GitHub commands, and JavaScript computation in Code Mode need no hand. When the task needs native binaries, package installation, builds, tests, a server, or a process session, reuse a suitable attached hand from accountInfo or mount output; otherwise call mount with provider cf_sandbox and a useful stable name. A known native command such as cargo test should go directly to a suitable hand. If a brain command reveals an unsupported binary or runtime capability, select or mount a hand and continue there, checking for partial effects before retrying. A compiler error or failing test on a hand should be investigated there. Use another provider only when the user supplied its exact connected VM factory name. Do not ask the user to request a routine sandbox mount. mount provisions and attaches the hand before it returns.",
-            `Subagents share your tools and permissions. Delegate bounded independent work; spawning another researcher does not repair an unavailable tool. The entire task tree may have at most ${MANAGED_SUBAGENT_MAX_CONCURRENCY} active subagents. When capacity is full, continue your assigned work with the available brain tools.`,
+            "Subagents share your tools and permissions. Delegate independent work when it advances the task.",
             "Hands appear as logical top-level paths returned by mount or listed in accountInfo().machines. exec_command defaults to /brain; omit workdir or use /brain for Just Bash. For native execution, set workdir to the exact hand mount or a path beneath it. The root of that cwd selects where the process runs. write_stdin remains pinned to the hand that created its session. There is no environment or host argument.",
             "A Code Mode cell captures its mount mapping. Commands in Promise.all may run concurrently on different cwd roots, and subagents use the same cwd rule independently. A disconnect or reconnect never retargets an admitted command or session.",
             "Cloudflare sandbox hands are separate retained workspaces mounted into each other's native filesystem namespaces. A process may write its executing hand through /workspace or that hand's logical mount path, read peer hand paths without mutating them, and read or write /brain using ordinary filesystem syscalls. The trees are mounted, never copied or synchronized. Connected user hands and future providers remain placement-only until their provider advertises a conforming native namespace adapter, so native_cross_mounts remains false globally while runtimeInfo.cloudflare_native_cross_mounts is true.",
@@ -6633,7 +6614,6 @@ export class DurableAgentSession extends DurableComputerSession {
       };
       Object.defineProperty(agentOptions, internalRuntime, { value: {
         ...hostedRuntime,
-        subagentMaxConcurrency: MANAGED_SUBAGENT_MAX_CONCURRENCY,
       } });
       Object.defineProperty(agentOptions, internalConfiguration, { value: this.#settings() });
       phaseStartedAt = performance.now();
@@ -6892,23 +6872,6 @@ export class DurableAgentSession extends DurableComputerSession {
       created = mount === undefined;
     }
     if (mount === undefined) {
-      const count = this.ctx.storage.sql.exec<{ count: number }>(
-        "SELECT COUNT(*) AS count FROM managed_mounts",
-      ).one().count;
-      if (count >= MAX_MANAGED_MOUNTS) {
-        throw new ManagedRequestError(
-          409,
-          "mount_limit_reached",
-          `an agent may retain at most ${MAX_MANAGED_MOUNTS} mounts`,
-        );
-      }
-      if (count + this.#userHandMachines(context).length >= MAX_NAMESPACE_MOUNTS - 1) {
-        throw new ManagedRequestError(
-          409,
-          "namespace_mount_limit_reached",
-          `the execution namespace may contain at most ${MAX_NAMESPACE_MOUNTS} mounts`,
-        );
-      }
       const id = uuidV7();
       const now = Date.now();
       const providerCount = this.ctx.storage.sql.exec<{ count: number }>(
@@ -7002,6 +6965,7 @@ export class DurableAgentSession extends DurableComputerSession {
           this.#cloudflareNamespaceMountsForPreparation(mount.id),
           this.env.NANOCODEX_SANDBOX_LOCAL === "true",
           { resourceId: session.session_id },
+          this.ctx.id.toString(),
         );
         return;
       }
@@ -7368,7 +7332,7 @@ export class DurableAgentSession extends DurableComputerSession {
 
   #nextCloudflareNamespaceSlot(): number {
     const used = new Set(this.#ensureCloudflareNamespaceSlots().values());
-    for (let slot = 0; slot < MAX_MANAGED_MOUNTS; slot += 1) {
+    for (let slot = 0; slot < CLOUDFLARE_NAMESPACE_BINDING_COUNT; slot += 1) {
       if (!used.has(slot)) return slot;
     }
     throw new Error("Cloudflare namespace has no free binding slot");
@@ -7382,7 +7346,7 @@ export class DurableAgentSession extends DurableComputerSession {
       const configuration = managedMountConfiguration(mount.configuration_json);
       const slot = configuration.namespace_slot;
       if (slot === undefined) continue;
-      if (!Number.isInteger(slot) || slot < 0 || slot >= MAX_MANAGED_MOUNTS || used.has(slot)) {
+      if (!Number.isInteger(slot) || slot < 0 || slot >= CLOUDFLARE_NAMESPACE_BINDING_COUNT || used.has(slot)) {
         throw new Error("retained Cloudflare mount has an invalid namespace slot");
       }
       slots.set(mount.id, slot);
@@ -7392,7 +7356,7 @@ export class DurableAgentSession extends DurableComputerSession {
       if (slots.has(mount.id)) continue;
       let slot = 0;
       while (used.has(slot)) slot += 1;
-      if (slot >= MAX_MANAGED_MOUNTS) {
+      if (slot >= CLOUDFLARE_NAMESPACE_BINDING_COUNT) {
         throw new Error("retained Cloudflare mounts exceed the namespace binding limit");
       }
       const configuration = managedMountConfiguration(mount.configuration_json);

--- a/js/managed/src/managed-egress.ts
+++ b/js/managed/src/managed-egress.ts
@@ -12,8 +12,6 @@ const MAX_VAULT_HEADERS = 64;
 const MAX_VAULT_HEADER_BYTES = 32 * 1024;
 const MAX_VAULT_HEADER_NAME_BYTES = 128;
 const MAX_VAULT_HEADER_VALUE_BYTES = 4 * 1024;
-const MAX_REDIRECTS = 5;
-const REDIRECTS = new Set([301, 302, 303, 307, 308]);
 const ORDINARY_METHODS = new Set(["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]);
 const BLOCKED_RESPONSE_HEADERS = new Set([
   "clear-site-data",
@@ -31,6 +29,7 @@ const BLOCKED_RESPONSE_HEADERS = new Set([
   "upgrade",
   "x-nanocodex-connector-connection",
   "x-nanocodex-subject",
+  "x-nanocodex-target-url",
 ]);
 
 export type ManagedEgressConnectorId =
@@ -61,9 +60,15 @@ export function exactConnectorAccess(
 type ProviderPolicy = Readonly<{
   connector: ManagedEgressConnectorId;
   path: (pathname: string) => boolean;
+  publicWithoutSubject?: boolean;
 }>;
 
 const PROVIDERS = new Map<string, readonly ProviderPolicy[]>([
+  ["github.com", [{
+    connector: "github",
+    path: (path) => /^\/[A-Za-z0-9_-]+\/[A-Za-z0-9_.-]+\/(?:info\/refs|git-upload-pack|git-receive-pack)$/.test(path),
+    publicWithoutSubject: true,
+  }]],
   ["api.github.com", [{
     connector: "github",
     path: (path) => path.startsWith("/"),
@@ -122,7 +127,7 @@ const PRIVATE_HEADER = /(?:^|[-_])(?:auth(?:orization)?|cookie|credential|passwo
 const FORBIDDEN_HEADERS = new Set([
   "connection", "host", "origin", "proxy-connection", "referer", "te", "trailer",
   "transfer-encoding", "upgrade", CONNECTOR_CONNECTION_HEADER, "x-nanocodex-subject",
-  VAULT_ID_HEADER,
+  VAULT_ID_HEADER, "x-nanocodex-target-url",
 ]);
 const VAULT_FORBIDDEN_HEADERS = new Set([
   "content-length", "cookie", "expect", "proxy-authorization", "via",
@@ -166,12 +171,15 @@ export async function handleManagedEgress(
 
   let url: URL;
   try { url = validateUrl(new URL(request.url)); } catch { return failure(403, "destination_denied"); }
-  const provider = providerFor(url);
+  const candidate = providerFor(url);
+  const provider = candidate?.publicWithoutSubject && subject === undefined ? undefined : candidate;
   const headerFailure = forbiddenHeader(request.headers, {
     allowConnectorConnection: provider !== undefined,
   });
   if (headerFailure) return failure(403, "credential_header_denied");
-  if (!provider && PROVIDERS.has(url.hostname)) return failure(403, "destination_denied");
+  if (!provider && PROVIDERS.has(url.hostname) && url.hostname !== "github.com") {
+    return failure(403, "destination_denied");
+  }
   if (provider) {
     const selected = request.headers.get(CONNECTOR_CONNECTION_HEADER) ?? undefined;
     if (selected !== undefined && !CONNECTOR_CONNECTION.test(selected)) {
@@ -200,10 +208,16 @@ export async function handleManagedEgress(
     })));
   }
 
-  const body = method === "GET" || method === "HEAD" || !request.body
-    ? undefined
-    : await request.arrayBuffer();
-  return fetchPublic(url, request, body);
+  const headers = new Headers(request.headers);
+  headers.set("x-nanocodex-target-url", url.href);
+  if (subject !== undefined) headers.set("x-nanocodex-subject", subject);
+  return projectResponse(await binding.fetch(new Request("https://public-egress.internal/v1/request", {
+    method,
+    headers,
+    ...(method === "GET" || method === "HEAD" || !request.body ? {} : { body: request.body }),
+    redirect: "manual",
+    signal: request.signal,
+  })));
 }
 
 async function handleVaultEgress(
@@ -275,48 +289,6 @@ function canonicalProviderPath(provider: ProviderPolicy, pathname: string): bool
     || (!pathname.includes("\\") && !/%(?:2e|2f|5c|25)/i.test(pathname));
 }
 
-async function fetchPublic(
-  initialUrl: URL,
-  request: Request,
-  originalBody: ArrayBuffer | undefined,
-): Promise<Response> {
-  let url = initialUrl;
-  let method = request.method.toUpperCase();
-  let body = originalBody;
-  for (let redirects = 0; ; redirects += 1) {
-    if (redirects > MAX_REDIRECTS) return failure(502, "too_many_redirects");
-    const headers = new Headers(request.headers);
-    if (method === "GET" || method === "HEAD") {
-      headers.delete("content-length");
-      headers.delete("content-type");
-      body = undefined;
-    }
-    try {
-      const response = await fetch(url, {
-        method,
-        headers,
-        body,
-        redirect: "manual",
-        signal: request.signal,
-      });
-      if (!REDIRECTS.has(response.status)) return projectResponse(response);
-      const location = response.headers.get("location");
-      await response.body?.cancel();
-      if (!location) return failure(502, "invalid_redirect");
-      try { url = validateUrl(new URL(location, url)); } catch { return failure(502, "redirect_denied"); }
-      if (providerFor(url) || PROVIDERS.has(url.hostname)) {
-        return failure(502, "redirect_to_connector_denied");
-      }
-      if (response.status === 303
-        || ((response.status === 301 || response.status === 302) && method === "POST")) {
-        method = "GET";
-        body = undefined;
-      }
-    } catch {
-      return failure(request.signal.aborted ? 499 : 502, "upstream_unavailable");
-    }
-  }
-}
 
 function validateUrl(url: URL): URL {
   if ((url.protocol !== "http:" && url.protocol !== "https:") || url.username || url.password

--- a/js/managed/src/sandbox-runtime.ts
+++ b/js/managed/src/sandbox-runtime.ts
@@ -17,24 +17,46 @@ export type SandboxRuntimeEnv = Readonly<{
 export class Sandbox extends CloudflareSandbox<SandboxRuntimeEnv> {
   override enableInternet = false;
   override interceptHttps = true;
+
+  /** Called over trusted Worker RPC, never derived from container headers. */
+  async bindAccountEgress(subject: string): Promise<void> {
+    if (!/^[A-Za-z0-9_-]{43,128}$/.test(subject)) throw new Error("invalid sandbox account subject");
+    await this.ctx.blockConcurrencyWhile(async () => {
+      const current = await this.ctx.storage.get<string>("nanocodex-egress-subject");
+      if (current !== undefined && current !== subject) throw new Error("sandbox belongs to another account subject");
+      if (current === subject) return;
+      await this.setOutboundHandler("account", { subject });
+      await this.ctx.storage.put("nanocodex-egress-subject", subject);
+    });
+  }
 }
 
 export async function handleSandboxEgress(
   request: Request,
   env: SandboxRuntimeEnv,
+  context?: Readonly<{ params?: unknown }>,
 ): Promise<Response> {
   const headers = new Headers(request.headers);
   // The transparent container proxy reconstructs this from the intercepted
   // destination. It is transport metadata, not a caller-controlled credential,
   // and Request will derive the upstream Host header from the validated URL.
   headers.delete("host");
+  // gh requires a token to enter its HTTP path. It receives only this public
+  // marker; the broker injects the actual credential for the bound account.
+  const origin = new URL(request.url).origin;
+  const authorization = headers.get("authorization") ?? "";
+  if ((origin === "https://api.github.com" || origin === "https://github.com")
+    && (/^(?:Bearer|token) NANOCODEX_PROVIDER_CREDENTIAL$/i.test(authorization)
+      || authorization === `Basic ${btoa("x-access-token:NANOCODEX_PROVIDER_CREDENTIAL")}`)) {
+    headers.delete("authorization");
+  }
   const sanitized = new Request(request, { headers });
-  // Shell traffic never receives account connector credentials. Those remain
-  // available through the turn-scoped connector tools owned by the brain.
-  return handleManagedEgress(sanitized, env.NANOCODEX, undefined, () => false);
+  const params = context?.params as { subject?: string } | undefined;
+  return handleManagedEgress(sanitized, env.NANOCODEX, params?.subject);
 }
 
 Sandbox.outbound = handleSandboxEgress;
+Sandbox.outboundHandlers = { account: handleSandboxEgress };
 
 /**
  * Required by the Sandbox SDK for transparent HTTP(S) interception. Sandbox

--- a/js/managed/src/sandbox-tools.ts
+++ b/js/managed/src/sandbox-tools.ts
@@ -125,7 +125,7 @@ type SandboxToolClient = {
   }>;
   startProcess(
     command: string,
-    options: { cwd: string; processId: string; autoCleanup: false },
+    options: { cwd: string; processId: string; autoCleanup: false; envVars?: Record<string, string> },
   ): Promise<SandboxProcess>;
   getProcess(id: string): Promise<SandboxProcess | null>;
   tunnels: {
@@ -148,9 +148,14 @@ export function cloudflareSandboxTools(
   outputCursorStorage?: SandboxOutputCursorStorage,
   namespaceMounts?: () => readonly CloudflareSandboxNamespaceMount[],
   brainWorkspace?: CloudflareBrainWorkspace,
+  accountSubject?: string,
 ): ToolMap {
   return createCloudflareSandboxTools(
-    () => namespaceMounts === undefined
+    async () => {
+      // Bind before provisioning or running any user process. The SDK retains
+      // this outbound handler across container sleep and Durable Object reload.
+      if (accountSubject !== undefined) await sandboxHandle(namespace, sessionId).bindAccountEgress(accountSubject);
+      return namespaceMounts === undefined
       ? prepareSandbox(namespace, sessionId, localBucket)
       : prepareSandboxNamespace(
           namespace,
@@ -158,7 +163,8 @@ export function cloudflareSandboxTools(
           localBucket,
           namespaceMounts(),
           brainWorkspace,
-        ),
+        );
+    },
     publicOrigin === undefined || previewSecret === undefined
       ? undefined
       : async (port) => ({
@@ -196,7 +202,9 @@ export async function prepareCloudflareSandboxHand(
   mounts: readonly CloudflareSandboxNamespaceMount[],
   localBucket = false,
   brainWorkspace?: CloudflareBrainWorkspace,
+  accountSubject?: string,
 ): Promise<void> {
+  if (accountSubject !== undefined) await sandboxHandle(namespace, resourceId).bindAccountEgress(accountSubject);
   const normalized = validateNamespaceMounts(mounts);
   if (brainWorkspace === undefined) {
     throw new Error("Cloudflare namespace requires a shared brain workspace");
@@ -297,6 +305,11 @@ export function createCloudflareSandboxTools(
             cwd,
             processId: sandboxProcessId(sessionId),
             autoCleanup: false,
+            envVars: {
+              GH_TOKEN: "NANOCODEX_PROVIDER_CREDENTIAL",
+              GH_PROMPT_DISABLED: "1",
+              GIT_TERMINAL_PROMPT: "0",
+            },
           });
           return await observeProcess(
             sandbox,

--- a/js/managed/test/brain-workspace.test.ts
+++ b/js/managed/test/brain-workspace.test.ts
@@ -18,6 +18,41 @@ const computer = () => ({
 });
 
 describe("durable brain without hands", () => {
+  it("clones a real Git pack beyond 16 MiB and retains its exact bytes after reopening", async () => {
+    const id = crypto.randomUUID();
+    const seen: Request[] = [];
+    const egress = { async fetch(request: Request) {
+      seen.push(request);
+      expect(request.headers.get("x-nanocodex-subject")).toBe("s".repeat(43));
+      expect(request.headers.get("authorization")).toBe("Bearer NANOCODEX_PROVIDER_CREDENTIAL");
+      // The provider fixture requires the broker's injected credential.
+      const headers = new Headers(request.headers);
+      headers.delete("x-nanocodex-subject");
+      headers.set("authorization", `Basic ${btoa("x-access-token:github-connector-access")}`);
+      return fetch(new Request(request, { headers }));
+    } } as unknown as Fetcher;
+    const runtime = await createManagedComputerRuntime({
+      computer: computer(), filesystem: createBrainWorkspace(bucket, id),
+      subject: "s".repeat(43), egress,
+    });
+    try {
+      const metadata = JSON.parse(new TextDecoder().decode((await runtime.fetch(
+        "https://api.github.com/repos/fixture/large",
+      )).body)) as { head: string; size: number; sha256: string };
+      expect(metadata.size).toBeGreaterThan(16 * 1024 * 1024);
+      const cloned = await runtime.tool.handler({ cmd: "gh repo clone fixture/large repository" }, context());
+      expect(cloned).toMatchObject({ exit_code: 0 });
+      expect((cloned as { output: string }).output).not.toMatch(/limit|credential|token/);
+      expect(await runtime.tool.handler({ cmd: "git rev-parse HEAD", workdir: "/brain/repository" }, context()))
+        .toMatchObject({ exit_code: 0, output: `${metadata.head}\n` });
+      const bytes = await createBrainWorkspace(bucket, id).readFile("repository/large.bin");
+      expect(bytes.byteLength).toBe(metadata.size);
+      const hash = new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
+      expect([...hash].map((value) => value.toString(16).padStart(2, "0")).join("")).toBe(metadata.sha256);
+      expect(seen.some((request) => request.url.endsWith("/git-upload-pack"))).toBe(true);
+    } finally { runtime.dispose(); }
+  }, 60_000);
+
   it("fences the retained R2 handle after disposal", async () => {
     const workspace = createBrainWorkspace(bucket, crypto.randomUUID());
     const runtime = await createManagedComputerRuntime({
@@ -50,7 +85,7 @@ describe("durable brain without hands", () => {
     } finally { runtime.dispose(); }
   });
 
-  it("cancels oversized chunked HTTP responses before buffering them in full", async () => {
+  it.each([false, true])("accepts bodies beyond 16 MiB (content-length: %s)", async (declared) => {
     let chunks = 0;
     const cancel = vi.fn();
     const runtime = await createManagedComputerRuntime({
@@ -58,15 +93,18 @@ describe("durable brain without hands", () => {
       subject: "s".repeat(43), connectorAllowed: () => true,
       egress: { async fetch() {
         return new Response(new ReadableStream<Uint8Array>({
-          pull(controller) { chunks++; controller.enqueue(new Uint8Array(1024 * 1024)); }, cancel,
-        }));
+          pull(controller) {
+            if (chunks++ < 17) controller.enqueue(new TextEncoder().encode(" ".repeat(1024 * 1024)));
+            else { controller.enqueue(new TextEncoder().encode('{"login":"large-response"}')); controller.close(); }
+          }, cancel,
+        }), { headers: declared ? { "content-length": String(17 * 1024 * 1024 + 26) } : {} });
       } } as unknown as Fetcher,
     });
     try {
       await expect(runtime.tool.handler({ cmd: "gh api user" }, context()))
-        .resolves.toMatchObject({ exit_code: 1, output: expect.stringContaining("exceeds 16 MiB") });
-      expect(cancel).toHaveBeenCalledOnce();
-      expect(chunks).toBeLessThanOrEqual(18);
+        .resolves.toMatchObject({ exit_code: 0, output: expect.stringContaining("large-response") });
+      expect(cancel).not.toHaveBeenCalled();
+      expect(chunks).toBe(18);
       await expect(runtime.tool.handler({ cmd: "echo still-working" }, context()))
         .resolves.toMatchObject({ exit_code: 0, output: "still-working\n" });
     } finally { runtime.dispose(); }

--- a/js/managed/test/durability-runtime.test.ts
+++ b/js/managed/test/durability-runtime.test.ts
@@ -3,9 +3,8 @@ import { expect, it } from "vitest";
 import { Agent } from "nanocodex/cloudflare";
 import { Subagents } from "nanocodex/host";
 import { createTools } from "nanocodex/tools";
-import { MANAGED_SUBAGENT_MAX_CONCURRENCY } from "../src/index";
 
-it("bounds a delegation storm with prepared tools and keeps checkpointed messaging usable", async () => {
+it("admits more than eight children with prepared tools and keeps checkpointed messaging usable", async () => {
   const namespace = (env as unknown as { NANOCODEX_MEMORY: DurableObjectNamespace }).NANOCODEX_MEMORY;
   await runInDurableObject(namespace.getByName(crypto.randomUUID()), async (_instance, ctx) => {
     const owner = { ctx, env: { NANOCODEX: { async fetch() {
@@ -16,20 +15,15 @@ it("bounds a delegation storm with prepared tools and keeps checkpointed messagi
     } } } };
     const tools = await createTools({ tools: [] });
     const options = { tools, eventPersistence: "caller" as const };
-    Object.defineProperty(options, Symbol.for("nanocodex.cloudflare.internalRuntime"), { value: {
-      subagentMaxConcurrency: MANAGED_SUBAGENT_MAX_CONCURRENCY,
-    } });
     const agent = await Agent.create(owner, options);
     try {
-      const attempts = await Promise.allSettled(Array.from({ length: 104 }, (_, index) => Subagents.spawn(agent, {
+      const attempts = await Promise.allSettled(Array.from({ length: 16 }, (_, index) => Subagents.spawn(agent, {
         role: `researcher-${index}`, task: "Research fixture without further delegation", outputSchema: { type: "object" },
       })));
-      expect(attempts.filter((attempt) => attempt.status === "fulfilled")).toHaveLength(MANAGED_SUBAGENT_MAX_CONCURRENCY);
-      const rejected = attempts.filter((attempt) => attempt.status === "rejected");
-      expect(rejected).toHaveLength(104 - MANAGED_SUBAGENT_MAX_CONCURRENCY);
-      for (const attempt of rejected) expect(String(attempt.reason)).toContain("sub-agent concurrency limit of 8");
+      expect(attempts.filter((attempt) => attempt.status === "fulfilled")).toHaveLength(16);
+      expect(attempts.filter((attempt) => attempt.status === "rejected")).toHaveLength(0);
       const directory = await Subagents.list(agent);
-      expect(directory.agents).toHaveLength(MANAGED_SUBAGENT_MAX_CONCURRENCY);
+      expect(directory.agents).toHaveLength(16);
       await expect(Subagents.send(agent, {
         agentId: directory.agents[0]!.agent_id, priority: "urgent", purpose: "question", message: "Still available?",
       })).resolves.toMatchObject({ to_agent_id: directory.agents[0]!.agent_id });

--- a/js/managed/test/managed-egress.test.ts
+++ b/js/managed/test/managed-egress.test.ts
@@ -272,33 +272,48 @@ describe("Computer egress gateway", () => {
     expect(publicFetch).not.toHaveBeenCalled();
   });
 
-  it("manually follows only revalidated public redirects", async () => {
+  it("routes public requests through the account broker without direct network access", async () => {
+    const direct = vi.fn();
+    vi.stubGlobal("fetch", direct);
     const requests: Request[] = [];
-    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const request = new Request(input, init);
+    const binding = { async fetch(request: Request) {
       requests.push(request);
-      if (request.url === "https://one.example/start") {
-        return new Response(null, { status: 302, headers: { location: "https://two.example/end" } });
-      }
-      return new Response("done", { headers: { "set-cookie": "credential=must-not-return" } });
-    }));
-    const gateway = testGateway({ fetch: vi.fn() } as unknown as Fetcher);
-    const followed = await gateway.fetch("https://one.example/start", { method: "POST", body: "small" });
-    expect(await followed.text()).toBe("done");
-    expect(followed.headers.get("set-cookie")).toBeNull();
-    expect(requests.map(({ method, url }) => [method, url])).toEqual([
-      ["POST", "https://one.example/start"],
-      ["GET", "https://two.example/end"],
-    ]);
+      return new Response("done", { headers: { "set-cookie": "must-not-return" } });
+    } } as unknown as Fetcher;
+    const response = await testGateway(binding).fetch("https://one.example/start", { method: "POST", body: "data" });
+    expect(await response.text()).toBe("done");
+    expect(response.headers.get("set-cookie")).toBeNull();
+    expect(direct).not.toHaveBeenCalled();
+    expect(requests).toHaveLength(1);
+    expect(requests[0]!.url).toBe("https://public-egress.internal/v1/request");
+    expect(requests[0]!.headers.get("x-nanocodex-target-url")).toBe("https://one.example/start");
+    expect(requests[0]!.headers.get("x-nanocodex-subject")).toBe(SUBJECT);
+    expect(await requests[0]!.text()).toBe("data");
+  });
 
-    vi.stubGlobal("fetch", vi.fn(async () => new Response(null, {
-      status: 302,
-      headers: { location: "http://169.254.169.254/latest" },
-    })));
-    const deniedRedirect = await gateway.fetch("https://one.example/start");
-    expect(deniedRedirect.status).toBe(502);
-    expect(await deniedRedirect.json()).toEqual({ error: "redirect_denied" });
-
+  it("uses the same exact GitHub connection for API and smart HTTP", async () => {
+    const selected = "c".repeat(43);
+    const seen: Request[] = [];
+    const binding = { async fetch(request: Request) { seen.push(request); return new Response("ok"); } } as unknown as Fetcher;
+    for (const url of [
+      "https://api.github.com/user",
+      "https://github.com/owner/private.git/info/refs?service=git-upload-pack",
+      "https://github.com/owner/private.git/git-upload-pack",
+      "https://github.com/owner/private.git/git-receive-pack",
+    ]) {
+      const request = new Request(url, { method: url.endsWith("pack") && !url.includes("?") ? "POST" : "GET" });
+      const response = await handleManagedEgress(request, binding, SUBJECT,
+        (connector, id) => connector === "github" ? exactConnectorAccess([selected], id) : false);
+      expect(response.status).toBe(200);
+      expect(seen.at(-1)!.headers.get("x-nanocodex-connector-connection")).toBe(selected);
+      expect(seen.at(-1)!.headers.get("x-nanocodex-subject")).toBe(SUBJECT);
+      expect(seen.at(-1)!.headers.get("authorization")).toBe("Bearer NANOCODEX_PROVIDER_CREDENTIAL");
+      const denied = await handleManagedEgress(new Request(url, {
+        headers: { "x-nanocodex-connector-connection": "d".repeat(43) },
+      }), binding, SUBJECT, (_connector, id) => exactConnectorAccess([selected], id));
+      expect(denied.status).toBe(403);
+    }
+    expect(seen).toHaveLength(4);
   });
 
   it("streams public responses without an application byte ceiling", async () => {
@@ -309,8 +324,9 @@ describe("Computer egress gateway", () => {
         value.enqueue(new TextEncoder().encode("first"));
       },
     });
-    vi.stubGlobal("fetch", vi.fn(async () => new Response(upstream)));
-    const gateway = testGateway({ fetch: vi.fn() } as unknown as Fetcher);
+    const direct = vi.fn();
+    vi.stubGlobal("fetch", direct);
+    const gateway = testGateway({ fetch: vi.fn(async () => new Response(upstream)) } as unknown as Fetcher);
 
     const response = await gateway.fetch("https://assets.example/compiler");
     const reader = response.body!.getReader();
@@ -319,6 +335,7 @@ describe("Computer egress gateway", () => {
     controller.close();
     expect(new TextDecoder().decode((await reader.read()).value)).toBe("second");
     expect((await reader.read()).done).toBe(true);
+    expect(direct).not.toHaveBeenCalled();
   });
 });
 

--- a/js/managed/test/sandbox-runtime.test.ts
+++ b/js/managed/test/sandbox-runtime.test.ts
@@ -22,12 +22,12 @@ describe("sandbox runtime egress", () => {
     expect(Sandbox.outbound).toBe(handleSandboxEgress);
   });
 
-  it("allows policy-validated public HTTPS without using account credentials", async () => {
+  it("routes policy-validated public HTTPS through the broker", async () => {
     const upstream = vi.fn(async () => new Response("ok", {
       headers: { "content-type": "text/plain" },
     }));
     vi.stubGlobal("fetch", upstream);
-    const broker = { fetch: vi.fn() } as unknown as Fetcher;
+    const broker = { fetch: vi.fn(async () => new Response("ok")) } as unknown as Fetcher;
 
     const response = await handleSandboxEgress(
       new Request("https://github.com/dtolnay/anyhow.git/info/refs?service=git-upload-pack", {
@@ -38,8 +38,8 @@ describe("sandbox runtime egress", () => {
 
     expect(response.status).toBe(200);
     expect(await response.text()).toBe("ok");
-    expect(upstream).toHaveBeenCalledTimes(1);
-    expect(broker.fetch).not.toHaveBeenCalled();
+    expect(upstream).not.toHaveBeenCalled();
+    expect(broker.fetch).toHaveBeenCalledTimes(1);
   });
 
   it("rejects account connector destinations and private network targets", async () => {
@@ -57,6 +57,34 @@ describe("sandbox runtime egress", () => {
     )).status).toBe(403);
     expect(upstream).not.toHaveBeenCalled();
     expect(broker.fetch).not.toHaveBeenCalled();
+  });
+
+  it("authenticates native gh and git using trusted outbound params, not caller identity", async () => {
+    const requests: Request[] = [];
+    const broker = { async fetch(request: Request) { requests.push(request); return new Response("ok"); } } as unknown as Fetcher;
+    const subject = "s".repeat(43);
+    for (const [url, authorization] of [
+      ["https://api.github.com/user", "token NANOCODEX_PROVIDER_CREDENTIAL"],
+      ["https://github.com/owner/private.git/info/refs?service=git-upload-pack", undefined],
+      ["https://github.com/owner/private.git/git-upload-pack", `Basic ${btoa("x-access-token:NANOCODEX_PROVIDER_CREDENTIAL")}`],
+    ]) {
+      const response = await handleSandboxEgress(new Request(url!, {
+        headers: { host: new URL(url!).hostname, ...(authorization ? { authorization } : {}) },
+      }), { NANOCODEX: broker }, { params: { subject } });
+      expect(response.status).toBe(200);
+      expect(requests.at(-1)!.headers.get("x-nanocodex-subject")).toBe(subject);
+      expect(requests.at(-1)!.headers.get("authorization")).toBe("Bearer NANOCODEX_PROVIDER_CREDENTIAL");
+    }
+    const forgedHeaders: Record<string, string>[] = [
+      { "x-nanocodex-subject": "a".repeat(43) },
+      { authorization: "Bearer real-user-token" },
+    ];
+    for (const headers of forgedHeaders) {
+      const denied = await handleSandboxEgress(new Request("https://api.github.com/user", { headers }),
+        { NANOCODEX: broker }, { params: { subject } });
+      expect(denied.status).toBe(403);
+    }
+    expect(requests).toHaveLength(3);
   });
 
   it("blocks the Sandbox SDK cross-binding copy prefix escape", () => {

--- a/js/managed/test/sandbox-tools.test.ts
+++ b/js/managed/test/sandbox-tools.test.ts
@@ -92,6 +92,7 @@ describe("Cloudflare sandbox tools", () => {
     });
     expect(sandbox.startProcess).toHaveBeenCalledWith("exec 2>&1\ntask", {
       cwd: "/workspace/repo",
+      envVars: { GH_TOKEN: "NANOCODEX_PROVIDER_CREDENTIAL", GH_PROMPT_DISABLED: "1", GIT_TERMINAL_PROMPT: "0" },
       processId: expect.stringMatching(/^nanocodex-[1-9][0-9]*$/),
       autoCleanup: false,
     });

--- a/js/managed/vitest.config.ts
+++ b/js/managed/vitest.config.ts
@@ -1,8 +1,15 @@
+import { gitProvider } from "../test-fixtures/git-provider.mjs";
 import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  plugins: [cloudflareTest({ wrangler: { configPath: "./wrangler.test.jsonc" } })],
+  plugins: [cloudflareTest({
+    wrangler: { configPath: "./wrangler.test.jsonc" },
+    miniflare: { outboundService: async (request) => {
+      const response = await gitProvider(request);
+      return response ?? new Response("Unexpected test network request", { status: 502 });
+    } },
+  })],
   test: {
     include: ["test/**/*.test.ts"],
     // Bundle cron-parser's CommonJS/Luxon boundary as Wrangler does in production.

--- a/js/nanocodex-tools/src/namespace.ts
+++ b/js/nanocodex-tools/src/namespace.ts
@@ -1,6 +1,7 @@
 import { utf8ByteLength } from "../runtime/utf8.mjs";
 
-export const MAX_NAMESPACE_MOUNTS = 64;
+/** @deprecated Namespace size is governed by the selected providers. */
+export const MAX_NAMESPACE_MOUNTS = Infinity;
 export const MAX_NAMESPACE_GRANTS = 128;
 export const MAX_NAMESPACE_PATH_BYTES = 4_096;
 export const MAX_NAMESPACE_PATH_SEGMENTS = 256;
@@ -118,10 +119,10 @@ export function createNamespaceManifest(input: NamespaceManifestInput): Namespac
   if (!isRecord(input) || !Array.isArray(input.mounts)) {
     throw new NamespaceError("invalid_manifest", "namespace manifest must contain a mounts array");
   }
-  if (input.mounts.length === 0 || input.mounts.length > MAX_NAMESPACE_MOUNTS) {
+  if (input.mounts.length === 0) {
     throw new NamespaceError(
       "invalid_manifest",
-      `namespace manifest must contain 1 to ${MAX_NAMESPACE_MOUNTS} mounts`,
+      "namespace manifest must contain at least one mount",
     );
   }
 

--- a/js/nanocodex-tools/src/runtime.ts
+++ b/js/nanocodex-tools/src/runtime.ts
@@ -4,7 +4,6 @@ import type { NamedTool, Workspace } from "../tools/types.mjs";
 
 import { createGhCommand, createGitCommand, type ShellFetch } from "./shell.js";
 
-const DEFAULT_MAX_ENTRIES = 20_000;
 const DEFAULT_MAX_OUTPUT_TOKENS = 10_000;
 
 export type ComputerCommandContext = Readonly<{
@@ -50,7 +49,7 @@ export async function createComputerRuntime(
   const shell = await justBash({
     filesystem: options.filesystem,
     refreshFilesystemBeforeExec: options.refreshFilesystemBeforeExec,
-    maxEntries: options.maxEntries ?? DEFAULT_MAX_ENTRIES,
+    maxEntries: options.maxEntries,
     maxOutputTokens: options.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS,
     fetch: options.fetch,
     networkMode: options.networkMode,

--- a/js/nanocodex-tools/src/shell.ts
+++ b/js/nanocodex-tools/src/shell.ts
@@ -16,10 +16,15 @@ export type ShellFetchResult = Readonly<{
   url: string;
 }>;
 
-export type ShellFetch = (
+export type ShellFetch = ((
   url: string,
   options?: ShellFetchOptions,
-) => Promise<ShellFetchResult>;
+) => Promise<ShellFetchResult>) & Readonly<{
+  /** Optional streaming transport for Git packfiles, without a buffered shell response. */
+  stream?: (url: string, options?: ShellFetchOptions) => Promise<
+    Omit<ShellFetchResult, "body"> & { body: AsyncIterable<Uint8Array> }
+  >;
+}>;
 
 type CommandContext = Readonly<{ cwd?: unknown; signal?: AbortSignal }>;
 type CommandResult = Readonly<{
@@ -34,8 +39,6 @@ type GitClone = (
 
 const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const GITHUB_REPOSITORY = /^https:\/\/github\.com\/([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+?)(?:\.git)?\/?$/;
-const MAX_GIT_HTTP_BODY_BYTES = 16 * 1024 * 1024;
-const MAX_GIT_ENTRIES = 20_000;
 
 /** gh compatibility command backed by the connected GitHub account. */
 export function createGhCommand(
@@ -176,7 +179,7 @@ function ghRepoCloneArguments(args: string[]): string[] {
   ];
 }
 
-/** Git compatibility command backed by durable workspace storage and public Git smart HTTP. */
+/** Git compatibility command backed by durable storage and host-authorized Git smart HTTP. */
 export function createGitCommand(
   fetch: ShellFetch,
   workspace: () => Workspace,
@@ -274,7 +277,6 @@ function logDepth(args: string[]): number {
   const value = explicit ?? compact?.slice(1);
   if (value === undefined) return 20;
   const depth = positiveInteger(value, "log depth");
-  if (depth > 200) throw new Error("log depth cannot exceed 200");
   return depth;
 }
 
@@ -335,7 +337,7 @@ function managedGitHttp(fetch: ShellFetch, signal?: AbortSignal): HttpClient {
       const body = request.body === undefined
         ? undefined
         : await collectGitBody(request.body);
-      const response = await fetch(request.url, {
+      const response = await (fetch.stream ?? fetch)(request.url, {
         method: request.method,
         headers: request.headers,
         body,
@@ -346,7 +348,10 @@ function managedGitHttp(fetch: ShellFetch, signal?: AbortSignal): HttpClient {
         statusCode: response.status,
         statusMessage: response.statusText,
         headers: response.headers,
-        body: (async function* () { yield response.body; })(),
+        body: (async function* () {
+          if (response.body instanceof Uint8Array) yield response.body;
+          else yield* response.body;
+        })(),
       };
     },
   };
@@ -357,7 +362,6 @@ async function collectGitBody(body: AsyncIterable<Uint8Array>): Promise<Uint8Arr
   let size = 0;
   for await (const chunk of body) {
     size += chunk.byteLength;
-    if (size > MAX_GIT_HTTP_BODY_BYTES) throw new Error("git HTTP request body is too large");
     chunks.push(chunk);
   }
   const joined = new Uint8Array(size);
@@ -379,7 +383,7 @@ function workspaceFs(workspace: Workspace) {
     },
     writeFile: async (path: string, contents: Uint8Array | string) => workspace.writeFile(resolve(path), contents),
     unlink: async (path: string) => workspace.remove(resolve(path)),
-    readdir: async (path: string) => (await workspace.list(resolve(path), { maxEntries: MAX_GIT_ENTRIES }))
+    readdir: async (path: string) => (await workspace.list(resolve(path)))
       .map(({ path: child }) => child.slice(child.lastIndexOf("/") + 1)),
     mkdir: async (path: string, options?: { recursive?: boolean }) => {
       path = resolve(path);
@@ -436,7 +440,7 @@ async function workspaceEntry(workspace: Workspace, path: string): Promise<Works
   const parent = path.slice(0, separator) || workspace.root;
   const target = path.slice(separator + 1);
   try {
-    return (await workspace.list(parent, { maxEntries: MAX_GIT_ENTRIES }))
+    return (await workspace.list(parent))
       .find((entry) => entry.path === target || entry.path.endsWith(`/${target}`));
   } catch (error) {
     if ((error as { code?: unknown })?.code === "ENOENT") return undefined;

--- a/js/nanocodex-tools/src/workspace.ts
+++ b/js/nanocodex-tools/src/workspace.ts
@@ -1,8 +1,8 @@
 import type { Workspace, WorkspaceEntry } from "../tools/types.mjs";
 
 const ROOT = "/workspace";
-const DEFAULT_MAX_ENTRIES = 2_000;
-const DEFAULT_MAX_FILE_BYTES = 64 * 1024 * 1024;
+const DEFAULT_MAX_ENTRIES = Infinity;
+const DEFAULT_MAX_FILE_BYTES = Infinity;
 
 type ComputerDirent = Readonly<{
   name: string;
@@ -74,21 +74,23 @@ function createFilesystem(
 
       while (pending.length > 0) {
         const current = pending.shift()!;
-        const remaining = maxEntries - entries.length;
-        const children = await fs.readdir(current, { limit: remaining + 1, offset: 0 });
-        if (children.length > remaining) {
-          throw new RangeError(`workspace listing exceeds ${maxEntries} entries`);
-        }
-        for (const child of children) {
-          const childPath = resolveChild(current, child.name);
-          requireSupportedEntry(child, childPath);
-          entries.push(Object.freeze({
-            kind: child.isDirectory ? "directory" : "file",
-            modifiedAt: child.mtime,
-            path: childPath,
-            ...(child.isFile ? { size: child.size } : {}),
-          }));
-          if (recursive && child.isDirectory) pending.push(childPath);
+        let offset = 0;
+        for (;;) {
+          const children = await fs.readdir(current, { limit: 1_000, offset });
+          if (!children.length) break;
+          for (const child of children) {
+            const childPath = resolveChild(current, child.name);
+            requireSupportedEntry(child, childPath);
+            entries.push(Object.freeze({
+              kind: child.isDirectory ? "directory" : "file",
+              modifiedAt: child.mtime,
+              path: childPath,
+              ...(child.isFile ? { size: child.size } : {}),
+            }));
+            if (entries.length > maxEntries) throw new RangeError(`workspace listing exceeds ${maxEntries} entries`);
+            if (recursive && child.isDirectory) pending.push(childPath);
+          }
+          offset += children.length;
         }
         if (!recursive) break;
       }

--- a/js/nanocodex-tools/test/namespace.test.mjs
+++ b/js/nanocodex-tools/test/namespace.test.mjs
@@ -6,7 +6,6 @@ import {
   createNamespaceScope,
   deriveChildNamespaceScope,
   isNamespacePathWithin,
-  MAX_NAMESPACE_MOUNTS,
   namespaceMountRoot,
   normalizeNamespacePath,
   resolveNamespaceCwd,
@@ -98,9 +97,8 @@ test("manifest admission rejects root ambiguity, aliases, reserved roots, and bo
     assert.throws(() => make([mount(root)]), /root|path/);
   assert.throws(() => make([mount("/one"), mount("/one", "mount:two")]), /duplicate mount root/);
   assert.throws(() => make([mount("/one", "same"), mount("/two", "same")]), /duplicate mount identity/);
-  assert.throws(
-    () => make(Array.from({ length: MAX_NAMESPACE_MOUNTS + 1 }, (_, index) => mount(`/m${index}`))),
-    /1 to 64 mounts/,
+  assert.doesNotThrow(
+    () => make(Array.from({ length: 100 }, (_, index) => mount(`/m${index}`))),
   );
 });
 

--- a/js/nanocodex-tools/tools/bash.mjs
+++ b/js/nanocodex-tools/tools/bash.mjs
@@ -4,13 +4,59 @@ import {
   EXECUTION_OUTPUT_SCHEMA,
 } from "./execution-contract.mjs";
 
-const DEFAULT_EXECUTION_TIMEOUT_MS = 30_000;
-const DEFAULT_MAX_ENTRIES = 2_000;
 const DEFAULT_MAX_OUTPUT_TOKENS = 10_000;
 const MAX_OUTPUT_TOKENS = 100_000;
 const OUTPUT_TRUNCATION_NOTICE = "\n[output truncated by exec_command]";
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
+
+// The host owns resources and cancellation. Interpreter ceilings must not
+// turn otherwise valid commands, repositories, or data files into errors.
+const UNLIMITED_EXECUTION_LIMITS = Object.freeze({
+  maxSourceBytes: Infinity,
+  maxExecDepth: Infinity,
+  maxCallDepth: Infinity,
+  maxCommandCount: Infinity,
+  maxLoopIterations: Infinity,
+  maxAwkIterations: Infinity,
+  maxSedIterations: Infinity,
+  maxJqIterations: Infinity,
+  maxQueryTokens: Infinity,
+  maxQueryDepth: Infinity,
+  maxQueryElements: Infinity,
+  maxAwkParserTokens: Infinity,
+  maxAwkParserDepth: Infinity,
+  maxAwkParserOperations: Infinity,
+  maxCsvRows: Infinity,
+  maxCsvCells: Infinity,
+  maxWorkUnits: Infinity,
+  maxTraversalEntries: Infinity,
+  maxTraversalDepth: Infinity,
+  maxTraversalWork: Infinity,
+  maxLiveBytes: Infinity,
+  maxInputBytes: Infinity,
+  maxFileSystemBytes: Infinity,
+  maxDatabaseBytes: Infinity,
+  maxDatabaseResultBytes: Infinity,
+  maxArchiveBytes: Infinity,
+  maxArchiveCompressedBytes: Infinity,
+  maxArchiveEntryBytes: Infinity,
+  maxArchiveEntries: Infinity,
+  maxWorkerMessageBytes: Infinity,
+  maxExecutionTimeMs: Infinity,
+  maxSqliteTimeoutMs: Infinity,
+  maxPythonTimeoutMs: Infinity,
+  maxJsTimeoutMs: Infinity,
+  maxGlobOperations: Infinity,
+  maxStringLength: Infinity,
+  maxArrayElements: Infinity,
+  maxHeredocSize: Infinity,
+  maxSubstitutionDepth: Infinity,
+  maxBraceExpansionResults: Infinity,
+  maxOutputSize: Infinity,
+  maxFileDescriptors: Infinity,
+  maxSourceDepth: Infinity,
+});
 
 const DEVICES = new Set(["/dev/full", "/dev/null", "/dev/stderr", "/dev/stdout"]);
 
@@ -21,10 +67,11 @@ export async function justBash(options) {
   validateWorkspace(options.filesystem);
   const executionTimeoutMs = positiveInteger(
     options.executionTimeoutMs,
-    DEFAULT_EXECUTION_TIMEOUT_MS,
+    undefined,
     "executionTimeoutMs",
   );
-  const maxEntries = positiveInteger(options.maxEntries, DEFAULT_MAX_ENTRIES, "maxEntries");
+  const maxEntries = options.maxEntries === undefined
+    ? undefined : positiveInteger(options.maxEntries, undefined, "maxEntries");
   const maxOutputTokens = Math.min(
     MAX_OUTPUT_TOKENS,
     positiveInteger(options.maxOutputTokens, DEFAULT_MAX_OUTPUT_TOKENS, "maxOutputTokens"),
@@ -60,15 +107,8 @@ export async function justBash(options) {
     defaultMaxOutputTokens: maxOutputTokens,
     maxOutputTokens,
     executionLimits: {
-      maxCommandCount: 10_000,
-      maxExecutionTimeMs: executionTimeoutMs,
-      maxFileSystemBytes: 64 * 1024 * 1024,
-      maxInputBytes: 16 * 1024 * 1024,
-      maxLiveBytes: 32 * 1024 * 1024,
-      maxOutputSize: maxOutputTokens * 4,
-      maxSourceBytes: 1024 * 1024,
-      maxStringLength: 16 * 1024 * 1024,
-      maxTraversalEntries: maxEntries,
+      ...(executionTimeoutMs === undefined ? {} : { maxExecutionTimeMs: executionTimeoutMs }),
+      ...(maxEntries === undefined ? {} : { maxTraversalEntries: maxEntries }),
     },
   });
 
@@ -89,7 +129,7 @@ export async function createJustBashRuntime(options) {
   const cwd = normalizeRoot(requiredString(options.cwd, "cwd"));
   const executionTimeoutMs = positiveInteger(
     options.executionTimeoutMs,
-    DEFAULT_EXECUTION_TIMEOUT_MS,
+    undefined,
     "executionTimeoutMs",
   );
   const defaultMaxOutputTokens = positiveInteger(
@@ -105,7 +145,7 @@ export async function createJustBashRuntime(options) {
   if (defaultMaxOutputTokens > maxOutputTokens) {
     throw new RangeError("defaultMaxOutputTokens cannot exceed maxOutputTokens");
   }
-  const executionLimits = Object.freeze({ ...options.executionLimits });
+  const executionLimits = Object.freeze({ ...UNLIMITED_EXECUTION_LIMITS, ...options.executionLimits });
   const { Bash, defineCommand } = await import("just-bash/browser");
   const customCommands = typeof options.customCommands === "function"
     ? await options.customCommands({ defineCommand })
@@ -120,7 +160,7 @@ export async function createJustBashRuntime(options) {
         ? {}
         : { network: options.network }),
     ...(customCommands === undefined ? {} : { customCommands: [...customCommands] }),
-    executionLimitProfile: "hardened",
+    executionLimitProfile: "normal",
     executionLimits,
   });
   const descriptor = describeRuntime({
@@ -201,7 +241,7 @@ async function executeCommand({
   const abort = () => deadline.abort(signal?.reason);
   signal?.addEventListener("abort", abort, { once: true });
   if (signal?.aborted) abort();
-  const timeout = setTimeout(
+  const timeout = executionTimeoutMs === undefined ? undefined : setTimeout(
     () => deadline.abort(new Error(`exec_command exceeded ${executionTimeoutMs} milliseconds`)),
     executionTimeoutMs,
   );
@@ -248,7 +288,7 @@ function describeRuntime({
     commands: Object.freeze([...bash.commands.keys()].sort()),
     customCommands: Object.freeze(customCommandNames.sort()),
     cwd,
-    limits: executionLimits,
+    limits: Object.freeze(Object.fromEntries(Object.entries(executionLimits).filter(([, value]) => Number.isFinite(value)))),
     network: Object.freeze({
       enabled: networkEnabled,
       mode: networkMode ?? (networkEnabled ? "http" : "disabled"),
@@ -289,7 +329,7 @@ class WorkspaceShellFileSystem {
   }
 
   async open() {
-    const entries = await this.#source.list(".", { recursive: true, maxEntries: this.#maxEntries });
+    const entries = await this.#source.list(".", { recursive: true, ...(this.#maxEntries === undefined ? {} : { maxEntries: this.#maxEntries }) });
     this.#entries.clear();
     this.#sortedPaths = undefined;
     this.#entries.set(this.#root, directoryEntry());
@@ -519,7 +559,7 @@ class WorkspaceShellFileSystem {
   }
 
   #set(path, entry) {
-    if (!this.#entries.has(path) && this.#entries.size - 1 >= this.#maxEntries) {
+    if (this.#maxEntries !== undefined && !this.#entries.has(path) && this.#entries.size - 1 >= this.#maxEntries) {
       throw fsError("EFBIG", `workspace exceeds ${this.#maxEntries} entries`);
     }
     this.#entries.set(path, entry);
@@ -527,6 +567,7 @@ class WorkspaceShellFileSystem {
   }
 
   #assertCapacity(path) {
+    if (this.#maxEntries === undefined) return;
     let additions = this.#entries.has(path) ? 0 : 1;
     const relative = path.slice(this.#root.length + 1);
     let current = this.#root;

--- a/js/nanocodex-tools/tools/repository-workspace.mjs
+++ b/js/nanocodex-tools/tools/repository-workspace.mjs
@@ -3,7 +3,6 @@ import git from "isomorphic-git";
 const DEFAULT_DIRECTORY = "repository";
 const MARKER_NAME = "nanocodex-repository.json";
 const MARKER_VERSION = 1;
-const MAX_HTTP_REQUEST_BYTES = 16 * 1024 * 1024;
 const MAX_MARKER_BYTES = 16 * 1024;
 const SHA1 = /^[a-f0-9]{40}$/;
 
@@ -213,7 +212,6 @@ async function collectBody(body) {
   for await (const chunk of body) {
     if (!(chunk instanceof Uint8Array)) throw new TypeError("git HTTP body must contain bytes");
     size += chunk.byteLength;
-    if (size > MAX_HTTP_REQUEST_BYTES) throw new RangeError("git HTTP request exceeds its byte bound");
     chunks.push(chunk);
   }
   const joined = new Uint8Array(size);

--- a/js/nanocodex/test/bash.test.mjs
+++ b/js/nanocodex/test/bash.test.mjs
@@ -17,8 +17,7 @@ test("Just Bash advertises its cloud workspace execution", async () => {
   assert.equal(descriptor.pty, false);
   assert.equal(descriptor.sessions, false);
   assert.equal(descriptor.sandboxEscalation, false);
-  assert.equal(descriptor.limits.maxFileSystemBytes, 64 * 1024 * 1024);
-  assert.equal(descriptor.limits.maxTraversalEntries, 2_000);
+  assert.deepEqual(descriptor.limits, {});
   assert(descriptor.commands.includes("grep"));
   assert(!descriptor.commands.includes("curl"));
   assert(!descriptor.commands.includes("wget"));
@@ -196,7 +195,7 @@ test("initial metadata, mutations, and returned output stay within configured bo
   });
   assert.deepEqual(defaultScan, {
     path: ".",
-    options: { recursive: true, maxEntries: 2_000 },
+    options: { recursive: true },
   });
 
   let initialScan;

--- a/js/nanocodex/test/browser-gh.test.mjs
+++ b/js/nanocodex/test/browser-gh.test.mjs
@@ -230,3 +230,33 @@ function secureJson(url, value) {
     url,
   };
 }
+
+
+test("browser runtime preserves binary Git uploads and returns the broker response stream", async () => {
+  const bytes = new Uint8Array([0, 255, 128, 254, 10]);
+  let envelope;
+  let cancelled = false;
+  const upstream = new Response(new ReadableStream({
+    start(controller) { controller.enqueue(bytes); },
+    cancel() { cancelled = true; },
+  }));
+  const fetch = createBrowserRuntimeFetch({
+    origin: "https://connect.example",
+    threadId: THREAD_ID,
+    async fetch(_input, init) {
+      envelope = JSON.parse(init.body);
+      return upstream;
+    },
+  });
+  const response = await fetch("https://github.com/fixture/large.git/git-upload-pack", {
+    method: "POST", body: bytes,
+    headers: { "content-type": "application/x-git-upload-pack-request" },
+  });
+  assert.equal(response, upstream);
+  assert.deepEqual(new Uint8Array(Buffer.from(envelope.body_base64, "base64")), bytes);
+  assert.equal(envelope.body, undefined);
+  const reader = response.body.getReader();
+  assert.deepEqual((await reader.read()).value, bytes);
+  await reader.cancel();
+  assert.equal(cancelled, true);
+});

--- a/js/nanocodex/tools/browser/browserEgress.mjs
+++ b/js/nanocodex/tools/browser/browserEgress.mjs
@@ -5,7 +5,7 @@ const VAULT_PLACEHOLDER = /\{\{NANOCODEX_VAULT_(?:USERNAME|PASSWORD|API_KEY|BASI
 const PRIVATE_HEADER = /(?:^|[-_])(?:auth(?:orization)?|cookie|credential|password|proxy|secret|token|api[-_]?key)(?:$|[-_])/i;
 const FORBIDDEN_HEADERS = new Set([
   "connection", "host", "origin", "proxy-connection", "referer", "te", "trailer",
-  "transfer-encoding", "upgrade", "x-nanocodex-subject",
+  "transfer-encoding", "upgrade", "x-nanocodex-subject", "x-nanocodex-target-url",
 ]);
 let installed;
 
@@ -56,7 +56,7 @@ export function createBrowserEgressFetch(options) {
     throw new TypeError("browser egress requires a valid thread id");
   }
   const endpoint = new URL("/v1/egress", options.origin);
-  return async (target, request = {}) => {
+  const responseFetch = async (target, request = {}) => {
     const url = new URL(target);
     if (!["http:", "https:"].includes(url.protocol) || url.username || url.password) {
       throw new Error("browser egress supports only credential-free http:// and https:// URLs");
@@ -77,8 +77,9 @@ export function createBrowserEgressFetch(options) {
         throw new Error(`browser egress does not accept credential or routing header '${name}'`);
       }
     }
+    const templateBody = request.body instanceof Uint8Array ? new TextDecoder().decode(request.body) : request.body;
     if (vaultId !== null && ![...headers.values()].some((value) => VAULT_PLACEHOLDER.test(value))
-      && (typeof request.body !== "string" || !VAULT_PLACEHOLDER.test(request.body))) {
+      && (typeof templateBody !== "string" || !VAULT_PLACEHOLDER.test(templateBody))) {
       throw new Error("browser egress Vault requests require a supported placeholder");
     }
     try {
@@ -92,24 +93,39 @@ export function createBrowserEgressFetch(options) {
           url: url.href,
           method: request.method ?? "GET",
           headers: Object.fromEntries(headers.entries()),
-          ...(request.body === undefined ? {} : { body: request.body }),
+          ...encodeRequestBody(vaultId === null ? request.body : templateBody),
         }),
         credentials: "same-origin",
         redirect: "manual",
         signal: request.signal,
       });
-      return {
-        status: response.status,
-        statusText: response.statusText,
-        headers: Object.fromEntries(response.headers.entries()),
-        body: new Uint8Array(await response.arrayBuffer()),
-        url: url.href,
-      };
+      return response;
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
       throw new Error(`browser egress failed (${detail})`);
     }
   };
+  return Object.assign(async (target, request = {}) => {
+    const response = await responseFetch(target, request);
+    return {
+      status: response.status,
+      statusText: response.statusText,
+      headers: Object.fromEntries(response.headers.entries()),
+      body: new Uint8Array(await response.arrayBuffer()),
+      url: new URL(target).href,
+    };
+  }, { response: responseFetch });
+}
+
+function encodeRequestBody(body) {
+  if (body === undefined) return {};
+  if (typeof body === "string") return { body };
+  if (!(body instanceof Uint8Array)) throw new TypeError("browser egress body must be text or bytes");
+  let encoded = "";
+  for (let offset = 0; offset < body.length; offset += 32_768) {
+    encoded += String.fromCharCode(...body.subarray(offset, offset + 32_768));
+  }
+  return { body_base64: btoa(encoded) };
 }
 
 function safeVaultHeaderValue(name, value) {
@@ -127,12 +143,15 @@ export function standardFetchFromEgress(secureFetch) {
   return async (input, init = {}) => {
     const request = new Request(input, init);
     const method = request.method.toUpperCase();
-    const result = await secureFetch(request.url, {
+    const send = secureFetch.response ?? secureFetch;
+    const textBody = /^(?:text\/|application\/(?:[a-z.+-]*json|x-www-form-urlencoded)(?:;|$))/.test(request.headers.get("content-type") ?? "");
+    const result = await send(request.url, {
       method,
       headers: request.headers,
-      ...(method === "GET" || method === "HEAD" ? {} : { body: await request.text() }),
+      ...(method === "GET" || method === "HEAD" ? {} : { body: textBody ? await request.text() : new Uint8Array(await request.arrayBuffer()) }),
       signal: request.signal,
     });
+    if (result instanceof Response) return result;
     return new Response(result.body, {
       status: result.status,
       statusText: result.statusText,

--- a/js/nanocodex/tools/browser/browserShell.mjs
+++ b/js/nanocodex/tools/browser/browserShell.mjs
@@ -10,10 +10,7 @@ const utf8 = new TextEncoder();
 const utf8Decoder = new TextDecoder();
 const diffDecoder = new TextDecoder("utf-8", { fatal: true });
 const MAX_OUTPUT_BYTES = 4 * 1024 * 1024;
-const MAX_EXECUTION_MS = 30_000;
-const MAX_GIT_LOG_DEPTH = 200;
 const MAX_DIFF_FILE_BYTES = 1024 * 1024;
-const MAX_INDEXED_PATHS = 100_000;
 const MAX_PROJECT_INSTRUCTIONS_BYTES = 32 * 1024;
 const PROJECT_INSTRUCTION_FILES = ["AGENTS.override.md", "AGENTS.md"];
 const DIFF_TRUNCATION_NOTICE = "\n[diff truncated by browser git]\n";
@@ -130,7 +127,7 @@ export async function createBrowserBash(rawFs, thread, options = {}) {
     const { createTwoFilesPatch } = await import("diff");
     const filesystem = new OpfsShellFileSystem(rawFs);
     await filesystem.refreshPaths();
-    const executionTimeoutMs = options.executionTimeoutMs ?? MAX_EXECUTION_MS;
+    const executionTimeoutMs = options.executionTimeoutMs;
     const origin = options.origin ?? globalThis.location?.origin;
     const workerEgress = {
         origin,
@@ -194,17 +191,7 @@ export async function createBrowserBash(rawFs, thread, options = {}) {
         executionTimeoutMs,
         defaultMaxOutputTokens: 10_000,
         maxOutputTokens: 100_000,
-        executionLimits: {
-            maxCommandCount: 10_000,
-            maxExecutionTimeMs: executionTimeoutMs,
-            maxFileSystemBytes: 256 * 1024 * 1024,
-            maxInputBytes: 16 * 1024 * 1024,
-            maxLiveBytes: 64 * 1024 * 1024,
-            maxOutputSize: MAX_OUTPUT_BYTES,
-            maxSourceBytes: 1024 * 1024,
-            maxStringLength: 16 * 1024 * 1024,
-            maxTraversalEntries: 100_000,
-        },
+        executionLimits: executionTimeoutMs === undefined ? {} : { maxExecutionTimeMs: executionTimeoutMs },
         supportsParallelToolCalls: true,
         instructions: browserInstructions,
         outputTruncationNotice: "\n[output truncated by browser exec_command]",
@@ -623,8 +610,8 @@ async function gitPull(fs, thread, args) {
 async function gitLog(fs, args) {
     const countArgument = args.find((arg) => /^-\d+$/.test(arg));
     const depth = countArgument ? Number(countArgument.slice(1)) : 20;
-    if (!Number.isSafeInteger(depth) || depth > MAX_GIT_LOG_DEPTH) {
-        throw new Error(`browser git log depth cannot exceed ${MAX_GIT_LOG_DEPTH}`);
+    if (!Number.isSafeInteger(depth) || depth < 1) {
+        throw new Error("browser git log depth must be a positive integer");
     }
     const commits = await git.log({ fs, dir: THREAD_GIT_DIRECTORY, depth }).catch(() => []);
     if (args.includes("--oneline")) {
@@ -990,9 +977,6 @@ class OpfsShellFileSystem {
     #addIndexedPath(paths, path) {
         if (paths.has(path))
             return false;
-        if (paths.size >= MAX_INDEXED_PATHS) {
-            throw fsError("EFBIG", `browser shell path index exceeds ${MAX_INDEXED_PATHS} entries`);
-        }
         paths.add(path);
         return true;
     }

--- a/js/test-fixtures/git-provider.d.mts
+++ b/js/test-fixtures/git-provider.d.mts
@@ -1,0 +1,6 @@
+export function gitProvider(request: {
+  url: string;
+  method: string;
+  headers: { get(name: string): string | null };
+  arrayBuffer(): Promise<ArrayBuffer>;
+}): Promise<Response | undefined>;

--- a/js/test-fixtures/git-provider.mjs
+++ b/js/test-fixtures/git-provider.mjs
@@ -1,0 +1,49 @@
+import { execFileSync } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let fixture;
+function repository() {
+  if (fixture) return fixture;
+  const directory = mkdtempSync(join(tmpdir(), "nanocodex-git-egress-"));
+  const git = (args, input) => execFileSync("git", ["-C", directory, ...args], {
+    input, maxBuffer: Infinity, stdio: ["pipe", "pipe", "pipe"],
+  });
+  git(["init", "--bare", "--initial-branch=master"]);
+  const bytes = randomBytes(17 * 1024 * 1024 + 123);
+  const blob = git(["hash-object", "-w", "--stdin"], bytes).toString().trim();
+  const tree = git(["mktree"], `100644 blob ${blob}\tlarge.bin\n`).toString().trim();
+  const head = git(["-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid",
+    "commit-tree", tree, "-m", "Large binary repository"]).toString().trim();
+  git(["update-ref", "refs/heads/master", head]);
+  process.once("exit", () => rmSync(directory, { recursive: true, force: true }));
+  fixture = { git, head, size: bytes.length, sha256: createHash("sha256").update(bytes).digest("hex") };
+  return fixture;
+}
+
+/** Native Git smart HTTP fixture: real pack negotiation and incompressible data. */
+export async function gitProvider(request) {
+  const url = new URL(request.url);
+  if (url.href === "https://api.github.com/repos/fixture/large") {
+    const { head, size, sha256 } = repository();
+    return Response.json({ head, size, sha256 });
+  }
+  if (url.hostname !== "github.com" || !url.pathname.startsWith("/fixture/large.git/")) return undefined;
+  if (request.headers.get("authorization") !== `Basic ${btoa("x-access-token:github-connector-access")}`) {
+    return new Response("Authentication required", { status: 401 });
+  }
+  const { git } = repository();
+  if (url.pathname.endsWith("/info/refs") && request.method === "GET") {
+    const refs = git(["upload-pack", "--stateless-rpc", "--advertise-refs", "."]);
+    return new Response(Buffer.concat([Buffer.from("001e# service=git-upload-pack\n0000"), refs]), {
+      headers: { "content-type": "application/x-git-upload-pack-advertisement" },
+    });
+  }
+  if (url.pathname.endsWith("/git-upload-pack") && request.method === "POST") {
+    const pack = git(["upload-pack", "--stateless-rpc", "."], Buffer.from(await request.arrayBuffer()));
+    return new Response(pack, { headers: { "content-type": "application/x-git-upload-pack-result" } });
+  }
+  return new Response(null, { status: 405 });
+}


### PR DESCRIPTION
Managed execution could reject a normal repository at the brain's 16 MiB HTTP ceiling, then fail GitHub authentication when the agent moved to a native sandbox. Connect's browser gateway also bypassed the broker for public traffic and imposed its own smaller transfer ceilings.

This PR makes the supported workload HTTP paths use the account broker and removes implicit workload quotas:

- Route brain, managed browser, Connect browser, and Cloudflare Sandbox public HTTP through the broker service binding. Bind a sandbox's outbound handler to its durable account subject before provisioning or process execution, retaining that binding across reloads.
- Apply GitHub connector identity selection to both API calls and Git smart HTTP. Inject the real Git Basic credential only at the provider boundary; native gh receives a public marker. Keep exact Connect grants, revocation, cross-account fencing, and destination checks.
- Stream Git and connector responses with cancellation and credential-reflection filtering across chunk boundaries. Preserve binary browser uploads and stream gateway responses.
- Remove the brain 16 MiB response cap, connector 8 MiB response cap and transfer deadline, Connect gateway request/response caps, implicit shell timeout and interpreter quotas, workspace file/list ceilings, browser path-index and Git-log ceilings, and managed subagent/client/trigger/queue/mount-count quotas. Explicit caller limits and actual provider capacity still apply, including the configured Cloudflare namespace binding slots.

Validation completed:
- Managed workerd suites: 69 tests passed, including a real native-Git fixture with a 17 MiB incompressible file cloned through the brain and verified by SHA-256 after reopening durable storage; 16 simultaneous subagents are admitted.
- Broker workerd suites: 15 focused tests passed, including authenticated Git pack transfer, exact connection revocation, public redirect routing, private-destination rejection, and streamed credential-reflection fencing.
- Connect API: all 74 tests and typecheck passed, including binary uploads above its former request cap, a response above 16 MiB, and exact Git connection selection.
- Browser/shell/repository: 20 focused tests passed; native Git marker handling and the final browser changes were rechecked.
- nanocodex-tools: build passed, 16 tests passed, one platform-specific test skipped. Managed and broker typechecks passed.
- A broader broker run had one sponsored WebSocket timing failure; its full 16-test suite passed on rerun.

Remaining validation:
- Full package smoke requires the generated Node WASM artifact, which is absent here. Worker tests used the exact base commit's published web WASM artifact.
- Docker is unavailable for the managed container build. Automatic approval review blocked Wrangler dry-runs because of possible source/build-context disclosure to Cloudflare, so deployment validation remains pending. No production deployment was performed.
- Live Cloudflare container interception and browser interaction should be exercised before merge; local evidence covers their routing protocol boundaries.
