### PR TITLE
fix(managed): retain sandbox filesystem metadata in R2

### DIFF
--- a/js/managed/README.md
+++ b/js/managed/README.md
@@ -49,6 +49,11 @@ storage ownership.
   injected only at the provider boundary. Exact Connect identities and revocation
   apply to both GitHub API calls and Git smart HTTP. Connect grants cannot use
   Vault-backed shell requests or SSH identities.
+  The pnpm patch for Sandbox SDK 0.12.4 preserves S3FS `x-amz-meta-*` metadata
+  through R2 uploads, metadata-replacing copies, multipart uploads, and reads.
+  Without it, native permissions and timestamps disappear after revalidation.
+  `sandbox-r2-metadata.test.ts` exercises the SDK proxy against the Worker R2
+  binding; remove the patch when an SDK release passes that contract unpatched.
   Shell execution, workspace traversal, and subagent admission have no implicit
   application quota; caller-specified limits, cancellation, and platform capacity
   still apply.

--- a/js/managed/test/sandbox-r2-metadata.test.ts
+++ b/js/managed/test/sandbox-r2-metadata.test.ts
@@ -1,0 +1,96 @@
+import { createExecutionContext, env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+import { ContainerProxy } from "../src/sandbox-runtime";
+
+const bucket = (env as unknown as { NANOCODEX_WORKSPACES: R2Bucket }).NANOCODEX_WORKSPACES;
+
+function mount(readOnly = false) {
+  const prefix = `sessions/${crypto.randomUUID()}`;
+  const context = createExecutionContext();
+  Object.defineProperty(context, "props", { value: {
+    outboundByHostOverrides: {
+      "r2.internal": {
+        method: "r2EgressMount",
+        params: { buckets: { NANOCODEX_WORKSPACES: { prefix, readOnly } } },
+      },
+    },
+  } });
+  const proxy = new ContainerProxy(context, { NANOCODEX_WORKSPACES: bucket });
+  return {
+    prefix,
+    request: (key: string, init?: RequestInit) => proxy.fetch(new Request(
+      `http://r2.internal/NANOCODEX_WORKSPACES/${key}`, init,
+    )),
+  };
+}
+
+describe("Sandbox SDK R2 filesystem metadata", () => {
+  it("retains directory type, permissions and times across uncached HEAD/GET", async () => {
+    const { prefix, request } = mount();
+    expect((await request("repo/", { method: "PUT", headers: {
+      "Content-Length": "0",
+      "Content-Type": "application/x-directory",
+      "x-amz-meta-mode": "16877",
+      "x-amz-meta-mtime": "1788724000",
+      "x-amz-meta-uid": "1000",
+      "x-amz-meta-gid": "1000",
+    } })).status).toBe(200);
+    expect((await bucket.head(`${prefix}/repo/`))?.customMetadata).toEqual({
+      mode: "16877", mtime: "1788724000", uid: "1000", gid: "1000",
+    });
+    for (const method of ["HEAD", "GET"]) {
+      const response = await request("repo/", { method });
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Content-Type")).toBe("application/x-directory");
+      expect(response.headers.get("x-amz-meta-mode")).toBe("16877");
+      expect(response.headers.get("x-amz-meta-mtime")).toBe("1788724000");
+      await response.arrayBuffer();
+    }
+  });
+
+  it("applies chmod metadata replacement and preserves metadata on ordinary copy", async () => {
+    const { request } = mount();
+    await request("script", { method: "PUT", body: "echo ok\n", headers: {
+      "Content-Length": "8", "Content-Type": "text/plain", "x-amz-meta-mode": "33188",
+    } });
+    expect((await request("script", { method: "PUT", headers: {
+      "x-amz-copy-source": "/NANOCODEX_WORKSPACES/script",
+      "x-amz-metadata-directive": "REPLACE",
+      "Content-Type": "text/plain", "x-amz-meta-mode": "33261",
+    } })).status).toBe(200);
+    await request("copied", { method: "PUT", headers: {
+      "x-amz-copy-source": "/NANOCODEX_WORKSPACES/script",
+    } });
+    const response = await request("copied");
+    expect(response.headers.get("x-amz-meta-mode")).toBe("33261");
+    expect(await response.text()).toBe("echo ok\n");
+  });
+
+  it("retains metadata when a file is uploaded in parts", async () => {
+    const { request } = mount();
+    const created = await request("large?uploads", { method: "POST", headers: {
+      "x-amz-meta-mode": "33188", "x-amz-meta-mtime": "1788724001",
+    } });
+    const uploadId = /<UploadId>(.*?)<\/UploadId>/.exec(await created.text())![1];
+    const uploaded = await request(`large?uploadId=${encodeURIComponent(uploadId!)}&partNumber=1`, {
+      method: "PUT", body: "part", headers: { "Content-Length": "4" },
+    });
+    const etag = uploaded.headers.get("ETag");
+    expect((await request(`large?uploadId=${encodeURIComponent(uploadId!)}`, {
+      method: "POST", body: `<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>${etag}</ETag></Part></CompleteMultipartUpload>`,
+    })).status).toBe(200);
+    const response = await request("large", { headers: { Range: "bytes=1-2" } });
+    expect(response.status).toBe(206);
+    expect(response.headers.get("x-amz-meta-mode")).toBe("33188");
+    expect(response.headers.get("x-amz-meta-mtime")).toBe("1788724001");
+    expect(await response.text()).toBe("ar");
+  });
+
+  it("keeps writes fenced by the mount's read-only permission", async () => {
+    const { request } = mount(true);
+    expect((await request("repo/", { method: "PUT", headers: {
+      "Content-Length": "0", "x-amz-meta-mode": "16877",
+    } })).status).toBe(403);
+  });
+});

--- a/patches/@cloudflare__sandbox@0.12.4.patch
+++ b/patches/@cloudflare__sandbox@0.12.4.patch
@@ -1,0 +1,50 @@
+diff --git a/dist/sandbox-CyqG4jca.js b/dist/sandbox-CyqG4jca.js
+index 7acd6e7ce4468e31cd2a4daa429ca5e3b00f8bec..b9f3d7d52d5462028153090c45c590d094c8740a 100644
+--- a/dist/sandbox-CyqG4jca.js
++++ b/dist/sandbox-CyqG4jca.js
+@@ -4766,6 +4766,7 @@ function buildResponseHeaders(obj) {
+ 	if (obj.httpMetadata?.contentEncoding) headers.set("Content-Encoding", obj.httpMetadata.contentEncoding);
+ 	if (obj.httpMetadata?.contentLanguage) headers.set("Content-Language", obj.httpMetadata.contentLanguage);
+ 	if (obj.httpMetadata?.cacheControl) headers.set("Cache-Control", obj.httpMetadata.cacheControl);
++	for (const [name, value] of Object.entries(obj.customMetadata ?? {})) headers.set(`x-amz-meta-${name}`, value);
+ 	return headers;
+ }
+ function buildContentRange(range, totalSize) {
+@@ -4794,6 +4795,13 @@ function extractHttpMetadata(request) {
+ 	if (cc) meta.cacheControl = cc;
+ 	return meta;
+ }
++function extractCustomMetadata(request) {
++	const metadata = {};
++	for (const [name, value] of request.headers) {
++		if (name.startsWith("x-amz-meta-")) metadata[name.slice(11)] = value;
++	}
++	return metadata;
++}
+ function parseCopySource(header) {
+ 	const sourcePath = header.split("?")[0] ?? "";
+ 	if (!sourcePath) return null;
+@@ -4886,12 +4894,12 @@ async function handlePutObject(r2, bucketName, key, request, env$1, permitted, m
+ 		const httpMetadata = request.headers.get("x-amz-metadata-directive")?.toUpperCase() === "REPLACE" ? extractHttpMetadata(request) : sourceObject.httpMetadata;
+ 		const result$1 = await r2.put(key, sourceObject.body, {
+ 			httpMetadata,
+-			customMetadata: sourceObject.customMetadata,
++			customMetadata: request.headers.get("x-amz-metadata-directive")?.toUpperCase() === "REPLACE" ? extractCustomMetadata(request) : sourceObject.customMetadata,
+ 			storageClass: normalizeStorageClass(sourceObject.storageClass)
+ 		});
+ 		return xmlResponse(buildCopyObjectXml(result$1.httpEtag, result$1.uploaded));
+ 	}
+-	const result = await putRequestBody(r2, key, request, { httpMetadata: extractHttpMetadata(request) });
++	const result = await putRequestBody(r2, key, request, { httpMetadata: extractHttpMetadata(request), customMetadata: extractCustomMetadata(request) });
+ 	if (result instanceof Response) return result;
+ 	const headers = new Headers();
+ 	headers.set("ETag", result.httpEtag);
+@@ -4906,7 +4914,7 @@ async function handleDeleteObject(r2, key) {
+ }
+ async function handleCreateMultipartUpload(r2, bucketName, key, request) {
+ 	const httpMetadata = extractHttpMetadata(request);
+-	return xmlResponse(buildInitiateMultipartUploadXml(bucketName, key, (await r2.createMultipartUpload(key, { httpMetadata })).uploadId));
++	return xmlResponse(buildInitiateMultipartUploadXml(bucketName, key, (await r2.createMultipartUpload(key, { httpMetadata, customMetadata: extractCustomMetadata(request) })).uploadId));
+ }
+ async function handleUploadPart(r2, key, url, request) {
+ 	const uploadId = url.searchParams.get("uploadId") ?? "";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 overrides:
   '@microsoft/dev-tunnels-ssh': 3.12.40
 
+patchedDependencies:
+  '@cloudflare/sandbox@0.12.4': 7fa7387e610c11eed36979117adfdd317b44eed0f2feffba0c35cdfa24aed2b2
+
 importers:
 
   .:
@@ -466,7 +469,7 @@ importers:
         version: 0.2.1(ai@7.0.90(zod@4.5.4))(supports-color@10.2.2)(zod@4.5.4)
       '@cloudflare/sandbox':
         specifier: 0.12.4
-        version: 0.12.4
+        version: 0.12.4(patch_hash=7fa7387e610c11eed36979117adfdd317b44eed0f2feffba0c35cdfa24aed2b2)
       '@jitl/quickjs-wasmfile-release-asyncify':
         specifier: 0.32.0
         version: 0.32.0
@@ -6602,7 +6605,7 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
-  '@cloudflare/sandbox@0.12.4':
+  '@cloudflare/sandbox@0.12.4(patch_hash=7fa7387e610c11eed36979117adfdd317b44eed0f2feffba0c35cdfa24aed2b2)':
     dependencies:
       '@cloudflare/containers': 0.3.7
       aws4fetch: 1.0.20

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,3 +19,6 @@ minimumReleaseAgeExclude:
   - "@ai-sdk/gateway@4.0.72"
   - "@ai-sdk/provider-utils@5.0.36"
   - "ai@7.0.90"
+
+patchedDependencies:
+  '@cloudflare/sandbox@0.12.4': patches/@cloudflare__sandbox@0.12.4.patch


### PR DESCRIPTION
Sandbox SDK 0.12.4 drops S3FS filesystem metadata on R2 uploads and reads, and ignores replacement metadata during chmod-style copies. Native file modes and timestamps therefore disappear after metadata revalidation.

Patch the SDK at its R2 protocol boundary to round-trip custom metadata for ordinary and multipart uploads, HEAD/GET (including ranges), and COPY/REPLACE. Keep the existing mount prefixes and read-only checks. The patch is pinned to 0.12.4 and can be removed when upstream passes the contract unpatched.

Validation: three real Worker/R2 protocol tests failed against the stock SDK and pass with the patch. All 17 focused R2/runtime tests, managed typecheck, and the managed build/dry-run pass. Production replay already verified the separately merged host archive clone and native GitHub credential fix.
