### PR TITLE
fix(managed): pass sandbox environment through SDK options

### DIFF
--- a/js/managed/src/sandbox-tools.ts
+++ b/js/managed/src/sandbox-tools.ts
@@ -1,4 +1,4 @@
-import { getSandbox } from "@cloudflare/sandbox";
+import { getSandbox, type ProcessOptions } from "@cloudflare/sandbox";
 import type { ToolMap } from "nanocodex";
 import {
   EXEC_COMMAND_PARAMETERS,
@@ -125,7 +125,7 @@ type SandboxToolClient = {
   }>;
   startProcess(
     command: string,
-    options: { cwd: string; processId: string; autoCleanup: false; envVars?: Record<string, string> },
+    options: ProcessOptions & { cwd: string; processId: string; autoCleanup: false },
   ): Promise<SandboxProcess>;
   getProcess(id: string): Promise<SandboxProcess | null>;
   tunnels: {
@@ -305,7 +305,7 @@ export function createCloudflareSandboxTools(
             cwd,
             processId: sandboxProcessId(sessionId),
             autoCleanup: false,
-            envVars: {
+            env: {
               GH_TOKEN: "NANOCODEX_PROVIDER_CREDENTIAL",
               GH_PROMPT_DISABLED: "1",
               GIT_TERMINAL_PROMPT: "0",

--- a/js/managed/test/sandbox-tools.test.ts
+++ b/js/managed/test/sandbox-tools.test.ts
@@ -92,7 +92,7 @@ describe("Cloudflare sandbox tools", () => {
     });
     expect(sandbox.startProcess).toHaveBeenCalledWith("exec 2>&1\ntask", {
       cwd: "/workspace/repo",
-      envVars: { GH_TOKEN: "NANOCODEX_PROVIDER_CREDENTIAL", GH_PROMPT_DISABLED: "1", GIT_TERMINAL_PROMPT: "0" },
+      env: { GH_TOKEN: "NANOCODEX_PROVIDER_CREDENTIAL", GH_PROMPT_DISABLED: "1", GIT_TERMINAL_PROMPT: "0" },
       processId: expect.stringMatching(/^nanocodex-[1-9][0-9]*$/),
       autoCleanup: false,
     });


### PR DESCRIPTION
The production replay caught native `gh api user` exiting with code 4 and asking for login. We passed `envVars` to `startProcess`, but Sandbox SDK 0.12.4 reads `env`, so it silently dropped the public GitHub credential marker and prompt settings.

Use `env` and the SDK's `ProcessOptions` type so this mismatch becomes a compile error. Real GitHub credentials still stay inside the egress broker.

Typecheck and the managed Worker dry-run pass. The production clone/cargo replay is retained for verification after deployment.
