### PR TITLE
feat(web): reskin website and Connect to match the native apps

### DIFF
--- a/js/account/index.html
+++ b/js/account/index.html
@@ -4,16 +4,17 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
     <link rel="icon" href="/paradigm-favicon.svg" type="image/svg+xml" sizes="any" />
-    <meta name="theme-color" content="#161616" />
+    <meta name="theme-color" content="#212121" />
     <script>
       (() => {
         try {
           const stored = localStorage.getItem("nanocodex-theme");
-          const theme = stored === "light" ? "light" : "dark";
+          const theme = stored === "light" || stored === "dark" ? stored
+            : window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
           document.documentElement.dataset.theme = theme;
           document
             .querySelector('meta[name="theme-color"]')
-            ?.setAttribute("content", theme === "dark" ? "#161616" : "#ffffff");
+            ?.setAttribute("content", theme === "dark" ? "#212121" : "#ffffff");
         } catch {
           document.documentElement.dataset.theme = "dark";
         }

--- a/js/account/src/AgentExperience.tsx
+++ b/js/account/src/AgentExperience.tsx
@@ -11,10 +11,12 @@ import {
 } from "react";
 import type { AgentControllerEvent } from "nanocodex-react/agent";
 import { AccountChooser } from "nanocodex-connect-ui/AccountChooser";
-import { Link } from "react-router";
+import { Link, useNavigate } from "react-router";
+import { Moon, PanelLeft, SquarePen, Sun } from "lucide-react";
 import type { AgentStatus, AgentTerminalMode, AgentTerminalState } from "./agentTerminalTypes";
 import { AgentTerminal, ManagedAgentTerminal } from "./AgentTerminal";
-import { ConversationHistoryRail, TerminalTranscriptSurface } from "nanocodex-terminal";
+import { TerminalTranscriptSurface } from "nanocodex-terminal";
+import { AgentSidebar } from "./AgentSidebar";
 import { useAccountSession } from "./AccountSession";
 import { browserAgentCapabilityError } from "./browserAgentCapabilities";
 import { clientFailureMessage } from "./clientFailure";
@@ -44,12 +46,17 @@ export const AgentExperience = memo(function AgentExperience({
   landing,
   mode,
   onAgentChange,
+  theme,
+  onThemeChange,
 }: {
   agentId?: string;
   landing?: boolean;
   mode: AgentTerminalMode;
   onAgentChange?(agentId: string, options?: { replace?: boolean }): void;
+  theme: "light" | "dark";
+  onThemeChange(theme: "light" | "dark"): void;
 }) {
+  const navigate = useNavigate();
   const [ephemeralThreadId, setEphemeralThreadId] = useState(() => crypto.randomUUID());
   const account = useAccountSession();
   const capabilityError = useMemo(() => browserAgentCapabilityError(), []);
@@ -58,6 +65,10 @@ export const AgentExperience = memo(function AgentExperience({
   const credentialSourceRef = useRef<CredentialSource | undefined>(undefined);
   const [runtimeState, setRuntimeState] = useState<AgentTerminalState>();
   const [railOpen, setRailOpen] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(() => safeGet("nanocodex:sidebar-collapsed") === "true");
+  const toggleDesktopSidebar = () => setSidebarCollapsed((collapsed) => { safeSet("nanocodex:sidebar-collapsed", String(!collapsed)); return !collapsed; });
+  const sidebarTriggerRef = useRef<HTMLButtonElement>(null);
+  const closeSidebar = useCallback(() => setRailOpen(false), []);
   const [managedConversations, setManagedConversations] = useState<readonly ManagedConversation[]>([]);
   const [managedConversationId, setManagedConversationId] = useState<string>();
   const [managedError, setManagedError] = useState<string>();
@@ -158,7 +169,8 @@ export const AgentExperience = memo(function AgentExperience({
       : authStatus,
     [authStatus, credentialSource, freePromptsRemaining],
   );
-  const agentStatus: AgentStatus = !canRun || activeCapabilityError
+  const sessionChecking = account.status === "checking" || authStatus === undefined || credentialSource === undefined;
+  const agentStatus: AgentStatus = sessionChecking ? "starting" : !canRun || activeCapabilityError
     ? "idle" : runtimeState?.status ?? "starting";
   const agentError = runtimeState?.error;
   const inactiveMessage = inactiveTerminalMessage({
@@ -167,12 +179,13 @@ export const AgentExperience = memo(function AgentExperience({
   });
 
   const selectManaged = useCallback((id: string) => {
+    setRailOpen(false);
+    if (id === visibleManagedConversationId) return;
     setManagedConversationId(id);
     if (account.account) safeSet(managedSelectionKey(account.account.id), id);
     setRuntimeState(undefined);
-    setRailOpen(false);
     onAgentChange?.(id);
-  }, [account.account, onAgentChange]);
+  }, [account.account, onAgentChange, visibleManagedConversationId]);
   const createConversation = useCallback(() => {
     if (conversationPending || !account.account) return;
     setConversationPending(true);
@@ -217,17 +230,37 @@ export const AgentExperience = memo(function AgentExperience({
     await refreshModelSession();
   }, [refreshModelSession]);
 
-  return <div className={`nanocodex-demo is-${mode}${landing ? " is-landing" : ""}`}>
-    <div className="conversation-workspace">
-      {landing || !hasDurableCredential ? null : <ConversationHistoryRail
-        agentStatus={agentStatus}
-        conversations={managedConversations} error={managedError}
-        mobileOpen={railOpen} pending={conversationPending} runtime="managed" selectedId={visibleManagedConversationId}
-        onClose={() => setRailOpen(false)} onCreate={createConversation} onOpen={() => setRailOpen(true)}
-        onRetry={retryManagedConversations}
-        onSelect={selectManaged}
-      />}
+  const newChat = () => {
+    closeSidebar();
+    if (landing) {
+      setRuntimeState(undefined);
+      setEphemeralThreadId(crypto.randomUUID());
+    } else if (hasDurableCredential) createConversation();
+    else void navigate("/connect");
+  };
+  const selectedConversation = managedConversations.find(({ id }) => id === visibleManagedConversationId);
+  const title = landing ? "New chat" : selectedConversation
+    ? /^Conversation [a-f\d]{8}$/i.test(selectedConversation.title) ? "New agent" : selectedConversation.title
+    : "Your agents";
+
+  return <div className={`nanocodex-demo chat-workspace is-${mode}${landing ? " is-landing" : ""}`}>
+    <div className={`conversation-workspace${sidebarCollapsed ? " is-sidebar-collapsed" : ""}`}>
+      <AgentSidebar key={account.account?.id ?? "anonymous"}
+        conversations={managedConversations} error={managedError} landing={!!landing} active={mode !== "hidden"}
+        open={railOpen && mode !== "hidden"} pending={conversationPending} selectedId={visibleManagedConversationId}
+        onClose={closeSidebar} onCollapse={toggleDesktopSidebar} collapsed={sidebarCollapsed} onCreate={newChat} onRetry={retryManagedConversations} onSelect={selectManaged}
+        persistent={account.account?.persistent === true} triggerRef={sidebarTriggerRef}
+      />
       <div className="conversation-main">
+        <header className="agent-chat-header">
+          <button ref={sidebarTriggerRef} className="agent-sidebar-toggle chat-icon-button" type="button" onClick={() => { if (window.matchMedia("(min-width: 761px)").matches) toggleDesktopSidebar(); else setRailOpen(true); }} aria-label="Open sidebar" aria-expanded={railOpen} aria-controls="agent-navigation"><PanelLeft aria-hidden="true" /></button>
+          <div className="agent-chat-heading"><strong>{landing ? "Nanocodex" : title}</strong></div>
+          <div className="agent-chat-header-actions">
+            {agentStatus === "starting" || agentStatus === "error" ? <span className={`agent-chat-status is-${agentStatus}`} role="status"><i aria-hidden="true" />{agentStatus === "starting" ? "Connecting…" : "Needs attention"}</span> : null}
+            <button className="chat-icon-button" type="button" onClick={() => onThemeChange(theme === "light" ? "dark" : "light")} aria-label={`Use ${theme === "light" ? "dark" : "light"} appearance`} title={`Use ${theme === "light" ? "dark" : "light"} appearance`}>{theme === "light" ? <Moon aria-hidden="true" /> : <Sun aria-hidden="true" />}</button>
+            <button className="chat-icon-button" type="button" disabled={conversationPending} onClick={newChat} aria-label={landing ? "New chat" : "New agent"} title={landing ? "New chat" : "New agent"}><SquarePen aria-hidden="true" /></button>
+          </div>
+        </header>
         {LOCAL_SPONSORED_TRIAL_RESET && showHomepageTrialReset ? (
           <Suspense fallback={null}>
             <LocalSponsoredTrialReset onReset={acceptSponsoredTrialReset} />
@@ -264,7 +297,12 @@ export const AgentExperience = memo(function AgentExperience({
                   source={credentialSource}
                   voiceEnabled={voiceEnabled}
                 />
-                : <ReservedTerminal message={inactiveMessage} mode={mode} />}
+                : <ReservedTerminal message={inactiveMessage} mode={mode}
+                  welcome={sessionChecking ? undefined : "# What should we work on?"}
+                  composer={sessionChecking ? <p className="agent-connection-loading" role="status">Opening your workspace…</p>
+                    : !hasDurableCredential ? <div className="agent-connect-prompt"><Link to="/connect">Connect your account</Link><span>Connect a model account to start a durable agent.</span></div> : null}
+                />}
+        <p className="agent-chat-footnote">{landing ? "Chats here are temporary. Use Agents to keep your work across sessions." : "Your agent keeps working when you leave. Come back anytime."}</p>
       </div>
     </div>
   </div>;

--- a/js/account/src/AgentModelMenu.tsx
+++ b/js/account/src/AgentModelMenu.tsx
@@ -1,0 +1,193 @@
+import * as Menu from "@radix-ui/react-dropdown-menu";
+import { Check, ChevronDown, ChevronRight, Zap } from "lucide-react";
+import { useState } from "react";
+import type { ManagedCreateSettings } from "nanocodex/managed";
+import { clientFailureMessage } from "./clientFailure";
+
+type Model = ManagedCreateSettings["model"];
+type Thinking = ManagedCreateSettings["thinking"];
+const models: readonly [Model, string][] = [
+  ["gpt-6-astra", "GPT-6 Astra"],
+  ["gpt-5.6-sol", "GPT-5.6 Sol"],
+  ["gpt-5.6-terra", "GPT-5.6 Terra"],
+  ["gpt-5.6-luna", "GPT-5.6 Luna"],
+];
+const efforts: readonly [Thinking, string][] = [
+  ["none", "None"],
+  ["low", "Low"],
+  ["medium", "Medium"],
+  ["high", "High"],
+  ["xhigh", "Extra high"],
+  ["max", "Maximum"],
+];
+
+export function AgentModelMenu({
+  agentReady,
+  modelLocked,
+  settings,
+  onFastMode,
+  onModel,
+  onThinking,
+}: {
+  agentReady: boolean;
+  modelLocked: boolean;
+  settings: ManagedCreateSettings;
+  onFastMode(enabled: boolean): Promise<unknown>;
+  onModel(model: Model): Promise<unknown>;
+  onThinking(thinking: Thinking): Promise<unknown>;
+}) {
+  const [error, setError] = useState<string>();
+  const [pending, setPending] = useState(false);
+  async function run(operation: () => Promise<unknown>) {
+    if (pending) return;
+    setPending(true);
+    setError(undefined);
+    try {
+      await operation();
+    } catch (cause) {
+      setError(
+        clientFailureMessage(cause, "Couldn’t update the model. Try again."),
+      );
+    } finally {
+      setPending(false);
+    }
+  }
+  const modelName =
+    models.find(([id]) => id === settings.model)?.[1] ?? settings.model;
+  const effortName =
+    efforts.find(([id]) => id === settings.thinking)?.[1] ?? settings.thinking;
+  return (
+    <div className="agent-runtime-controls">
+      <Menu.Root>
+        <Menu.Trigger
+          className="agent-model-trigger"
+          disabled={!agentReady || pending}
+          aria-label={`Model settings: ${modelName}, ${effortName}`}
+        >
+          {settings.fastMode ? <Zap aria-hidden="true" /> : null}
+          <span>{modelName}</span>
+          <span className="agent-model-effort">{effortName}</span>
+          <ChevronDown aria-hidden="true" />
+        </Menu.Trigger>
+        <Menu.Portal>
+          <Menu.Content
+            className="agent-model-menu"
+            side="top"
+            align="end"
+            sideOffset={12}
+            collisionPadding={12}
+          >
+            <Menu.Sub>
+              <Menu.SubTrigger className="agent-model-menu-item">
+                <span>
+                  <strong>{modelName}</strong>
+                  <small>
+                    {modelLocked
+                      ? "Start a new chat to change models"
+                      : "Choose a model"}
+                  </small>
+                </span>
+                <ChevronRight />
+              </Menu.SubTrigger>
+              <Menu.Portal>
+                <Menu.SubContent
+                  className="agent-model-menu"
+                  sideOffset={6}
+                  collisionPadding={12}
+                >
+                  <Menu.Label className="agent-model-menu-label">
+                    Model
+                  </Menu.Label>
+                  <Menu.RadioGroup
+                    value={settings.model}
+                    onValueChange={(value) =>
+                      void run(() => onModel(value as Model))
+                    }
+                  >
+                    {models.map(([id, label]) => (
+                      <Menu.RadioItem
+                        className="agent-model-menu-item"
+                        key={id}
+                        value={id}
+                        disabled={modelLocked || pending}
+                      >
+                        <span>{label}</span>
+                        <Menu.ItemIndicator>
+                          <Check />
+                        </Menu.ItemIndicator>
+                      </Menu.RadioItem>
+                    ))}
+                  </Menu.RadioGroup>
+                </Menu.SubContent>
+              </Menu.Portal>
+            </Menu.Sub>
+            <Menu.Separator className="agent-model-menu-separator" />
+            <Menu.Sub>
+              <Menu.SubTrigger className="agent-model-menu-item">
+                <span>Thinking</span>
+                <span className="agent-model-fast">
+                  {effortName}
+                  <ChevronRight />
+                </span>
+              </Menu.SubTrigger>
+              <Menu.Portal>
+                <Menu.SubContent
+                  className="agent-model-menu"
+                  sideOffset={6}
+                  collisionPadding={12}
+                >
+                  <Menu.Label className="agent-model-menu-label">
+                    Thinking
+                  </Menu.Label>
+                  <Menu.RadioGroup
+                    value={settings.thinking}
+                    onValueChange={(value) =>
+                      void run(() => onThinking(value as Thinking))
+                    }
+                  >
+                    {efforts.map(([id, label]) => (
+                      <Menu.RadioItem
+                        className="agent-model-menu-item"
+                        key={id}
+                        value={id}
+                        disabled={
+                          pending ||
+                          (settings.model === "gpt-6-astra" && id === "none")
+                        }
+                      >
+                        <span>{label}</span>
+                        <Menu.ItemIndicator>
+                          <Check />
+                        </Menu.ItemIndicator>
+                      </Menu.RadioItem>
+                    ))}
+                  </Menu.RadioGroup>
+                </Menu.SubContent>
+              </Menu.Portal>
+            </Menu.Sub>
+            <Menu.Separator className="agent-model-menu-separator" />
+            <Menu.CheckboxItem
+              className="agent-model-menu-item"
+              checked={settings.fastMode}
+              disabled={pending}
+              onCheckedChange={(value) => void run(() => onFastMode(value))}
+            >
+              <span className="agent-model-fast">
+                <Zap />
+                Fast mode
+              </span>
+              <Menu.ItemIndicator>
+                <Check />
+              </Menu.ItemIndicator>
+            </Menu.CheckboxItem>
+          </Menu.Content>
+        </Menu.Portal>
+      </Menu.Root>
+      {error ? (
+        <p className="agent-model-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/js/account/src/AgentSearchDialog.tsx
+++ b/js/account/src/AgentSearchDialog.tsx
@@ -1,0 +1,102 @@
+import { MessageCircle, Search, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import type { ManagedConversation } from "./managedAgentRuntime";
+
+export function AgentSearchDialog({
+  conversations,
+  onClose,
+  onSelect,
+}: {
+  conversations: readonly ManagedConversation[];
+  onClose(): void;
+  onSelect(id: string): void;
+}) {
+  const dialog = useRef<HTMLDialogElement>(null);
+  const [query, setQuery] = useState("");
+  const matches = conversations.filter(({ title }) =>
+    title.toLocaleLowerCase().includes(query.trim().toLocaleLowerCase()),
+  );
+  useEffect(() => {
+    const element = dialog.current;
+    element?.showModal();
+    return () => element?.close();
+  }, []);
+  return (
+    <dialog
+      className="agent-search-dialog"
+      ref={dialog}
+      aria-label="Search agents"
+      onClose={onClose}
+      onCancel={(event) => {
+        event.preventDefault();
+        onClose();
+      }}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div className="agent-search-panel">
+        <header>
+          <Search aria-hidden="true" />
+          <input
+            autoFocus
+            type="search"
+            aria-label="Search agents"
+            placeholder="Search your agents…"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && matches[0]) {
+                event.preventDefault();
+                onSelect(matches[0].id);
+                onClose();
+              }
+            }}
+          />
+          <button
+            className="chat-icon-button"
+            aria-label="Close search"
+            type="button"
+            onClick={onClose}
+          >
+            <X aria-hidden="true" />
+          </button>
+        </header>
+        <div className="agent-search-results">
+          <p>
+            {query
+              ? `${matches.length} ${matches.length === 1 ? "result" : "results"}`
+              : "Recent agents"}
+          </p>
+          {matches.map((conversation) => (
+            <button
+              key={conversation.id}
+              type="button"
+              onClick={() => {
+                onSelect(conversation.id);
+                onClose();
+              }}
+            >
+              <MessageCircle aria-hidden="true" />
+              <span>
+                {/^Conversation [a-f\d]{8}$/i.test(conversation.title)
+                  ? "New agent"
+                  : conversation.title}
+              </span>
+            </button>
+          ))}
+          {!matches.length ? (
+            <div className="agent-search-empty">
+              {query
+                ? "No agents found. Try a different search."
+                : "Your agents will appear here."}
+            </div>
+          ) : null}
+        </div>
+        <footer>
+          Enter to open the first result <span>Esc to close</span>
+        </footer>
+      </div>
+    </dialog>
+  );
+}

--- a/js/account/src/AgentSidebar.tsx
+++ b/js/account/src/AgentSidebar.tsx
@@ -1,0 +1,277 @@
+import {
+  BookOpen,
+  ChevronDown,
+  CircleUserRound,
+  Compass,
+  Layers,
+  Link2,
+  MessageCircle,
+  PanelLeftClose,
+  Search,
+  SquarePen,
+} from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
+import { Link, useLocation } from "react-router";
+import { AgentSearchDialog } from "./AgentSearchDialog";
+import type { ManagedConversation } from "./managedAgentRuntime";
+import { useModalBoundary } from "./modalBoundary";
+import {
+  connectDemoUrl,
+  demoNavigation,
+  gitNavigation,
+  pathForSurface,
+  primaryNavigation,
+} from "./navigation";
+
+/** Web navigation owns presentation; the managed runtime still owns conversation selection. */
+export function AgentSidebar({
+  conversations,
+  error,
+  landing,
+  onClose,
+  onCollapse,
+  collapsed,
+  onCreate,
+  onRetry,
+  onSelect,
+  open,
+  pending,
+  persistent,
+  selectedId,
+  triggerRef,
+  active,
+}: {
+  active: boolean;
+  conversations: readonly ManagedConversation[];
+  error?: string;
+  landing: boolean;
+  onClose(): void;
+  onCollapse(): void;
+  collapsed: boolean;
+  onCreate(): void;
+  onRetry(): void;
+  onSelect(id: string): void;
+  open: boolean;
+  pending: boolean;
+  persistent: boolean;
+  selectedId?: string;
+  triggerRef: RefObject<HTMLButtonElement | null>;
+}) {
+  const [searchOpen, setSearchOpen] = useState(false);
+  const panelRef = useRef<HTMLElement>(null);
+  const backdropRef = useRef<HTMLDivElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const location = useLocation();
+  const dismiss = useCallback(() => onClose(), [onClose]);
+  useModalBoundary({
+    open,
+    onDismiss: dismiss,
+    panelRef,
+    backdropRef,
+    initialFocusRef: closeRef,
+    returnFocusRef: triggerRef,
+  });
+  useEffect(() => {
+    onClose();
+  }, [location.pathname, location.search, onClose]);
+  useEffect(() => {
+    const desktop = window.matchMedia("(min-width: 761px)");
+    const closeOnDesktop = () => {
+      if (desktop.matches) onClose();
+    };
+    desktop.addEventListener("change", closeOnDesktop);
+    return () => desktop.removeEventListener("change", closeOnDesktop);
+  }, [onClose]);
+  useEffect(() => {
+    if (!active || landing) return;
+    const searchShortcut = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        onClose();
+        setSearchOpen(true);
+      }
+    };
+    window.addEventListener("keydown", searchShortcut);
+    return () => window.removeEventListener("keydown", searchShortcut);
+  }, [active, landing, onClose]);
+
+  return (
+    <>
+      {open ? (
+        <div
+          className="agent-navigation-backdrop"
+          ref={backdropRef}
+          onClick={onClose}
+          aria-hidden="true"
+        />
+      ) : null}
+      <aside
+        id="agent-navigation"
+        ref={panelRef}
+        className={`agent-navigation${open ? " is-open" : ""}${collapsed ? " is-collapsed" : ""}`}
+        aria-label="Workspace navigation"
+        role={open ? "dialog" : undefined}
+        aria-modal={open || undefined}
+      >
+        <div className="agent-navigation-brand">
+          <Link to="/" aria-label="Nanocodex home">
+            <span className="paradigm-mark" aria-hidden="true" />
+            <span>Nanocodex</span>
+          </Link>
+          {!landing ? (
+            <button
+              className="chat-icon-button agent-search-open"
+              type="button"
+              aria-label="Search agents"
+              title="Search agents (⌘K / Ctrl+K)"
+              onClick={() => {
+                onClose();
+                setSearchOpen(true);
+              }}
+            >
+              <Search aria-hidden="true" />
+            </button>
+          ) : null}
+          <button
+            ref={closeRef}
+            className="agent-navigation-close chat-icon-button"
+            onClick={() => {
+              if (open) onClose();
+              else onCollapse();
+            }}
+            aria-label="Close sidebar"
+            title="Close sidebar"
+            type="button"
+          >
+            <PanelLeftClose />
+          </button>
+        </div>
+        <nav className="agent-navigation-primary" aria-label="Chat navigation">
+          <button type="button" onClick={onCreate} disabled={pending}>
+            <SquarePen />
+            <span>{landing ? "New chat" : "New agent"}</span>
+          </button>
+          <Link to="/" aria-current={landing ? "page" : undefined}>
+            <MessageCircle />
+            <span>Chat</span>
+          </Link>
+          <Link to="/agent" aria-current={!landing ? "page" : undefined}>
+            <Layers aria-hidden="true" />
+            <span>Agents</span>
+          </Link>
+          <Link to="/connect">
+            <Link2 />
+            <span>Connections</span>
+          </Link>
+        </nav>
+        <div className="agent-navigation-history">
+          <div className="agent-navigation-heading">
+            <span>{landing ? "Your workspace" : "Recents"}</span>
+          </div>
+          <div className="agent-navigation-list" aria-busy={pending}>
+            {!landing
+              ? conversations.map((conversation) => (
+                  <button
+                    className="agent-navigation-thread"
+                    key={conversation.id}
+                    type="button"
+                    title={conversation.title}
+                    disabled={pending}
+                    aria-current={
+                      conversation.id === selectedId ? "location" : undefined
+                    }
+                    onClick={() => {
+                      onSelect(conversation.id);
+                    }}
+                  >
+                    <span>
+                      {/^Conversation [a-f\d]{8}$/i.test(conversation.title)
+                        ? "New agent"
+                        : conversation.title}
+                    </span>
+                  </button>
+                ))
+              : null}
+            {landing ? (
+              <div className="agent-navigation-empty">
+                <p>Give your work a place to keep going.</p>
+                <Link to="/agent">
+                  Open your agents <span aria-hidden="true">↗</span>
+                </Link>
+              </div>
+            ) : !conversations.length ? (
+              <p className="agent-navigation-empty">
+                {pending
+                  ? "Loading your agents…"
+                  : "Your agents will appear here."}
+              </p>
+            ) : null}
+            {error ? (
+              <div className="agent-navigation-error">
+                <p role="alert">{error}</p>
+                <button type="button" disabled={pending} onClick={onRetry}>
+                  Try again
+                </button>
+              </div>
+            ) : null}
+          </div>
+        </div>
+        <div className="agent-navigation-footer">
+          <Link to="/docs">
+            <BookOpen aria-hidden="true" />
+            <span>Documentation</span>
+          </Link>
+          <details className="agent-navigation-explore">
+            <summary>
+              <Compass aria-hidden="true" />
+              <span>Explore</span>
+              <ChevronDown aria-hidden="true" />
+            </summary>
+            <nav aria-label="Explore Nanocodex">
+              {[
+                ...demoNavigation.filter(({ surface }) => surface !== "agent"),
+                ...primaryNavigation.filter(
+                  ({ surface }) => surface !== "docs",
+                ),
+                ...gitNavigation,
+              ].map(({ surface, label }) => (
+                <Link key={surface} to={pathForSurface(surface)}>
+                  {label}
+                </Link>
+              ))}
+              <a
+                href={connectDemoUrl(window.location.origin)}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Connect playground ↗
+              </a>
+            </nav>
+          </details>
+          <Link className="agent-navigation-account" to="/connect">
+            <CircleUserRound aria-hidden="true" />
+            <span>
+              <strong>{persistent ? "Your account" : "Get started"}</strong>
+              <small>
+                {persistent ? "Connections & settings" : "Sign in to Nanocodex"}
+              </small>
+            </span>
+          </Link>
+        </div>
+      </aside>
+      {searchOpen && active ? (
+        <AgentSearchDialog
+          conversations={conversations}
+          onClose={() => setSearchOpen(false)}
+          onSelect={onSelect}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/js/account/src/AgentTerminal.tsx
+++ b/js/account/src/AgentTerminal.tsx
@@ -33,6 +33,7 @@ import {
   type BrowserAccountMcpConnection,
 } from "./browserMcp";
 import { clientFailureMessage } from "./clientFailure";
+import { AgentModelMenu } from "./AgentModelMenu";
 import { attachManagedBrowserHand } from "./managedBrowserHand";
 import { managedTerminalAgent, openManagedAgent } from "./managedAgentRuntime";
 
@@ -41,12 +42,7 @@ export { AgentTerminalView } from "nanocodex-terminal";
 
 type Model = ManagedCreateSettings["model"];
 type Thinking = ManagedCreateSettings["thinking"];
-const MODELS: readonly Model[] = [
-  "gpt-5.6-sol",
-  "gpt-5.6-terra",
-  "gpt-5.6-luna",
-  "gpt-6-astra",
-];
+
 
 /** Authenticated website policy around the headless Agent SDK and shared transcript view. */
 type AgentTerminalProps = Readonly<{
@@ -186,6 +182,7 @@ const BrowserAgentTerminal = memo(function BrowserAgentTerminal({
       agent={agent}
       agentError={isError ? errorMessage(error) : undefined}
       composer={composer}
+      composerPlaceholder="Ask Nanocodex"
       inactiveMessage={({ agentError, agentStatus }) => inactiveTerminalMessage({
         agentError,
         agentStatus,
@@ -201,7 +198,7 @@ const BrowserAgentTerminal = memo(function BrowserAgentTerminal({
       voice={voiceEnabled}
       welcome={welcome}
       controls={source === "brokered" ? ({ agentReady }) => (
-        <TerminalSettingsControls
+        <AgentModelMenu
           agentReady={agentReady}
           modelLocked={conversationStarted}
           settings={settings}
@@ -330,9 +327,11 @@ export const ManagedAgentTerminal = memo(function ManagedAgentTerminal({
       onStateChange={onStateChange}
       retryAgent={retryAgent}
       voice={voiceEnabled}
+      welcome={settingsReady && !conversationStarted ? "# What should we work on?" : undefined}
+      composerPlaceholder="Ask Nanocodex"
       controls={({ agentReady }) => (
         <>
-          <TerminalSettingsControls
+          <AgentModelMenu
             agentReady={agentReady && settingsReady}
             modelLocked={conversationStarted}
             settings={settings}
@@ -372,58 +371,6 @@ function terminalDefaultSettings(source: CredentialSource | undefined): ManagedC
   };
 }
 
-function TerminalSettingsControls({
-  agentReady,
-  modelLocked,
-  settings,
-  onFastMode,
-  onModel,
-  onThinking,
-}: Readonly<{
-  agentReady: boolean;
-  modelLocked: boolean;
-  settings: ManagedCreateSettings;
-  onFastMode(enabled: boolean): Promise<unknown>;
-  onModel(model: Model): Promise<unknown>;
-  onThinking(thinking: Thinking): Promise<unknown>;
-}>) {
-  const [error, setError] = useState<string>();
-  const run = (operation: Promise<unknown>) => {
-    setError(undefined);
-    void operation.catch((cause) => setError(errorMessage(cause)));
-  };
-  const thinking: readonly Thinking[] = ["none", "low", "medium", "high", "xhigh", "max"];
-  return <div className="agent-runtime-controls" title={error}>
-    <select
-      aria-label="Model"
-      disabled={!agentReady || modelLocked}
-      value={settings.model}
-      onChange={(event) => run(onModel(event.currentTarget.value as Model))}
-    >
-      {MODELS.map((model) => <option key={model} value={model}>{model.replace("gpt-5.6-", "").replace("gpt-6-", "")}</option>)}
-    </select>
-    <select
-      aria-label="Thinking"
-      disabled={!agentReady}
-      value={settings.thinking}
-      onChange={(event) => run(onThinking(event.currentTarget.value as Thinking))}
-    >
-      {thinking.map((effort) => <option
-        key={effort}
-        value={effort}
-        disabled={settings.model === "gpt-6-astra" && effort === "none"}
-      >{effort}</option>)}
-    </select>
-    <button
-      aria-label="Fast mode"
-      aria-pressed={settings.fastMode}
-      className={settings.fastMode ? "is-active" : undefined}
-      disabled={!agentReady}
-      type="button"
-      onClick={() => run(onFastMode(!settings.fastMode))}
-    >fast</button>
-  </div>;
-}
 
 function artifactFollowOnPrompt(
   artifact: ArtifactDocument,

--- a/js/account/src/DeviceConnect.css
+++ b/js/account/src/DeviceConnect.css
@@ -3,16 +3,23 @@
   background: var(--surface);
 }
 
+.device-connect-route .connect-onboarding {
+  font-family: var(--font-sans);
+  --muted: var(--text-muted);
+  --faint: var(--text-secondary);
+}
+
 .device-connect-route .connect-wizard {
   display: flex;
   min-height: calc(100dvh - var(--header-height));
   flex-direction: column;
-  font: 11px/1.45 var(--font-mono);
+  font: 13px/1.5 var(--font-sans);
 }
 
 .device-connect-route .connect-wizard button,
 .device-connect-route .connect-wizard input {
   font: inherit;
+  border-radius: 8px;
 }
 
 .connect-wizard .wizard-content {
@@ -25,7 +32,7 @@
 .connect-wizard .dialog-error {
   width: min(1000px, calc(100% - (2 * var(--page-margin))));
   margin-right: auto;
-  margin-left: var(--page-margin);
+  margin-left: auto;
 }
 
 .connect-wizard .wizard-page {
@@ -43,9 +50,9 @@
   overflow: hidden;
   padding: 32px;
   border: 1px solid var(--border-soft);
-  border-radius: var(--radius-medium);
-  background: color-mix(in srgb, var(--surface-raised) 88%, var(--surface));
-  box-shadow: 0 22px 70px rgba(0, 0, 0, 0.22);
+  border-radius: 22px;
+  background: var(--surface);
+  box-shadow: none;
 }
 
 .connect-wizard .wizard-review-page {
@@ -77,7 +84,7 @@
 .connect-wizard .wizard-app > span,
 .connect-wizard .wizard-section-title span {
   color: var(--faint);
-  font-size: 8px;
+  font-size: 12px;
   letter-spacing: 0.09em;
   text-transform: uppercase;
 }
@@ -121,7 +128,7 @@
 }
 
 .connect-wizard .sms-auth-panel .sms-otp-form > p {
-  font-size: 10px;
+  font-size: 12px;
   line-height: 1.55;
 }
 
@@ -180,7 +187,7 @@
 }
 
 .connect-wizard .sms-auth-panel .account-failure p {
-  font-size: 11px;
+  font-size: 13px;
 }
 
 .connect-wizard .sms-auth-panel .sms-otp-change {
@@ -192,7 +199,7 @@
   background: transparent;
   color: var(--text-muted);
   cursor: pointer;
-  font-size: 10px;
+  font-size: 12px;
   text-decoration: underline;
   text-underline-offset: 3px;
 }
@@ -216,11 +223,11 @@
   border: 1px solid color-mix(in srgb, var(--positive) 55%, var(--border-soft));
   border-radius: 50%;
   color: var(--positive);
-  font-size: 10px;
+  font-size: 12px;
 }
 
 .connect-wizard .sms-auth-security p {
-  font-size: 9px;
+  font-size: 12px;
   line-height: 1.45;
 }
 
@@ -296,7 +303,7 @@
 .connect-wizard .wizard-account-copy small {
   overflow: hidden;
   color: var(--muted);
-  font-size: 10px;
+  font-size: 12px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -307,7 +314,7 @@
 }
 
 .connect-wizard .wizard-account-choice.is-current .wizard-account-arrow {
-  font-size: 9px;
+  font-size: 12px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
@@ -331,7 +338,7 @@
   outline: none;
   background: transparent;
   color: var(--text);
-  font-size: 11px;
+  font-size: 13px;
 }
 
 .connect-wizard .wizard-account-create-form input:focus {
@@ -361,7 +368,7 @@
   background: transparent;
   color: var(--muted);
   cursor: pointer;
-  font-size: 10px;
+  font-size: 12px;
 }
 
 .connect-wizard .wizard-cancel:hover:not(:disabled) {
@@ -378,7 +385,7 @@
 
 .connect-wizard .wizard-terminal-code span {
   color: var(--faint);
-  font-size: 8px;
+  font-size: 12px;
 }
 
 .connect-wizard .wizard-terminal-code strong {
@@ -419,7 +426,7 @@
 .connect-wizard .wizard-section-title small,
 .connect-wizard .wizard-section-title > strong {
   color: var(--faint);
-  font-size: 8px;
+  font-size: 12px;
   font-weight: 400;
 }
 
@@ -470,20 +477,20 @@
 
 .connect-wizard .wizard-account-options button > span {
   color: var(--faint);
-  font-size: 8px;
+  font-size: 12px;
   letter-spacing: 0.05em;
   text-transform: uppercase;
 }
 
 .connect-wizard .wizard-account-options button > strong {
-  font-size: 10px;
+  font-size: 12px;
   font-weight: 500;
 }
 
 .connect-wizard .wizard-account-options button > small,
 .connect-wizard .wizard-account-ready {
   color: var(--muted);
-  font-size: 8px;
+  font-size: 12px;
   line-height: 1.45;
 }
 
@@ -504,7 +511,7 @@
 .account-inline .account-summary {
   min-height: 58px;
   padding: 12px 0;
-  font-size: 10px;
+  font-size: 12px;
 }
 
 .account-inline .account-summary button,
@@ -519,7 +526,7 @@
   padding: 0 13px;
   border: 1px solid var(--border-strong);
   background: transparent;
-  font-size: 9px;
+  font-size: 12px;
 }
 
 .account-inline .account-auth-actions {
@@ -544,7 +551,7 @@
   min-width: 180px;
   min-height: 44px;
   padding: 0 18px;
-  font-size: 10px;
+  font-size: 12px;
 }
 
 .account-inline .account-auth-actions .account-primary-action {
@@ -571,7 +578,7 @@
 .account-inline .api-key-heading p {
   max-width: 620px;
   margin-top: 6px;
-  font-size: 10px;
+  font-size: 12px;
   line-height: 1.5;
 }
 
@@ -598,6 +605,7 @@
   color: var(--text);
   background: transparent;
   border: 1px solid var(--border-soft);
+  border-radius: 14px;
   text-align: left;
   gap: 13px;
 }
@@ -631,6 +639,7 @@
   color: var(--text);
   background: var(--surface-raised);
   border: 1px solid var(--border-soft);
+  border-radius: 12px;
 }
 
 .account-inline .connector-logo svg {
@@ -665,7 +674,7 @@
 .account-inline .connection-card-copy > span {
   overflow: hidden;
   color: var(--muted);
-  font-size: 9px;
+  font-size: 12px;
   line-height: 1.45;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -674,7 +683,7 @@
 .account-inline .connection-card-action {
   align-self: end;
   color: var(--faint);
-  font-size: 8px;
+  font-size: 12px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
@@ -700,7 +709,7 @@
   background: transparent;
   color: var(--text);
   cursor: pointer;
-  font-size: 8px;
+  font-size: 12px;
 }
 
 .account-inline .mcp-connection-actions button:hover:not(:disabled),
@@ -739,7 +748,7 @@
 .account-inline .ssh-identity-intro {
   max-width: 680px;
   color: var(--muted);
-  font-size: 10px;
+  font-size: 12px;
 }
 
 .account-inline .ssh-identity-form {
@@ -749,15 +758,15 @@
 }
 
 .account-inline .ssh-identity-form label {
-  font-size: 9px;
+  font-size: 12px;
 }
 
 .account-inline .ssh-identity-form input {
   height: 40px;
   padding: 0 12px;
   border-color: var(--border-strong);
-  border-radius: 0;
-  font-size: 11px;
+  border-radius: 8px;
+  font-size: 13px;
 }
 
 .account-inline .ssh-identity-form input[type="file"] {
@@ -779,7 +788,7 @@
   background: transparent;
   color: var(--text);
   cursor: pointer;
-  font-size: 9px;
+  font-size: 12px;
 }
 
 .account-inline .ssh-identity-list li {
@@ -797,13 +806,13 @@
 }
 
 .account-inline .account-provider-row strong {
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 500;
 }
 
 .account-inline .account-provider-row span,
 .account-inline .api-key-create > label {
-  font-size: 9px;
+  font-size: 12px;
 }
 
 .account-inline .api-key-create {
@@ -815,8 +824,8 @@
   height: 40px;
   padding: 0 12px;
   border-color: var(--border-strong);
-  border-radius: 0;
-  font-size: 11px;
+  border-radius: 8px;
+  font-size: 13px;
 }
 
 .account-inline .api-key-list li {
@@ -895,7 +904,7 @@
 .connect-wizard .wizard-connectors .connection-card-copy > span {
   overflow: hidden;
   color: var(--muted);
-  font-size: 9px;
+  font-size: 12px;
   line-height: 1.4;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -904,7 +913,7 @@
 .connect-wizard .wizard-connectors .connection-card-action {
   align-self: end;
   color: var(--faint);
-  font-size: 8px;
+  font-size: 12px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
@@ -929,12 +938,12 @@
 
 .connect-wizard .tempo-wallet-card .tempo-wallet-balance {
   color: var(--positive);
-  font-size: 10px;
+  font-size: 12px;
 }
 
 .connect-wizard .tempo-wallet-message {
   color: var(--faint);
-  font-size: 9px;
+  font-size: 12px;
   line-height: 1.4;
   white-space: normal;
 }
@@ -963,7 +972,7 @@
   background: transparent;
   cursor: pointer;
   font: inherit;
-  font-size: 9px;
+  font-size: 12px;
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
@@ -988,7 +997,7 @@
 .connect-wizard .tempo-wallet-payment-status {
   align-self: end;
   color: var(--positive);
-  font-size: 8px;
+  font-size: 12px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
@@ -1043,7 +1052,7 @@
 .connect-wizard .mcp-connection-copy small,
 .connect-wizard .mcp-connection-state {
   color: var(--muted);
-  font-size: 8px;
+  font-size: 12px;
 }
 
 .connect-wizard .mcp-connection-card.is-connected .mcp-connection-state {
@@ -1056,7 +1065,7 @@
   border: 1px solid var(--border-strong);
   background: transparent;
   cursor: pointer;
-  font-size: 8px;
+  font-size: 12px;
 }
 
 .connect-wizard .mcp-connection-card button:hover:not(:disabled),
@@ -1082,7 +1091,7 @@
   border: 1px solid var(--text);
   background: var(--text);
   color: var(--surface);
-  font-size: 9px;
+  font-size: 12px;
   text-decoration: none;
 }
 
@@ -1099,7 +1108,7 @@
   justify-content: space-between;
   padding: 10px 0;
   border-bottom: 1px solid var(--border-soft);
-  font-size: 8px;
+  font-size: 12px;
 }
 
 .connect-wizard .wizard-device-code span {
@@ -1108,7 +1117,7 @@
 
 .connect-wizard .wizard-device-code strong {
   color: var(--positive);
-  font-size: 10px;
+  font-size: 12px;
   font-weight: 500;
   letter-spacing: 0.08em;
 }
@@ -1124,12 +1133,12 @@
   padding: 0 10px;
   border: 1px solid var(--border-strong);
   background: transparent;
-  font-size: 8px;
+  font-size: 12px;
 }
 
 .connect-wizard .account-wallet-session > span {
   color: var(--muted);
-  font-size: 8px;
+  font-size: 12px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
@@ -1164,7 +1173,7 @@
 
 .connect-wizard .wizard-visibility > div > span {
   color: var(--positive);
-  font-size: 8px;
+  font-size: 12px;
 }
 
 .connect-wizard .wizard-visibility > div > div {
@@ -1172,14 +1181,14 @@
 }
 
 .connect-wizard .wizard-visibility strong {
-  font-size: 8px;
+  font-size: 12px;
   font-weight: 500;
 }
 
 .connect-wizard .wizard-visibility small {
   overflow: hidden;
   color: var(--faint);
-  font-size: 8px;
+  font-size: 12px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1190,7 +1199,7 @@
 
 .connect-wizard .advanced-details summary {
   color: var(--faint);
-  font-size: 8px;
+  font-size: 12px;
 }
 
 .connect-wizard .wizard-actions {
@@ -1211,7 +1220,7 @@
   border: 1px solid var(--border-strong);
   background: transparent;
   cursor: pointer;
-  font-size: 9px;
+  font-size: 12px;
 }
 
 .connect-wizard .wizard-actions button:last-child {
@@ -1427,7 +1436,7 @@
   padding: 0 14px;
   place-items: center;
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: 12px;
 }
 
 .connect-home-navigation a:hover,
@@ -1472,7 +1481,7 @@
 .connect-wizard .connect-route-sms-auth .sms-otp-input-row input,
 .connect-wizard .connect-route-sms-auth .sms-otp-input-row button {
   min-height: 44px;
-  border-radius: 0;
+  border-radius: 12px;
 }
 
 .connect-wizard .connect-route-sms-auth .sms-otp-input-row button {
@@ -1486,7 +1495,7 @@
 
 .vault-content {
   width: min(820px, calc(100% - (2 * var(--page-margin))));
-  margin-left: var(--page-margin);
+  margin-left: auto;
   padding: 42px 0 72px;
 }
 
@@ -1506,7 +1515,7 @@
 .vault-heading span,
 .vault-section-heading span {
   color: var(--text-faint);
-  font-size: 8px;
+  font-size: 12px;
   letter-spacing: 0.09em;
   text-transform: uppercase;
 }
@@ -1521,7 +1530,7 @@
 .vault-heading p {
   max-width: 430px;
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: 12px;
   line-height: 1.55;
 }
 
@@ -1545,7 +1554,7 @@
 
 .vault-ssh .ssh-identity-intro {
   max-width: 680px;
-  font-size: 10px;
+  font-size: 12px;
 }
 
 .vault-ssh .ssh-identity-form {
@@ -1558,7 +1567,7 @@
   height: 40px;
   border-color: var(--border-soft);
   border-radius: 0;
-  font-size: 11px;
+  font-size: 13px;
 }
 
 .vault-ssh .ssh-fingerprint-field,
@@ -1574,7 +1583,7 @@
   background: transparent;
   color: var(--text);
   cursor: pointer;
-  font-size: 9px;
+  font-size: 12px;
 }
 
 .vault-ssh .ssh-identity-list li {
@@ -1603,7 +1612,7 @@
 
 .vault-section-heading small {
   color: var(--text-faint);
-  font-size: 8px;
+  font-size: 12px;
 }
 
 .vault-entry-list {
@@ -1648,7 +1657,7 @@
 
 .vault-entry-list strong {
   overflow: hidden;
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1656,7 +1665,7 @@
 
 .vault-entry-list span {
   color: var(--text-faint);
-  font-size: 8px;
+  font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -1744,7 +1753,7 @@
 
 .vault-dialog header p {
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: 12px;
 }
 
 .vault-dialog header button {
@@ -1793,7 +1802,7 @@
   display: flex;
   align-items: center;
   color: var(--text-muted);
-  font-size: 9px;
+  font-size: 12px;
   font-weight: 500;
   gap: 6px;
 }
@@ -1833,7 +1842,7 @@
   width: max-content;
   padding: 5px 0;
   cursor: pointer;
-  font-size: 9px;
+  font-size: 12px;
   list-style: none;
 }
 
@@ -1982,3 +1991,15 @@
     font-size: 16px;
   }
 }
+
+/* Account settings share the native app's grouped surfaces. */
+.device-connect-route { --faint: var(--text-secondary); --muted: var(--text-muted); --border-strong: var(--border-soft); }
+.connect-wizard .wizard-account-chooser { border-radius: 16px; }
+.connect-wizard .wizard-account-avatar, .connect-wizard .connector-logo { border-radius: 12px; }
+.connect-wizard .wizard-connectors .connection-card { padding: 14px; border: 1px solid var(--border-soft); border-radius: 14px; background: var(--surface-subtle); }
+.connect-wizard .wizard-connectors { gap: 12px; }
+.connect-wizard .wizard-connectors .connection-card:focus-visible { outline: 2px solid var(--text); outline-offset: 2px; }
+.connect-wizard .wizard-visibility { padding: 16px; border-radius: 14px; background: var(--surface-subtle); }
+.connect-wizard .wizard-review-page { padding-bottom: 32px; }
+.connect-wizard .wizard-actions { padding-bottom: max(24px, env(safe-area-inset-bottom)); }
+.connect-wizard .wizard-actions button { min-height: 46px; border-radius: 12px; }

--- a/js/account/src/Home.css
+++ b/js/account/src/Home.css
@@ -958,5 +958,6 @@ html[data-theme="light"] .chat-workspace {
   .agent-model-menu {
     scroll-behavior: auto !important;
     transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
   }
 }

--- a/js/account/src/Home.css
+++ b/js/account/src/Home.css
@@ -39,10 +39,923 @@
   box-shadow: none;
 }
 
+/* Chat presentation belongs to the web app; SDK demos keep their own theme. */
+.site-shell:is(.surface-home, .surface-agent) > .site-header {
+  display: none;
+}
+
+.site-shell:is(.surface-home, .surface-agent) {
+  --shell-header-height: 0px;
+}
+
+.chat-workspace {
+  --font-sans:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  --chat-background: #212121;
+  --chat-sidebar: #191919;
+  --chat-input: #303030;
+  --chat-composer: #303030;
+  --chat-text: #ececec;
+  --chat-muted: #a3a3a3;
+  --chat-line: #383838;
+  --chat-hover: #2b2b2b;
+  --chat-selected: #303030;
+  --chat-positive: #72ba96;
+  --terminal-background: var(--chat-background);
+  --terminal-foreground: var(--chat-text);
+  --terminal-muted: var(--chat-muted);
+  --terminal-secondary: var(--chat-muted);
+  --terminal-faint: var(--chat-muted);
+  --terminal-border: var(--chat-line);
+  --terminal-hover: var(--chat-hover);
+  --terminal-font-sans: var(--font-sans);
+  color: var(--chat-text);
+  background: var(--chat-background);
+  font: 14px/1.5 var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+}
+
+html[data-theme="light"] .chat-workspace {
+  --chat-background: #fff;
+  --chat-sidebar: #f9f9f9;
+  --chat-input: #f4f4f4;
+  --chat-composer: #fff;
+  --chat-text: #0d0d0d;
+  --chat-muted: #747474;
+  --chat-line: #e8e8e8;
+  --chat-hover: #ededed;
+  --chat-selected: #eaeaea;
+  --chat-positive: #24855b;
+}
+
+.chat-workspace button,
+.chat-workspace input,
+.chat-workspace select {
+  font: inherit;
+}
+
+.chat-workspace :is(button, a, input, select, summary):focus-visible {
+  outline: 2px solid #7a9cc6;
+  outline-offset: 2px;
+}
+
+.chat-workspace button:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+.chat-workspace button,
+.chat-workspace a {
+  -webkit-tap-highlight-color: transparent;
+}
+.chat-workspace svg {
+  width: 18px;
+  height: 18px;
+  stroke-width: 1.65;
+}
+
+.nanocodex-demo.chat-workspace .conversation-workspace {
+  flex: 1 1 auto;
+  grid-template-columns: 260px minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr);
+  border: 0;
+}
+
+.nanocodex-demo.chat-workspace .conversation-main {
+  grid-column: 2;
+  grid-row: 1;
+  position: relative;
+}
+
+.agent-navigation {
+  display: flex;
+  grid-column: 1;
+  grid-row: 1;
+  min-height: 0;
+  flex-direction: column;
+  padding: 8px 8px 10px;
+  border-right: 1px solid color-mix(in srgb, var(--chat-text) 5%, transparent);
+  background: var(--chat-sidebar);
+}
+
+.agent-navigation-brand {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 44px;
+  margin-bottom: 12px;
+  padding: 0 10px;
+}
+
+.agent-navigation-brand > a {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.4px;
+}
+.agent-navigation-brand .paradigm-mark {
+  width: 22px;
+  height: 24px;
+  background: var(--chat-text);
+  opacity: 1;
+}
+.agent-navigation-brand .agent-search-open {
+  margin-left: auto;
+}
+.agent-navigation-primary {
+  display: grid;
+  gap: 3px;
+}
+.agent-navigation-primary :is(a, button),
+.agent-navigation-footer > a,
+.agent-navigation-explore > summary {
+  display: flex;
+  width: 100%;
+  min-height: 36px;
+  gap: 11px;
+  align-items: center;
+  padding: 8px 10px;
+  border-radius: 8px;
+  color: var(--chat-text);
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.agent-navigation-primary :is(a, button):hover,
+.agent-navigation-footer > a:hover,
+.agent-navigation-explore > summary:hover,
+.agent-navigation-thread:hover {
+  background: var(--chat-hover);
+}
+.agent-navigation-primary [aria-current="page"],
+.agent-navigation-thread[aria-current="location"] {
+  background: var(--chat-selected);
+}
+.agent-navigation-history {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 90px;
+  margin-top: 30px;
+}
+.agent-navigation-heading {
+  padding: 0 10px 10px;
+  color: var(--chat-muted);
+  font-size: 13px;
+  font-weight: 500;
+}
+.agent-navigation-list {
+  min-height: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+  scrollbar-color: var(--chat-line) transparent;
+}
+.agent-navigation-thread {
+  display: flex;
+  width: 100%;
+  min-height: 36px;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 10px;
+  color: var(--chat-text);
+  background: transparent;
+  border-radius: 8px;
+  text-align: left;
+  cursor: pointer;
+}
+.agent-navigation-thread svg {
+  width: 15px;
+  height: 15px;
+  color: var(--chat-muted);
+}
+.agent-navigation-thread span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 14px;
+}
+.agent-navigation-empty {
+  padding: 4px 10px;
+  color: var(--chat-muted);
+  font-size: 12px;
+  line-height: 1.7;
+}
+.agent-navigation-empty a {
+  display: inline-block;
+  margin-top: 9px;
+  color: var(--chat-text);
+}
+.agent-navigation-empty a:hover {
+  text-decoration: underline;
+}
+.agent-navigation-error {
+  padding: 10px;
+  font-size: 12px;
+}
+.agent-navigation-error button {
+  margin-top: 8px;
+  padding: 7px 12px;
+  color: var(--chat-text);
+  background: var(--chat-hover);
+  border-radius: 8px;
+  cursor: pointer;
+}
+.agent-navigation-footer {
+  flex-shrink: 0;
+  padding-top: 12px;
+}
+.agent-navigation-explore > summary {
+  list-style: none;
+}
+.agent-navigation-explore > summary::-webkit-details-marker {
+  display: none;
+}
+.agent-navigation-explore > summary svg:last-child {
+  margin-left: auto;
+  width: 13px;
+  height: 13px;
+}
+.agent-navigation-explore[open] > summary svg:last-child {
+  transform: rotate(180deg);
+}
+.agent-navigation-explore nav {
+  display: grid;
+  max-height: 220px;
+  overflow: auto;
+  padding: 5px 0;
+}
+.agent-navigation-explore nav a {
+  padding: 6px 10px 6px 39px;
+  border-radius: 8px;
+  font-size: 12px;
+  color: var(--chat-muted);
+}
+.agent-navigation-explore nav a:hover {
+  color: var(--chat-text);
+  background: var(--chat-hover);
+}
+.agent-navigation-footer > .agent-navigation-account {
+  gap: 10px;
+  margin-top: 12px;
+  padding-top: 14px;
+  border-top: 1px solid var(--chat-line);
+  border-radius: 0;
+}
+.agent-navigation-account > svg {
+  width: 29px;
+  height: 29px;
+  stroke-width: 1.2;
+}
+.agent-navigation-account span {
+  display: grid;
+  gap: 2px;
+}
+.agent-navigation-account strong {
+  font-size: 12px;
+  font-weight: 500;
+}
+.agent-navigation-account small {
+  color: var(--chat-muted);
+  font-size: 11px;
+}
+
+.chat-workspace .chat-icon-button {
+  display: grid;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  flex-shrink: 0;
+  place-items: center;
+  background: transparent;
+  color: var(--chat-muted);
+  border-radius: 9px;
+  cursor: pointer;
+}
+.chat-workspace .chat-icon-button:hover {
+  background: var(--chat-hover);
+  color: var(--chat-text);
+}
+.chat-workspace .agent-sidebar-toggle {
+  display: none;
+}
+.chat-workspace .agent-navigation-close {
+  display: grid;
+}
+@media (min-width: 761px) {
+  .nanocodex-demo.chat-workspace .conversation-workspace.is-sidebar-collapsed {
+    grid-template-columns: 0 minmax(0, 1fr);
+  }
+}
+.chat-workspace .is-sidebar-collapsed .agent-navigation {
+  visibility: hidden;
+  overflow: hidden;
+  padding: 0;
+  border: 0;
+}
+.chat-workspace .is-sidebar-collapsed .agent-sidebar-toggle {
+  display: grid;
+}
+.agent-chat-header {
+  display: flex;
+  min-height: 60px;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 20px;
+}
+.agent-chat-heading {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+.agent-chat-heading strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 18px;
+  font-weight: 500;
+}
+.agent-chat-heading > span {
+  color: var(--chat-muted);
+  font-size: 11px;
+}
+.agent-chat-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+}
+.agent-chat-status {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin-right: 9px;
+  white-space: nowrap;
+  color: var(--chat-muted);
+  font-size: 11px;
+}
+.agent-chat-status i {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--chat-muted);
+}
+.agent-chat-status.is-ready i {
+  background: var(--chat-positive);
+}
+.agent-chat-status.is-error i {
+  background: var(--negative);
+}
+.agent-chat-footnote {
+  flex-shrink: 0;
+  padding: 0 20px max(14px, env(safe-area-inset-bottom));
+  color: var(--chat-muted);
+  font-size: 12px;
+  line-height: 1.5;
+  text-align: center;
+}
+
+.chat-workspace .agent-terminal-shell {
+  border: 0;
+}
+.chat-workspace .agent-dom-transcript-inner {
+  width: min(100%, 780px);
+  margin: 0 auto;
+  padding: 24px 24px 28px;
+  font: 16px/1.7 var(--font-sans);
+}
+.chat-workspace .agent-terminal-user {
+  width: fit-content;
+  max-width: 85%;
+  margin: 10px 0 32px auto;
+  padding: 12px 19px;
+  color: var(--chat-text);
+  background: var(--chat-input);
+  border: 0;
+  border-radius: 24px;
+  font: 400 16px/1.65 var(--font-sans);
+}
+.chat-workspace .agent-terminal-markdown {
+  margin-bottom: 28px;
+}
+.chat-workspace .agent-terminal-markdown :is(h1, h2, h3) {
+  font-family: var(--font-sans);
+  font-size: 1.15em;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+}
+.chat-workspace .agent-terminal-markdown :is(pre, code) {
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+.chat-workspace .agent-terminal-markdown pre {
+  border-radius: 12px;
+}
+.chat-workspace .agent-terminal-markdown.is-reasoning {
+  font-size: 13px;
+}
+.chat-workspace .agent-terminal-entry-label {
+  font-size: 11px;
+}
+.chat-workspace .agent-terminal-tool {
+  margin-bottom: 10px;
+  border: 0;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--chat-text) 3%, var(--chat-background));
+}
+.chat-workspace .agent-terminal-tool summary {
+  padding: 12px;
+}
+.chat-workspace .agent-terminal-tool-heading strong {
+  font: 500 13px/1.5 var(--font-sans);
+}
+.chat-workspace .agent-terminal-tool-heading > span {
+  display: none;
+}
+.chat-workspace .agent-terminal-tool-meta {
+  font-family: var(--font-sans);
+  text-transform: none;
+  letter-spacing: 0;
+}
+.chat-workspace .agent-terminal-status {
+  font: 13px/1.6 var(--font-sans);
+  color: var(--chat-muted);
+}
+.chat-workspace .agent-terminal-shell:has(.is-welcome) {
+  grid-template-rows: auto auto;
+  align-content: center;
+  padding-bottom: min(12vh, 120px);
+  overflow-y: auto;
+}
+.chat-workspace .agent-terminal-shell:has(.is-welcome) .agent-dom-transcript {
+  overflow: visible;
+}
+.chat-workspace .agent-dom-transcript-inner:has(> .is-welcome) {
+  min-height: 0;
+  padding: 20px 24px 22px;
+  text-align: center;
+}
+.chat-workspace .is-welcome {
+  margin: 0;
+}
+.chat-workspace .agent-terminal-markdown.is-welcome h1 {
+  font-size: 28px;
+  font-weight: 500;
+  line-height: 1.3;
+  letter-spacing: -0.7px;
+}
+.chat-workspace .is-welcome p {
+  margin-top: 12px;
+  color: var(--chat-muted);
+  font-size: 14px;
+  line-height: 1.6;
+}
+.chat-workspace .agent-transcript-keyboard-spacer {
+  display: none;
+}
+
+.chat-workspace .agent-touch-composer {
+  width: min(100%, 820px);
+  margin: 0 auto;
+  padding: 8px 24px 12px;
+  border: 0;
+  min-height: 0;
+  background: var(--chat-background);
+  font-family: var(--font-sans);
+}
+.chat-workspace .agent-touch-field {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  min-height: 112px;
+  padding: 12px 10px 8px;
+  background: var(--chat-composer);
+  border: 1px solid color-mix(in srgb, var(--chat-text) 14%, transparent);
+  border-radius: 28px;
+  box-shadow: 0 2px 12px rgb(0 0 0 / 0.04);
+}
+.chat-workspace .agent-touch-field:focus-within {
+  border-color: color-mix(in srgb, var(--chat-text) 27%, transparent);
+}
+.chat-workspace .agent-touch-composer textarea {
+  min-height: 44px;
+  max-height: 180px;
+  padding: 3px 10px 14px;
+  font: 400 16px/1.625 var(--font-sans);
+  field-sizing: content;
+}
+.chat-workspace .agent-touch-composer textarea::placeholder {
+  color: var(--chat-muted);
+}
+.chat-workspace .agent-touch-actions {
+  width: 100%;
+  align-items: center;
+  gap: 4px;
+  padding: 0;
+  border: 0;
+}
+.chat-workspace .agent-touch-actions button {
+  width: 36px;
+  min-width: 36px;
+  min-height: 36px;
+  border-radius: 50%;
+  color: var(--chat-muted);
+}
+.chat-workspace .agent-touch-actions button:hover {
+  background: var(--chat-hover);
+  color: var(--chat-text);
+}
+.chat-workspace .agent-touch-actions > button[type="submit"] {
+  order: 5;
+  color: var(--chat-background);
+  background: var(--chat-text);
+}
+.chat-workspace .agent-touch-actions > button[type="submit"]:hover {
+  opacity: 0.8;
+}
+.chat-workspace .agent-touch-actions > button[type="submit"]:disabled {
+  opacity: 0.25;
+}
+.chat-workspace .agent-runtime-controls {
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+  order: 2;
+}
+.chat-workspace .agent-touch-actions .agent-model-trigger {
+  display: flex;
+  gap: 6px;
+  width: auto;
+  min-width: 0;
+  padding: 0 10px;
+  border-radius: 18px;
+  font-size: 13px;
+  white-space: nowrap;
+}
+.chat-workspace .agent-model-trigger svg {
+  width: 14px;
+  height: 14px;
+}
+.chat-workspace .agent-model-effort {
+  color: var(--chat-muted);
+}
+.chat-workspace :is(.agent-voice-button, .agent-voice-cancel-button) {
+  order: 3;
+}
+.chat-workspace .agent-touch-actions > button[aria-label="Stop response"] {
+  order: 4;
+  color: var(--chat-background);
+  background: var(--chat-text);
+}
+.chat-workspace
+  .agent-touch-actions:has(> button[aria-label="Stop response"])
+  > button[type="submit"]:disabled {
+  display: none;
+}
+.chat-workspace .agent-touch-actions > button:only-child {
+  margin-left: auto;
+}
+.agent-model-menu {
+  z-index: 80;
+  min-width: 250px;
+  max-width: calc(100vw - 24px);
+  max-height: var(--radix-dropdown-menu-content-available-height);
+  overflow-y: auto;
+  padding: 7px;
+  color: var(--text);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  box-shadow: 0 8px 36px rgb(0 0 0 / 0.13);
+  font: 14px/1.4 var(--font-sans);
+  animation: chat-menu-in 120ms ease-out;
+}
+.agent-model-menu-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  min-height: 36px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  cursor: pointer;
+  outline: none;
+}
+.agent-model-menu-item[data-highlighted] {
+  background: color-mix(in srgb, var(--text) 6%, transparent);
+}
+.agent-model-menu-item[data-disabled] {
+  opacity: 0.4;
+  cursor: default;
+}
+.agent-model-menu-item svg {
+  width: 16px;
+  height: 16px;
+}
+.agent-model-menu-item strong {
+  font-size: 14px;
+  font-weight: 500;
+}
+.agent-model-menu-item small {
+  display: block;
+  margin-top: 3px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.agent-model-menu-label {
+  padding: 7px 10px 5px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.agent-model-menu-separator {
+  height: 1px;
+  margin: 6px 4px;
+  background: var(--border);
+}
+.agent-model-fast {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+.agent-model-error {
+  position: absolute;
+  bottom: calc(100% + 20px);
+  right: 0;
+  width: 280px;
+  padding: 12px 16px;
+  color: var(--negative);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  box-shadow: 0 4px 20px rgb(0 0 0 / 0.08);
+  font-size: 13px;
+}
+@keyframes chat-menu-in {
+  from {
+    opacity: 0;
+    transform: translateY(3px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+.chat-workspace .agent-voice-feedback {
+  right: 0;
+  bottom: calc(100% + 18px);
+  text-align: left;
+}
+.chat-workspace :is(.agent-voice-status, .agent-voice-error) {
+  padding: 10px 14px;
+  border-radius: 12px;
+  font-family: var(--font-sans);
+}
+
+.chat-workspace .terminal-sms-auth {
+  width: min(100%, 520px);
+  margin: 0 auto;
+  padding: 20px 28px 28px;
+  border: 0;
+}
+.chat-workspace .terminal-sms-auth .wizard-app h1 {
+  font: 500 18px var(--font-sans);
+}
+.chat-workspace .terminal-sms-auth .wizard-app p,
+.chat-workspace .terminal-sms-auth .sms-otp-form > p {
+  font: 14px/1.6 var(--font-sans);
+}
+.chat-workspace .terminal-sms-auth :is(input, button) {
+  border-radius: 12px;
+  min-height: 44px;
+  font-family: var(--font-sans);
+}
+.chat-workspace .terminal-sms-auth input {
+  font-size: 16px;
+}
+.chat-workspace .homepage-trial-actions {
+  width: min(100%, 752px);
+  margin: 0 auto 16px;
+  padding: 20px;
+  border: 1px solid var(--chat-line);
+  border-radius: 22px;
+  font-family: var(--font-sans);
+}
+.agent-connect-prompt {
+  display: grid;
+  gap: 12px;
+  justify-items: center;
+  padding: 20px 24px 36px;
+}
+.agent-connect-prompt a {
+  padding: 12px 22px;
+  border-radius: 24px;
+  color: var(--chat-background);
+  background: var(--chat-text);
+  font-size: 14px;
+  font-weight: 500;
+}
+.agent-connect-prompt span {
+  color: var(--chat-muted);
+  font-size: 12px;
+  text-align: center;
+}
+.agent-connection-loading {
+  padding: 32px;
+  color: var(--chat-muted);
+  text-align: center;
+  font-size: 13px;
+}
+
+.agent-search-dialog {
+  width: min(600px, calc(100vw - 32px));
+  max-height: min(560px, calc(100dvh - 80px));
+  margin: max(40px, 15vh) auto auto;
+  padding: 0;
+  color: var(--chat-text);
+  background: var(--chat-background);
+  border: 1px solid var(--chat-line);
+  border-radius: 20px;
+  box-shadow: 0 20px 80px rgb(0 0 0 / 0.2);
+  overflow: auto;
+}
+.agent-search-dialog::backdrop {
+  background: rgb(0 0 0 / 0.35);
+}
+.agent-search-panel header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--chat-line);
+}
+.agent-search-panel input {
+  flex: 1;
+  min-width: 0;
+  color: var(--chat-text);
+  background: transparent;
+  font: 16px/1.5 var(--font-sans);
+  outline: none;
+}
+.agent-search-results {
+  max-height: 360px;
+  overflow-y: auto;
+  padding: 12px 8px;
+}
+.agent-search-results > p {
+  padding: 0 12px 8px;
+  color: var(--chat-muted);
+  font-size: 12px;
+}
+.agent-search-results button {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  min-height: 48px;
+  padding: 12px;
+  text-align: left;
+  color: var(--chat-text);
+  background: transparent;
+  border-radius: 10px;
+  cursor: pointer;
+}
+.agent-search-results button:hover {
+  background: var(--chat-hover);
+}
+.agent-search-results button svg {
+  flex-shrink: 0;
+  color: var(--chat-muted);
+}
+.agent-search-results button span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.agent-search-empty {
+  padding: 30px 12px;
+  color: var(--chat-muted);
+  text-align: center;
+}
+.agent-search-panel footer {
+  display: flex;
+  justify-content: space-between;
+  padding: 12px 20px;
+  color: var(--chat-muted);
+  font-size: 11px;
+  border-top: 1px solid var(--chat-line);
+}
+
+@media (max-width: 760px) {
+  .nanocodex-demo.chat-workspace .conversation-workspace {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .nanocodex-demo.chat-workspace .conversation-main {
+    grid-column: 1;
+  }
+  .chat-workspace :is(.agent-sidebar-toggle, .agent-navigation-close) {
+    display: grid;
+  }
+  .agent-navigation {
+    display: none;
+    position: fixed;
+    z-index: 51;
+    inset: 0 auto 0 0;
+    width: min(300px, calc(100vw - 48px));
+    padding-top: max(14px, env(safe-area-inset-top));
+    padding-bottom: max(12px, env(safe-area-inset-bottom));
+  }
+  .chat-workspace .agent-navigation.is-open {
+    display: flex;
+    visibility: visible;
+    padding: max(8px, env(safe-area-inset-top)) 8px
+      max(12px, env(safe-area-inset-bottom));
+  }
+  .agent-navigation-backdrop {
+    position: fixed;
+    z-index: 50;
+    inset: 0;
+    background: rgb(0 0 0 / 0.35);
+  }
+  .agent-chat-header {
+    gap: 8px;
+    min-height: 68px;
+    padding: max(8px, env(safe-area-inset-top)) 12px 8px;
+  }
+  .agent-chat-heading strong {
+    font-size: 16px;
+  }
+  .agent-chat-heading > span,
+  .agent-chat-status {
+    display: none;
+  }
+  .agent-chat-header-actions {
+    gap: 2px;
+  }
+  .chat-workspace .chat-icon-button {
+    width: 40px;
+    height: 44px;
+  }
+  .chat-workspace .agent-dom-transcript-inner {
+    padding: 20px 20px 28px;
+    font-size: 17px;
+  }
+  .chat-workspace .agent-terminal-user {
+    max-width: 90%;
+    font-size: 17px;
+    border-radius: 24px;
+  }
+  .chat-workspace .agent-touch-composer {
+    padding: 8px 12px;
+  }
+  .chat-workspace .agent-touch-field {
+    padding: 10px 10px 8px;
+    border: 0;
+    border-radius: 28px;
+    background: var(--chat-input);
+  }
+  .chat-workspace .agent-touch-composer textarea {
+    font-size: 16px;
+  }
+  .chat-workspace .agent-touch-actions button {
+    width: 40px;
+    min-width: 40px;
+    min-height: 44px;
+  }
+  .chat-workspace .agent-model-effort {
+    display: none;
+  }
+  .chat-workspace .agent-touch-actions .agent-model-trigger {
+    padding-inline: 8px;
+    font-size: 13px;
+  }
+  .chat-workspace .agent-terminal-shell:has(.is-welcome) {
+    padding-bottom: 8vh;
+  }
+  .chat-workspace .agent-terminal-markdown.is-welcome h1 {
+    font-size: 26px;
+  }
+  .agent-chat-footnote {
+    font-size: 10px;
+    padding: 0 20px max(10px, env(safe-area-inset-bottom));
+  }
+  .agent-navigation-primary :is(a, button),
+  .agent-navigation-thread,
+  .agent-navigation-footer > a,
+  .agent-navigation-explore > summary {
+    min-height: 44px;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .home-page *,
-  .home-page *::before,
-  .home-page *::after {
+  .chat-workspace *,
+  .chat-workspace *::before,
+  .chat-workspace *::after,
+  .agent-model-menu {
     scroll-behavior: auto !important;
     transition-duration: 0.01ms !important;
   }

--- a/js/account/src/NanocodexApp.tsx
+++ b/js/account/src/NanocodexApp.tsx
@@ -244,11 +244,12 @@ function NanocodexShell({ preparedRoute }: Required<NanocodexAppProps>) {
   const navigate = useNavigate();
   const [theme, setTheme] = useState<Theme>(() => {
     const stored = localStorage.getItem("nanocodex-theme");
-    const initial = stored === "light" || stored === "dark" ? stored : "dark";
+    const initial = stored === "light" || stored === "dark" ? stored
+      : window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
     document.documentElement.dataset.theme = initial;
     document
       .querySelector('meta[name="theme-color"]')
-      ?.setAttribute("content", initial === "dark" ? "#161616" : "#ffffff");
+      ?.setAttribute("content", initial === "dark" ? "#212121" : "#ffffff");
     return initial;
   });
   const surface = surfaceFromUrl({
@@ -631,7 +632,7 @@ function NanocodexShell({ preparedRoute }: Required<NanocodexAppProps>) {
     document.documentElement.dataset.theme = theme;
     document
       .querySelector('meta[name="theme-color"]')
-      ?.setAttribute("content", theme === "dark" ? "#161616" : "#ffffff");
+      ?.setAttribute("content", theme === "dark" ? "#212121" : "#ffffff");
     localStorage.setItem("nanocodex-theme", theme);
   }, [theme]);
 
@@ -1356,10 +1357,12 @@ function NanocodexShell({ preparedRoute }: Required<NanocodexAppProps>) {
                   className="sr-only"
                   id={surface === "agent" ? "agent-page-title" : "home-title"}
                 >
-                  {surface === "agent" ? "Nanocodex durable agent" : "High-performance Codex SDK. Runs anywhere."}
+                  {surface === "agent" ? "Your Nanocodex agents" : "Chat with Nanocodex"}
                 </h1>
                 <section className="home-demo" id="agent-demo">
                   <AgentExperience
+                    theme={theme}
+                    onThemeChange={setTheme}
                     agentId={routeAgentId}
                     landing={agentExperienceSurface === "home"}
                     mode={

--- a/js/account/src/homeTerminalWelcome.ts
+++ b/js/account/src/homeTerminalWelcome.ts
@@ -1,15 +1,6 @@
 import type { CredentialSource } from "./modelSession";
 
-const HOME_TERMINAL_WELCOME = `# High-performance Codex SDK. Runs anywhere.
-
-\`curl -fsSL https://nanocodex.paradigm.xyz | bash\`
-
-Rust · Node · browser WASM
-One agent keeps its WebSocket, typed history, tools, and context across turns.
-
-**Terminal-Bench 2.1 high · 82.2% · 890/890 runs**
-
-This is the local browser agent.`;
+const HOME_TERMINAL_WELCOME = `# What should we work on?`;
 
 export function homeTerminalWelcome(
   source: CredentialSource | undefined,
@@ -19,7 +10,7 @@ export function homeTerminalWelcome(
   if (source === "brokered") {
     return `${HOME_TERMINAL_WELCOME}
 
-This homepage demo uses your connected model account and is ephemeral: reloading discards the model thread.`;
+Using your connected model account.`;
   }
   const included = source === "sponsored" && freePromptsRemaining === 0
     ? "Your three free Luna prompts are used."
@@ -28,5 +19,5 @@ This homepage demo uses your connected model account and is ephemeral: reloading
       : "Verify your phone by SMS to get three free Luna prompts.";
   return `${HOME_TERMINAL_WELCOME}
 
-${included} Free prompts use Luna without thinking and are ephemeral: reloading discards the model thread.`;
+${included}`;
 }

--- a/js/account/src/index.css
+++ b/js/account/src/index.css
@@ -1,6 +1,6 @@
 :root {
   color-scheme: dark;
-  font-family: var(--font-mono);
+  font-family: var(--font-sans);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   --black: #000000;
@@ -16,16 +16,16 @@
   --grey-600: #666666;
   --grey-700: #333333;
   --grey-800: #161616;
-  --text: var(--white);
+  --text: #ececec;
   --text-muted: color-mix(in srgb, var(--text) 60%, transparent);
   --text-secondary: color-mix(in srgb, var(--text) 64%, transparent);
   --text-faint: color-mix(in srgb, var(--text) 42%, transparent);
   --text-inverse: var(--black);
-  --border: var(--grey-600);
+  --border: #484848;
   --border-soft: rgba(255, 255, 255, 0.12);
-  --surface: var(--grey-800);
-  --surface-subtle: var(--grey-700);
-  --surface-raised: #202020;
+  --surface: #212121;
+  --surface-subtle: #191919;
+  --surface-raised: #2b2b2b;
   --surface-overlay: rgba(51, 51, 51, 0.68);
   --surface-hover: rgba(255, 255, 255, 0.06);
   --positive: #73d89b;
@@ -33,16 +33,17 @@
   --on-positive: var(--black);
   --on-negative: var(--black);
   --on-accent: var(--black);
-  --header-height: 48px;
+  --header-height: 56px;
   --shell-header-height: var(--header-height);
   --page-margin: 36px;
   --gutter: 36px;
-  --radius-small: 4px;
-  --radius-medium: 12px;
+  --radius-small: 8px;
+  --radius-medium: 16px;
   --shadow-overlay: 0 24px 70px rgba(0, 0, 0, 0.55);
-  --font-site: "Berkeley Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-site: var(--font-sans);
   --font-display: var(--font-site);
-  --font-mono: var(--font-site);
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   --content-max: 1120px;
   --wide-max: 1440px;
   --coarse-target-size: 44px;
@@ -50,12 +51,12 @@
 
 html[data-theme="light"] {
   color-scheme: light;
-  --text: var(--black);
+  --text: #262626;
   --text-inverse: var(--white);
-  --border: var(--grey-400);
+  --border: #dedede;
   --border-soft: rgba(0, 0, 0, 0.1);
   --surface: var(--white);
-  --surface-subtle: var(--grey-100);
+  --surface-subtle: #f9f9f9;
   --surface-raised: var(--white);
   --surface-overlay: rgba(224, 224, 224, 0.6);
   --surface-hover: rgba(0, 0, 0, 0.04);
@@ -85,8 +86,9 @@ body {
   min-height: 100vh;
   background: var(--surface);
   color: var(--text);
-  font-size: 12px;
-  line-height: 1.25;
+  font-size: 13px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
 }
 
 .artifact-runtime-page,
@@ -205,8 +207,8 @@ body.agent-viewport-locked {
   align-items: center;
   min-height: 44px;
   color: var(--text-muted);
-  font-family: var(--font-mono);
-  font-size: 11px;
+  font-family: var(--font-sans);
+  font-size: 15px;
   line-height: 1;
   white-space: nowrap;
 }
@@ -242,7 +244,7 @@ body.agent-viewport-locked {
 .wordmark {
   justify-self: start;
   color: var(--text);
-  font-family: var(--font-mono);
+  font-family: var(--font-sans);
   font-weight: 600;
   letter-spacing: -0.03em;
 }
@@ -275,7 +277,7 @@ body.agent-viewport-locked {
   color: var(--text-muted);
   background: transparent;
   cursor: pointer;
-  font-size: 11px;
+  font-size: 13px;
   line-height: 1;
   touch-action: manipulation;
 }
@@ -319,6 +321,7 @@ body.agent-viewport-locked {
   padding: 5px;
   background: var(--surface-raised);
   border: 1px solid var(--border);
+  border-radius: 12px;
   box-shadow: 0 14px 36px rgb(0 0 0 / 24%);
 }
 
@@ -329,7 +332,8 @@ body.agent-viewport-locked {
   justify-content: space-between;
   padding: 0 9px;
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: 13px;
+  border-radius: 7px;
   touch-action: manipulation;
 }
 
@@ -391,7 +395,7 @@ body.agent-viewport-locked {
   min-height: 34px;
   padding: 0 8px;
   color: var(--text-muted);
-  font: 600 10px/1 var(--font-mono);
+  font: 500 12px/1 var(--font-sans);
   background: transparent;
   border-radius: var(--radius-small);
   cursor: pointer;
@@ -889,7 +893,7 @@ body.agent-viewport-locked {
   min-height: 34px;
   padding: 0 10px;
   color: var(--text);
-  font: 600 10px/1 var(--font-mono);
+  font: 500 12px/1 var(--font-sans);
   background: transparent;
   border: 0;
   border-radius: var(--radius-small);
@@ -4264,7 +4268,7 @@ html[data-theme="dark"] .tui-syntax .shiki span {
   }
 
   .wordmark {
-    font-size: 10px;
+    font-size: 16px;
   }
 
   .header-install-trigger {

--- a/js/connect-dialog/index.html
+++ b/js/connect-dialog/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="color-scheme" content="dark" />
+    <meta name="color-scheme" content="light dark" />
     <title>Nanocodex Connect</title>
   </head>
   <body>

--- a/js/connect-dialog/src/main.tsx
+++ b/js/connect-dialog/src/main.tsx
@@ -8,6 +8,19 @@ import "nanocodex-connect-ui/styles.css";
 
 startWalletHost({ logout: logoutAccount });
 document.documentElement.classList.add("connect-dialog-standalone");
+function syncAppearance() {
+  try {
+    const theme = localStorage.getItem("nanocodex-theme");
+    if (theme === "light" || theme === "dark") document.documentElement.dataset.theme = theme;
+    else delete document.documentElement.dataset.theme;
+  } catch {
+    // Storage can be unavailable in third-party frames. Use the system.
+  }
+}
+syncAppearance();
+window.addEventListener("storage", (event) => {
+  if (event.key === "nanocodex-theme" || event.key === null) syncAppearance();
+});
 
 const root = document.getElementById("root");
 if (!root) throw new Error("Nanocodex Connect root element is missing");

--- a/js/connect-playground/index.html
+++ b/js/connect-playground/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#f5f3ed" />
+    <meta name="theme-color" content="#f5f3ed" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#19211c" media="(prefers-color-scheme: dark)" />
     <link
       rel="icon"
       href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='10' fill='%232b5144'/%3E%3Cpath d='M8 14h6V8h4v6h6v4h-6v6h-4v-6H8z' fill='%23ffffff'/%3E%3C/svg%3E"

--- a/js/connect-playground/index.html
+++ b/js/connect-playground/index.html
@@ -3,16 +3,16 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#161616" />
+    <meta name="theme-color" content="#f5f3ed" />
     <link
       rel="icon"
-      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='4' fill='%23161616'/%3E%3Cpath d='M8 14h6V8h4v6h6v4h-6v6h-4v-6H8z' fill='%23ffffff'/%3E%3C/svg%3E"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='10' fill='%232b5144'/%3E%3Cpath d='M8 14h6V8h4v6h6v4h-6v6h-4v-6H8z' fill='%23ffffff'/%3E%3C/svg%3E"
     />
     <meta
       name="description"
-      content="Private playground for the Nanocodex Connect API"
+      content="Atlas — a workspace powered by your Nanocodex agent."
     />
-    <title>Nanocodex Connect</title>
+    <title>Atlas · Your agent workspace</title>
   </head>
   <body>
     <div id="root"></div>

--- a/js/connect-playground/src/App.tsx
+++ b/js/connect-playground/src/App.tsx
@@ -198,18 +198,16 @@ export function App() {
     });
   }
 
-  if (connect.connectionStatus === "connecting" && !connect.isPending) return null;
-
   return (
     <main className={`app-shell${connection ? " is-connected" : ""}`} data-testid="connect-playground">
       <header className="topbar">
         <div className="brand">
           <span className="brand-mark" aria-hidden="true" />
-          <span className="brand-product">Nanocodex Connect</span>
+          <span className="brand-product">Atlas<span className="brand-caption">Workspace</span></span>
         </div>
         <div className="environment">
           <span className="environment-dot" aria-hidden="true" />
-          <span>{connection ? "Atlas connected" : "Playground · mainnet"}</span>
+          <span>{connection ? "Connected with Nanocodex" : "A Nanocodex Connect playground"}</span>
         </div>
       </header>
 
@@ -219,16 +217,17 @@ export function App() {
               <section className="panel panel-dark connect-method">
                 <header className="panel-heading">
                   <div>
-                    <h1>Connect Atlas</h1>
-                    <p className="panel-kicker">wallet_connect</p>
+                    <h1>Your Atlas workspace</h1>
+                    <p className="panel-kicker">Bring your agent. Make yourself at home.</p>
                   </div>
-                  <span className="status-pill" data-testid="connection-status">Not connected</span>
+                  <span className="status-pill" data-testid="connection-status">{isMutating ? "Connecting…" : "Welcome"}</span>
                 </header>
                 <div className="panel-body empty-state">
                   <div className="empty-orbit" aria-hidden="true" />
                   <div className="connect-copy">
-                    <h2>One approval.</h2>
-                    <p>Sign in and grant this app the capabilities configured at right.</p>
+                    <span className="hero-eyebrow">A little space for big ideas</span>
+                    <h2>Your next idea<br />starts here.</h2>
+                    <p>Bring your Nanocodex agent and connected apps into Atlas. Think something through, explore a question, or get a little work done.</p>
                   </div>
                   {error ? (
                     <div className="error-banner connect-error" data-testid="error-message" role="alert">
@@ -243,16 +242,18 @@ export function App() {
                     onClick={startConnect}
                     type="button"
                   >
-                    Connect
+                    {isMutating ? "Connecting…" : "Continue with Nanocodex"}
+                    <span aria-hidden="true">↗</span>
                   </button>
+                  <p className="connect-reassurance">You’ll review what Atlas can access before connecting.</p>
                 </div>
               </section>
               <aside className="playground-config">
                 <section className="panel configuration-panel">
                   <header className="panel-heading">
                     <div>
-                      <h2>Configuration</h2>
-                      <p className="panel-kicker">Requested capabilities</p>
+                      <h2>Make it yours</h2>
+                      <p className="panel-kicker">Choose what you’d like to bring into Atlas.</p>
                     </div>
                   </header>
                   <div className="panel-body">
@@ -360,13 +361,13 @@ function AppProjectionPanel({ audit, observation, visibility }: Readonly<{
       <header className="panel-heading">
         <div>
           <h2>Atlas can see</h2>
-          <p className="panel-kicker">Grant-enforced projection</p>
+          <p className="panel-kicker">Only what you approved</p>
         </div>
         <span className="status-pill">Scoped</span>
       </header>
       <VisibilityInspector observation={observation} visibility={visibility} />
       <details className="audit-details">
-        <summary>Audit · {audit.length}</summary>
+        <summary>Connection activity · {audit.length}</summary>
         <ol className="audit-list" data-testid="audit-events">
           {audit.map((event) => (
             <li className="audit-event" key={event.id}>
@@ -425,7 +426,7 @@ function PermissionBuilder({ disabled, onChange, request }: Readonly<{
   return (
     <div className="permission-builder" data-testid="permission-builder">
       <fieldset>
-        <legend>Connectors</legend>
+        <legend>Your connected apps</legend>
         <div className="permission-options">
           {connectors.map((item) => (
             <label key={item.id} title={item.required ? "Required to run this embedded agent" : item.label}>
@@ -446,7 +447,7 @@ function PermissionBuilder({ disabled, onChange, request }: Readonly<{
         </div>
       </fieldset>
       <fieldset>
-        <legend>Atlas sees</legend>
+        <legend>What Atlas can see</legend>
         <div className="permission-options">
           {visibility.map((item) => (
             <label key={item.id} title={item.detail}>
@@ -456,7 +457,7 @@ function PermissionBuilder({ disabled, onChange, request }: Readonly<{
                 onChange={(event) => setVisibility(item.id, event.target.checked)}
                 type="checkbox"
               />
-              <span>{item.label}</span>
+              <span>{item.label}<small>{item.detail}</small></span>
             </label>
           ))}
         </div>

--- a/js/connect-playground/src/ConnectAgentExperience.tsx
+++ b/js/connect-playground/src/ConnectAgentExperience.tsx
@@ -108,8 +108,8 @@ export function ConnectAgentExperience({
     >
       <header className="connect-chat-header">
         <div>
-          <h3 id="connect-chat-title">Nanocodex</h3>
-          <p>Durable agent · scoped by Atlas</p>
+          <h3 id="connect-chat-title">Atlas</h3>
+          <p>Your Nanocodex agent, at home in Atlas</p>
         </div>
         <div className="connect-chat-actions">
           <span className="connect-agent-status">Live</span>
@@ -129,7 +129,7 @@ export function ConnectAgentExperience({
       <div className="nanocodex-demo is-preview">
         <div className="conversation-workspace">
           <div className="conversation-main">
-            <AgentTerminalView
+            <AgentTerminalView composerPlaceholder="Ask your agent anything…"
               agent={terminalAgent}
               agentError={undefined}
               maxEntries={visibility.conversationHistory ? Number.MAX_SAFE_INTEGER : undefined}

--- a/js/connect-playground/src/styles.css
+++ b/js/connect-playground/src/styles.css
@@ -1,34 +1,29 @@
 :root {
-  color-scheme: dark;
-  font-family: "Berkeley Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    "Liberation Mono", monospace;
+  color-scheme: light;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
-  --surface: #161616;
-  --surface-raised: #1d1d1d;
-  --surface-hover: #242424;
-  --text: #f5f5f5;
-  --text-secondary: rgba(255, 255, 255, 0.76);
-  --text-muted: rgba(255, 255, 255, 0.56);
-  --text-faint: rgba(255, 255, 255, 0.38);
-  --border: rgba(255, 255, 255, 0.19);
-  --border-soft: rgba(255, 255, 255, 0.11);
-  --positive: #73d89b;
-  --negative: #ff8585;
-  --blue: #7ca7ff;
-  --black: #000000;
-  --font-mono: "Berkeley Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    "Liberation Mono", monospace;
-  --font-sans: Inter, ui-sans-serif, system-ui, sans-serif;
-  --header-height: 48px;
-  --radius-small: 0;
-  --radius-medium: 0;
+  --surface: #fffefa;
+  --surface-raised: #f5f3ed;
+  --surface-hover: #eeeee5;
+  --text: #283b32;
+  --text-secondary: #49594f;
+  --text-muted: #637168;
+  --text-faint: #637168;
+  --border: #cbd2c7;
+  --border-soft: #e0e3d9;
+  --positive: #316e4e;
+  --negative: #a23d34;
+  --accent: #2b5144;
+  --on-accent: #fffefa;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --header-height: 76px;
 }
 
 * {
   box-sizing: border-box;
 }
-
 html,
 body,
 #root {
@@ -36,23 +31,28 @@ body,
   height: 100%;
   margin: 0;
 }
-
 body {
   overflow: hidden;
   color: var(--text);
-  background: var(--surface);
+  background: var(--surface-raised);
+  -webkit-font-smoothing: antialiased;
 }
-
 button,
 input,
 textarea {
   font: inherit;
 }
-
 button {
-  border-radius: 0;
+  cursor: pointer;
 }
-
+button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+:where(button, input, textarea, summary, a):focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
 h1,
 h2,
 h3,
@@ -61,7 +61,6 @@ dl,
 dd {
   margin: 0;
 }
-
 .app-shell {
   display: grid;
   width: 100%;
@@ -69,19 +68,14 @@ dd {
   min-height: 0;
   grid-template-rows: var(--header-height) minmax(0, 1fr);
   overflow: hidden;
-  background: var(--surface);
 }
-
 .topbar {
   display: flex;
-  min-width: 0;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 0 20px;
-  border-bottom: 1px solid var(--border-soft);
+  padding: 0 32px;
 }
-
 .brand,
 .environment,
 .connect-chat-actions,
@@ -91,851 +85,754 @@ dd {
   display: flex;
   align-items: center;
 }
-
 .brand {
+  gap: 12px;
   min-width: 0;
-  gap: 10px;
-  font-size: 12px;
-  font-weight: 600;
 }
-
-.brand-product,
-.environment span:last-child {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .brand-mark {
-  width: 9px;
-  height: 9px;
-  flex: 0 0 auto;
-  background: var(--text);
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+  position: relative;
+  border-radius: 12px;
+  background: var(--accent);
 }
-
-.environment {
-  min-width: 0;
-  gap: 7px;
+.brand-mark::after {
+  content: "✳";
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: var(--on-accent);
+  font:
+    30px/1 Georgia,
+    serif;
+}
+.brand-product {
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.7px;
+}
+.brand-caption {
+  margin-left: 12px;
+  padding-left: 12px;
+  border-left: 1px solid var(--border);
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: 13px;
+  font-weight: 400;
+  letter-spacing: 0;
 }
-
+.environment {
+  gap: 8px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
 .environment-dot,
-.connect-agent-status::before {
-  width: 5px;
-  height: 5px;
-  flex: 0 0 auto;
-  background: var(--positive);
+.connect-agent-status::before,
+.status-pill::before {
   content: "";
+  width: 6px;
+  height: 6px;
+  flex-shrink: 0;
+  background: currentColor;
+  border-radius: 50%;
 }
-
 .workspace-grid {
   display: grid;
   width: min(100%, 1480px);
   height: 100%;
   min-height: 0;
   margin: 0 auto;
-  padding: 16px 20px 20px;
-  grid-template-columns: minmax(0, 1fr) 340px;
-  gap: 12px;
+  padding: 0 24px 24px;
+  grid-template-columns: minmax(0, 1fr) 370px;
+  gap: 20px;
   overflow: hidden;
 }
-
 .panel {
   min-width: 0;
   min-height: 0;
   overflow: hidden;
   background: var(--surface);
   border: 1px solid var(--border-soft);
+  border-radius: 20px;
 }
-
 .panel-heading {
   display: flex;
-  min-height: 58px;
-  align-items: flex-start;
+  min-height: 76px;
+  align-items: center;
   justify-content: space-between;
-  gap: 16px;
-  padding: 12px 14px;
+  gap: 12px;
+  padding: 18px 22px;
   border-bottom: 1px solid var(--border-soft);
 }
-
 .panel-heading h1,
 .panel-heading h2 {
-  color: var(--text);
-  font-size: 12px;
+  font-size: 15px;
   font-weight: 600;
-  line-height: 1.35;
+  line-height: 1.4;
 }
-
 .panel-kicker {
-  margin-top: 3px;
-  color: var(--text-faint);
-  font-size: 9px;
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.5;
 }
-
 .panel-body {
-  padding: 14px;
+  padding: 22px;
 }
-
 .status-pill {
   display: inline-flex;
-  flex: 0 0 auto;
   align-items: center;
   gap: 6px;
-  color: var(--text-faint);
-  font-size: 8px;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-size: 11px;
+  background: var(--surface-raised);
+  padding: 6px 9px;
+  border-radius: 20px;
 }
-
-.status-pill::before {
-  width: 5px;
-  height: 5px;
-  background: currentColor;
-  content: "";
-}
-
 .status-pill.active {
   color: var(--positive);
 }
-
 .connect-method {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
 }
-
+.connect-method .panel-heading {
+  border-bottom: 0;
+}
 .empty-state {
   display: grid;
   min-height: 0;
   align-content: center;
-  grid-template-columns: 52px minmax(0, 1fr) auto;
-  gap: 18px;
-  padding: clamp(20px, 5vw, 56px);
+  justify-items: start;
+  gap: 22px;
+  padding: 36px clamp(28px, 6vw, 88px) 70px;
+  overflow-y: auto;
 }
-
 .empty-orbit {
   position: relative;
-  width: 52px;
-  height: 52px;
+  width: 62px;
+  height: 62px;
   border: 1px solid var(--border);
+  border-radius: 50%;
+  margin-bottom: 4px;
 }
-
-.empty-orbit::before,
-.empty-orbit::after {
-  position: absolute;
-  background: var(--text-secondary);
-  content: "";
-}
-
 .empty-orbit::before {
-  top: 25px;
-  left: 13px;
-  width: 26px;
-  height: 1px;
+  content: "✳";
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font:
+    46px/1 Georgia,
+    serif;
+  color: var(--accent);
 }
-
-.empty-orbit::after {
-  top: 13px;
-  left: 25px;
-  width: 1px;
-  height: 26px;
-}
-
-.connect-copy h2 {
-  font-size: 14px;
-  font-weight: 600;
-}
-
-.connect-copy p {
-  max-width: 470px;
-  margin-top: 6px;
+.hero-eyebrow {
+  display: block;
+  margin-bottom: 16px;
   color: var(--text-muted);
-  font-size: 11px;
-  line-height: 1.55;
+  font-size: 13px;
 }
-
+.connect-copy h2 {
+  font:
+    400 clamp(40px, 4.6vw, 68px) / 1.06 Georgia,
+    "Times New Roman",
+    serif;
+  letter-spacing: -0.055em;
+}
+.connect-copy p {
+  max-width: 440px;
+  margin-top: 22px;
+  color: var(--text-secondary);
+  font-size: 16px;
+  line-height: 1.75;
+}
+.connect-reassurance {
+  max-width: 360px;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.6;
+}
+.primary-button,
+.secondary-button,
+.connect-sign-out,
+.connection-rail-open,
+.connection-rail-close {
+  display: inline-flex;
+  min-height: 40px;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 14px;
+  color: var(--text);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  font-size: 13px;
+}
+.primary-button {
+  color: var(--on-accent);
+  background: var(--accent);
+  border-color: var(--accent);
+  font-weight: 500;
+}
+.primary-button:hover:not(:disabled) {
+  filter: brightness(1.15);
+}
+.secondary-button:hover:not(:disabled),
+.connect-sign-out:hover:not(:disabled),
+.connection-rail-open:hover:not(:disabled),
+.connection-rail-close:hover:not(:disabled) {
+  background: var(--surface-hover);
+}
+.connect-button {
+  min-height: 50px;
+  padding-inline: 22px;
+  border-radius: 14px;
+  font-size: 14px;
+}
+.connect-button > span {
+  margin-left: 14px;
+  font-size: 18px;
+}
+.danger-button {
+  color: var(--negative);
+  border-color: color-mix(in srgb, var(--negative) 35%, transparent);
+}
 .playground-config,
 .connected-rail {
   min-width: 0;
   min-height: 0;
 }
-
 .configuration-panel {
   display: grid;
   height: 100%;
   grid-template-rows: auto minmax(0, 1fr);
 }
-
 .configuration-panel .panel-body {
-  padding: 14px;
   overflow-y: auto;
   overscroll-behavior: contain;
 }
-
 .permission-builder {
   display: grid;
-  width: 100%;
-  gap: 14px;
+  gap: 28px;
 }
-
 .permission-builder fieldset {
   min-width: 0;
   margin: 0;
   padding: 0;
   border: 0;
 }
-
 .permission-builder legend {
-  margin-bottom: 7px;
-  color: var(--text-faint);
-  font-size: 9px;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  margin-bottom: 12px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 500;
 }
-
 .permission-options {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1px;
-  padding: 1px;
-  background: var(--border-soft);
+  gap: 7px;
 }
-
 .permission-options label {
-  position: relative;
   display: flex;
-  min-width: 0;
-  min-height: 44px;
   align-items: center;
-  justify-content: center;
-  padding: 8px;
-  color: var(--text-faint);
-  background: var(--surface);
+  min-height: 42px;
+  gap: 9px;
+  padding: 8px 10px;
+  color: var(--text-secondary);
+  background: var(--surface-raised);
+  border: 1px solid transparent;
+  border-radius: 10px;
+  font-size: 13px;
   cursor: pointer;
-  font-size: 10px;
 }
-
-.permission-options input {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  opacity: 0;
-}
-
 .permission-options label:has(input:checked) {
-  color: var(--text);
-  box-shadow: inset 0 -2px 0 var(--positive);
+  border-color: var(--border);
 }
-
-.permission-options label:has(input:focus-visible) {
-  outline: 1px solid var(--text);
-  outline-offset: -2px;
-}
-
 .permission-options label:has(input:disabled) {
   cursor: default;
 }
-
-.permission-options label:has(input:disabled)::after {
-  position: absolute;
-  top: 5px;
-  right: 6px;
-  color: var(--positive);
-  content: "·";
+.permission-options input {
+  width: 15px;
+  height: 15px;
+  margin: 0;
+  flex-shrink: 0;
+  accent-color: var(--accent);
 }
-
-.primary-button,
-.secondary-button,
-.danger-button,
-.connect-sign-out,
-.connection-rail-open,
-.connection-rail-close {
-  display: inline-flex;
-  min-height: 36px;
-  align-items: center;
-  justify-content: center;
-  padding: 0 12px;
-  color: var(--text);
-  background: transparent;
-  border: 1px solid var(--border);
-  cursor: pointer;
-  font-size: 10px;
+.permission-options small {
+  display: block;
+  margin-top: 3px;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.4;
 }
-
-.primary-button {
-  color: #111;
-  background: #d8d8d8;
-  border-color: #d8d8d8;
-  font-weight: 600;
+.permission-builder fieldset:last-child .permission-options {
+  grid-template-columns: 1fr;
 }
-
-.danger-button {
+.error-banner {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 12px;
   color: var(--negative);
-  border-color: color-mix(in srgb, var(--negative) 45%, transparent);
+  background: color-mix(in srgb, var(--negative) 6%, var(--surface));
+  border: 1px solid color-mix(in srgb, var(--negative) 30%, transparent);
+  border-radius: 12px;
+  font-size: 13px;
+  line-height: 1.5;
 }
-
-.primary-button:hover:not(:disabled),
-.secondary-button:hover:not(:disabled),
-.connect-sign-out:hover:not(:disabled),
-.connection-rail-open:hover:not(:disabled),
-.connection-rail-close:hover:not(:disabled) {
-  filter: brightness(1.16);
+.error-banner button {
+  min-width: 24px;
+  min-height: 24px;
+  color: inherit;
+  background: transparent;
+  border: 0;
 }
-
-button:disabled {
-  opacity: 0.46;
-  cursor: default;
-}
-
-.connect-button {
-  min-width: 112px;
-}
-
-.connect-error {
-  grid-column: 1 / -1;
-}
-
-.chat-primary,
 .chat-primary .connect-chat,
 .chat-primary .nanocodex-demo,
 .chat-primary .conversation-workspace,
 .chat-primary .conversation-main {
   min-height: 0;
+  height: 100%;
 }
-
 .chat-primary .connect-chat {
   display: grid;
-  height: 100%;
   grid-template-rows: auto minmax(0, 1fr);
 }
-
 .connect-chat-header {
   display: flex;
-  min-height: 58px;
+  min-height: 76px;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 9px 12px 9px 14px;
+  padding: 12px 20px;
   border-bottom: 1px solid var(--border-soft);
 }
-
+.connect-chat-header h3 {
+  font-size: 16px;
+  font-weight: 600;
+}
+.connect-chat-header p {
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.connect-chat-actions {
+  gap: 8px;
+  flex-shrink: 0;
+}
+.connect-agent-status {
+  gap: 6px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.connect-sign-out {
+  white-space: nowrap;
+}
 .connect-chat {
   --terminal-background: var(--surface);
   --terminal-foreground: var(--text);
   --terminal-muted: var(--text-muted);
   --terminal-border: var(--border-soft);
-  --terminal-hover: var(--surface-hover);
+  --terminal-hover: var(--surface-raised);
+  --terminal-font-sans: var(--font-sans);
 }
-
-.connect-chat-header h3 {
-  font-size: 12px;
-}
-
-.connect-chat-header p {
-  margin-top: 3px;
-  color: var(--text-faint);
-  font-size: 9px;
-}
-
-.connect-chat-actions {
-  flex: 0 0 auto;
-  gap: 7px;
-}
-
-.connect-agent-status {
-  gap: 6px;
-  color: var(--text-muted);
-  font-size: 9px;
-}
-
-.connect-sign-out {
-  white-space: nowrap;
-}
-
-.connection-rail-open,
-.connection-rail-close,
-.connection-rail-backdrop {
-  display: none;
-}
-
-.chat-primary .nanocodex-demo,
-.chat-primary .conversation-workspace,
-.chat-primary .conversation-main {
-  width: 100%;
-  height: 100%;
-}
-
-.chat-primary .conversation-workspace {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  border-top: 0;
-}
-
 .chat-primary .conversation-main {
   min-width: 0;
   overflow: hidden;
 }
-
 .chat-primary .agent-terminal-shell {
   width: 100%;
   height: 100%;
   min-height: 0;
   border: 0;
 }
-
 .connect-chat .agent-terminal-toolbar {
   display: none;
 }
-
 .connect-chat .agent-dom-transcript-inner {
-  width: min(100%, 920px);
-  padding: 18px clamp(16px, 3vw, 34px) 30px;
-  color: var(--text-secondary);
-  font-size: 14px;
-  line-height: 1.55;
+  width: min(100%, 800px);
+  padding: 24px 28px 32px;
+  font: 16px/1.7 var(--font-sans);
 }
-
 .connect-chat .agent-terminal-shell.is-dom {
   grid-template-rows: minmax(0, 1fr) auto;
 }
-
+.connect-chat .agent-terminal-user {
+  width: fit-content;
+  max-width: 88%;
+  margin-left: auto;
+  padding: 12px 18px;
+  border: 0;
+  border-radius: 20px;
+  color: var(--text);
+  background: var(--surface-raised);
+  font: 16px/1.7 var(--font-sans);
+}
 .connect-chat .agent-touch-composer {
-  min-height: 58px;
-  padding: 7px 9px;
+  width: min(100%, 800px);
+  margin: 0 auto;
+  min-height: 72px;
+  padding: 12px 20px 20px;
   background: var(--surface);
-  border-top: 1px solid var(--border-soft);
+  border: 0;
 }
-
 .connect-chat .agent-touch-field {
-  min-height: 44px;
+  min-height: 52px;
+  padding: 4px 6px;
+  border: 1px solid var(--border);
+  background: var(--surface-raised);
+  border-radius: 20px;
 }
-
 .connect-chat .agent-touch-composer textarea {
   min-height: 44px;
-  max-height: 110px;
-  padding: 10px 12px;
-  font-size: 14px;
-  line-height: 22px;
+  max-height: 150px;
+  padding: 10px;
+  font: 16px/1.5 var(--font-sans);
 }
-
+.connect-chat .agent-touch-actions {
+  border: 0;
+}
+.connect-chat .agent-touch-actions > button {
+  width: 36px;
+  height: 36px;
+  color: var(--on-accent);
+  background: var(--accent);
+  border-radius: 50%;
+}
+.connection-rail-open,
+.connection-rail-close,
+.connection-rail-backdrop {
+  display: none;
+}
 .connected-rail {
   display: grid;
   align-content: start;
-  gap: 12px;
+  gap: 16px;
   overflow-y: auto;
   overscroll-behavior: contain;
   scrollbar-width: thin;
 }
-
 .connection-panel .panel-body {
   display: grid;
-  gap: 12px;
+  gap: 16px;
 }
-
-.error-banner {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 10px;
-  color: var(--negative);
-  background: color-mix(in srgb, var(--negative) 8%, transparent);
-  border: 1px solid color-mix(in srgb, var(--negative) 30%, transparent);
-  font-size: 10px;
-  line-height: 1.45;
-}
-
-.error-banner button {
-  color: inherit;
-  background: transparent;
-  border: 0;
-}
-
 .balance-card,
 .action-card {
-  padding: 12px;
+  padding: 16px;
   border: 1px solid var(--border-soft);
+  border-radius: 14px;
 }
-
 .mercator-balance-heading {
   justify-content: space-between;
   gap: 10px;
 }
-
 .balance-label,
 .balance-meta,
 .mercator-connected,
 .mercator-locked {
-  color: var(--text-faint);
-  font-size: 8px;
-  text-transform: uppercase;
+  color: var(--text-muted);
+  font-size: 12px;
 }
-
 .mercator-connected {
   color: var(--positive);
 }
-
-.mercator-locked {
-  color: var(--text-muted);
-}
-
 .balance-value {
-  margin-top: 10px;
-  font-size: 22px;
-  font-weight: 600;
+  margin-top: 12px;
+  font-size: 28px;
+  font-weight: 500;
+  letter-spacing: -0.8px;
 }
-
 .balance-value span {
   color: var(--positive);
-  font-size: 9px;
+  font-size: 12px;
 }
-
 .balance-meta {
-  margin-top: 5px;
-  text-transform: none;
+  margin-top: 6px;
 }
-
-.action-grid {
-  display: grid;
-  gap: 8px;
-}
-
+.action-grid,
 .action-card {
   display: grid;
-  gap: 10px;
+  gap: 12px;
 }
-
 .action-card strong {
-  font-size: 10px;
-  font-weight: 600;
+  font-size: 14px;
+  font-weight: 500;
 }
-
 .action-card p {
-  margin-top: 4px;
-  color: var(--text-faint);
-  font-size: 9px;
-  line-height: 1.5;
+  margin-top: 5px;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.6;
 }
-
 .grant-details,
 .audit-details {
   border-top: 1px solid var(--border-soft);
 }
-
 .grant-details summary,
 .audit-details summary {
-  padding: 12px 14px;
+  padding: 16px 22px;
   color: var(--text-muted);
   cursor: pointer;
-  font-size: 9px;
-  list-style: none;
-  text-transform: uppercase;
+  font-size: 12px;
 }
-
-.grant-details summary::-webkit-details-marker,
-.audit-details summary::-webkit-details-marker {
-  display: none;
-}
-
-.detail-row {
-  display: grid;
-  grid-template-columns: 78px minmax(0, 1fr);
-  gap: 10px;
-  padding: 9px 14px;
-  border-top: 1px solid var(--border-soft);
-  font-size: 9px;
-}
-
-.detail-row dt {
-  color: var(--text-faint);
-}
-
-.detail-row dd {
-  overflow: hidden;
-  color: var(--text-muted);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.account-actions {
-  gap: 8px;
-}
-
-.app-view-panel {
-  flex: 0 0 auto;
-}
-
-.visibility-inspector {
-  display: grid;
-}
-
+.detail-row,
 .projection-row {
   display: grid;
-  grid-template-columns: 72px minmax(0, 1fr);
+  grid-template-columns: 82px minmax(0, 1fr);
   gap: 10px;
-  padding: 10px 14px;
-  border-bottom: 1px solid var(--border-soft);
-  font-size: 9px;
+  padding: 12px 22px;
+  border-top: 1px solid var(--border-soft);
+  font-size: 12px;
+  line-height: 1.5;
 }
-
+.detail-row dt,
 .projection-row dt {
-  color: var(--text-faint);
+  color: var(--text-muted);
 }
-
+.detail-row dd,
 .projection-row dd {
   overflow: hidden;
-  color: var(--text-muted);
+  color: var(--text-secondary);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-
 .projection-row.is-private dd {
-  color: var(--negative);
+  color: var(--text-muted);
 }
-
 .projection-row.is-allowed dd {
-  color: var(--text-secondary);
+  color: var(--positive);
 }
-
+.account-actions {
+  flex-wrap: wrap;
+  gap: 8px;
+}
 .audit-list {
   margin: 0;
   padding: 0;
   list-style: none;
 }
-
 .audit-event {
   display: grid;
-  grid-template-columns: 5px minmax(0, 1fr) auto;
+  grid-template-columns: 6px minmax(0, 1fr) auto;
   gap: 8px;
-  padding: 10px 14px;
+  padding: 12px 22px;
   border-top: 1px solid var(--border-soft);
 }
-
 .audit-dot {
-  width: 5px;
-  height: 5px;
-  margin-top: 4px;
-  background: var(--text-faint);
+  width: 6px;
+  height: 6px;
+  margin-top: 5px;
+  border-radius: 50%;
+  background: var(--text-muted);
 }
-
 .audit-dot.success {
   background: var(--positive);
 }
-
 .audit-dot.error {
   background: var(--negative);
 }
-
 .audit-event strong {
   display: block;
-  font-size: 9px;
+  font-size: 12px;
+  font-weight: 500;
 }
-
 .audit-event p,
 .audit-event time {
-  color: var(--text-faint);
-  font-size: 8px;
-  line-height: 1.45;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.5;
 }
-
 .audit-event p {
-  margin-top: 3px;
+  margin-top: 4px;
 }
-
 body > dialog[aria-label="Nanocodex Connect permissions"] {
   padding: 0 !important;
-  color: var(--text);
   background: transparent !important;
   border: 0 !important;
-  border-radius: 0 !important;
+  border-radius: 24px;
 }
-
 body > dialog[aria-label="Nanocodex Connect permissions"]::backdrop {
-  background: rgba(0, 0, 0, 0.72);
+  background: rgb(25 35 28 / 0.38);
+  backdrop-filter: blur(6px);
 }
-
 body > dialog[aria-label="Nanocodex Connect permissions"] > iframe {
-  background: var(--surface) !important;
-  border: 1px solid var(--border) !important;
-  border-radius: 0 !important;
+  background: transparent !important;
+  border-radius: 24px;
 }
 
-@media (width < 760px) {
-  .topbar {
-    padding: 0 14px;
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+    --surface: #202923;
+    --surface-raised: #19211c;
+    --surface-hover: #303d33;
+    --text: #eeeede;
+    --text-secondary: #c8ccbf;
+    --text-muted: #a4afa2;
+    --text-faint: #a4afa2;
+    --border: #435044;
+    --border-soft: #344136;
+    --positive: #9ac4a6;
+    --negative: #f1a295;
+    --accent: #c5d8b8;
+    --on-accent: #203426;
   }
+}
 
+@media (max-width: 900px) {
+  .workspace-grid {
+    grid-template-columns: minmax(0, 1fr) 320px;
+    gap: 14px;
+    padding-inline: 16px;
+  }
+  .empty-state {
+    padding-inline: 28px;
+  }
+  .environment {
+    font-size: 11px;
+  }
+  .brand-caption {
+    display: none;
+  }
+}
+
+@media (max-width: 759px) {
+  :root {
+    --header-height: 64px;
+  }
+  .topbar {
+    padding: 0 18px;
+  }
+  .brand-product {
+    font-size: 20px;
+  }
+  .environment {
+    max-width: 160px;
+    line-height: 1.5;
+  }
   .workspace-grid {
     position: relative;
     width: 100%;
-    padding: 0;
+    padding: 0 12px 12px;
     grid-template-columns: minmax(0, 1fr);
-    gap: 0;
+    gap: 14px;
   }
-
   .workspace-grid:not(.is-connected) {
-    grid-template-rows: auto minmax(0, 1fr);
+    grid-template-rows: auto auto;
     overflow-y: auto;
   }
-
-  .workspace-grid:not(.is-connected) .playground-config {
-    grid-row: 1;
-  }
-
-  .workspace-grid:not(.is-connected) .connect-method {
-    grid-row: 2;
-    min-height: 260px;
-    border-top: 0;
-  }
-
-  .configuration-panel {
-    border-inline: 0;
-    border-top: 0;
-  }
-
-  .configuration-panel .panel-heading {
-    min-height: 48px;
-    padding-block: 9px;
-  }
-
-  .configuration-panel .panel-body {
-    padding: 10px 14px 12px;
-  }
-
-  .permission-builder {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 10px;
-  }
-
-
-  .permission-options label {
-    min-height: 40px;
-  }
-
   .connect-method {
-    border-inline: 0;
+    min-height: 500px;
   }
-
+  .connect-method .status-pill {
+    display: none;
+  }
+  .panel-heading {
+    padding: 16px 20px;
+  }
   .empty-state {
-    align-content: center;
-    grid-template-columns: 44px minmax(0, 1fr);
-    gap: 14px;
-    padding: 18px 14px;
+    padding: 20px 28px 36px;
+    gap: 18px;
   }
-
   .empty-orbit {
-    width: 44px;
-    height: 44px;
+    width: 48px;
+    height: 48px;
   }
-
   .empty-orbit::before {
-    top: 21px;
-    left: 11px;
-    width: 22px;
+    font-size: 36px;
   }
-
-  .empty-orbit::after {
-    top: 11px;
-    left: 21px;
-    height: 22px;
+  .connect-copy h2 {
+    font-size: 46px;
   }
-
+  .connect-copy p {
+    font-size: 15px;
+  }
   .connect-button {
-    min-height: 44px;
-    grid-column: 1 / -1;
+    width: 100%;
+    justify-content: space-between;
   }
-
+  .configuration-panel .panel-body {
+    overflow: visible;
+  }
+  .permission-options label {
+    min-height: 44px;
+  }
   .workspace-grid.is-connected {
     grid-template-rows: minmax(0, 1fr);
-    overflow: hidden;
   }
-
   .chat-primary {
     height: 100%;
-    border: 0;
   }
-
   .connect-chat-header {
-    min-height: 54px;
-    padding: 6px 10px 6px 14px;
+    padding: 10px 14px;
+    min-height: 68px;
   }
-
   .connect-chat-header p,
   .connect-agent-status {
     display: none;
   }
-
   .connect-sign-out,
   .connection-rail-open,
   .connection-rail-close {
     min-height: 44px;
   }
-
   .connection-rail-open,
   .connection-rail-close {
     display: inline-flex;
   }
-
   .connect-chat .agent-dom-transcript-inner {
-    width: 100%;
-    padding: 16px 14px 22px;
-    font-size: 13px;
+    padding: 20px 16px 24px;
   }
-
-  .connect-chat .agent-terminal-user,
-  .connect-chat .agent-terminal-error,
-  .connect-chat .agent-terminal-status,
-  .connect-chat .agent-terminal-plan,
-  .connect-chat .agent-terminal-tool {
-    font-size: 13px;
-  }
-
   .connect-chat .agent-touch-composer {
-    min-height: calc(58px + env(safe-area-inset-bottom));
-    padding: 7px 8px max(7px, env(safe-area-inset-bottom));
+    padding: 8px 10px max(10px, env(safe-area-inset-bottom));
   }
-
-  .connect-chat .agent-touch-composer textarea {
-    font-size: 16px;
+  .connect-chat .agent-touch-actions > button {
+    min-height: 44px;
+    min-width: 44px;
   }
-
   .connected-rail {
     position: absolute;
     z-index: 21;
     inset: auto 0 0;
     display: block;
     width: 100%;
-    max-height: min(78dvh, 660px);
+    max-height: min(85dvh, 750px);
     overflow-y: auto;
     visibility: hidden;
     background: var(--surface);
-    border-top: 1px solid var(--border);
+    border: 1px solid var(--border);
+    border-radius: 24px 24px 0 0;
     transform: translateY(100%);
-    transition: transform 150ms ease, visibility 0s linear 150ms;
-    overscroll-behavior: contain;
+    transition:
+      transform 150ms ease,
+      visibility 0s linear 150ms;
   }
-
   .connected-rail.is-open {
     visibility: visible;
     transform: translateY(0);
     transition-delay: 0s;
   }
-
   .connected-rail > .panel {
     border-inline: 0;
     border-bottom: 0;
+    border-radius: 0;
   }
-
   .connection-rail-close {
     position: sticky;
     z-index: 1;
     top: 0;
     width: 100%;
+    min-height: 52px;
     background: var(--surface);
-    border-inline: 0;
-    border-top: 0;
+    border: 0;
+    border-bottom: 1px solid var(--border-soft);
+    border-radius: 0;
   }
-
   .connection-rail-backdrop {
     position: absolute;
     z-index: 20;
@@ -943,48 +840,34 @@ body > dialog[aria-label="Nanocodex Connect permissions"] > iframe {
     width: 100%;
     height: 100%;
     padding: 0;
-    background: rgba(0, 0, 0, 0.68);
+    background: rgb(15 25 18 / 0.45);
     border: 0;
     opacity: 0;
     pointer-events: none;
   }
-
   .connection-rail-backdrop.is-open {
     display: block;
     opacity: 1;
     pointer-events: auto;
   }
-
   body > dialog[aria-label="Nanocodex Connect permissions"] {
     width: 100% !important;
     max-width: none !important;
     margin: auto 0 0 !important;
+    border-radius: 24px 24px 0 0;
   }
-
   body > dialog[aria-label="Nanocodex Connect permissions"] > iframe {
     width: 100% !important;
     max-width: none !important;
-    border-inline: 0 !important;
-    border-bottom: 0 !important;
-  }
-}
-
-@media (height < 680px) and (width < 760px) {
-  .workspace-grid:not(.is-connected) {
-    grid-template-rows: auto auto;
-  }
-
-  .permission-options label {
-    min-height: 36px;
-  }
-
-  .connect-method .panel-heading {
-    display: none;
+    border-radius: 24px 24px 0 0;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .connected-rail {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
     transition-duration: 0.01ms !important;
   }
 }

--- a/js/nanocodex-connect-ui/src/App.tsx
+++ b/js/nanocodex-connect-ui/src/App.tsx
@@ -1540,22 +1540,16 @@ function ConnectionWizard({
   const requester = presentation === "wizard" ? "Nanocodex CLI" : request.app.name;
   const hostedAuthorization = request.auth.resources.includes(hostedAuthorizationResource);
   if (!request.hostPrincipalExchange && !connectorStatuses && !accountAddress) {
-    const requestContext = <RequestedConnectionContext
-      appVisibility={appVisibility}
-      request={request}
-      requester={requester}
-    />;
     return (
       <AccountChooser
         authOrigin={nanocodexOriginFor(request.apiUrl)}
         confirmationCode={confirmationCode}
         description={reauthenticationRequired
-          ? `Your session expired. Sign in by SMS, then connect your account to approve ${requester}.`
-          : `Sign in by SMS, then connect your account to approve ${requester}.`}
+          ? `Your session expired. Sign in to continue to ${requester}. You’ll review its requested access next.`
+          : `Sign in to continue to ${requester}. You’ll review its requested access next.`}
         disabled={disabled}
         onCancel={onCancel}
         onChooseAccount={onChooseAccount}
-        requestContext={requestContext}
       />
     );
   }
@@ -1634,53 +1628,6 @@ function ConnectionWizard({
           <WizardRequestSummary appVisibility={appVisibility} request={request} />
         </AccountConnectionSection> : null}
     </AccountConnectionSurface>
-  );
-}
-
-function RequestedConnectionContext({ appVisibility, request, requester }: Readonly<{
-  appVisibility: ReturnType<typeof appVisibilityPermissions>;
-  request: ConnectionView;
-  requester: string;
-}>) {
-  const hostedAuthorization = request.auth.resources.includes(hostedAuthorizationResource);
-  return (
-    <>
-      {request.permission.connectors.length ? <AccountConnectionSection
-        eyebrow="Requested service"
-        meta={`${request.permission.connectors.length} requested`}
-        title="Connections"
-        titleId="requested-services-heading"
-      >
-        <WizardConnectorList
-          connectorStatuses={undefined}
-          disabled
-          onConnectConnector={() => undefined}
-          request={request}
-        />
-      </AccountConnectionSection> : null}
-      {request.mcpConnections.length ? <AccountConnectionSection
-        eyebrow="Requested MCP"
-        meta={`${request.mcpConnections.length} requested`}
-        title="MCP connections"
-        titleId="requested-mcp-heading"
-      >
-        <McpConnectionList
-          connections={request.mcpConnections}
-          disabled
-          onConnect={() => undefined}
-        />
-      </AccountConnectionSection> : null}
-      <AccountConnectionSection
-        eyebrow="Requested access"
-        meta={hostedAuthorization
-          ? "No delegated key"
-          : request.accessKey ? "New delegated key" : "Active delegated key"}
-        title={`${requester} permissions`}
-        titleId="requested-access-heading"
-      >
-        <WizardRequestSummary appVisibility={appVisibility} request={request} />
-      </AccountConnectionSection>
-    </>
   );
 }
 

--- a/js/nanocodex-connect-ui/src/App.tsx
+++ b/js/nanocodex-connect-ui/src/App.tsx
@@ -423,7 +423,7 @@ export function ConnectOnboarding({
         data-testid={complete ? "device-connect-complete" : "device-connect-error"}
       >
         {!wizard ? <header className="dialog-header">
-          <span className="wordmark">nanocodex/connect</span>
+          <span className="wordmark">Nanocodex Connect</span>
           <span className="secure-label"><span aria-hidden="true" /> device</span>
         </header> : null}
         <div className={wizard ? "wizard-content wizard-complete" : "dialog-content"}>
@@ -1264,7 +1264,7 @@ export function ConnectOnboarding({
       data-testid={wizard ? "device-connect-wizard" : "remote-connect-dialog"}
     >
       {!wizard ? <header className="dialog-header">
-        <span className="wordmark">nanocodex/connect</span>
+        <span className="wordmark">Nanocodex Connect</span>
           <span className="secure-label"><span aria-hidden="true" /> {hostPrincipalRequest
             ? "host identity"
             : "SMS account"}</span>

--- a/js/nanocodex-connect-ui/styles.css
+++ b/js/nanocodex-connect-ui/styles.css
@@ -1,20 +1,20 @@
 :root.connect-dialog-standalone {
-  color-scheme: dark;
+  color-scheme: light dark;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
-  --surface: #212121;
-  --surface-raised: #303030;
-  --surface-subtle: #191919;
-  --text: #ececec;
-  --text-inverse: #212121;
-  --negative: #ffaaaa;
+  --surface: light-dark(#fff, #212121);
+  --surface-raised: light-dark(#f4f4f4, #303030);
+  --surface-subtle: light-dark(#f9f9f9, #191919);
+  --text: light-dark(#262626, #ececec);
+  --text-inverse: light-dark(#fff, #212121);
+  --negative: light-dark(#b72f2f, #ffaaaa);
   --muted: color-mix(in srgb, var(--text) 72%, transparent);
   --faint: color-mix(in srgb, var(--text) 65%, transparent);
-  --border: rgba(255, 255, 255, 0.1);
+  --border: color-mix(in srgb, var(--text) 12%, transparent);
   --border-strong: color-mix(in srgb, var(--text) 18%, transparent);
-  --positive: #73d89b;
-  --warning: #e8c77a;
+  --positive: light-dark(#0d7136, #73d89b);
+  --warning: light-dark(#886013, #e8c77a);
   background: transparent;
   color: var(--text);
 }
@@ -30,6 +30,12 @@
 .connect-dialog-standalone #root {
   min-width: 0;
   height: 100%;
+}
+
+.connect-dialog-standalone #root {
+  display: grid;
+  width: 100%;
+  place-items: center;
 }
 
 .connect-dialog-standalone body {
@@ -66,7 +72,7 @@
   --muted: color-mix(in srgb, var(--text) 72%, transparent);
   --faint: color-mix(in srgb, var(--text) 65%, transparent);
   --border-strong: color-mix(in srgb, var(--text) 18%, transparent);
-  --warning: #e8c77a;
+  --warning: light-dark(#886013, #e8c77a);
   color: var(--text);
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-size: 14px;
@@ -1409,13 +1415,9 @@ dd {
 
 @media (max-width: 440px) {
   :scope.dialog-shell {
-    width: 100vw;
-    max-height: 90dvh;
-    margin: 0;
-    border-inline: 0;
-    border-bottom: 0;
-    border-radius: 24px 24px 0 0;
-    box-shadow: 0 -24px 72px rgba(0, 0, 0, 0.55);
+    width: calc(100vw - 24px);
+    max-height: calc(100dvh - 24px);
+    margin: 12px auto;
   }
 
   .dialog-header {
@@ -1469,28 +1471,10 @@ dd {
 }
 }
 
-@media (max-width: 440px) {
-  .connect-dialog-standalone #root {
-    display: grid;
-    place-items: end center;
-  }
-}
 
-/* The hosted consent surface follows the native app's system appearance. */
-@media (prefers-color-scheme: light) {
-  :root.connect-dialog-standalone {
-    color-scheme: light;
-    --surface: #fff;
-    --surface-raised: #f4f4f4;
-    --surface-subtle: #f9f9f9;
-    --text: #262626;
-    --text-inverse: #fff;
-    --border: rgba(0, 0, 0, .1);
-    --positive: #0d7136;
-    --negative: #b72f2f;
-    --warning: #886013;
-  }
-}
+/* Honor the website's saved appearance, otherwise follow the system. */
+:root.connect-dialog-standalone[data-theme="light"] { color-scheme: light; }
+:root.connect-dialog-standalone[data-theme="dark"] { color-scheme: dark; }
 
 @scope (.connect-onboarding) {
   button, input, .app-sees-permission { border-radius: 10px; }
@@ -1510,4 +1494,43 @@ dd {
   .wizard-account-copy small { line-height: 1.5; }
   .sms-otp-change { min-height: 44px; }
   .wizard-account-choice:focus-visible, input:focus-visible { outline: 2px solid var(--text); outline-offset: -3px; }
+}
+
+@scope (.connect-onboarding) {
+  .sms-auth-panel .wizard-app > span {
+    color: var(--muted);
+    font-size: 12px;
+  }
+
+  .sms-auth-panel .sms-otp-form {
+    margin-top: 0;
+    padding: 0;
+    overflow: visible;
+    border: 0;
+    border-radius: 0;
+    gap: 10px;
+  }
+
+  .sms-auth-panel .sms-otp-form > p {
+    font-size: 12px;
+  }
+
+  .sms-auth-security {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    margin-top: 16px;
+    color: var(--muted);
+    font-size: 12px;
+  }
+
+  .sms-auth-security > span {
+    color: var(--positive);
+  }
+
+  .sms-auth-panel .wizard-cancel {
+    width: 100%;
+    min-height: 44px;
+    margin-top: 8px;
+  }
 }

--- a/js/nanocodex-connect-ui/styles.css
+++ b/js/nanocodex-connect-ui/styles.css
@@ -1,17 +1,18 @@
 :root.connect-dialog-standalone {
   color-scheme: dark;
-  font-family: "Berkeley Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    "Liberation Mono", monospace;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
-  --surface: #141414;
-  --surface-raised: #1c1c1c;
-  --surface-subtle: #171717;
-  --text: #ffffff;
-  --muted: rgba(255, 255, 255, 0.62);
-  --faint: rgba(255, 255, 255, 0.4);
+  --surface: #212121;
+  --surface-raised: #303030;
+  --surface-subtle: #191919;
+  --text: #ececec;
+  --text-inverse: #212121;
+  --negative: #ffaaaa;
+  --muted: color-mix(in srgb, var(--text) 72%, transparent);
+  --faint: color-mix(in srgb, var(--text) 65%, transparent);
   --border: rgba(255, 255, 255, 0.1);
-  --border-strong: rgba(255, 255, 255, 0.2);
+  --border-strong: color-mix(in srgb, var(--text) 18%, transparent);
   --positive: #73d89b;
   --warning: #e8c77a;
   background: transparent;
@@ -36,9 +37,9 @@
   place-items: center;
   margin: 0;
   overflow: hidden;
-  background: rgba(0, 0, 0, 0.66);
+  background: transparent;
   color: var(--text);
-  font-size: 12px;
+  font-size: 14px;
   line-height: 1.45;
 }
 
@@ -49,7 +50,7 @@
 
 .connect-onboarding button:focus-visible,
 .connect-onboarding summary:focus-visible {
-  outline: 1px solid var(--text);
+  outline: 2px solid var(--text);
   outline-offset: 2px;
 }
 
@@ -62,26 +63,26 @@
 }
 
 .connect-onboarding {
-  --muted: rgba(255, 255, 255, 0.62);
-  --faint: rgba(255, 255, 255, 0.4);
-  --border-strong: rgba(255, 255, 255, 0.2);
+  --muted: color-mix(in srgb, var(--text) 72%, transparent);
+  --faint: color-mix(in srgb, var(--text) 65%, transparent);
+  --border-strong: color-mix(in srgb, var(--text) 18%, transparent);
   --warning: #e8c77a;
   color: var(--text);
-  font-family: "Berkeley Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    "Liberation Mono", monospace;
-  font-size: 12px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 14px;
   line-height: 1.45;
 }
 
 @scope (.connect-onboarding) {
 :scope.dialog-shell {
   display: flex;
-  width: min(408px, calc(100vw - 24px));
-  max-height: min(650px, calc(100vh - 24px));
+  width: min(440px, calc(100vw - 24px));
+  max-height: min(696px, calc(100dvh - 24px));
   min-height: 0;
   margin: 0 auto;
   overflow: hidden;
   border: 1px solid var(--border-strong);
+  border-radius: 24px;
   background: var(--surface);
   box-shadow: 0 28px 80px rgba(0, 0, 0, 0.55);
 }
@@ -105,13 +106,13 @@
 
 .dialog-header {
   flex: 0 0 auto;
-  min-height: 46px;
-  padding: 0 20px;
+  min-height: 60px;
+  padding: 0 24px;
   border-bottom: 1px solid var(--border);
 }
 
 .wordmark {
-  font-size: 11px;
+  font-size: 13px;
   font-weight: 600;
   letter-spacing: -0.03em;
 }
@@ -121,7 +122,7 @@
   align-items: center;
   gap: 6px;
   color: var(--muted);
-  font-size: 9px;
+  font-size: 12px;
 }
 
 .secure-label > span {
@@ -133,7 +134,7 @@
 .dialog-content {
   flex: 1 1 auto;
   min-height: 0;
-  padding: 0 20px 18px;
+  padding: 0 24px 24px;
   overflow-x: hidden;
   overflow-y: auto;
   scrollbar-color: var(--border-strong) transparent;
@@ -182,7 +183,7 @@
   display: block;
   margin-top: 2px;
   color: var(--faint);
-  font-size: 8px;
+  font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
@@ -200,19 +201,19 @@
 
 .terminal-code span {
   color: var(--muted);
-  font-size: 8px;
+  font-size: 11px;
 }
 
 .terminal-code strong {
   color: var(--positive);
-  font-size: 12px;
+  font-size: 14px;
   letter-spacing: 0.08em;
 }
 
 .eyebrow {
   margin-bottom: 7px;
   color: var(--positive);
-  font-size: 9px;
+  font-size: 12px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -228,7 +229,7 @@
   max-width: 350px;
   margin-top: 6px;
   color: var(--muted);
-  font-size: 10px;
+  font-size: 13px;
   line-height: 1.55;
 }
 
@@ -247,7 +248,7 @@
   background: transparent;
   cursor: pointer;
   color: var(--faint);
-  font-size: 10px;
+  font-size: 13px;
 }
 
 .account-mode button:last-child {
@@ -351,7 +352,7 @@
   background: var(--surface-raised);
   color: var(--muted);
   content: attr(data-tooltip);
-  font-size: 8px;
+  font-size: 11px;
   line-height: 1.5;
   opacity: 0;
   pointer-events: none;
@@ -387,7 +388,7 @@
   border: 1px solid var(--surface);
   background: var(--positive);
   color: #0b0b0b;
-  font-size: 8px;
+  font-size: 11px;
   font-style: normal;
   font-weight: 700;
 }
@@ -404,7 +405,7 @@
 }
 
 .capability-token:focus-visible {
-  outline: 1px solid var(--text);
+  outline: 2px solid var(--text);
   outline-offset: 3px;
 }
 
@@ -420,7 +421,7 @@
   padding: 7px 0 0;
   overflow: visible;
   color: var(--faint);
-  font-size: 8px;
+  font-size: 11px;
   line-height: 1;
   white-space: nowrap;
 }
@@ -450,7 +451,7 @@
   background: var(--surface-raised);
   color: var(--muted);
   content: attr(data-tooltip);
-  font-size: 8px;
+  font-size: 11px;
   line-height: 1.4;
   opacity: 0;
   pointer-events: none;
@@ -470,7 +471,7 @@
 }
 
 .app-sees-permission:focus-visible {
-  outline: 1px solid var(--text);
+  outline: 2px solid var(--text);
   outline-offset: 2px;
 }
 
@@ -497,7 +498,7 @@
   border: 1px solid var(--surface);
   background: var(--surface-raised);
   color: var(--muted);
-  font-size: 8px;
+  font-size: 11px;
   font-weight: 700;
 }
 
@@ -514,13 +515,13 @@
   padding: 10px 1px;
   border-bottom: 1px solid var(--border);
   color: var(--muted);
-  font-size: 8px;
+  font-size: 11px;
   text-decoration: none;
 }
 
 .device-code strong {
   color: var(--text);
-  font-size: 11px;
+  font-size: 13px;
   letter-spacing: 0.08em;
 }
 
@@ -553,7 +554,7 @@
   place-items: center;
   background: var(--surface-raised);
   color: var(--text);
-  font-size: 10px;
+  font-size: 13px;
 }
 
 .mcp-connection-copy {
@@ -564,7 +565,7 @@
 
 .mcp-connection-copy strong {
   overflow: hidden;
-  font-size: 10px;
+  font-size: 13px;
   font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -574,7 +575,7 @@
 .mcp-connection-copy small,
 .mcp-connection-state {
   color: var(--muted);
-  font-size: 8px;
+  font-size: 11px;
 }
 
 .mcp-connection-actions {
@@ -593,7 +594,7 @@
   border: 1px solid var(--border-strong);
   background: transparent;
   cursor: pointer;
-  font-size: 8px;
+  font-size: 11px;
 }
 
 .mcp-connection-card button:disabled {
@@ -611,17 +612,17 @@
 
 .grant-boundary > span {
   color: var(--muted);
-  font-size: 8px;
+  font-size: 11px;
 }
 
 .grant-boundary strong {
-  font-size: 12px;
+  font-size: 14px;
   font-weight: 500;
 }
 
 .grant-boundary small {
   color: var(--faint);
-  font-size: 8px;
+  font-size: 11px;
   font-weight: 400;
 }
 
@@ -682,21 +683,21 @@
 }
 
 .preview-header strong {
-  font-size: 10px;
+  font-size: 13px;
   font-weight: 500;
 }
 
 .preview-header div > span {
   overflow: hidden;
   color: var(--faint);
-  font-size: 8px;
+  font-size: 11px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .preview-state {
   color: var(--positive);
-  font-size: 8px;
+  font-size: 11px;
   letter-spacing: 0.05em;
   text-transform: uppercase;
 }
@@ -728,7 +729,7 @@
   font-weight: 600;
   width: 28px;
   height: 28px;
-  font-size: 8px;
+  font-size: 11px;
 }
 
 .preview-service strong {
@@ -736,14 +737,14 @@
   min-width: 0;
   align-items: center;
   gap: 5px;
-  font-size: 8px;
+  font-size: 11px;
   font-weight: 500;
   line-height: 1.25;
 }
 
 .preview-service > span {
   color: var(--positive);
-  font-size: 8px;
+  font-size: 11px;
   letter-spacing: 0.05em;
   text-transform: uppercase;
 }
@@ -770,13 +771,13 @@
 }
 
 .section-heading h2 {
-  font-size: 10px;
+  font-size: 13px;
   font-weight: 500;
 }
 
 .section-heading > span {
   color: var(--faint);
-  font-size: 8px;
+  font-size: 11px;
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
@@ -802,12 +803,12 @@
 
 .permission-row span {
   color: var(--faint);
-  font-size: 9px;
+  font-size: 12px;
 }
 
 .permission-row strong {
   color: var(--text);
-  font-size: 9px;
+  font-size: 12px;
   font-weight: 500;
   text-align: right;
 }
@@ -815,7 +816,7 @@
 .period-note {
   margin-top: 8px;
   color: var(--faint);
-  font-size: 8px;
+  font-size: 11px;
   line-height: 1.45;
 }
 
@@ -829,7 +830,7 @@
   padding: 9px 1px;
   color: var(--muted);
   cursor: pointer;
-  font-size: 9px;
+  font-size: 12px;
 }
 
 .advanced-details[open] summary {
@@ -851,13 +852,13 @@
 
 dt {
   color: var(--faint);
-  font-size: 9px;
+  font-size: 12px;
 }
 
 dd {
   overflow: hidden;
   color: var(--muted);
-  font-size: 9px;
+  font-size: 12px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -869,7 +870,7 @@ dd {
   padding: 10px 11px;
   border-top: 1px solid var(--border);
   color: var(--faint);
-  font-size: 8px;
+  font-size: 11px;
   list-style: none;
 }
 
@@ -887,7 +888,7 @@ dd {
   border-top: 1px solid var(--border);
   color: var(--muted);
   font: inherit;
-  font-size: 8px;
+  font-size: 11px;
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -895,7 +896,7 @@ dd {
 .signature-note {
   padding: 10px 1px 0;
   color: var(--faint);
-  font-size: 8px;
+  font-size: 11px;
   line-height: 1.5;
 }
 
@@ -904,7 +905,7 @@ dd {
   flex: 0 0 auto;
   grid-template-columns: 0.65fr 1.35fr;
   gap: 7px;
-  padding: 12px 20px 16px;
+  padding: 16px 24px 20px;
   border-top: 1px solid var(--border);
   background: var(--surface);
 }
@@ -915,22 +916,22 @@ dd {
   border: 1px solid var(--border-strong);
   background: transparent;
   cursor: pointer;
-  font-size: 10px;
+  font-size: 13px;
 }
 
 .dialog-actions button:last-child {
   border-color: var(--text);
   background: var(--text);
-  color: #000000;
+  color: var(--surface);
   font-weight: 600;
 }
 
 .dialog-actions button:not(:disabled):hover {
-  background: rgba(255, 255, 255, 0.06);
+  background: color-mix(in srgb, var(--text) 6%, transparent);
 }
 
 .dialog-actions button:last-child:not(:disabled):hover {
-  background: rgba(255, 255, 255, 0.86);
+  background: color-mix(in srgb, var(--text) 86%, var(--surface));
 }
 
 .dialog-actions button:disabled {
@@ -943,8 +944,8 @@ dd {
   padding: 9px 10px;
   border: 1px solid rgba(255, 105, 105, 0.42);
   background: rgba(255, 105, 105, 0.07);
-  color: #ffaaaa;
-  font-size: 9px;
+  color: var(--negative, #ffaaaa);
+  font-size: 12px;
 }
 
 .onramp-card {
@@ -955,12 +956,12 @@ dd {
 
 .card-topline {
   color: var(--muted);
-  font-size: 9px;
+  font-size: 12px;
 }
 
 .card-method {
   color: var(--positive);
-  font-size: 8px;
+  font-size: 11px;
   letter-spacing: 0.05em;
   text-transform: uppercase;
 }
@@ -980,7 +981,7 @@ dd {
 
 .funding-caption {
   color: var(--faint);
-  font-size: 9px;
+  font-size: 12px;
 }
 
 .funding-details {
@@ -996,7 +997,7 @@ dd {
   padding-top: 14px;
   border-top: 1px solid var(--border);
   color: var(--muted);
-  font-size: 9px;
+  font-size: 12px;
   line-height: 1.55;
 }
 
@@ -1020,14 +1021,14 @@ dd {
 }
 
 .passkey-note strong {
-  font-size: 9px;
+  font-size: 12px;
   font-weight: 500;
 }
 
 .passkey-note p {
   margin-top: 3px;
   color: var(--muted);
-  font-size: 8px;
+  font-size: 11px;
   line-height: 1.5;
 }
 
@@ -1055,7 +1056,7 @@ dd {
 
 .wizard-app p {
   color: var(--muted);
-  font-size: 9px;
+  font-size: 12px;
   line-height: 1.55;
 }
 
@@ -1072,11 +1073,11 @@ dd {
 .wizard-section-title span,
 .wizard-section-title small {
   color: var(--faint);
-  font-size: 8px;
+  font-size: 11px;
 }
 
 .wizard-terminal-code strong {
-  font-size: 10px;
+  font-size: 13px;
   font-weight: 500;
   letter-spacing: 0.09em;
 }
@@ -1104,7 +1105,7 @@ dd {
 }
 
 .wizard-section-title h2 {
-  font-size: 10px;
+  font-size: 13px;
   font-weight: 500;
 }
 
@@ -1123,13 +1124,13 @@ dd {
 }
 
 .sms-otp-form > label {
-  font-size: 10px;
+  font-size: 13px;
   font-weight: 500;
 }
 
 .sms-otp-form > p {
   color: var(--muted);
-  font-size: 8px;
+  font-size: 11px;
   line-height: 1.5;
 }
 
@@ -1177,7 +1178,7 @@ dd {
   background: transparent;
   color: var(--muted);
   cursor: pointer;
-  font-size: 8px;
+  font-size: 11px;
 }
 
 .wizard-account-choice {
@@ -1220,7 +1221,7 @@ dd {
   place-items: center;
   border: 1px solid var(--border-strong);
   background: var(--surface-raised);
-  font-size: 12px;
+  font-size: 14px;
 }
 
 .wizard-passkey-avatar {
@@ -1241,18 +1242,18 @@ dd {
 }
 
 .wizard-account-copy strong {
-  font-size: 10px;
+  font-size: 13px;
   font-weight: 500;
 }
 
 .wizard-account-copy small {
   color: var(--muted);
-  font-size: 8px;
+  font-size: 11px;
 }
 
 .wizard-account-arrow {
   color: var(--faint);
-  font-size: 8px;
+  font-size: 11px;
 }
 
 .wizard-account-create-form {
@@ -1292,7 +1293,7 @@ dd {
   background: transparent;
   color: var(--muted);
   cursor: pointer;
-  font-size: 9px;
+  font-size: 12px;
 }
 
 .wizard-connectors {
@@ -1331,7 +1332,7 @@ dd {
 }
 
 .wizard-connectors .connection-card-copy strong {
-  font-size: 9px;
+  font-size: 12px;
   font-weight: 500;
 }
 
@@ -1339,7 +1340,7 @@ dd {
 .wizard-connectors .connection-card-action {
   overflow: hidden;
   color: var(--muted);
-  font-size: 8px;
+  font-size: 11px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1365,7 +1366,7 @@ dd {
 
 .wizard-visibility > div > span {
   color: var(--positive);
-  font-size: 8px;
+  font-size: 11px;
 }
 
 .wizard-visibility > div > div {
@@ -1375,7 +1376,7 @@ dd {
 .wizard-visibility strong,
 .wizard-visibility small {
   overflow: hidden;
-  font-size: 8px;
+  font-size: 11px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1394,7 +1395,7 @@ dd {
   justify-content: space-between;
   padding: 9px 0;
   color: var(--muted);
-  font-size: 8px;
+  font-size: 11px;
 }
 
 .wizard-device-code strong {
@@ -1413,6 +1414,7 @@ dd {
     margin: 0;
     border-inline: 0;
     border-bottom: 0;
+    border-radius: 24px 24px 0 0;
     box-shadow: 0 -24px 72px rgba(0, 0, 0, 0.55);
   }
 
@@ -1472,4 +1474,40 @@ dd {
     display: grid;
     place-items: end center;
   }
+}
+
+/* The hosted consent surface follows the native app's system appearance. */
+@media (prefers-color-scheme: light) {
+  :root.connect-dialog-standalone {
+    color-scheme: light;
+    --surface: #fff;
+    --surface-raised: #f4f4f4;
+    --surface-subtle: #f9f9f9;
+    --text: #262626;
+    --text-inverse: #fff;
+    --border: rgba(0, 0, 0, .1);
+    --positive: #0d7136;
+    --negative: #b72f2f;
+    --warning: #886013;
+  }
+}
+
+@scope (.connect-onboarding) {
+  button, input, .app-sees-permission { border-radius: 10px; }
+  .app-mark, .connector-logo, .mcp-connection-logo, .wizard-account-avatar { border-radius: 12px; }
+  .secure-label > span, .connector-state, .passkey-icon { border-radius: 50%; }
+  .wizard-account-chooser, .sms-otp-form, .permission-rows, .mcp-connection-card, .dialog-error { border-radius: 14px; overflow: hidden; }
+  .wizard-account-choice { border-radius: 0; }
+  .dialog-actions button, .sms-otp-input-row :is(button, input) { min-height: 46px; }
+  .sms-otp-input-row { grid-template-columns: minmax(0, 1fr); }
+  .sms-otp-input-row input { font-size: 16px; }
+  .request-title, .consent-hero { padding-block: 24px 20px; }
+  .request-title h1, .wizard-app h1 { font-size: 24px; line-height: 1.2; letter-spacing: -.035em; }
+  .wordmark { font-size: 15px; letter-spacing: -.025em; }
+  .wizard-section { padding-block: 18px; }
+  .app-sees, .capability-logos { flex-wrap: wrap; }
+  .wizard-section-title { flex-wrap: wrap; }
+  .wizard-account-copy small { line-height: 1.5; }
+  .sms-otp-change { min-height: 44px; }
+  .wizard-account-choice:focus-visible, input:focus-visible { outline: 2px solid var(--text); outline-offset: -3px; }
 }

--- a/js/nanocodex-terminal/src/AgentTerminalView.tsx
+++ b/js/nanocodex-terminal/src/AgentTerminalView.tsx
@@ -38,6 +38,7 @@ export function AgentTerminalView({
   agent,
   agentError,
   composer,
+  composerPlaceholder,
   controls,
   inactiveMessage,
   maxEntries,
@@ -57,6 +58,7 @@ export function AgentTerminalView({
   agentError: string | undefined;
   /** Replaces the default composer without detaching the transcript controller. */
   composer?: ReactNode;
+  composerPlaceholder?: string;
   controls?(controls: Pick<AgentTerminalAccessory, "agentReady">): ReactNode;
   inactiveMessage?(state: Readonly<{
     agentError: string | undefined;
@@ -231,6 +233,7 @@ export function AgentTerminalView({
             {controls?.({ agentReady: agentStatus === "ready" })}
           </> : undefined}
           draft={touchDraft}
+          placeholder={composerPlaceholder}
           pending={pendingTouchSubmission !== undefined}
           running={terminalRunning}
           status={agentStatus}

--- a/js/nanocodex-terminal/src/TerminalComposer.tsx
+++ b/js/nanocodex-terminal/src/TerminalComposer.tsx
@@ -5,11 +5,12 @@ import { useEffect, useRef, type ReactNode } from "react";
 import type { AgentStatus } from "./types.js";
 import { COARSE_POINTER_QUERY, terminalComposerAction } from "./policy.js";
 
-/** One native, paste-capable composer shared by desktop and touch terminals. */
+/** One paste-capable composer shared by desktop and touch terminals. */
 export function TerminalComposer({
   controls,
   draft,
   pending,
+  placeholder,
   running,
   status,
   onCancel,
@@ -19,6 +20,7 @@ export function TerminalComposer({
   controls?: ReactNode;
   draft: string;
   pending: boolean;
+  placeholder?: string;
   running: boolean;
   status: AgentStatus;
   onCancel(): void;
@@ -42,7 +44,7 @@ export function TerminalComposer({
 
   const submit = () => {
     const value = textarea.current?.value ?? draft;
-    if (pending || !value.trim()) return;
+    if (pending || status !== "ready" || !value.trim()) return;
     onSubmit(value);
   };
   const action = terminalComposerAction(running, draft);
@@ -62,6 +64,7 @@ export function TerminalComposer({
           aria-label="Message Nanocodex"
           enterKeyHint="send"
           rows={1}
+          placeholder={placeholder}
           value={draft}
           onChange={(event) => onChange(event.currentTarget.value)}
           onCompositionStart={() => { composing.current = true; }}
@@ -78,11 +81,11 @@ export function TerminalComposer({
         <div className="agent-touch-actions">
           {controls}
           {action === "stop" ? (
-            <button type="button" aria-label="Stop response" disabled={status !== "ready"} onClick={onCancel}>
+            <button type="button" aria-label="Stop response" title="Stop response" disabled={status !== "ready"} onClick={onCancel}>
               <Square aria-hidden="true" />
             </button>
           ) : null}
-          <button type="submit" aria-label="Send message" disabled={pending || status !== "ready"}>
+          <button type="submit" aria-label="Send message" title="Send message" disabled={pending || status !== "ready" || !draft.trim()}>
             <ArrowUp aria-hidden="true" />
           </button>
         </div>

--- a/js/nanocodex-terminal/src/TerminalTranscriptSurface.tsx
+++ b/js/nanocodex-terminal/src/TerminalTranscriptSurface.tsx
@@ -315,8 +315,9 @@ function ResponseActions({ text }: { text: string }) {
     return () => clearTimeout(timer);
   }, [state]);
   return <div className="agent-response-actions">
-    <button type="button" aria-label={state === "copied" ? "Copied response" : "Copy response"} title={state === "copied" ? "Copied" : "Copy response"} onClick={() => {
-      void navigator.clipboard.writeText(text).then(() => setState("copied")).catch(() => setState("error"));
+    <button type="button" aria-label={state === "copied" ? "Copied response" : "Copy response"} title={state === "copied" ? "Copied" : "Copy response"} onClick={async () => {
+      try { await navigator.clipboard.writeText(text); setState("copied"); }
+      catch { setState("error"); }
     }}>{state === "copied" ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}</button>
     <span role="status">{state === "copied" ? "Copied" : state === "error" ? "Couldn’t copy. Select the text to copy it." : ""}</span>
   </div>;

--- a/js/nanocodex-terminal/src/TerminalTranscriptSurface.tsx
+++ b/js/nanocodex-terminal/src/TerminalTranscriptSurface.tsx
@@ -8,8 +8,10 @@ import {
   useLayoutEffect,
   useMemo,
   useRef,
+  useState,
 } from "react";
 import type { AgentEntry, ToolActivity } from "nanocodex-react/agent";
+import { ArrowDown, Check, Copy } from "lucide-react";
 import { Streamdown } from "streamdown";
 
 import type { AgentStatus, AgentTerminalMode } from "./types.js";
@@ -55,6 +57,7 @@ export function TerminalTranscriptSurface({
 }) {
   const transcript = useRef<HTMLDivElement>(null);
   const followTail = useRef(true);
+  const [showLatest, setShowLatest] = useState(false);
   const handledFollowTailRequest = useRef(followTailRequest);
   const loadOlderArmed = useRef(false);
   const preserveScroll = useRef<{ scrollHeight: number; scrollTop: number } | undefined>(undefined);
@@ -105,6 +108,7 @@ export function TerminalTranscriptSurface({
         onScroll={(event) => {
           const element = event.currentTarget;
           followTail.current = element.scrollHeight - element.scrollTop - element.clientHeight < 48;
+          setShowLatest(!followTail.current);
           const lineHeight = Number.parseFloat(getComputedStyle(element).lineHeight) || 22;
           const nearTop = element.scrollTop <= lineHeight * 12;
           if (!nearTop) {
@@ -141,7 +145,15 @@ export function TerminalTranscriptSurface({
           <div className="agent-transcript-keyboard-spacer" aria-hidden="true" />
         </div>
       </div>
-      {composer}
+      <div className="agent-composer-dock">
+        {showLatest ? <button className="agent-jump-latest" type="button" aria-label="Jump to latest response" title="Jump to latest response" onClick={() => {
+          const element = transcript.current;
+          if (!element) return;
+          followTail.current = true;
+          element.scrollTo({ top: element.scrollHeight, behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "instant" : "smooth" });
+        }}><ArrowDown aria-hidden="true" /></button> : null}
+        {composer}
+      </div>
     </section>
   );
 }
@@ -275,12 +287,13 @@ const TerminalEntryView = memo(function TerminalEntryView({
       <Streamdown
         caret={entry.streaming ? "block" : undefined}
         components={MARKDOWN_COMPONENTS}
-        controls={false}
+        controls={MARKDOWN_CONTROLS}
         isAnimating={entry.streaming}
         linkSafety={LINK_SAFETY}
         mode={entry.streaming ? "streaming" : "static"}
         skipHtml
       >{entry.text}</Streamdown>
+      {entry.kind === "assistant" && !entry.streaming && entry.text.trim() ? <ResponseActions text={entry.text} /> : null}
     </article>
   );
   if (entry.kind === "error") return <p className="agent-terminal-error" role="alert">! {entry.text}</p>;
@@ -294,6 +307,21 @@ const TerminalEntryView = memo(function TerminalEntryView({
   return null;
 });
 
+function ResponseActions({ text }: { text: string }) {
+  const [state, setState] = useState<"idle" | "copied" | "error">("idle");
+  useEffect(() => {
+    if (state === "idle") return;
+    const timer = setTimeout(() => setState("idle"), 2000);
+    return () => clearTimeout(timer);
+  }, [state]);
+  return <div className="agent-response-actions">
+    <button type="button" aria-label={state === "copied" ? "Copied response" : "Copy response"} title={state === "copied" ? "Copied" : "Copy response"} onClick={() => {
+      void navigator.clipboard.writeText(text).then(() => setState("copied")).catch(() => setState("error"));
+    }}>{state === "copied" ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}</button>
+    <span role="status">{state === "copied" ? "Copied" : state === "error" ? "Couldn’t copy. Select the text to copy it." : ""}</span>
+  </div>;
+}
+
 function MarkdownInput({
   node: _node,
   ref: _ref,
@@ -306,6 +334,7 @@ function MarkdownInput({
 }
 
 const MARKDOWN_COMPONENTS = { input: MarkdownInput };
+const MARKDOWN_CONTROLS = { code: { copy: true, download: false }, table: false, mermaid: false } as const;
 const LINK_SAFETY = { enabled: true } as const;
 
 function TerminalToolView({ isChild = false, tool }: { isChild?: boolean; tool: ToolActivity }) {

--- a/js/nanocodex-terminal/styles.css
+++ b/js/nanocodex-terminal/styles.css
@@ -204,6 +204,15 @@
   grid-template-rows: minmax(0, 1fr) auto;
 }
 
+.agent-composer-dock { position: relative; min-width: 0; }
+.agent-jump-latest { position: absolute; z-index: 2; bottom: calc(100% + 12px); left: 50%; display: grid; place-items: center; width: 34px; height: 34px; padding: 0; transform: translateX(-50%); color: var(--terminal-foreground, #111); background: var(--terminal-background, #fff); border: 1px solid var(--terminal-border, #ddd); border-radius: 50%; box-shadow: 0 2px 8px rgb(0 0 0 / .06); cursor: pointer; }
+.agent-jump-latest svg { width: 18px; height: 18px; }
+.agent-response-actions { display: flex; min-height: 32px; align-items: center; gap: 6px; margin: 10px 0 0 -7px; color: var(--terminal-muted, #6b6b6b); font: 12px/1.4 var(--terminal-font-sans, system-ui, sans-serif); }
+.agent-response-actions button { display: grid; place-items: center; width: 32px; height: 32px; padding: 0; border: 0; border-radius: 8px; color: inherit; background: transparent; cursor: pointer; }
+.agent-response-actions button:hover { color: var(--terminal-foreground, #111); background: var(--terminal-hover, #f4f4f4); }
+.agent-response-actions svg { width: 16px; height: 16px; }
+.agent-response-actions button:focus-visible, .agent-jump-latest:focus-visible { outline: 2px solid var(--terminal-muted, #6b6b6b); outline-offset: 2px; }
+
 .agent-terminal-standby {
   margin: 0;
   padding: 12px;
@@ -302,6 +311,16 @@
   border-radius: 0;
   white-space: pre;
 }
+
+.agent-terminal-markdown [data-streamdown="code-block"] { display: grid; grid-template-columns: minmax(0, 1fr) auto; margin: 18px 0; overflow: hidden; background: var(--terminal-hover, #f4f4f4); border: 1px solid var(--terminal-border, #ddd); border-radius: 14px; }
+.agent-terminal-markdown [data-streamdown="code-block-header"] { display: flex; align-items: center; min-height: 42px; padding: 8px 16px; grid-column: 1; grid-row: 1; color: var(--terminal-muted, #6b6b6b); font: 12px/1.4 var(--terminal-font-sans, system-ui, sans-serif); }
+.agent-terminal-markdown [data-streamdown="code-block-header"] + div { display: flex; align-items: center; padding-right: 8px; grid-column: 2; grid-row: 1; }
+.agent-terminal-markdown [data-streamdown="code-block-actions"] { display: flex; align-items: center; }
+.agent-terminal-markdown [data-streamdown="code-block-copy-button"] { display: grid; place-items: center; width: 32px; height: 32px; padding: 0; color: var(--terminal-muted, #6b6b6b); background: transparent; border: 0; border-radius: 8px; cursor: pointer; }
+.agent-terminal-markdown [data-streamdown="code-block-copy-button"]:hover { color: var(--terminal-foreground, #111); background: var(--terminal-background, #fff); }
+.agent-terminal-markdown [data-streamdown="code-block-body"] { grid-column: 1 / -1; overflow-x: auto; padding: 16px; border-top: 1px solid var(--terminal-border, #ddd); }
+.agent-terminal-markdown [data-streamdown="code-block-body"] pre { margin: 0; padding: 0; border: 0; border-radius: 0; background: transparent; }
+.agent-terminal-markdown [data-streamdown="code-block-body"] pre > code > span { display: block; }
 
 .agent-terminal-markdown a {
   color: inherit;

--- a/js/nanocodex-terminal/test/components.test.mjs
+++ b/js/nanocodex-terminal/test/components.test.mjs
@@ -67,6 +67,7 @@ test("controller-backed terminal remains caller-owned when no Agent is attached"
       agent: undefined,
       agentError: undefined,
       mode: "preview",
+      composerPlaceholder: "Ask your agent",
       onConversationActivity() {},
       onStateChange(state) { states.push(state); },
       retryAgent() {},
@@ -80,6 +81,7 @@ test("controller-backed terminal remains caller-owned when no Agent is attached"
   });
   assert.equal(renderer.root.findByProps({ role: "log" }).props["aria-live"], "off");
   assert.equal(renderer.root.findByType("form").props["aria-label"], "Nanocodex message composer");
+  assert.equal(renderer.root.findByType("textarea").props.placeholder, "Ask your agent");
   assert.equal(renderer.root.findAllByProps({ "aria-label": "Start voice" }).length, 0);
   assert.equal(states.at(-1).status, "starting");
   await act(async () => renderer.update(React.createElement(AgentTerminalView, {
@@ -295,7 +297,7 @@ test("composer keeps stop available beside send throughout an active turn", asyn
     renderer.root.findAllByType("button").map((button) => button.props["aria-label"]),
     ["Stop response", "Send message"],
   );
-  assert.equal(renderer.root.findByProps({ "aria-label": "Send message" }).props.disabled, false);
+  assert.equal(renderer.root.findByProps({ "aria-label": "Send message" }).props.disabled, true);
   await act(async () => renderer.root.findByProps({ "aria-label": "Stop response" }).props.onClick());
   assert.equal(cancelled, 2);
   await act(async () => renderer.unmount());


### PR DESCRIPTION
Match the website and Connect to the current iOS/macOS appearance: system typography, neutral light/dark surfaces, a persistent chat sidebar, rounded composer, model controls, conversation search, and response copy actions.

Give the Connect playground its own Atlas identity with a forest/cream palette, clearer access choices, and a distinct embedded-agent workspace. Keep Connect sign-in on one screen: enter the phone number first, then review the full requested access after signing in and before approval.

Validation:
- Full workspace builds passed for the website, Connect dialog, and playground (8 tasks).
- Website: 74 tests; Connect UI: 22 tests plus type checks; dialog: 29 policy/protocol tests plus 18 Vitest tests; terminal: 12 tests plus package checks.
- Canonical Portless browser checks covered website navigation/appearance, responsive Atlas layout, opening the hosted Connect dialog, and the compact phone sign-in step at 375 × 667. The sign-in content measured 477px tall with scrollHeight also 477px, and Cancel returned to Atlas. Authenticated approval and sending a verification SMS were not exercised locally.

No changes to the public SDK contracts, requested permissions, credential handling, Worker bindings, migrations, or Rust.

Production verification after merge: Cloudflare deployed `d33abc8614dae822bd6c69e6147dc99184fc3841` successfully. All three live apps serve the updated bundles. A live model turn and response copy succeeded; the hosted Connect sign-in fit the phone viewport without scrolling, Cancel returned to Atlas, and no app or CSP errors were captured for that journey.
