### PR TITLE
fix(ui): show command exit codes in expanded results

### DIFF
--- a/js/nanocodex-terminal/src/toolPresentation.ts
+++ b/js/nanocodex-terminal/src/toolPresentation.ts
@@ -65,10 +65,12 @@ function semanticExecutionDetails(
     ? stringField(outputRecord, family === "exec_command" || family === "write_stdin" ? "output" : "stdout")
     : undefined;
   const stderr = outputRecord ? stringField(outputRecord, "stderr") : undefined;
+  const exitCode = outputRecord ? numberField(outputRecord, "exit_code") : undefined;
   return {
     ...(command ? { inputDetail: { label: "Command", value: command } } : {}),
-    ...(stdout === undefined && stderr === undefined ? {} : {
+    ...(stdout === undefined && stderr === undefined && exitCode === undefined ? {} : {
       outputDetails: [
+        ...(exitCode === undefined ? [] : [{ label: "Exit code", value: String(exitCode) }]),
         ...(stdout === undefined ? [] : [{ label: family === "exec_command" || family === "write_stdin" ? "Output" : "Stdout", value: stdout || "(empty)" }]),
         ...(stderr === undefined ? [] : [{ label: "Stderr", value: stderr || "(empty)" }]),
       ],

--- a/js/nanocodex-terminal/test/components.test.mjs
+++ b/js/nanocodex-terminal/test/components.test.mjs
@@ -405,7 +405,7 @@ test("transcript renders semantic reasoning, plans, and accessible nested tools"
     "Authorize Google",
   );
   assert.deepEqual(renderer.root.findAllByType("h4").map((heading) => heading.children.join("")), [
-    "Command", "Stdout", "Stderr",
+    "Command", "Exit code", "Stdout", "Stderr",
   ]);
   assert.equal(renderer.root.findAllByProps({ className: "agent-terminal-brand" }).length, 0);
   await act(async () => renderer.update(React.createElement(TerminalTranscriptSurface, {
@@ -532,7 +532,10 @@ test("all-tool renderer adapts known families and keeps unknown tools excellent"
   assert.ok(renderer.root.findAllByProps({ className: "agent-terminal-tool-meta" })[0]
     .children.some((node) => node.children?.join("") === "1.25 s"));
   const detailHeadings = renderer.root.findAllByType("h4").map((node) => node.children.join(""));
-  assert.deepEqual(detailHeadings.slice(0, 3), ["Command", "Stdout", "Stderr"]);
+  assert.deepEqual(detailHeadings.slice(0, 4), ["Command", "Exit code", "Stdout", "Stderr"]);
+  assert.deepEqual(renderer.root.findAllByProps({ className: "agent-terminal-tool-detail agent-terminal-tool-result" })
+    .filter((section) => section.findByType("h4").children.join("") === "Exit code")
+    .map((section) => section.findByType("pre").children.join("")), ["0", "1", "7"]);
   assert.equal(detailHeadings.filter((label) => label === "Stdout").length, 2);
   assert.equal(detailHeadings.filter((label) => label === "Stderr").length, 2);
   const links = renderer.root.findAllByType("a");


### PR DESCRIPTION
The account theme hides compact command summaries, including the exit code. Show an explicit Exit code field in expanded terminal results so successful and failing commands retain a visible numeric outcome alongside their output.

Validation: all 12 terminal tests and package checks passed. Renderer coverage verifies exit codes 0, 1, and 7 in the expanded result body. This closes the remaining web display gap found while verifying #290; deployed browser verification follows rollout.
