### PR TITLE
fix(managed): purge actor-local brain files on agent deletion

### DIFF
--- a/js/managed/src/index.ts
+++ b/js/managed/src/index.ts
@@ -5879,7 +5879,7 @@ export class DurableAgentSession extends DurableComputerSession {
         deleteCloudflareSandboxWorkspace(this.env.NANOCODEX_WORKSPACES, resourceId)
       )));
       await deleteCloudflareBrainWorkspace(
-        this.env.NANOCODEX_WORKSPACES,
+        this.#brainBucket(),
         session.session_id,
       );
     }

--- a/js/managed/test/brain-bucket.test.ts
+++ b/js/managed/test/brain-bucket.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createBrainBucket } from "../src/brain-bucket";
 import { createBrainWorkspace } from "../src/brain-workspace";
 import { ContainerProxy, serveBrainFilesystem } from "../src/sandbox-runtime";
+import { deleteCloudflareBrainWorkspace } from "../src/sandbox-tools";
 import type { DurableAgentSession } from "../src/index";
 
 const bindings = env as unknown as {
@@ -138,5 +139,26 @@ describe("brain storage local to its agent", () => {
     Object.defineProperty(unmounted, "props", { value: {} });
     expect((await new ContainerProxy(unmounted, { NANOCODEX_SESSIONS: bindings.NANOCODEX_SESSIONS })
       .fetch(new Request("http://r2.internal/NANOCODEX_BRAIN/owned", { headers: { "x-brain-id": id } }))).status).toBe(403);
+  });
+
+  it("purges inline and R2 files across cleanup pages without deleting another agent's data", async () => {
+    const id = crypto.randomUUID();
+    const backing = bindings.NANOCODEX_WORKSPACES;
+    const foreignKey = `brains/${crypto.randomUUID()}/retained`;
+    await backing.put(foreignKey, "retained");
+    await backing.put(`brains/${id}/legacy`, "legacy");
+    await runInDurableObject(bindings.NANOCODEX_SESSIONS.getByName(id), async (_instance, state) => {
+      const bucket = createBrainBucket(state.storage, backing, id);
+      for (let file = 0; file < 1001; file++) await bucket.put(`brains/${id}/file-${file}`, "inline");
+      await bucket.put(`brains/${id}/legacy`, "inline replacement");
+      await bucket.put(`brains/${id}/large`, new Uint8Array(1024 * 1024 + 1));
+      await deleteCloudflareBrainWorkspace(bucket, id);
+      expect(state.storage.sql.exec<{ count: number }>(
+        "SELECT COUNT(*) AS count FROM nanocodex_brain_objects",
+      ).one().count).toBe(0);
+      expect((await backing.list({ prefix: `brains/${id}/` })).objects).toHaveLength(0);
+      expect(await (await backing.get(foreignKey))!.text()).toBe("retained");
+      expect((await createBrainBucket(state.storage, backing, id).list()).objects).toHaveLength(0);
+    });
   });
 });


### PR DESCRIPTION
Agent deletion still passed the raw R2 binding to brain workspace cleanup after #287 moved small files into the owning actor’s SQLite storage. Route cleanup through the same brain bucket used for reads and writes so deletion removes both inline bodies and R2 objects.

Verified pagination over 1,003 files, removal of legacy R2 objects shadowed by inline replacements, large-file removal, empty state after reopening, and retention of another agent’s data. All five brain storage tests, managed typecheck, and Wrangler build/dry-run passed.

Production verification on `d0634663122c323fd7da748066d02467e7e8d2e7`: deleted the owned synthetic storage fixture containing pre-deploy R2 files and new inline SQLite files. Deletion returned **204 in 2.411 seconds**, followed by **404** on reading the deleted agent. The clone/Cargo evidence thread was preserved.
