### PR TITLE
fix(managed): download source archives for host clones

### DIFF
--- a/js/egress/src/connector-broker.ts
+++ b/js/egress/src/connector-broker.ts
@@ -379,6 +379,10 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
   }
 
   async #proxy(provider: ProviderRule, request: Request, url: URL): Promise<Response> {
+    const archiveRepository = provider.id === "github" && request.method === "GET"
+      && url.origin === "https://api.github.com"
+      ? /^\/repos\/([A-Za-z0-9_-]+\/[A-Za-z0-9_.-]+)\/tarball(?:\/[^/]+)?$/.exec(url.pathname)?.[1]
+      : undefined;
     if (!CONNECTOR_METHODS.has(request.method)) {
       throw new ConnectorFailure(403, "method_denied");
     }
@@ -396,7 +400,7 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
     } catch (error) {
       // Public Git remains usable before an account connects GitHub. Never
       // fall back when an exact connection was selected or has expired.
-      if (provider.origin !== "https://github.com" || selectedConnectionId !== null
+      if ((provider.origin !== "https://github.com" && archiveRepository === undefined) || selectedConnectionId !== null
         || !(error instanceof ConnectorFailure) || error.code !== "connector_not_connected") throw error;
     }
     const connector = selected?.connector;
@@ -408,6 +412,7 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
       ? await slackRequestBody(request)
       : request.body;
     let upstream: Response;
+    const archiveCredentials: string[] = [];
     try {
       upstream = await fetch(new Request(url, {
         method: request.method,
@@ -430,8 +435,33 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
       throw new ConnectorFailure(409, "connector_reauthentication_required");
     }
     if (REDIRECT_STATUS.has(upstream.status)) {
+      // GitHub's archive API returns a codeload URL. Resolve that one redirect
+      // inside the broker; neither OAuth credentials nor signed URLs reach tools.
+      const location = upstream.headers.get("location");
       await upstream.body?.cancel();
-      throw new ConnectorFailure(502, "connector_redirect_blocked");
+      let target: URL | undefined;
+      try { if (location) target = new URL(location); } catch { /* Fail closed below. */ }
+      if (!archiveRepository || !target || target.origin !== "https://codeload.github.com"
+        || target.username || target.password || target.hash || target.href.length > MAX_CONNECTOR_URL_BYTES
+        || !target.pathname.startsWith(`/${archiveRepository}/legacy.tar.gz/`)) {
+        throw new ConnectorFailure(502, "connector_redirect_blocked");
+      }
+      for (const name of ["token", "access_token"]) {
+        const value = target.searchParams.get(name);
+        if (value) archiveCredentials.push(value);
+      }
+      try {
+        upstream = await fetch(target, {
+          method: "GET", redirect: "manual", signal: request.signal,
+          headers: { "user-agent": "nanocodex-connector-broker", accept: "application/gzip" },
+        });
+      } catch {
+        throw new ConnectorFailure(503, "connector_provider_unavailable");
+      }
+      if (REDIRECT_STATUS.has(upstream.status)) {
+        await upstream.body?.cancel();
+        throw new ConnectorFailure(502, "connector_redirect_blocked");
+      }
     }
     let body: ReadableStream<Uint8Array> | null;
     if (request.method === "HEAD" || !responseBodyPermitted(upstream.status)) {
@@ -440,9 +470,9 @@ export class UserConnectorBroker extends DurableObject<ConnectorBrokerEnv> {
     } else {
       body = upstream.body;
     }
-    const credentials = connector ? [connector.accessToken, connector.refreshToken,
+    const credentials = [...archiveCredentials, ...(connector ? [connector.accessToken, connector.refreshToken,
       headers.get("authorization")?.split(" ", 2)[1]]
-      .filter((value): value is string => Boolean(value)) : [];
+      .filter((value): value is string => Boolean(value)) : [])];
     const responseHeaders = connectorResponseHeaders(upstream.headers);
     for (const value of responseHeaders.values()) {
       if (credentials.some((credential) => value.includes(credential))) {

--- a/js/egress/test/connector-connections.test.ts
+++ b/js/egress/test/connector-connections.test.ts
@@ -22,6 +22,34 @@ const workerEnv = env as unknown as EgressEnv;
 const redirectUri = "https://nanocodex.test/v1/connectors/callback";
 
 describe("provider-neutral connector identities", () => {
+  it("keeps source archive redirects inside the broker and fences credentials and destinations", async () => {
+    const user = "source-archive-egress";
+    const subject = "A".repeat(43);
+    await bindSubject(subject, user);
+    const headers: Record<string, string> = {
+      authorization: "Bearer NANOCODEX_PROVIDER_CREDENTIAL",
+      "x-nanocodex-subject": subject,
+    };
+    const archive = "https://api.github.com/repos/fixture/large/tarball/";
+    for (const connected of [false, true]) {
+      if (connected) headers["x-nanocodex-connector-connection"] = await connect(user, "github", "github-code");
+      const response = await SELF.fetch(`${archive}HEAD`, { headers });
+      expect(response.status).toBe(200);
+      expect(response.headers.has("location")).toBe(false);
+      expect((await response.arrayBuffer()).byteLength).toBeGreaterThan(16 * 1024 * 1024);
+    }
+    for (const ref of ["foreign", "external", "redirect"]) {
+      const response = await SELF.fetch(`${archive}${ref}`, { headers });
+      expect(response.status).toBe(502);
+      expect(await response.json()).toEqual({ error: "connector_redirect_blocked" });
+    }
+    const reflected = await SELF.fetch(`${archive}reflect`, { headers });
+    await expect(reflected.text()).rejects.toThrow();
+    const connection = headers["x-nanocodex-connector-connection"]!;
+    await SELF.fetch(`https://broker.test/users/${user}/connectors/github/connections/${connection}`, { method: "DELETE" });
+    expect((await SELF.fetch(`${archive}HEAD`, { headers })).status).toBe(404);
+  }, 60_000);
+
   it("streams authenticated Git packs beyond 16 MiB and fences a disconnected connection", async () => {
     const user = "large-git-egress";
     const subject = "L".repeat(43);

--- a/js/managed/src/brain-workspace.ts
+++ b/js/managed/src/brain-workspace.ts
@@ -8,6 +8,11 @@ export function createBrainWorkspace(bucket: R2Bucket, resourceId: string): Work
     throw new TypeError("brain workspace has an invalid resource id");
   }
   const prefix = `brains/${resourceId}/`;
+  // Just Bash refreshes the complete namespace before each command. Reuse that
+  // snapshot for metadata probes during the command; Git otherwise turns every
+  // stat/mkdir into repeated R2 HEAD/LIST calls. File contents stay in R2.
+  let snapshot: Map<string, WorkspaceEntry> | undefined;
+  let markers = new Set<string>();
   const resolve = (path: string): string => {
     const absolute = resolveNamespaceCwd(ROOT, path);
     if (absolute !== ROOT && !absolute.startsWith(`${ROOT}/`)) {
@@ -18,6 +23,7 @@ export function createBrainWorkspace(bucket: R2Bucket, resourceId: string): Work
   const key = (path: string): string => `${prefix}${path.slice(ROOT.length + 1)}`;
   const stat = async (path: string): Promise<"file" | "directory" | undefined> => {
     if (path === ROOT) return "directory";
+    if (snapshot) return snapshot.get(path)?.kind;
     if (await bucket.head(key(path))) return "file";
     const page = await bucket.list({ prefix: `${key(path)}/`, limit: 1 });
     return page.objects.length ? "directory" : undefined;
@@ -26,7 +32,9 @@ export function createBrainWorkspace(bucket: R2Bucket, resourceId: string): Work
     let current = ROOT;
     for (const segment of path.slice(ROOT.length + 1).split("/").slice(0, -1)) {
       current += `/${segment}`;
-      if (await bucket.head(key(current))) throw error("ENOTDIR", `${current} is not a directory`);
+      if (snapshot ? snapshot.get(current)?.kind === "file" : await bucket.head(key(current))) {
+        throw error("ENOTDIR", `${current} is not a directory`);
+      }
     }
   };
   const mkdir = async (path: string): Promise<void> => {
@@ -39,19 +47,36 @@ export function createBrainWorkspace(bucket: R2Bucket, resourceId: string): Work
     let current = ROOT;
     for (const segment of absolute.slice(ROOT.length + 1).split("/")) {
       current += `/${segment}`;
-      if (!await bucket.head(`${key(current)}/`)) await bucket.put(`${key(current)}/`, new Uint8Array(), {
-        httpMetadata: { contentType: "application/x-directory" },
-      });
+      if (snapshot ? !markers.has(current) : !await bucket.head(`${key(current)}/`)) {
+        await bucket.put(`${key(current)}/`, new Uint8Array(), {
+          httpMetadata: { contentType: "application/x-directory" },
+        });
+      }
+      markers.add(current);
+      snapshot?.set(current, { path: current, kind: "directory" });
     }
   };
   const list: Workspace["list"] = async (path = ".", options = {}) => {
     const absolute = resolve(path);
+    const refresh = absolute === ROOT && options.recursive === true;
+    if (refresh) {
+      snapshot = undefined;
+      markers = new Set();
+    }
     await ancestors(absolute);
     const kind = await stat(absolute);
     if (kind !== "directory") throw error(kind === "file" ? "ENOTDIR" : "ENOENT", `${absolute} is not a directory`);
     const maximum = options.maxEntries ?? Infinity;
     if (options.maxEntries !== undefined && (!Number.isSafeInteger(maximum) || maximum < 1)) {
       throw new RangeError("workspace listing limit must be a positive integer");
+    }
+    if (snapshot) {
+      const children = [...snapshot.values()].filter((entry) => {
+        if (!entry.path.startsWith(`${absolute}/`)) return false;
+        return options.recursive || !entry.path.slice(absolute.length + 1).includes("/");
+      });
+      if (children.length > maximum) throw new RangeError(`workspace listing exceeds ${maximum} entries`);
+      return children.sort((a, b) => a.path < b.path ? -1 : a.path > b.path ? 1 : 0);
     }
     const entries = new Map<string, WorkspaceEntry>();
     const directoryPrefix = absolute === ROOT ? prefix : `${key(absolute)}/`;
@@ -82,10 +107,15 @@ export function createBrainWorkspace(bucket: R2Bucket, resourceId: string): Work
         }
         if (entries.size > maximum) throw new RangeError(`workspace listing exceeds ${maximum} entries`);
       };
-      for (const object of page.objects) add(object.key, object.key.endsWith("/") ? "directory" : "file", object);
+      for (const object of page.objects) {
+        const directory = object.key.endsWith("/");
+        if (directory) markers.add(`${ROOT}/${object.key.slice(prefix.length, -1)}`);
+        add(object.key, directory ? "directory" : "file", object);
+      }
       for (const directory of page.delimitedPrefixes) add(directory, "directory");
       cursor = page.truncated ? page.cursor : undefined;
     } while (cursor !== undefined);
+    if (refresh) snapshot = new Map(entries);
     return [...entries.values()].sort((a, b) => a.path < b.path ? -1 : a.path > b.path ? 1 : 0);
   };
   return Object.freeze({
@@ -96,6 +126,11 @@ export function createBrainWorkspace(bucket: R2Bucket, resourceId: string): Work
       const absolute = resolve(path);
       if (absolute === ROOT) throw error("EISDIR", "cannot read the workspace root as a file");
       await ancestors(absolute);
+      if (snapshot) {
+        const kind = snapshot.get(absolute)?.kind;
+        if (kind === "directory") throw error("EISDIR", `${absolute} is a directory`);
+        if (kind === undefined) throw error("ENOENT", `brain workspace file not found: ${absolute}`);
+      }
       const object = await bucket.get(key(absolute));
       if (!object) {
         if (await stat(absolute) === "directory") throw error("EISDIR", `${absolute} is a directory`);
@@ -114,6 +149,7 @@ export function createBrainWorkspace(bucket: R2Bucket, resourceId: string): Work
       await ancestors(absolute);
       await mkdir(absolute.slice(0, absolute.lastIndexOf("/")));
       await bucket.put(key(absolute), bytes);
+      snapshot?.set(absolute, { path: absolute, kind: "file", size: bytes.byteLength, modifiedAt: Date.now() });
     },
     async remove(path, options = {}) {
       const absolute = resolve(path);
@@ -123,6 +159,7 @@ export function createBrainWorkspace(bucket: R2Bucket, resourceId: string): Work
       if (kind === undefined) throw error("ENOENT", `${absolute} does not exist`);
       if (kind === "file") {
         await bucket.delete(key(absolute));
+        snapshot?.delete(absolute);
         return;
       }
       const entries = await list(absolute, { recursive: true });
@@ -130,6 +167,10 @@ export function createBrainWorkspace(bucket: R2Bucket, resourceId: string): Work
       const keys = entries.map((entry) => `${key(entry.path)}${entry.kind === "directory" ? "/" : ""}`);
       keys.push(`${key(absolute)}/`);
       for (let offset = 0; offset < keys.length; offset += 1_000) await bucket.delete(keys.slice(offset, offset + 1_000));
+      for (const entry of [...entries, { path: absolute }]) {
+        snapshot?.delete(entry.path);
+        markers.delete(entry.path);
+      }
     },
   } satisfies Workspace);
 }

--- a/js/managed/src/computer-runtime.ts
+++ b/js/managed/src/computer-runtime.ts
@@ -142,25 +142,45 @@ function createManagedShellFetch(
   }, { stream });
 }
 
-async function* shellResponseChunks(response: Response, signal?: AbortSignal): AsyncIterable<Uint8Array> {
-  if (response.body === null) { signal?.throwIfAborted(); return; }
+function shellResponseChunks(response: Response, signal?: AbortSignal): AsyncIterable<Uint8Array> {
+  if (response.body === null) return (async function* () { signal?.throwIfAborted(); })();
+  // Own cancellation as soon as headers arrive, including before the archive
+  // decoder starts reading. A lazy generator would leave that body open.
   const reader = response.body.getReader();
-  const abort = () => { void reader.cancel(signal?.reason).catch(() => {}); };
-  signal?.addEventListener("abort", abort, { once: true });
-  let complete = false;
-  try {
-    for (;;) {
-      signal?.throwIfAborted();
-      const { done, value } = await reader.read();
-      if (done) { complete = true; break; }
-      yield value;
-    }
-    signal?.throwIfAborted();
-  } finally {
-    if (!complete) {
-      try { await reader.cancel(signal?.reason); } catch { /* Preserve the read failure. */ }
-    }
+  let finished: Promise<void> | undefined;
+  const finish = (complete = false): Promise<void> => finished ??= (async () => {
     signal?.removeEventListener("abort", abort);
-    reader.releaseLock();
-  }
+    try {
+      if (!complete) await reader.cancel(signal?.reason);
+    } finally { reader.releaseLock(); }
+  })();
+  const abort = () => { void finish().catch(() => {}); };
+  signal?.addEventListener("abort", abort, { once: true });
+  if (signal?.aborted) abort();
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          try {
+            signal?.throwIfAborted();
+            if (finished) { await finished; return { done: true, value: undefined } as const; }
+            const next = await reader.read();
+            signal?.throwIfAborted();
+            if (next.done) {
+              await finish(true);
+              return { done: true, value: undefined } as const;
+            }
+            return next;
+          } catch (error) {
+            await finish().catch(() => {});
+            throw error;
+          }
+        },
+        async return() {
+          await finish();
+          return { done: true, value: undefined } as const;
+        },
+      };
+    },
+  };
 }

--- a/js/managed/test/brain-workspace.test.ts
+++ b/js/managed/test/brain-workspace.test.ts
@@ -18,7 +18,7 @@ const computer = () => ({
 });
 
 describe("durable brain without hands", () => {
-  it("clones a real Git pack beyond 16 MiB and retains its exact bytes after reopening", async () => {
+  it.each([false, true])("downloads a real repository beyond 16 MiB and retains exact bytes (git: %s)", async (withGit) => {
     const id = crypto.randomUUID();
     const seen: Request[] = [];
     const egress = { async fetch(request: Request) {
@@ -29,7 +29,7 @@ describe("durable brain without hands", () => {
       const headers = new Headers(request.headers);
       headers.delete("x-nanocodex-subject");
       headers.set("authorization", `Basic ${btoa("x-access-token:github-connector-access")}`);
-      return fetch(new Request(request, { headers }));
+      return fetch(new Request(request, { headers, redirect: "follow" }));
     } } as unknown as Fetcher;
     const runtime = await createManagedComputerRuntime({
       computer: computer(), filesystem: createBrainWorkspace(bucket, id),
@@ -40,16 +40,20 @@ describe("durable brain without hands", () => {
         "https://api.github.com/repos/fixture/large",
       )).body)) as { head: string; size: number; sha256: string };
       expect(metadata.size).toBeGreaterThan(16 * 1024 * 1024);
-      const cloned = await runtime.tool.handler({ cmd: "gh repo clone fixture/large repository" }, context());
+      const cloned = await runtime.tool.handler({ cmd: `gh repo clone fixture/large repository${withGit ? " -- --depth 1" : ""}` }, context());
       expect(cloned).toMatchObject({ exit_code: 0 });
       expect((cloned as { output: string }).output).not.toMatch(/limit|credential|token/);
-      expect(await runtime.tool.handler({ cmd: "git rev-parse HEAD", workdir: "/brain/repository" }, context()))
-        .toMatchObject({ exit_code: 0, output: `${metadata.head}\n` });
+      if (withGit) {
+        expect(await runtime.tool.handler({ cmd: "git rev-parse HEAD", workdir: "/brain/repository" }, context()))
+          .toMatchObject({ exit_code: 0, output: `${metadata.head}\n` });
+      } else {
+        expect(await runtime.tool.handler({ cmd: "test ! -e repository/.git" }, context())).toMatchObject({ exit_code: 0 });
+      }
       const bytes = await createBrainWorkspace(bucket, id).readFile("repository/large.bin");
       expect(bytes.byteLength).toBe(metadata.size);
       const hash = new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
       expect([...hash].map((value) => value.toString(16).padStart(2, "0")).join("")).toBe(metadata.sha256);
-      expect(seen.some((request) => request.url.endsWith("/git-upload-pack"))).toBe(true);
+      expect(seen.some((request) => request.url.endsWith(withGit ? "/git-upload-pack" : "/tarball/HEAD"))).toBe(true);
     } finally { runtime.dispose(); }
   }, 60_000);
 
@@ -63,12 +67,14 @@ describe("durable brain without hands", () => {
     expect(await workspace.list()).toEqual([]);
   });
 
-  it("cancels a stalled HTTP body when its tool call is aborted", async () => {
+  it.each(["gh api user", "gh repo clone fixture/large repository"])("cancels a stalled HTTP body when %s is aborted", async (cmd) => {
     let started!: () => void;
     const requestStarted = new Promise<void>((resolve) => { started = resolve; });
     const cancel = vi.fn();
+    const filesystem = createBrainWorkspace(bucket, crypto.randomUUID());
+    await filesystem.writeFile("retained", "keep this");
     const runtime = await createManagedComputerRuntime({
-      computer: computer(), filesystem: createBrainWorkspace(bucket, crypto.randomUUID()),
+      computer: computer(), filesystem,
       subject: "s".repeat(43), connectorAllowed: () => true,
       egress: { async fetch() {
         started();
@@ -77,11 +83,13 @@ describe("durable brain without hands", () => {
     });
     try {
       const controller = new AbortController();
-      const pending = runtime.tool.handler({ cmd: "gh api user" }, { ...context(), signal: controller.signal });
+      const pending = runtime.tool.handler({ cmd }, { ...context(), signal: controller.signal });
       await requestStarted;
       controller.abort(new Error("caller cancelled"));
       await expect(pending).resolves.toMatchObject({ exit_code: 124 });
       expect(cancel).toHaveBeenCalledOnce();
+      expect((await filesystem.list(".", { recursive: true })).map((entry) => entry.path)).toEqual(["/brain/retained"]);
+      expect(new TextDecoder().decode(await filesystem.readFile("retained"))).toBe("keep this");
     } finally { runtime.dispose(); }
   });
 
@@ -180,6 +188,38 @@ describe("durable brain without hands", () => {
     await expect(workspace.writeFile("a/b/file/child", "no")).rejects.toMatchObject({ code: "ENOTDIR" });
     await expect(workspace.writeFile("a", "no")).rejects.toMatchObject({ code: "EISDIR" });
     await workspace.remove("a", { recursive: true });
+    expect(await workspace.list()).toEqual([]);
+    expect((await bucket.list({ prefix: `brains/${id}/` })).objects).toEqual([]);
+  });
+
+  it("reuses command metadata and refreshes native changes before the next command", async () => {
+    const id = crypto.randomUUID();
+    const head = vi.fn((key: string) => bucket.head(key));
+    const list = vi.fn((options: R2ListOptions) => bucket.list(options));
+    const storage = {
+      head, list,
+      get: bucket.get.bind(bucket), put: bucket.put.bind(bucket), delete: bucket.delete.bind(bucket),
+    } as unknown as R2Bucket;
+    const workspace = createBrainWorkspace(storage, id);
+    await workspace.list(".", { recursive: true });
+    list.mockClear();
+    await workspace.writeFile("repo/src/main.rs", "fn main() {}\n");
+    for (let index = 0; index < 20; index += 1) {
+      expect(await workspace.list("repo/src")).toMatchObject([{ path: "/brain/repo/src/main.rs", kind: "file" }]);
+      await workspace.mkdir("repo/src");
+      await workspace.readFile("repo/src/main.rs");
+    }
+    expect(head).not.toHaveBeenCalled();
+    expect(list).not.toHaveBeenCalled();
+
+    await bucket.delete(`brains/${id}/repo/src/main.rs`);
+    await bucket.put(`brains/${id}/repo/src/native.rs`, "from the hand\n");
+    await workspace.list(".", { recursive: true });
+    expect(await workspace.list("repo/src")).toMatchObject([{ path: "/brain/repo/src/native.rs", kind: "file" }]);
+    expect(await workspace.list("repo/src")).toHaveLength(1);
+    await expect(workspace.writeFile("repo/src/native.rs/child", "no")).rejects.toMatchObject({ code: "ENOTDIR" });
+    await expect(workspace.writeFile("repo", "no")).rejects.toMatchObject({ code: "EISDIR" });
+    await workspace.remove("repo", { recursive: true });
     expect(await workspace.list()).toEqual([]);
     expect((await bucket.list({ prefix: `brains/${id}/` })).objects).toEqual([]);
   });

--- a/js/nanocodex-tools/package.json
+++ b/js/nanocodex-tools/package.json
@@ -101,7 +101,8 @@
     "hyparquet": "1.28.2",
     "hyparquet-compressors": "1.1.1",
     "isomorphic-git": "^1.41.5",
-    "just-bash": "^3.4.0"
+    "just-bash": "^3.4.0",
+    "modern-tar": "0.7.7"
   },
   "devDependencies": {
     "typescript": "5.9.3"

--- a/js/nanocodex-tools/src/repository-archive.ts
+++ b/js/nanocodex-tools/src/repository-archive.ts
@@ -1,0 +1,104 @@
+import { createGzipDecoder, createTarDecoder } from "modern-tar";
+import type { Workspace } from "../tools/types.mjs";
+import type { ShellFetch } from "./shell.js";
+
+/** Extract a GitHub source snapshot directly into the host-owned workspace. */
+export async function downloadRepositoryArchive(
+  fetch: ShellFetch,
+  workspace: Workspace,
+  repository: string,
+  ref: string,
+  directory: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  signal?.throwIfAborted();
+  const transfer = new AbortController();
+  const transferSignal = signal ? AbortSignal.any([signal, transfer.signal]) : transfer.signal;
+  const response = await (fetch.stream ?? fetch)(
+    `https://api.github.com/repos/${repository}/tarball/${encodeURIComponent(ref)}`,
+    { headers: { accept: "application/vnd.github+json" }, signal: transferSignal },
+  );
+  const iterator = (async function* () {
+    if (response.body instanceof Uint8Array) yield response.body;
+    else yield* response.body;
+  })()[Symbol.asyncIterator]();
+  if (response.status !== 200) {
+    transfer.abort();
+    await iterator.return(undefined);
+    throw new Error(`repository archive download failed (HTTP ${response.status})`);
+  }
+  const source = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      signal?.throwIfAborted();
+      const next = await iterator.next();
+      if (next.done) controller.close();
+      else controller.enqueue(next.value);
+    },
+    async cancel() { await iterator.return(undefined); },
+  });
+  const entries = source.pipeThrough(createGzipDecoder()).pipeThrough(createTarDecoder({ strict: true })).getReader();
+  const writes = new Set<Promise<void>>();
+  let writeFailure: unknown;
+  let archiveRoot: string | undefined;
+  let files = 0;
+  const paths = new Set<string>();
+  try {
+    await workspace.mkdir(directory);
+    for (;;) {
+      signal?.throwIfAborted();
+      if (writeFailure !== undefined) throw writeFailure;
+      const { done, value: entry } = await entries.read();
+      if (done) break;
+      const name = entry.header.name.replace(/\/$/, "");
+      const parts = name.split("/");
+      if (parts.some((part) => !part || part === "." || part === ".." || part === ".git")
+        || name.includes("\\") || name.includes("\0")) {
+        await entry.body.cancel();
+        throw new Error("repository archive contains an unsafe path");
+      }
+      archiveRoot ??= parts[0];
+      if (parts[0] !== archiveRoot || (parts.length === 1 && entry.header.type !== "directory")) {
+        await entry.body.cancel();
+        throw new Error("repository archive must contain one root directory");
+      }
+      if (entry.header.type !== "directory" && entry.header.type !== "file") {
+        await entry.body.cancel();
+        throw new Error(`repository archive entry type '${entry.header.type}' is unsupported`);
+      }
+      if (parts.length === 1) { await entry.body.cancel(); continue; }
+      const relative = parts.slice(1).join("/");
+      if (paths.has(relative)) {
+        await entry.body.cancel();
+        throw new Error("repository archive contains duplicate paths");
+      }
+      paths.add(relative);
+      const target = `${directory}/${relative}`;
+      if (entry.header.type === "directory") {
+        await entry.body.cancel();
+        await workspace.mkdir(target);
+        continue;
+      }
+      const contents = new Uint8Array(await new Response(entry.body).arrayBuffer());
+      signal?.throwIfAborted();
+      files += 1;
+      // Overlap durable writes without retaining the complete archive in memory.
+      const write = workspace.writeFile(target, contents)
+        .catch((error: unknown) => { writeFailure ??= error; })
+        .finally(() => { writes.delete(write); });
+      writes.add(write);
+      if (writes.size >= 8) await Promise.race(writes);
+    }
+    await Promise.all(writes);
+    if (writeFailure !== undefined) throw writeFailure;
+    if (!archiveRoot || files === 0) throw new Error("repository archive contains no files");
+    signal?.throwIfAborted();
+  } finally {
+    // Stop an upstream read before cancelling the decoder, including when
+    // validation or a durable write failed while the network was still active.
+    transfer.abort();
+    await entries.cancel().catch(() => {});
+    entries.releaseLock();
+    // The caller may clean up the destination only after every write has settled.
+    await Promise.all(writes);
+  }
+}

--- a/js/nanocodex-tools/src/shell.ts
+++ b/js/nanocodex-tools/src/shell.ts
@@ -1,5 +1,6 @@
 import git, { type GitHttpRequest, type HttpClient } from "isomorphic-git";
 import type { Workspace, WorkspaceEntry } from "../tools/types.mjs";
+import { downloadRepositoryArchive } from "./repository-archive.js";
 
 export type ShellFetchOptions = Readonly<{
   method?: string | undefined;
@@ -20,7 +21,7 @@ export type ShellFetch = ((
   url: string,
   options?: ShellFetchOptions,
 ) => Promise<ShellFetchResult>) & Readonly<{
-  /** Optional streaming transport for Git packfiles, without a buffered shell response. */
+  /** Optional streaming transport for source archives and Git packfiles. */
   stream?: (url: string, options?: ShellFetchOptions) => Promise<
     Omit<ShellFetchResult, "body"> & { body: AsyncIterable<Uint8Array> }
   >;
@@ -179,7 +180,7 @@ function ghRepoCloneArguments(args: string[]): string[] {
   ];
 }
 
-/** Git compatibility command backed by durable storage and host-authorized Git smart HTTP. */
+/** Git compatibility command backed by durable storage and host-authorized GitHub downloads. */
 export function createGitCommand(
   fetch: ShellFetch,
   workspace: () => Workspace,
@@ -192,7 +193,7 @@ export function createGitCommand(
         const mounted = commandWorkspace(workspace(), context.signal);
         const command = args[0];
         if (command === "clone") {
-          return ok(await cloneRepository(fetch, mounted, args.slice(1), context));
+          return ok(await cloneRepository(fetch, workspace(), args.slice(1), context));
         }
         const dir = await gitDirectory(mounted, context.cwd);
         const fs = workspaceFs(mounted);
@@ -313,12 +314,17 @@ async function cloneRepository(
   const dir = `${root}/${destination}`;
   if (await workspaceEntry(workspace, dir)) throw new Error(`destination path '${destination}' already exists`);
   try {
+    if (depth === undefined) {
+      await downloadRepositoryArchive(fetch, commandWorkspace(workspace, signal), repository, branch ?? "HEAD", dir, signal);
+      return `Downloaded source files into '${destination}' (no .git or history).\n`;
+    }
     await git.clone({
-      fs: workspaceFs(workspace),
+      fs: workspaceFs(commandWorkspace(workspace, signal)),
       http: managedGitHttp(fetch, signal),
       dir,
       url: `https://github.com/${repository}.git`,
-      ...(depth === undefined ? {} : { depth, singleBranch: true }),
+      depth,
+      singleBranch: true,
       ...(branch === undefined ? {} : { ref: branch }),
     });
   } catch (error) {

--- a/js/nanocodex-tools/test/repository-archive.test.mjs
+++ b/js/nanocodex-tools/test/repository-archive.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { gzipSync } from "node:zlib";
+import test from "node:test";
+import { packTar } from "modern-tar";
+import { downloadRepositoryArchive } from "../dist/repository-archive.js";
+
+const entry = (name, type = "file", body = "source") => ({
+  header: { name, type, size: type === "file" ? Buffer.byteLength(body) : 0 },
+  body: type === "file" ? body : undefined,
+});
+const root = entry("repo/", "directory");
+
+for (const bad of [
+  entry("repo/../escape"), entry("/escape"), entry("repo/.git/config"),
+  entry("other/file"), entry("repo/link", "symlink"), entry("repo/device", "fifo"),
+]) {
+  test(`archive rejects ${bad.header.type} ${bad.header.name} before writing it`, async () => {
+    const data = gzipSync(await packTar([root, bad]));
+    const writes = [];
+    const workspace = { mkdir: async () => {}, writeFile: async (path) => { writes.push(path); } };
+    await assert.rejects(downloadRepositoryArchive(async () => ({ status: 200, body: data }),
+      workspace, "fixture/repo", "HEAD", "/brain/repo"));
+    assert.deepEqual(writes, []);
+  });
+}
+
+test("archive drains outstanding writes before returning a failure", async () => {
+  const data = gzipSync(await packTar([root, entry("repo/good"), entry("repo/../bad")]));
+  let finished = false;
+  const workspace = {
+    mkdir: async () => {},
+    writeFile: async () => { await new Promise((resolve) => setTimeout(resolve, 10)); finished = true; },
+  };
+  await assert.rejects(downloadRepositoryArchive(async () => ({ status: 200, body: data }),
+    workspace, "fixture/repo", "HEAD", "/brain/repo"));
+  assert.equal(finished, true);
+});
+
+test("archive cancellation settles in-flight writes before cleanup and stops the transport", async () => {
+  const data = gzipSync(await packTar([root, entry("repo/file")]));
+  const caller = new AbortController();
+  let transportSignal;
+  let finished = false;
+  const workspace = {
+    mkdir: async () => {},
+    writeFile: async () => {
+      caller.abort(new Error("caller cancelled"));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      finished = true;
+    },
+  };
+  await assert.rejects(downloadRepositoryArchive(async (_url, options) => {
+    transportSignal = options.signal;
+    return { status: 200, body: data };
+  }, workspace, "fixture/repo", "HEAD", "/brain/repo", caller.signal), /caller cancelled/);
+  assert.equal(finished, true);
+  assert.equal(transportSignal.aborted, true);
+});
+
+test("archive rejects truncated input instead of reporting a partial checkout as complete", async () => {
+  const tar = await packTar([root, entry("repo/file", "file", "source".repeat(1_000))]);
+  const workspace = { mkdir: async () => {}, writeFile: async () => {} };
+  await assert.rejects(downloadRepositoryArchive(async () => ({ status: 200, body: gzipSync(tar.subarray(0, 1400)) }),
+    workspace, "fixture/repo", "HEAD", "/brain/repo"));
+});

--- a/js/nanocodex-tools/tools/bash.mjs
+++ b/js/nanocodex-tools/tools/bash.mjs
@@ -308,6 +308,8 @@ Use exec_command for shell work. When the user requests an explicit shell operat
 available command, call exec_command immediately and once with the complete command. Do not inspect the runtime,
 account, or workspace, search for another tool, or split the operation into exploratory calls before trying it.
 For an ordinary clone request, use exactly gh repo clone OWNER/REPO DESTINATION or git clone URL DESTINATION.
+By default these commands download and extract a source archive: all current files, without .git or history.
+Use --branch for a requested revision. An explicit --depth requests a Git checkout with that history depth.
 Do not add depth, filter, branch, or other flags unless the user requests them, and do not inspect a successful clone.
 Only investigate after that direct command fails or when the user explicitly asks for investigation.
 Available commands: ${descriptor.commands.join(", ")}. Use ${descriptor.cwd}/tmp, not /tmp, for temporary files. Commands run without a host process, container, PTY, session, or sandbox

--- a/js/nanocodex/test/bash.test.mjs
+++ b/js/nanocodex/test/bash.test.mjs
@@ -28,6 +28,7 @@ test("Just Bash advertises its cloud workspace execution", async () => {
   );
   assert.match(instructions, /exactly gh repo clone OWNER\/REPO DESTINATION/);
   assert.match(instructions, /git clone URL DESTINATION/);
+  assert.match(instructions, /all current files, without .git or history/);
   assert.match(instructions, /Do not add depth, filter, branch, or other flags/);
   assert.doesNotMatch(instructions, /\bwget\b/);
 });

--- a/js/nanocodex/test/repository-workspace.test.mjs
+++ b/js/nanocodex/test/repository-workspace.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -10,7 +10,7 @@ import * as NodeWorkspace from "../node/workspace.mjs";
 import { materializeRepositoryWorkspace } from "../tools/repository-workspace.mjs";
 import { createComputerRuntime } from "nanocodex-tools";
 
-test("Just Bash gh clone creates a usable repository with the requested history", async () => {
+test("Just Bash downloads source archives by default and honors explicit Git history depth", async () => {
   const fixture = await gitFixture();
   const destination = await mkdtemp(join(tmpdir(), "nanocodex-shell-clone-"));
   try {
@@ -19,9 +19,12 @@ test("Just Bash gh clone creates a usable repository with the requested history"
       networkMode: "test",
       fetch: async (url, options) => {
         const target = new URL(url);
-        assert.equal(target.origin, "https://github.com");
+        assert.ok(["https://github.com", "https://api.github.com"].includes(target.origin));
         assert.ok(options.signal instanceof AbortSignal);
-        const response = await fetch(`${fixture.url}/git/${fixture.head}${target.pathname.slice("/fixture/repo.git".length)}${target.search}`, options);
+        const path = target.origin === "https://api.github.com"
+          ? `/archive/${target.pathname.split("/").at(-1)}`
+          : `/git/${fixture.head}${target.pathname.slice("/fixture/repo.git".length)}${target.search}`;
+        const response = await fetch(`${fixture.url}${path}`, options);
         return {
           status: response.status, statusText: response.statusText,
           headers: Object.fromEntries(response.headers),
@@ -31,20 +34,25 @@ test("Just Bash gh clone creates a usable repository with the requested history"
     });
     const call = { signal: new AbortController().signal, sessionId: "fixture" };
     const cloned = await runtime.tool.handler({
-      cmd: "gh repo clone fixture/repo /workspace/source && cd source && git log --oneline && git status --porcelain",
+      cmd: "gh repo clone fixture/repo /workspace/source && cat source/README.md",
     }, call);
     assert.equal(cloned.exit_code, 0, cloned.output);
-    assert.match(cloned.output, /Cloning into 'source'/);
-    assert.match(cloned.output, /second/);
-    assert.match(cloned.output, /seed/);
+    assert.match(cloned.output, /Downloaded source files into 'source'/);
     assert.equal(await readFile(join(destination, "source/README.md"), "utf8"), "immutable\n");
-    assert.equal(await git(["rev-list", "--count", "HEAD"], join(destination, "source")), "2\n");
-    assert.equal(await git(["tag"], join(destination, "source")), "v1\n");
+    await assert.rejects(access(join(destination, "source/.git")), { code: "ENOENT" });
+    assert.equal(await readFile(join(destination, "source/.gitignore"), "utf8"), "target/\n");
     const shallow = await runtime.tool.handler({
-      cmd: "gh repo clone fixture/repo shallow -- --depth 1",
+      cmd: "git clone --branch v1 https://github.com/fixture/repo.git snapshot",
     }, call);
     assert.equal(shallow.exit_code, 0, shallow.output);
-    assert.equal(await git(["rev-list", "--count", "HEAD"], join(destination, "shallow")), "1\n");
+    await assert.rejects(access(join(destination, "snapshot/.git")), { code: "ENOENT" });
+    assert.equal(await readFile(join(destination, "snapshot/README.md"), "utf8"), "immutable\n");
+    const deeper = await runtime.tool.handler({
+      cmd: "gh repo clone fixture/repo deeper -- --depth 2 --branch main",
+    }, call);
+    assert.equal(deeper.exit_code, 0, deeper.output);
+    assert.equal(await git(["rev-list", "--count", "HEAD"], join(destination, "deeper")), "2\n");
+    assert.equal(await git(["branch", "--show-current"], join(destination, "deeper")), "main\n");
   } finally {
     await fixture.close();
     await rm(destination, { recursive: true, force: true });
@@ -147,7 +155,8 @@ async function gitFixture() {
   await git(["config", "user.name", "Nanocodex Test"], source);
   await git(["config", "user.email", "test@nanocodex.dev"], source);
   await writeFile(join(source, "README.md"), "immutable\n");
-  await git(["add", "README.md"], source);
+  await writeFile(join(source, ".gitignore"), "target/\n");
+  await git(["add", "README.md", ".gitignore"], source);
   await git(["commit", "-q", "-m", "seed"], source);
   await git(["tag", "v1"], source);
   await git(["commit", "-q", "--allow-empty", "-m", "second"], source);
@@ -157,6 +166,12 @@ async function gitFixture() {
   const server = createServer(async (request, response) => {
     try {
       const requestUrl = new URL(request.url, "http://localhost");
+      if (requestUrl.pathname.startsWith("/archive/")) {
+        const ref = decodeURIComponent(requestUrl.pathname.slice("/archive/".length));
+        const archive = await command("git", ["archive", "--format=tar.gz", "--prefix=fixture-repo/", ref], source);
+        response.writeHead(200, { "content-type": "application/gzip" }).end(archive);
+        return;
+      }
       const suffix = requestUrl.pathname.match(/^\/git\/[a-f0-9]{40}(\/.*)$/)?.[1];
       if (!suffix) {
         response.writeHead(404).end();

--- a/js/test-fixtures/git-provider.mjs
+++ b/js/test-fixtures/git-provider.mjs
@@ -30,6 +30,25 @@ export async function gitProvider(request) {
     const { head, size, sha256 } = repository();
     return Response.json({ head, size, sha256 });
   }
+  if (url.origin === "https://api.github.com" && url.pathname.startsWith("/repos/fixture/large/tarball/")) {
+    const ref = url.pathname.slice("/repos/fixture/large/tarball/".length);
+    const location = ref === "foreign" ? "https://codeload.github.com/another/repo/legacy.tar.gz/HEAD"
+      : ref === "external" ? "https://example.com/fixture/large/legacy.tar.gz/HEAD"
+      : `https://codeload.github.com/fixture/large/legacy.tar.gz/${ref}?token=archive-download-secret`;
+    return new Response(null, { status: 302, headers: { location } });
+  }
+  if (url.origin === "https://codeload.github.com" && url.pathname.startsWith("/fixture/large/legacy.tar.gz/")) {
+    if (request.headers.has("authorization") || request.headers.has("x-nanocodex-subject")
+      || url.searchParams.get("token") !== "archive-download-secret") {
+      return new Response("invalid archive credentials", { status: 403 });
+    }
+    if (url.pathname.endsWith("/reflect")) return new Response("archive-download-secret");
+    if (url.pathname.endsWith("/redirect")) return Response.redirect("https://example.com/", 302);
+    const { git, head } = repository();
+    return new Response(git(["archive", "--format=tar.gz", "--prefix=fixture-large/", head]), {
+      headers: { "content-type": "application/gzip" },
+    });
+  }
   if (url.hostname !== "github.com" || !url.pathname.startsWith("/fixture/large.git/")) return undefined;
   if (request.headers.get("authorization") !== `Basic ${btoa("x-access-token:github-connector-access")}`) {
     return new Response("Authentication required", { status: 401 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -705,6 +705,9 @@ importers:
       just-bash:
         specifier: ^3.4.0
         version: 3.4.2(supports-color@10.2.2)
+      modern-tar:
+        specifier: 0.7.7
+        version: 0.7.7
     devDependencies:
       typescript:
         specifier: 5.9.3


### PR DESCRIPTION
Host clone requests were downloading and indexing Git history just to inspect files. Just Bash now downloads the source archive into `/brain` by default, including dotfiles but without `.git`. Explicit `--depth` still requests a Git checkout; native sandbox Git is unchanged.

Archive redirects stay inside the GitHub credential broker. R2 metadata is reused within each command and refreshed before the next one. Failed or cancelled downloads stop the stream, settle pending writes, and remove the partial destination.

Verified against gakonst/nanocodex: 2,096 files matched the Git checkout byte-for-byte, with an 8.2 MB download. Tools, clone contracts, R2 persistence, cancellation, and broker tests pass, along with typechecks and both Worker dry-runs. Live clone → sandbox → cargo test verification follows the master deployment.
