### PR TITLE
fix(managed): remove per-file R2 latency from brain workspaces

### DIFF
--- a/js/managed/README.md
+++ b/js/managed/README.md
@@ -33,9 +33,15 @@ storage ownership.
   storage byte counts, hot receipt counts, and archive counts without loading
   the runtime or returning conversation contents.
 - Managed agents execute Just Bash in durable `/brain` without a hand.
-  `exec_command` defaults there; `/brain` and `.` also select the brain. Its R2
-  prefix is shared with the native hand mounts, and listings refresh between
-  commands. Text/file processing, HTTP, and supported Git/GitHub commands run
+  `exec_command` defaults there; `/brain` and `.` also select the brain. File
+  metadata and small bodies live in the owning agent's SQLite storage. Bodies
+  above 1 MiB and streaming uploads remain in R2; this selects storage and does
+  not reject larger files. Existing R2 trees are indexed without copying their
+  bodies. Native hand mounts use the SDK's S3 protocol through trusted RPC to
+  that same actor, preserving prefix and read-only fences without a remote R2
+  request for every filesystem stat. Listings refresh between commands. Local
+  Sandbox SDK replication continues using its existing R2 binding. Text/file
+  processing, HTTP, and supported Git/GitHub commands run
   here; native binaries, package installs, builds, and process sessions need a
   hand. The agent reuses a suitable attached hand or mounts one when needed.
   Known native work such as `cargo test` can go directly to a hand; an

--- a/js/managed/src/brain-bucket.ts
+++ b/js/managed/src/brain-bucket.ts
@@ -1,0 +1,207 @@
+import { createHash } from "node:crypto";
+
+// Storage placement, not a file-size limit: larger bodies keep streaming to R2.
+// SQLite's maximum row size is 2 MB, so leave room for the key and metadata.
+export const BRAIN_INLINE_BYTES = 1024 * 1024;
+type Row = { key: string; metadata: string; body: ArrayBuffer | null };
+type Metadata = {
+  key: string; version: string; size: number; etag: string; uploaded: number;
+  httpMetadata: R2HTTPMetadata; customMetadata: Record<string, string>;
+};
+
+/** Agent-owned file metadata and small bodies stay beside the executing brain. */
+export function createBrainBucket(storage: DurableObjectStorage, backing: R2Bucket, resourceId: string): R2Bucket {
+  if (!/^[A-Za-z0-9._:-]{1,256}$/.test(resourceId)) throw new TypeError("invalid brain resource id");
+  const prefix = `brains/${resourceId}/`;
+  storage.sql.exec(`CREATE TABLE IF NOT EXISTS nanocodex_brain_objects (
+    key TEXT PRIMARY KEY, metadata TEXT NOT NULL, body BLOB
+  )`);
+  storage.sql.exec(`CREATE TABLE IF NOT EXISTS nanocodex_brain_catalog (
+    prefix TEXT PRIMARY KEY
+  )`);
+  const validate = (key: string): void => {
+    if (!key.startsWith(prefix) || key.includes("\0")
+      || key.slice(prefix.length).split("/").some((part) => part === "." || part === "..")) {
+      throw new Error("brain object is outside its owning agent");
+    }
+  };
+  const retain = (object: R2Object, body: ArrayBuffer | null): R2Object => {
+    const metadata: Metadata = {
+      key: object.key, version: object.version, size: object.size, etag: object.etag,
+      uploaded: object.uploaded.getTime(), httpMetadata: object.httpMetadata ?? {},
+      customMetadata: object.customMetadata ?? {},
+    };
+    storage.sql.exec("INSERT OR REPLACE INTO nanocodex_brain_objects VALUES (?, ?, ?)",
+      object.key, JSON.stringify(metadata), body);
+    return object;
+  };
+  let opening: Promise<void> | undefined;
+  const ready = (): Promise<void> => opening ??= (async () => {
+    if (storage.sql.exec("SELECT prefix FROM nanocodex_brain_catalog WHERE prefix = ?", prefix).toArray().length) return;
+    let cursor: string | undefined;
+    do {
+      const page = await backing.list({ prefix, cursor, include: ["httpMetadata", "customMetadata"] });
+      for (const object of page.objects) retain(object, null);
+      cursor = page.truncated ? page.cursor : undefined;
+    } while (cursor !== undefined);
+    storage.sql.exec("INSERT OR IGNORE INTO nanocodex_brain_catalog VALUES (?)", prefix);
+  })().catch((error) => { opening = undefined; throw error; });
+  const row = (key: string): Row | undefined => storage.sql.exec<Row>(
+    "SELECT key, metadata, body FROM nanocodex_brain_objects WHERE key = ?", key,
+  ).toArray()[0];
+  const head = async (key: string): Promise<R2Object | null> => {
+    validate(key); await ready();
+    const found = storage.sql.exec<{ metadata: string }>(
+      "SELECT metadata FROM nanocodex_brain_objects WHERE key = ?", key,
+    ).toArray()[0];
+    return found ? objectMetadata(JSON.parse(found.metadata)) : null;
+  };
+  const multipart = (upload: R2MultipartUpload): R2MultipartUpload => ({
+    key: upload.key, uploadId: upload.uploadId,
+    uploadPart: (number, value, options) => upload.uploadPart(number, value, options),
+    abort: () => upload.abort(),
+    async complete(parts) {
+      await ready();
+      return retain(await upload.complete(parts), null);
+    },
+  });
+  return {
+    head,
+    async get(key: string, options: R2GetOptions = {}) {
+      validate(key); await ready();
+      const found = row(key);
+      if (!found) return null;
+      if (found.body === null) return backing.get(key, options);
+      const object = objectMetadata(JSON.parse(found.metadata));
+      if (!conditionMatches(object, options.onlyIf)) return object;
+      let bytes = new Uint8Array(found.body);
+      const range = options.range instanceof Headers ? undefined : options.range;
+      let selected: { offset: number; length: number } | undefined;
+      if (range) {
+        const offset = "suffix" in range ? Math.max(0, bytes.length - range.suffix) : range.offset ?? 0;
+        const length = "suffix" in range ? bytes.length - offset : Math.min(range.length ?? bytes.length, bytes.length - offset);
+        if (offset < 0 || length < 0 || offset >= bytes.length && bytes.length !== 0) throw new RangeError("invalid object range");
+        bytes = bytes.slice(offset, offset + length);
+        selected = { offset, length };
+      }
+      const response = new Response(bytes);
+      return {
+        ...object, ...(selected ? { range: selected } : {}), body: response.body!,
+        get bodyUsed() { return response.bodyUsed; },
+        arrayBuffer: () => response.arrayBuffer(), text: () => response.text(),
+        json: <T>() => response.json<T>(), blob: () => response.blob(),
+      } as R2ObjectBody;
+    },
+    async put(key: string, value: ReadableStream | ArrayBuffer | ArrayBufferView | string | Blob | null,
+      options: R2PutOptions = {}) {
+      validate(key); await ready();
+      if (options.onlyIf && !conditionMatches(await head(key), options.onlyIf)) return null;
+      const size = typeof value === "string" ? new TextEncoder().encode(value).byteLength
+        : value instanceof Blob ? value.size
+        : value instanceof ArrayBuffer || ArrayBuffer.isView(value) ? value.byteLength : 0;
+      // Forward streams intact: R2 needs the runtime's known-length body, and
+      // attachments/native multipart uploads must never be buffered here.
+      if (value instanceof ReadableStream || size > BRAIN_INLINE_BYTES) {
+        const object = await backing.put(key, value, options);
+        return object ? retain(object, null) : null;
+      }
+      const bytes = new Uint8Array(await new Response(value as BodyInit | null).arrayBuffer());
+      const object = objectMetadata({
+        key, size, version: crypto.randomUUID(), etag: createHash("md5").update(bytes).digest("hex"),
+        uploaded: Date.now(), httpMetadata: httpMetadata(options.httpMetadata),
+        customMetadata: options.customMetadata ?? {},
+      });
+      return retain(object, bytes.buffer);
+    },
+    async delete(keys: string | string[]) {
+      const selected = typeof keys === "string" ? [keys] : keys;
+      selected.forEach(validate); await ready();
+      // Also remove any older R2 version shadowed by an inline replacement.
+      if (selected.length) await backing.delete(selected);
+      storage.transactionSync(() => {
+        for (const key of selected) storage.sql.exec("DELETE FROM nanocodex_brain_objects WHERE key = ?", key);
+      });
+    },
+    async list(options: R2ListOptions = {}) {
+      const requested = options.prefix ?? prefix;
+      if (!requested.startsWith(prefix)) throw new Error("brain listing is outside its owning agent");
+      await ready();
+      const objects: R2Object[] = [];
+      const delimitedPrefixes: string[] = [];
+      const candidates = new Map<string, R2Object | null>();
+      const after = options.cursor ? decodeURIComponent(options.cursor) : options.startAfter ?? "";
+      const limit = options.limit ?? 1000;
+      if (!Number.isSafeInteger(limit) || limit < 1 || limit > 1000) throw new RangeError("invalid R2 listing limit");
+      let truncated = false;
+      for (const found of storage.sql.exec<{ key: string; metadata: string }>(
+        "SELECT key, metadata FROM nanocodex_brain_objects WHERE key >= ? AND key < ? AND key > ? ORDER BY key",
+        requested, `${requested}\uffff`, after,
+      )) {
+        if (!found.key.startsWith(requested)) continue;
+        const delimiterAt = options.delimiter ? found.key.indexOf(options.delimiter, requested.length) : -1;
+        const key = delimiterAt !== -1 ? found.key.slice(0, delimiterAt + options.delimiter!.length) : found.key;
+        if (key <= after || candidates.has(key)) continue;
+        if (candidates.size === limit) { truncated = true; break; }
+        candidates.set(key, delimiterAt !== -1 ? null : objectMetadata(JSON.parse(found.metadata)));
+      }
+      const entries = [...candidates];
+      for (const [key, object] of entries) {
+        if (object) objects.push(object); else delimitedPrefixes.push(key);
+      }
+      return { objects, delimitedPrefixes, truncated,
+        ...(truncated ? { cursor: encodeURIComponent(entries[limit - 1]![0]) } : {}) };
+    },
+    async createMultipartUpload(key: string, options?: R2MultipartOptions) {
+      validate(key); await ready();
+      return multipart(await backing.createMultipartUpload(key, options));
+    },
+    resumeMultipartUpload(key: string, uploadId: string) {
+      validate(key);
+      return multipart(backing.resumeMultipartUpload(key, uploadId));
+    },
+  } as R2Bucket;
+}
+
+function httpMetadata(value: R2HTTPMetadata | Headers | undefined): R2HTTPMetadata {
+  if (!(value instanceof Headers)) return value ?? {};
+  return Object.fromEntries([
+    ["contentType", "content-type"], ["contentLanguage", "content-language"],
+    ["contentDisposition", "content-disposition"], ["contentEncoding", "content-encoding"],
+    ["cacheControl", "cache-control"],
+  ].flatMap(([field, header]) => value.has(header!) ? [[field!, value.get(header!)!]] : []));
+}
+
+function objectMetadata(metadata: Metadata): R2Object {
+  if (metadata.httpMetadata.cacheExpiry) metadata.httpMetadata.cacheExpiry = new Date(metadata.httpMetadata.cacheExpiry);
+  const object = {
+    ...metadata, uploaded: new Date(metadata.uploaded), httpEtag: `"${metadata.etag}"`,
+    checksums: { toJSON: () => ({}) }, storageClass: "Standard",
+    writeHttpMetadata(headers: Headers) {
+      for (const [field, header] of [
+        ["contentType", "content-type"], ["contentLanguage", "content-language"],
+        ["contentDisposition", "content-disposition"], ["contentEncoding", "content-encoding"],
+        ["cacheControl", "cache-control"],
+      ] as const) {
+        const value = metadata.httpMetadata[field];
+        if (value !== undefined) headers.set(header, value);
+      }
+      if (metadata.httpMetadata.cacheExpiry) headers.set("expires", new Date(metadata.httpMetadata.cacheExpiry).toUTCString());
+    },
+  };
+  return object as R2Object;
+}
+
+function conditionMatches(object: R2Object | null, condition?: R2Conditional | Headers): boolean {
+  if (!condition) return true;
+  const value = condition instanceof Headers ? {
+    etagMatches: condition.get("if-match") ?? undefined,
+    etagDoesNotMatch: condition.get("if-none-match") ?? undefined,
+    uploadedBefore: condition.has("if-unmodified-since") ? new Date(condition.get("if-unmodified-since")!) : undefined,
+    uploadedAfter: condition.has("if-modified-since") ? new Date(condition.get("if-modified-since")!) : undefined,
+  } : condition;
+  const matches = (etag: string) => etag === "*" ? object !== null : object?.etag === etag.replace(/^"|"$/g, "");
+  return (!value.etagMatches || matches(value.etagMatches))
+    && (!value.etagDoesNotMatch || !matches(value.etagDoesNotMatch))
+    && (!value.uploadedBefore || object !== null && object.uploaded <= value.uploadedBefore)
+    && (!value.uploadedAfter || object !== null && object.uploaded > value.uploadedAfter);
+}

--- a/js/managed/src/index.ts
+++ b/js/managed/src/index.ts
@@ -21,6 +21,7 @@ import { imageGeneration, updatePlan, viewImage, web } from "nanocodex/tools";
 import { createWorkspaceFilesystem } from "nanocodex-tools";
 import { SessionAttachments } from "./attachments";
 import { createBrainWorkspace } from "./brain-workspace";
+import { createBrainBucket } from "./brain-bucket";
 import { managedCodeEvaluator } from "./code-evaluator";
 import { CronTriggers, CRON_TRIGGER_ID, cronTriggerView, nextCronRun, parseCronTrigger, type CronTriggerConfig } from "./cron-triggers";
 import { createCronTool } from "./cron-tool";
@@ -44,6 +45,7 @@ import {
 import {
   ContainerProxy,
   Sandbox,
+  serveBrainFilesystem,
 } from "./sandbox-runtime";
 import {
   connectedManagedAccountMcps,
@@ -2456,6 +2458,7 @@ const DurableComputerSession = withWorkspace(
 );
 
 export class DurableAgentSession extends DurableComputerSession {
+  #brainStorage?: R2Bucket;
   #agent?: CloudflareAgent.Agent;
   #agentPromise?: Promise<CloudflareAgent.Agent>;
   #agentPrewarmTask?: Promise<void>;
@@ -3332,9 +3335,22 @@ export class DurableAgentSession extends DurableComputerSession {
 
   #attachmentStore(): SessionAttachments {
     return this.#attachments ??= new SessionAttachments(
-      this.ctx.storage, this.env.NANOCODEX_WORKSPACES, this.#sessionId()!,
+      this.ctx.storage, this.#brainBucket(), this.#sessionId()!,
       () => !this.#deleting && !this.#deleted && !this.#durabilityExported,
     );
+  }
+
+  #brainBucket(): R2Bucket {
+    if (this.env.NANOCODEX_SANDBOX_LOCAL === "true") return this.env.NANOCODEX_WORKSPACES;
+    return this.#brainStorage ??= createBrainBucket(this.ctx.storage, this.env.NANOCODEX_WORKSPACES, this.#sessionId()!);
+  }
+
+  /** Trusted container-proxy RPC; public HTTP routes never expose this method. */
+  async brainFilesystem(request: Request, readOnly: boolean): Promise<Response> {
+    const session = this.#session();
+    if (!session || this.#deleting || this.#deleted || this.#durabilityExported
+      || this.#durabilityImportState === "pending") return new Response(null, { status: 409 });
+    return serveBrainFilesystem(request, this.#brainBucket(), session.session_id, readOnly);
   }
 
   async webSocketMessage(socket: WebSocket, message: string | ArrayBuffer): Promise<void> {
@@ -6350,7 +6366,7 @@ export class DurableAgentSession extends DurableComputerSession {
     // fail closed without a subject, while ordinary public HTTP remains usable.
     const computer = await createManagedComputerRuntime({
       computer: workspace,
-      ...(multiplayer ? {} : { filesystem: createBrainWorkspace(this.env.NANOCODEX_WORKSPACES, session.session_id) }),
+      ...(multiplayer ? {} : { filesystem: createBrainWorkspace(this.#brainBucket(), session.session_id) }),
       egress: this.env.NANOCODEX,
       ...(multiplayer ? {} : { subject: this.ctx.id.toString() }),
       connectorAllowed: (connector, connectionId, context) => (
@@ -6362,7 +6378,7 @@ export class DurableAgentSession extends DurableComputerSession {
         && this.#hasFullAccountAuthority(this.#authorizationForToolContext(context)),
     });
     const sharedBrainWorkspace = createSharedBrainReadWorkspace(
-      this.env.NANOCODEX_WORKSPACES,
+      this.#brainBucket(),
       session.session_id,
       { readFile: async (path: string) => {
         if (multiplayer || !path.startsWith("/")) return computer.filesystem.readFile(path);

--- a/js/managed/src/sandbox-runtime.ts
+++ b/js/managed/src/sandbox-runtime.ts
@@ -4,6 +4,7 @@ import {
 } from "@cloudflare/sandbox";
 
 import { handleManagedEgress } from "./managed-egress";
+import { BRAIN_INLINE_BYTES } from "./brain-bucket";
 
 export type SandboxRuntimeEnv = Readonly<{
   NANOCODEX: Fetcher;
@@ -70,8 +71,47 @@ export class ContainerProxy extends CloudflareContainerProxy {
     if (isCrossBindingR2Copy(request)) {
       return Promise.resolve(new Response("Cross-binding R2 copy is forbidden", { status: 403 }));
     }
+    const url = new URL(request.url);
+    if (url.hostname === "r2.internal" && bucketBinding(url.pathname) === "NANOCODEX_BRAIN") {
+      const props = this.ctx.props as { outboundByHostOverrides?: Record<string, {
+        method: string; params?: { buckets?: Record<string, { prefix?: string; readOnly?: boolean }> };
+      }> };
+      const override = props.outboundByHostOverrides?.["r2.internal"];
+      const mount = override?.method === "r2EgressMount" ? override.params?.buckets?.NANOCODEX_BRAIN : undefined;
+      const match = /^\/?brains\/([A-Za-z0-9._:-]{1,256})\/?$/.exec(mount?.prefix ?? "");
+      if (!match) return Promise.resolve(new Response("Brain mount is not authorized", { status: 403 }));
+      const sessions = (this.env as { NANOCODEX_SESSIONS?: {
+        getByName(name: string): { brainFilesystem(request: Request, readOnly: boolean): Promise<Response> };
+      } }).NANOCODEX_SESSIONS;
+      if (!sessions) return Promise.resolve(new Response("Brain storage binding is unavailable", { status: 503 }));
+      // The actor id comes only from the SDK's trusted mount configuration.
+      return sessions.getByName(match[1]!).brainFilesystem(request, mount?.readOnly === true);
+    }
     return super.fetch(request);
   }
+}
+
+/** Reuse the SDK's S3 protocol, prefix and read-only checks over actor-local storage. */
+export function serveBrainFilesystem(request: Request, bucket: R2Bucket, resourceId: string, readOnly: boolean): Promise<Response> {
+  if (isCrossBindingR2Copy(request)) return Promise.resolve(new Response("Cross-binding R2 copy is forbidden", { status: 403 }));
+  const context = { props: { outboundByHostOverrides: {
+    "r2.internal": { method: "r2EgressMount", params: {
+      buckets: { NANOCODEX_BRAIN: { prefix: `brains/${resourceId}`, readOnly } },
+    } },
+  } } } as unknown as ExecutionContext;
+  const length = Number(request.headers.get("Content-Length") ?? NaN);
+  const inline = request.method === "PUT" && !request.headers.has("x-amz-copy-source")
+    && !new URL(request.url).searchParams.has("uploadId")
+    && Number.isSafeInteger(length) && length >= 0 && length <= BRAIN_INLINE_BYTES;
+  const selected = inline ? {
+    ...bucket,
+    async put(key: string, value: ReadableStream | ArrayBuffer | ArrayBufferView | string | Blob | null, options?: R2PutOptions) {
+      // The SDK validates Content-Length and bounds this stream with
+      // FixedLengthStream before invoking put. Larger bodies stay streaming.
+      return bucket.put(key, value instanceof ReadableStream ? await new Response(value).arrayBuffer() : value, options);
+    },
+  } as R2Bucket : bucket;
+  return new CloudflareContainerProxy(context, { NANOCODEX_BRAIN: selected }).fetch(request);
 }
 
 export function isCrossBindingR2Copy(request: Request): boolean {

--- a/js/managed/test/brain-bucket.test.ts
+++ b/js/managed/test/brain-bucket.test.ts
@@ -1,0 +1,142 @@
+import { createExecutionContext, env, runInDurableObject } from "cloudflare:test";
+import { describe, expect, it, vi } from "vitest";
+import { createBrainBucket } from "../src/brain-bucket";
+import { createBrainWorkspace } from "../src/brain-workspace";
+import { ContainerProxy, serveBrainFilesystem } from "../src/sandbox-runtime";
+import type { DurableAgentSession } from "../src/index";
+
+const bindings = env as unknown as {
+  NANOCODEX_SESSIONS: DurableObjectNamespace<DurableAgentSession>;
+  NANOCODEX_WORKSPACES: R2Bucket;
+};
+
+describe("brain storage local to its agent", () => {
+  it("persists an archive-sized file tree without a remote write per entry and reopens it", async () => {
+    const id = crypto.randomUUID();
+    await runInDurableObject(bindings.NANOCODEX_SESSIONS.getByName(id), async (_instance, state) => {
+      const backing = bindings.NANOCODEX_WORKSPACES;
+      const put = vi.fn(backing.put.bind(backing));
+      const head = vi.fn(backing.head.bind(backing));
+      const list = vi.fn(backing.list.bind(backing));
+      const bucket = createBrainBucket(state.storage, { ...backing, put, head, list } as unknown as R2Bucket, id);
+      const workspace = createBrainWorkspace(bucket, id);
+      await workspace.list(".", { recursive: true });
+      for (let dir = 0; dir < 100; dir++) {
+        await workspace.mkdir(`repo/dir-${dir}`);
+        await Promise.all(Array.from({ length: 20 }, (_, file) =>
+          workspace.writeFile(`repo/dir-${dir}/file-${file}`, `contents-${dir}-${file}`)));
+      }
+      expect(put).not.toHaveBeenCalled();
+      expect(head).not.toHaveBeenCalled();
+      expect(list).toHaveBeenCalledTimes(1);
+      const reopened = createBrainWorkspace(createBrainBucket(state.storage, backing, id), id);
+      expect(await reopened.list(".", { recursive: true })).toHaveLength(2101);
+      expect(new TextDecoder().decode(await reopened.readFile("repo/dir-99/file-19"))).toBe("contents-99-19");
+      const first = await bucket.list({ prefix: `brains/${id}/repo/dir-`, delimiter: "/", limit: 2 });
+      expect(first.delimitedPrefixes).toHaveLength(2);
+      expect(first.truncated).toBe(true);
+      const second = await bucket.list({ prefix: `brains/${id}/repo/dir-`, delimiter: "/", limit: 2,
+        cursor: first.truncated ? first.cursor : undefined });
+      expect(second.delimitedPrefixes).toHaveLength(2);
+      expect(new Set([...first.delimitedPrefixes, ...second.delimitedPrefixes]).size).toBe(4);
+    });
+  });
+
+  it("serves host files through the native S3 protocol and retains native changes", async () => {
+    const id = crypto.randomUUID();
+    await runInDurableObject(bindings.NANOCODEX_SESSIONS.getByName(id), async (_instance, state) => {
+      const bucket = createBrainBucket(state.storage, bindings.NANOCODEX_WORKSPACES, id);
+      const workspace = createBrainWorkspace(bucket, id);
+      await workspace.writeFile("repo/file", "host bytes");
+      const request = (path: string, init?: RequestInit, readOnly = false) => serveBrainFilesystem(
+        new Request(`http://r2.internal/NANOCODEX_BRAIN/${path}`, init), bucket, id, readOnly);
+      const get = await request("repo/file");
+      expect(get.status).toBe(200);
+      expect(await get.text()).toBe("host bytes");
+      const range = await request("repo/file", { headers: { range: "bytes=1-3" } });
+      expect(range.status).toBe(206);
+      expect(await range.text()).toBe("ost");
+      expect((await request("repo/file", { method: "HEAD" })).headers.get("Content-Length")).toBe("10");
+      const listed = await request("?list-type=2&prefix=repo/&delimiter=/");
+      expect(await listed.text()).toContain("<Key>repo/file</Key>");
+      expect((await request("repo/native", { method: "PUT", body: "native bytes", headers: {
+        "Content-Length": "12", "x-amz-meta-mode": "33261",
+      } })).status).toBe(200);
+      expect(new TextDecoder().decode(await workspace.readFile("repo/native"))).toBe("native bytes");
+      expect((await request("repo/native", { method: "HEAD" })).headers.get("x-amz-meta-mode")).toBe("33261");
+      expect((await request("repo/copied", { method: "PUT", headers: {
+        "x-amz-copy-source": "/NANOCODEX_BRAIN/repo/file",
+        "x-amz-metadata-directive": "REPLACE", "x-amz-meta-mode": "33261",
+      } })).status).toBe(200);
+      expect((await request("repo/copied", { method: "HEAD" })).headers.get("x-amz-meta-mode")).toBe("33261");
+      expect(await (await request("repo/copied")).text()).toBe("host bytes");
+      const started = await request("repo/multipart?uploads", { method: "POST", headers: { "x-amz-meta-mode": "33188" } });
+      const uploadId = /<UploadId>(.*?)<\/UploadId>/.exec(await started.text())![1];
+      const part = await request(`repo/multipart?uploadId=${encodeURIComponent(uploadId!)}&partNumber=1`, {
+        method: "PUT", body: "part", headers: { "Content-Length": "4" },
+      });
+      expect(part.status).toBe(200);
+      expect((await request(`repo/multipart?uploadId=${encodeURIComponent(uploadId!)}`, { method: "POST",
+        body: `<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>${part.headers.get("ETag")}</ETag></Part></CompleteMultipartUpload>`,
+      })).status).toBe(200);
+      expect(await (await request("repo/multipart")).text()).toBe("part");
+      expect((await request("repo/multipart", { method: "HEAD" })).headers.get("x-amz-meta-mode")).toBe("33188");
+      expect((await request("repo/native", { method: "DELETE" }, true)).status).toBe(403);
+      expect((await request("repo/native", { method: "DELETE" })).status).toBe(204);
+      expect((await request("repo/native", { method: "HEAD" })).status).toBe(404);
+      await expect(bucket.head(`brains/another-agent/secret`)).rejects.toThrow("owning agent");
+    });
+  });
+
+  it("adopts legacy R2 files without copying them and keeps large files in R2", async () => {
+    const id = crypto.randomUUID();
+    const backing = bindings.NANOCODEX_WORKSPACES;
+    await backing.put(`brains/${id}/legacy`, "legacy bytes", { customMetadata: { mode: "33261" } });
+    await runInDurableObject(bindings.NANOCODEX_SESSIONS.getByName(id), async (_instance, state) => {
+      const bucket = createBrainBucket(state.storage, backing, id);
+      expect(await (await bucket.get(`brains/${id}/legacy`))!.text()).toBe("legacy bytes");
+      expect((await bucket.head(`brains/${id}/legacy`))!.customMetadata?.mode).toBe("33261");
+      const large = new Uint8Array(2 * 1024 * 1024 + 17).fill(73);
+      await bucket.put(`brains/${id}/large`, large);
+      expect((await backing.head(`brains/${id}/large`))!.size).toBe(large.length);
+      const actual = await (await bucket.get(`brains/${id}/large`))!.arrayBuffer();
+      expect(actual.byteLength).toBe(large.length);
+      const hash = async (bytes: ArrayBuffer | Uint8Array) => Array.from(new Uint8Array(
+        await crypto.subtle.digest("SHA-256", bytes),
+      )).join(",");
+      expect(await hash(actual)).toBe(await hash(large));
+      await bucket.put(`brains/${id}/legacy`, "replacement");
+      expect(await (await bucket.get(`brains/${id}/legacy`))!.text()).toBe("replacement");
+      await bucket.delete(`brains/${id}/legacy`);
+      expect(await backing.head(`brains/${id}/legacy`)).toBeNull();
+      expect(await createBrainBucket(state.storage, backing, id).head(`brains/${id}/legacy`)).toBeNull();
+    });
+  });
+
+  it("routes the trusted native brain mount to its owning actor and rejects forged bindings", async () => {
+    const id = crypto.randomUUID();
+    await runInDurableObject(bindings.NANOCODEX_SESSIONS.getByName(id), async (_instance, state) => {
+      state.storage.sql.exec(`INSERT INTO session_state (
+        singleton, session_id, owner_id, organization_id, team_id, authorization_epoch,
+        public_origin, runtime_profile, completed_turns, last_active
+      ) VALUES (1, ?, 'owner', 'org', 'team', 1, 'https://example.test', 'managed', 0, ?)`, id, Date.now());
+      const bucket = createBrainBucket(state.storage, bindings.NANOCODEX_WORKSPACES, id);
+      await bucket.put(`brains/${id}/owned`, "owned bytes");
+    });
+    const context = createExecutionContext();
+    Object.defineProperty(context, "props", { value: { outboundByHostOverrides: {
+      "r2.internal": { method: "r2EgressMount", params: {
+        buckets: { NANOCODEX_BRAIN: { prefix: `brains/${id}`, readOnly: true } },
+      } },
+    } } });
+    const proxy = new ContainerProxy(context, { NANOCODEX_SESSIONS: bindings.NANOCODEX_SESSIONS });
+    const response = await proxy.fetch(new Request("http://r2.internal/NANOCODEX_BRAIN/owned"));
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("owned bytes");
+    expect((await proxy.fetch(new Request("http://r2.internal/NANOCODEX_BRAIN/owned", { method: "DELETE" }))).status).toBe(403);
+    const unmounted = createExecutionContext();
+    Object.defineProperty(unmounted, "props", { value: {} });
+    expect((await new ContainerProxy(unmounted, { NANOCODEX_SESSIONS: bindings.NANOCODEX_SESSIONS })
+      .fetch(new Request("http://r2.internal/NANOCODEX_BRAIN/owned", { headers: { "x-brain-id": id } }))).status).toBe(403);
+  });
+});


### PR DESCRIPTION
A fresh source-only clone took 72.6 seconds even though the same archive downloaded through the production host in 1.4 seconds. We were expanding it into 2,102 R2 file writes and 411 directory entries. The follow-up Cargo run then spent minutes waiting on S3FS metadata revalidation.

Keep brain metadata and small file bodies in the owning agent’s SQLite storage. Large bodies and streaming uploads remain in R2. Native `/brain` mounts use the existing Sandbox S3 protocol through trusted RPC to the same actor, so host and sandbox operations share the filesystem without an R2 request for every stat. Existing R2 trees are indexed without copying their contents; mount prefixes, read-only permissions, attachment streaming, and local SDK replication remain supported.

For the measured repository, 2,101 files fit in SQLite and only one needs an R2 upload. The 1 MiB boundary selects storage; it does not reject larger files. The implementation adds no Worker, binding, or external service.

Validation:
- 35 Worker storage, sandbox, and attachment checks passed, including a 2,000-file tree with zero per-file R2 writes and reopening it from persistent state.
- Native S3 reads/writes, ranges, prefix fencing, cross-agent routing, legacy data, and large-file retention verified against real local Worker/SQLite/R2 implementations.
- Managed typecheck and Wrangler build/dry-run passed.
- The final four storage protocol tests passed, including pagination, metadata-copy, multipart completion, and native RPC routing. Production replay is recorded below.

Production verification on `ee3e3eb6e08632e3e935b17c095a07673cfdab94`:
- Fresh prompt `Clone gakonst nanocodex`: one host `gh repo clone` command, exit 0, **3.456 seconds** vs **72.633 seconds** before (~21× faster). Entire model turn: **9.980 seconds** vs **79.584 seconds**. No sandbox provisioned for clone.
- Plain `Run cargo test` follow-up: cloud hand mounted in **5.028 seconds**; the original Cargo command completed with exit 0, **1 integration test + 3 doctests passed** (root default member). Observed command duration: **1,950.676 seconds (32m 30.676s)**; Cargo reported the build finished in **32m 21s**. Native FUSE metadata lookup latency remains unresolved; compiler worker stacks showed `fuse_dentry_revalidate` / `statx` waits. It first tried the connected Mac, found the brain path unavailable there, then mounted Cloudflare automatically.
- Native manifest stat/read measured 0.126/0.291 seconds. Repeated uncached FUSE lookups still cause substantial Cargo startup latency; first output was observed 214.415 seconds after command submission.
- Existing pre-deploy R2 data remained readable. Browser reload restored the completed clone and live follow-up; no application console errors observed.
- Evidence thread: https://nanocodex.gakonst.workers.dev/agent/01a0788c-a640-734e-bb31-99cb0dafbe23

The JavaScript apps CI job passed. The deployed long-history check hit its 18-minute global timeout after 96 ordered turns, 432 cancellations, and exact archived replay; the failed job has been rerun separately. Follow-up #288 routes agent deletion through the new storage facade so inline bodies are purged alongside R2 objects.
