### PR TITLE
fix(apple): retain command progress across recovery replays

### DIFF
--- a/apple/InboxCore/Sources/InboxCore/Protocol.swift
+++ b/apple/InboxCore/Sources/InboxCore/Protocol.swift
@@ -144,6 +144,8 @@ public struct TranscriptRow: Identifiable, Codable, Equatable, Sendable {
 public func transcript(_ events: [AgentEvent]) -> [TranscriptRow] {
     var rows: [TranscriptRow] = []
     var seen = Set<String>()
+    var seenToolCalls = Set<String>()
+    var seenToolResults = Set<String>()
     var terminalSessions: [String: Int] = [:]
     var terminalPolls: [String: Int] = [:]
     var toolStartedAt: [String: Double] = [:]
@@ -217,8 +219,10 @@ public func transcript(_ events: [AgentEvent]) -> [TranscriptRow] {
                     rows[last].running = false
                 } else { rows.append(.init(id: id, role: "Agent", text: p["text"].string)) }
             case "tool.call":
+                let toolID = prefix + ":tool:" + p["call_id"].string
+                guard seenToolCalls.insert(toolID).inserted, !seenToolResults.contains(toolID) else { continue }
                 if case .number(let time) = d["created_at"], time.isFinite, time >= 0 {
-                    toolStartedAt[prefix + ":tool:" + p["call_id"].string] = time
+                    toolStartedAt[toolID] = time
                 }
                 if p["tool"].string == "write_stdin",
                    let index = terminalSessions[d["agent_id"].pretty + ":" + p["arguments"]["session_id"].pretty] {
@@ -229,6 +233,7 @@ public func transcript(_ events: [AgentEvent]) -> [TranscriptRow] {
                 rows.append(.init(id: prefix + ":tool:" + p["call_id"].string, role: "Tool", text: tool.title, running: true, tool: tool))
             case "tool.result":
                 let toolID = prefix + ":tool:" + p["call_id"].string
+                guard seenToolResults.insert(toolID).inserted else { continue }
                 guard let result = envelope.preparedToolResult else { break }
                 if result.terminalCommand == true {
                     let result = p["structured_result"] == .null ? p["result"] : p["structured_result"]

--- a/apple/InboxCore/Tests/InboxCoreTests/ToolPresentationTests.swift
+++ b/apple/InboxCore/Tests/InboxCoreTests/ToolPresentationTests.swift
@@ -2,6 +2,26 @@ import XCTest
 @testable import InboxCore
 
 final class ToolPresentationTests: XCTestCase {
+    func testRecoveryReplayKeepsOneCommandAndItsOriginalStartTime() throws {
+        func event(_ cursor: String, _ time: Double, _ type: String, _ payload: JSON) throws -> AgentEvent {
+            try AgentEvent(.object(["cursor": .string(cursor), "created_at": .number(time), "type": .string("event"), "turn_id": .string("t"), "event": .object(["type": .string(type), "payload": payload])]))
+        }
+        let call: JSON = .object(["call_id": .string("c"), "tool": .string("exec_command"), "arguments": .object(["cmd": .string("sleep 120")])])
+        let initial: JSON = .object(["call_id": .string("c"), "tool": .string("exec_command"), "status": .string("completed"), "structured_result": .object(["session_id": .number(42), "output": .string("START\n")])])
+        let poll: JSON = .object(["call_id": .string("p"), "tool": .string("write_stdin"), "arguments": .object(["session_id": .number(42)])])
+        let rows = try transcript([
+            event("1", 1000, "tool.call", call), event("2", 2000, "tool.result", initial),
+            event("3", 3000, "tool.call", poll),
+            event("4", 57000, "tool.call", call), event("5", 57000, "tool.result", initial),
+            event("6", 57000, "tool.call", poll),
+            event("7", 58000, "tool.result", .object(["call_id": .string("p"), "tool": .string("write_stdin"), "status": .string("failed"), "structured_result": .string("unknown or stale namespace process session")]))
+        ])
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0].tool?.status, "Failed")
+        XCTAssertTrue(rows[0].tool!.output.contains { $0.label == "Output" && $0.value == "START\nunknown or stale namespace process session" })
+        XCTAssertTrue(rows[0].tool!.output.contains { $0.label == "Elapsed (seconds)" && $0.value == "57" })
+        XCTAssertFalse(rows[0].tool!.output.contains { $0.label == "Exit code" })
+    }
     func testCommandElapsedTimeIncludesExecutionBetweenPolls() throws {
         func event(_ cursor: String, _ time: Double, _ type: String, _ payload: JSON) throws -> AgentEvent {
             try AgentEvent(.object(["cursor": .string(cursor), "created_at": .number(time), "type": .string("event"), "turn_id": .string("t"), "event": .object(["type": .string(type), "payload": payload])]))

--- a/apple/NanocodexInbox/InboxView.swift
+++ b/apple/NanocodexInbox/InboxView.swift
@@ -1552,7 +1552,12 @@ private struct ConversationActivityStep: View {
                     Image(systemName: failed ? "exclamationmark.circle" : row.role == "Tool" ? "terminal" : "text.alignleft")
                         .font(.system(size: 12)).frame(width: 18, height: 18).foregroundStyle(failed ? Ink.amber : Ink.muted)
                     VStack(alignment: .leading, spacing: 3) {
-                        Text(title).font(.system(size: 13, weight: .medium)).foregroundStyle(Ink.text).lineLimit(1)
+                        HStack(spacing: 8) {
+                            Text(title).font(.system(size: 13, weight: .medium)).foregroundStyle(Ink.text).lineLimit(1)
+                            if let status = row.tool?.status {
+                                Text(status).font(.system(size: 11)).foregroundStyle(failed ? Ink.amber : Ink.muted)
+                            }
+                        }
                         if !subject.isEmpty { Text(subject).font(.system(size: 12)).foregroundStyle(Ink.muted).lineLimit(1) }
                     }.frame(maxWidth: .infinity, alignment: .leading)
                     if live { ProgressView().controlSize(.mini) }

--- a/apple/NanocodexInboxUITests/InboxUITests.swift
+++ b/apple/NanocodexInboxUITests/InboxUITests.swift
@@ -41,6 +41,16 @@ final class InboxUITests: XCTestCase {
 
     @MainActor
     func testLiveTerminalProgressAndFailure() async throws {
+        try await verifyLiveTerminal(historyOnly: false)
+    }
+
+    @MainActor
+    func testLiveTerminalReceiptHistory() async throws {
+        try await verifyLiveTerminal(historyOnly: true)
+    }
+
+    @MainActor
+    private func verifyLiveTerminal(historyOnly: Bool) async throws {
         let environment = ProcessInfo.processInfo.environment
         guard let key = environment["NANOCODEX_LIVE_TEST_API_KEY"], !key.isEmpty else {
             throw XCTSkip("Requires an explicitly supplied managed account key and a live service.")
@@ -74,26 +84,37 @@ final class InboxUITests: XCTestCase {
             app.buttons["Connect account"].tap()
         }
         try require(app.buttons["Browse agents"].waitForExistence(timeout: 30), "The inbox did not connect")
-        let created = try await request("/v1/agents")
-        let agentID = try XCTUnwrap(created["agent_id"] as? String)
-        let marker = "E12 progress " + String(UUID().uuidString.prefix(8))
-        print("E12_LIVE_AGENT \(agentID) \(marker)")
-        _ = try await request("/v1/agents/\(agentID)/turns", body: [
-            "id": UUID().uuidString.lowercased(),
-            "input": "\(marker). In one Cloudflare Linux sandbox, run exactly: printf 'E12_START\\n'; sleep 60; printf 'E12_MID\\n'; sleep 60; printf 'E12_DONE\\n'. Use exec_command with yield_time_ms 1000, then poll the same process until exit. Do not use a connected device."
-        ])
-        func openThread() throws {
+        let agentID: String, marker: String, successTurnID: String, failureTurnID: String
+        if historyOnly {
+            guard let savedAgent = environment["NANOCODEX_LIVE_TEST_HISTORY_AGENT"],
+                  let savedMarker = environment["NANOCODEX_LIVE_TEST_HISTORY_MARKER"],
+                  let savedSuccess = environment["NANOCODEX_LIVE_TEST_SUCCESS_TURN"],
+                  let savedFailure = environment["NANOCODEX_LIVE_TEST_FAILURE_TURN"] else {
+                throw XCTSkip("Requires an explicitly selected completed success/failure fixture.")
+            }
+            agentID = savedAgent; marker = savedMarker; successTurnID = savedSuccess; failureTurnID = savedFailure
+            print("E12_HISTORY_AGENT \(agentID) \(marker)")
+        } else {
+            let created = try await request("/v1/agents")
+            agentID = try XCTUnwrap(created["agent_id"] as? String)
+            marker = "E12 progress " + String(UUID().uuidString.prefix(8))
+            successTurnID = UUID().uuidString.lowercased(); failureTurnID = UUID().uuidString.lowercased()
+            print("E12_LIVE_AGENT \(agentID) \(marker)")
+            _ = try await request("/v1/agents/\(agentID)/turns", body: [
+                "id": successTurnID,
+                "input": "\(marker). In one Cloudflare Linux sandbox, run exactly: printf 'E12_START\\n'; sleep 60; printf 'E12_MID\\n'; sleep 60; printf 'E12_DONE\\n'. Use exec_command with yield_time_ms 1000, then poll the same process until exit. Do not use a connected device."
+            ])
+        }
+        func openThread(turnID: String, commandText: String) throws {
             app.terminate(); app.launch()
             try require(app.buttons["Browse agents"].waitForExistence(timeout: 30), "The inbox did not connect")
-            let ready = XCTNSPredicateExpectation(predicate: NSPredicate(format: "enabled == true"), object: app.buttons["Refresh agents"])
-            try require(XCTWaiter.wait(for: [ready], timeout: 30) == .completed, "The inbox did not finish loading")
+            let ready = XCTNSPredicateExpectation(predicate: NSPredicate(format: "hittable == true"), object: app.buttons["Browse agents"])
+            try require(XCTWaiter.wait(for: [ready], timeout: 10) == .completed, "The inbox did not finish loading")
             let title = app.staticTexts["agent-title"]
             if !title.label.contains(marker) {
                 app.buttons["Browse agents"].tap()
+                try require(app.otherElements["inbox-sidebar"].waitForExistence(timeout: 10), "The agent sidebar did not open")
                 let listing = app.collectionViews.firstMatch
-                if !listing.waitForExistence(timeout: 5) {
-                    app.buttons["Browse agents"].tap()
-                }
                 try require(listing.waitForExistence(timeout: 5), "The agent list did not open")
                 let entry = app.buttons.matching(NSPredicate(format: "label CONTAINS %@", marker)).firstMatch
                 for _ in 0..<30 {
@@ -106,46 +127,109 @@ final class InboxUITests: XCTestCase {
                     throw NSError(domain: "E12", code: 1)
                 }
                 entry.tap()
+                let selected = XCTNSPredicateExpectation(predicate: NSPredicate(format: "label CONTAINS %@ AND hittable == true", marker), object: title)
+                try require(XCTWaiter.wait(for: [selected], timeout: 10) == .completed, "The requested agent did not open")
             }
             title.tap()
-            try require(app.scrollViews["conversation"].waitForExistence(timeout: 5), "The conversation did not open")
+            let conversation = app.scrollViews["conversation"]
+            try require(conversation.waitForExistence(timeout: 5), "The conversation did not open")
+            let group = app.otherElements["message-activity-" + turnID]
+            let activity = group.buttons["activity-disclosure"]
+            for _ in 0..<10 {
+                if activity.exists && activity.isHittable { break }
+                conversation.swipeDown()
+            }
+            try require(activity.waitForExistence(timeout: 10) && activity.isHittable, "The turn's Activity did not appear")
+            activity.tap()
+            let timeline = group.scrollViews["activity-timeline"]
+            try require(timeline.waitForExistence(timeout: 5), "Activity did not expand")
+            for _ in 0..<30 {
+                if command(commandText).exists && command(commandText).isHittable { break }
+                timeline.swipeUp()
+            }
         }
         func command(_ text: String) -> XCUIElement {
             app.buttons.matching(NSPredicate(format: "label BEGINSWITH 'Run command,' AND label CONTAINS %@", text)).firstMatch
         }
-        try openThread()
+        func revealOutput(_ predicate: NSPredicate, command: XCUIElement) throws {
+            let detailID = command.identifier.replacingOccurrences(of: "activity-step-", with: "activity-detail-")
+            let detail = app.scrollViews[detailID]
+            let turnID = command.identifier.replacingOccurrences(of: "activity-step-", with: "").components(separatedBy: "::")[0]
+            let group = app.otherElements["message-activity-" + turnID]
+            let timeline = group.scrollViews["activity-timeline"]
+            let conversation = app.scrollViews["conversation"]
+            try require(detail.waitForExistence(timeout: 5), "Command details did not expand")
+            // Drag the outer margin, then the timeline margin, so nested scroll views
+            // cannot forward a gesture to the conversation and hide the result.
+            func drag(x: CGFloat, from: CGFloat, to: CGFloat) {
+                let origin = app.coordinate(withNormalizedOffset: .zero)
+                origin.withOffset(CGVector(dx: x, dy: from)).press(forDuration: 0.01,
+                    thenDragTo: origin.withOffset(CGVector(dx: x, dy: to)))
+            }
+            for _ in 0..<6 {
+                let top = timeline.frame.minY
+                let target = max(conversation.frame.minY + 110, 180)
+                if abs(top - target) < 30 { break }
+                let start = app.frame.midY
+                drag(x: 8, from: start, to: start + max(-250, min(250, target - top)))
+            }
+            for _ in 0..<8 {
+                let viewport = timeline.frame.intersection(conversation.frame).intersection(app.frame)
+                let delta = detail.frame.maxY - viewport.maxY + 8
+                if delta <= 12 && detail.frame.minY >= viewport.minY { break }
+                let movement = delta > 0 ? -min(180, delta) : min(180, viewport.minY - detail.frame.minY)
+                drag(x: timeline.frame.minX + 12, from: viewport.midY, to: viewport.midY + movement)
+            }
+            let output = detail.staticTexts.matching(predicate).firstMatch
+            try require(output.waitForExistence(timeout: 5), "The command result did not contain the expected output")
+            func visibleTail() -> Bool {
+                let viewport = detail.frame.intersection(timeline.frame).intersection(conversation.frame).intersection(app.frame)
+                return !viewport.isNull && output.frame.maxY > viewport.minY && output.frame.maxY <= viewport.maxY + 4
+            }
+            for _ in 0..<40 {
+                if visibleTail() { break }
+                let viewport = detail.frame.intersection(timeline.frame).intersection(conversation.frame).intersection(app.frame)
+                try require(viewport.height > 50, "The command detail viewport was not visible")
+                drag(x: viewport.midX, from: viewport.maxY - 15, to: viewport.minY + 15)
+            }
+            try require(visibleTail(), "The command output tail was not visible")
+        }
+        try openThread(turnID: successTurnID, commandText: "E12_START")
         let success = command("E12_START")
         try require(success.waitForExistence(timeout: 90), "The command card did not appear")
-        try require(success.label.contains("Running"), "The yielded command must remain Running")
-        success.tap()
-        try require(app.staticTexts.matching(NSPredicate(format: "label BEGINSWITH %@", "E12_START\n")).firstMatch.waitForExistence(timeout: 10), "Initial command output was not visible")
-        capture(app, "E12-live-running")
-        try openThread()
-        try require(command("E12_START").waitForExistence(timeout: 15), "The command was lost after relaunch")
-        try require(command("E12_START").label.contains("Running"), "Running status was lost after relaunch")
+        if !historyOnly {
+            try require(success.label.contains("Running"), "The yielded command must remain Running")
+            success.tap()
+            try revealOutput(NSPredicate(format: "label BEGINSWITH %@", "E12_START\n"), command: success)
+            capture(app, "E12-live-running")
+            try openThread(turnID: successTurnID, commandText: "E12_START")
+            try require(command("E12_START").waitForExistence(timeout: 15), "The command was lost after relaunch")
+            try require(command("E12_START").label.contains("Running"), "Running status was lost after relaunch")
+        }
         let completed = XCTNSPredicateExpectation(predicate: NSPredicate(format: "label CONTAINS 'Completed'"), object: command("E12_START"))
         await fulfillment(of: [completed], timeout: 180)
         try require(command("E12_START").label.contains("Completed"), "The command did not complete")
         command("E12_START").tap()
-        try require(app.staticTexts["E12_START\nE12_MID\nE12_DONE\n"].waitForExistence(timeout: 5), "Polling output was not folded into the original command")
+        try revealOutput(NSPredicate(format: "label == %@", "E12_START\nE12_MID\nE12_DONE\n"), command: command("E12_START"))
         try require(app.staticTexts["Elapsed (seconds)"].exists, "Final elapsed time was missing")
         capture(app, "E12-live-completed")
-        _ = try await request("/v1/agents/\(agentID)/turns", body: [
-            "id": UUID().uuidString.lowercased(),
-            "input": "In the same sandbox, run exactly: printf 'E12_FAIL_START\\n'; sleep 30; for i in $(seq 1 300); do printf 'E12_STDOUT_%04d\\n' \"$i\"; printf 'E12_STDERR_%04d\\n' \"$i\" >&2; done; printf 'E12_EXPECTED_FAILURE\\n' >&2; exit 7. Use exec_command with yield_time_ms 1000 and max_output_tokens 10000, then poll until exit. This is an intentional failure fixture; do not retry or fix it."
-        ])
-        try openThread()
-        let failed = command("E12_FAIL_START")
-        try require(failed.waitForExistence(timeout: 60), "The failure fixture command did not appear")
-        try require(failed.label.contains("Running") || failed.label.contains("Failed"), "The failure fixture reported an unexpected status")
-        let failure = XCTNSPredicateExpectation(predicate: NSPredicate(format: "label CONTAINS 'Failed'"), object: failed)
-        await fulfillment(of: [failure], timeout: 90)
-        try require(failed.label.contains("Failed"), "Nonzero exit did not produce Failed status")
-        try openThread()
+        if !historyOnly {
+            _ = try await request("/v1/agents/\(agentID)/turns", body: [
+                "id": failureTurnID,
+                "input": "In the same sandbox, run exactly: printf 'E12_FAIL_START\\n'; sleep 30; for i in $(seq 1 300); do printf 'E12_STDOUT_%04d\\n' \"$i\"; printf 'E12_STDERR_%04d\\n' \"$i\" >&2; done; printf 'E12_EXPECTED_FAILURE\\n' >&2; exit 7. Use exec_command with yield_time_ms 1000 and max_output_tokens 10000, then poll until exit. This is an intentional failure fixture; do not retry or fix it."
+            ])
+            try openThread(turnID: failureTurnID, commandText: "E12_FAIL_START")
+            let failed = command("E12_FAIL_START")
+            try require(failed.waitForExistence(timeout: 60), "The failure fixture command did not appear")
+            try require(failed.label.contains("Running") || failed.label.contains("Failed"), "The failure fixture reported an unexpected status")
+            let failure = XCTNSPredicateExpectation(predicate: NSPredicate(format: "label CONTAINS 'Failed'"), object: failed)
+            await fulfillment(of: [failure], timeout: 90)
+            try require(failed.label.contains("Failed"), "Nonzero exit did not produce Failed status")
+        }
+        try openThread(turnID: failureTurnID, commandText: "E12_FAIL_START")
         try require(command("E12_FAIL_START").waitForExistence(timeout: 15) && command("E12_FAIL_START").label.contains("Failed"), "Failed status was lost after relaunch")
         command("E12_FAIL_START").tap()
-        let output = app.staticTexts.matching(NSPredicate(format: "label CONTAINS 'E12_STDOUT_0300' AND label CONTAINS 'E12_STDERR_0300' AND label ENDSWITH %@", "E12_EXPECTED_FAILURE\n")).firstMatch
-        try require(output.waitForExistence(timeout: 5), "Large stdout/stderr lost their final output")
+        try revealOutput(NSPredicate(format: "label CONTAINS 'E12_STDOUT_0300' AND label CONTAINS 'E12_STDERR_0300' AND label ENDSWITH %@", "E12_EXPECTED_FAILURE\n"), command: command("E12_FAIL_START"))
         try require(app.staticTexts["7"].exists, "The final exit code was not retained")
         try require(app.buttons.matching(NSPredicate(format: "label BEGINSWITH 'Command progress,'")).count == 0, "Empty polls created separate cards")
         capture(app, "E12-live-failed-after-relaunch")

--- a/docs/EXECUTION_ACCEPTANCE.md
+++ b/docs/EXECUTION_ACCEPTANCE.md
@@ -220,8 +220,8 @@ feature variants, Miri, fuzzing, and the rest of itoa's CI were not exercised.
 
 Before the E12 fix, the deployed UI displayed the initial Cargo yield as “Succeeded 1.56 s”
 with empty output, even while compilation continued. The final assistant
-message and durable tool result correctly reported success. This confirms B01's
-execution path while leaving E12's progress presentation acceptance open.
+message and durable tool result correctly reported success. This confirmed
+B01's execution path; E12's later verification is recorded below.
 
 The progress patch now derives elapsed time from persisted command-call
 and result timestamps. Replaying this run produces a single Cargo card that
@@ -318,6 +318,17 @@ passed all 12 terminal tests. The native replay policy passed all 8 focused
 from the live observations so a reopened receipt is not described as a fresh
 successful execution.
 
+The final physical iPhone `testLiveTerminalReceiptHistory` passed in 212.080 s
+at 10:07 UTC. It created no agents or turns: it reopened the two receipts above,
+expanded each turn's Activity and command details, and verified the completed
+output, elapsed field, failure output tail, and exit 7 after app relaunch.
+Both final screenshots were visually inspected. Local evidence is retained in
+`/tmp/nanocodex-progress-live-centaur-history-3.xcresult`; its device diagnostics
+and account credentials must not be uploaded as a whole bundle. Earlier
+history attempts failed in test navigation, before this corrected scoped
+scrolling check. The full final InboxCore suite also passed: 64 tests passed,
+3 opt-in live tests skipped, 0 failures.
+
 ### Remaining recovery failures
 
 The full fresh live XCTest is not green. An earlier rollout-time fixture lost
@@ -331,6 +342,12 @@ at cursors 29–45, and cursor 46 returned
 Neither run recovered the command's terminal exit receipt. The later failure's
 cause is not established. E13/E14 remain open; UI deduplication does not restore
 the backend process.
+
+The error originates in the [namespace session lookup](../js/managed/src/namespace-tools.ts),
+which currently retains process bindings in an in-memory map and rejects a
+missing binding or mismatched owner session. It does not by itself establish
+that the native sandbox process exited. Recovering that binding and retrieving
+the original provider receipt is the next diagnostic step.
 
 The successful fixture also exposed a separate Code Mode receipt gap: a
 yielding `exec` containing `tools.mount` returned the mounted result through

--- a/docs/EXECUTION_ACCEPTANCE.md
+++ b/docs/EXECUTION_ACCEPTANCE.md
@@ -179,9 +179,9 @@ of retained evidence. An assistant summary, green tool-transport status, or
    the ambiguous-submit and Stop cases, before an explicitly authorized live
    order is used as evidence.
 
-The local web/iPhone progress patch and its passing tests do not yet satisfy
-the deployed acceptance cases. The original workspace Cargo run lost its
-process after approximately 38m 42s and produced no terminal Cargo result.
+Command progress is deployed; the web and iPhone observations are recorded
+below. Process recovery remains open: the original workspace Cargo run lost
+its process after approximately 38m 42s and produced no terminal Cargo result.
 
 ## itoa baseline — 2026-09-07
 
@@ -218,18 +218,17 @@ Rust toolchain or sandbox image digest, and dependency download time was not
 separately instrumented. It ran ordinary debug-profile `cargo test`; release,
 feature variants, Miri, fuzzing, and the rest of itoa's CI were not exercised.
 
-The deployed UI still displayed the initial Cargo yield as “Succeeded 1.56 s”
+Before the E12 fix, the deployed UI displayed the initial Cargo yield as “Succeeded 1.56 s”
 with empty output, even while compilation continued. The final assistant
 message and durable tool result correctly reported success. This confirms B01's
 execution path while leaving E12's progress presentation acceptance open.
 
-The local progress patch now derives elapsed time from persisted command-call
+The progress patch now derives elapsed time from persisted command-call
 and result timestamps. Replaying this run produces a single Cargo card that
 remains Running during compilation and completes with 112.089 s, exit 0, and
 the final test output. Summing poll RPC durations would incorrectly show
 65.107 s because the process also runs between polls. Live reduction and full
-history replay agree. This patch is not deployed or verified on an installed
-iPhone yet.
+history replay agree. The deployed verification is recorded below.
 
 ### itoa reruns — 2026-09-07
 
@@ -271,3 +270,70 @@ Implementation owners: [namespace routing](../js/managed/src/namespace-tools.ts)
 [managed runtime policy](../js/managed/README.md),
 [React projection](../js/nanocodex-react/agent/transcript.mjs), and
 [iPhone projection](../apple/InboxCore/Sources/InboxCore/Protocol.swift).
+
+## Terminal command presentation — 2026-09-07
+
+[PR #290](https://github.com/gakonst/nanocodex/pull/290) retains yielded commands
+as Running, folds later `write_stdin` output into the original command, and
+measures elapsed time from its persisted start through observed completion.
+[PR #291](https://github.com/gakonst/nanocodex/pull/291) exposes the actual exit
+code in expanded web results. Production revision
+`f7f7b80a8826db185b7daf1d8adaa56017f1f9fd` completed its account deployment at
+09:44:34 UTC. The deployment job succeeded; that does not imply all longer CI
+or service tests finished.
+
+On the deployed web app, reopening the original itoa thread now shows the cold
+command as Succeeded 112 s with final test output. The two warm commands show
+4.63 s and 4.48 s. The `cargocargo` typo correctly shows Failed with exit 127.
+
+The fresh [E12 progress 09B5D4C9 thread](https://nanocodex.gakonst.workers.dev/agent/01a07b41-da6a-73ff-94aa-7df8dee07245)
+used one Cloudflare sandbox, `01a07b42-147d-7de0-81e9-f76f009887b9`, mounted at
+`/mnt-e12-009887b9`. Both commands used this environment.
+
+| Fixture | Durable receipt | Result |
+| --- | --- | --- |
+| Print `E12_START`, sleep 60 s, print `E12_MID`, sleep 60 s, print `E12_DONE`; yield after 1 s and poll the original session. | Turn `59cfbaca-2f82-40f7-9227-c958016e77b0`, process session `492682587`. | First output after 1.283 s; completion observed after 121.316 s; exit 0; all three lines retained. |
+| Print a start marker, sleep 30 s, emit 300 numbered stdout lines and 300 numbered stderr lines, print `E12_EXPECTED_FAILURE` to stderr, exit 7; poll without retrying the command. | Turn `2607ae86-0d21-48d7-bca2-3b4b3d897472`, process session `2067236829`. | First output after 1.262 s; completion observed after 30.868 s; exit 7. |
+
+The web command stayed Running with initial output across reload, then became
+Succeeded 121 s with exit 0 and all three lines in the original card. Reopening
+the failure showed Failed 30.9 s, exit 7, and the output tail through
+`E12_STDOUT_0300`, `E12_STDERR_0300`, and `E12_EXPECTED_FAILURE`. Empty polling
+calls did not create separate command cards. Card output is bounded; this does
+not claim all 600 lines remain visible at once. The durable receipt retains
+the full fixture output.
+
+The signed Centaur app (`xyz.paradigm.centaur`) was installed on a physical
+iPhone 17 Pro. Its live fixture showed Running with initial output, restored
+Running after relaunch, and displayed Completed with exit 0, elapsed 121.316 s,
+and all three output lines. The native follow-up makes tool status visible in
+the Activity list and deduplicates replayed calls/results by their original
+turn and call identity, preserving the original elapsed-time start.
+
+Validation includes the original 76 focused tests (42 React, 12 terminal,
+20 Swift, 2 account runtime), React type/package checks, terminal package
+checks, account typecheck, and a signed iPhone build. The exit-code follow-up
+passed all 12 terminal tests. The native replay policy passed all 8 focused
+`ToolPresentationTests`. Physical history verification is recorded separately
+from the live observations so a reopened receipt is not described as a fresh
+successful execution.
+
+### Remaining recovery failures
+
+The full fresh live XCTest is not green. An earlier rollout-time fixture lost
+process session `770702757` after retaining its initial and middle output:
+[thread](https://nanocodex.gakonst.workers.dev/agent/01a07b1d-6675-76c7-85e8-ecf2d7a1a283),
+cursors 13–47. A later [Centaur fixture](https://nanocodex.gakonst.workers.dev/agent/01a07b46-97da-7d3b-b35e-a70d509528b9)
+lost session `2050295544` at 09:51:39 UTC, after the recorded account deployment
+had completed. Its command began at cursor 13, recovered events were replayed
+at cursors 29–45, and cursor 46 returned
+`unknown or stale namespace process session`, 57.517 s after the original call.
+Neither run recovered the command's terminal exit receipt. The later failure's
+cause is not established. E13/E14 remain open; UI deduplication does not restore
+the backend process.
+
+The successful fixture also exposed a separate Code Mode receipt gap: a
+yielding `exec` containing `tools.mount` returned the mounted result through
+`wait`, but emitted no inner mount `tool.result`. Consequently the web Mount
+card remained Running after the turn ended. This receipt gap remains open;
+the command progress fix does not infer a successful mount receipt.

--- a/docs/EXECUTION_CHECKLIST.md
+++ b/docs/EXECUTION_CHECKLIST.md
@@ -4,25 +4,25 @@ Work through these in the order below, one case at a time. Case IDs match the
 [full acceptance criteria](EXECUTION_ACCEPTANCE.md). Each item names the expected
 environment and the result to verify.
 
-**Latest completed baseline: `dtolnay/itoa` clone → Cargo test.**
+**Completed: `dtolnay/itoa` clone → Cargo test, warm reruns, and E12 command progress.**
 
 - [x] **B01 — Small-repository clone and test, selected by the user.** Production Worker host clone: 0.642 s; one Cloudflare sandbox mount: 6.660 s; cold Cargo run: 112.089 s, exit 0, 11 integration tests and 2 doc tests passed. Full prompt-to-completion turns: 9.579 s for clone and 132.429 s for Cargo. All 16 upstream files matched by SHA-256; no `.git`. Both final responses survived browser reload. [Evidence](EXECUTION_ACCEPTANCE.md#itoa-baseline--2026-09-07).
 - [x] **B02 — itoa reruns in the existing sandbox mount.** Immediate warm Cargo: 4.634 s, 13.923 s for the full turn, no downloads/recompilation, all 13 tests passed. The preceding rerun after approximately 45 minutes idle rebuilt dependencies and took 121.510 s. [Evidence](EXECUTION_ACCEPTANCE.md#itoa-reruns--2026-09-07).
 
 B01 demonstrates the basic E01 → E03 path. The full case variants below remain
 pending, including the original larger-repository regression. Next pending
-reliability case: E12; the deployed command card still reports the initial yield
-as success and omits subsequent output.
+reliability case: E13 process recovery. E12's command presentation is verified
+on deployed web and a physical iPhone.
 
 Check an item only after its acceptance criteria have been demonstrated on the
 relevant deployed service or installed app, with evidence recorded below.
-Local patches and passing unit tests count as progress. All 37 cases remain
-unchecked until that verification is recorded. Missing software, a device, or
+Local patches and passing unit tests count as progress. Each case remains
+unchecked until its verification is recorded. Missing software, a device, or
 an integration leaves its case pending with the specific dependency noted.
 
 ## 1. Reliable execution and shared files
 
-- [ ] **E12 — Correct progress and completion.** Cloudflare Linux sandbox → web and iPhone. Keep yielded commands Running, accumulate output in the original card, and retain the actual successful or failing exit code after reload. Measure elapsed time from command call to observed completion, including time between polls.
+- [x] **E12 — Correct progress and completion.** Cloudflare Linux sandbox → web and iPhone. Yielded commands remain Running, subsequent output folds into the original card, and actual successful/failing exit codes survive reload. Elapsed time includes execution between polls. [Evidence](EXECUTION_ACCEPTANCE.md#terminal-command-presentation--2026-09-07). Process recovery and missing Code Mode mount receipts remain open under E13/E14.
 - [ ] **E13 — Long jobs and reconnect.** Same Cloudflare sandbox. Run a 60-minute job through app closure, event reconnect, and Worker reconnection; recover its progress and final result without duplicate execution.
 - [ ] **E14 — Process/container failure.** Isolated Cloudflare sandbox. Exercise termination, resource exhaustion, and restart; retain output and a truthful interrupted/failed outcome.
 - [ ] **E15 — Steering and Stop.** Original Cloudflare sandbox or explicitly selected device. Apply steering to the active turn; stop its work without confirmation or orphaned processes, preserving unrelated work.
@@ -100,8 +100,8 @@ cold/warm cache state and baseline conditions; set budgets from measurements.
 
 | Case | Progress / result | Evidence | Remaining work |
 | --- | --- | --- | --- |
-| E12 | Local web/iPhone progress and elapsed-time patches; 76 tests passed (42 React, 12 terminal, 20 Swift, 2 account runtime), plus package/type checks. | Branch `fix/terminal-command-progress`; saved production events replay as one Cargo card with Running → Completed, final output, exit 0, and 112.089 s. Live and history reduction agree. | Verify the deployed web and installed iPhone behavior, including completion/failure and reload. |
-| E13 / E14 | A production rollout interrupted the two-minute E12 fixture: retained process session `770702757` became unknown/stale during a poll. The original command has no recovered exit receipt. | [Interrupted fixture](https://nanocodex.gakonst.workers.dev/agent/01a07b1d-6675-76c7-85e8-ecf2d7a1a283), cursors 13–47; initial and middle output were retained. | Preserve process-session ownership across Worker replacement and recover the original command’s terminal receipt. |
+| E12 | Verified deployed web and physical iPhone command presentation, including Running across reload/relaunch and completed/failed receipts. The read-only iPhone history XCTest passed for both final receipts. | [Production and native evidence](EXECUTION_ACCEPTANCE.md#terminal-command-presentation--2026-09-07): success 121.316 s / exit 0; intentional failure 30.868 s / exit 7. Original 76 focused tests passed; final InboxCore suite: 64 passed, 3 opt-in live tests skipped. | Command presentation complete. Full fresh live XCTest remains affected by the separate E13/E14 process-recovery failure. |
+| E13 / E14 | Two two-minute fixtures lost their namespace process session; one coincided with a rollout, another failed after the recorded deployment finished. Neither recovered an exit receipt. A yielding Code Mode mount also omitted its inner tool-result event. | [Recovery failures](EXECUTION_ACCEPTANCE.md#remaining-recovery-failures); later session `2050295544` became stale after 57.517 s. | Preserve process-session ownership through runtime recovery, recover terminal receipts, and emit the missing inner mount receipt. Then run the full long-job and failure matrix. |
 | B01 / E01 → E03 | `dtolnay/itoa` production baseline passed, with one host clone and one Cloudflare Cargo invocation. | [Production thread](https://nanocodex.gakonst.workers.dev/agent/01a07acf-461d-70be-8f61-ec5cbe319540); [timings and scope](EXECUTION_ACCEPTANCE.md#itoa-baseline--2026-09-07). | Device-availability variants, iPhone verification, and the full E01/E03 matrix remain separate cases. |
 | B02 / E06 | itoa warm rerun passed in 4.634 s with caches reused; after-idle rerun rebuilt dependencies in 121.510 s. Both used the existing mount and passed 13 tests. | [Rerun timings and receipts](EXECUTION_ACCEPTANCE.md#itoa-reruns--2026-09-07). | Build-cache persistence across idle restarts, larger-repository warm runs, and device-availability variants remain open. |
 | E05 | Prior workspace run lost its process after approximately 38m 42s; no Cargo exit code was recovered. | [Production thread](https://nanocodex.gakonst.workers.dev/agent/01a0788c-a640-734e-bb31-99cb0dafbe23), “Run all” turn. | Diagnose process loss, fix it, and retain a real final result from a fresh run. |

--- a/typos.toml
+++ b/typos.toml
@@ -13,6 +13,10 @@ extend-exclude = [
 extend-glob = ["*.pbxproj"]
 extend-ignore-re = ['\b[0-9A-F]{24}\b']
 
+[type.go]
+# Exact executable name used by the remote-screen hand.
+extend-ignore-re = ['\bwaymote-streamd\b']
+
 [default.extend-words]
 # The Rust and Swift voice transcript parsers recognize this legacy XML tag.
 soruce = "soruce"

--- a/typos.toml
+++ b/typos.toml
@@ -13,11 +13,9 @@ extend-exclude = [
 extend-glob = ["*.pbxproj"]
 extend-ignore-re = ['\b[0-9A-F]{24}\b']
 
-[type.rust.extend-words]
-# The voice transcript parser deliberately recognizes this legacy XML tag.
-soruce = "soruce"
-
 [default.extend-words]
+# The Rust and Swift voice transcript parsers recognize this legacy XML tag.
+soruce = "soruce"
 ratatui = "ratatui"
 serde = "serde"
 wasm = "wasm"


### PR DESCRIPTION
Recovery replays could duplicate command rows on iPhone and reset their elapsed time. Keep the original turn/call identity, retain the first start timestamp, and show Running, Completed, or Failed inside the Activity list.

Update the live UI test for Centaur’s grouped Activity and add a read-only history check for explicitly selected success/failure receipts. E12 now has deployed web and physical iPhone evidence; E13/E14 remain open because fresh execution can still lose its namespace process binding. Also fix spelling checks for the intentional legacy voice tag and Waymote executable name.

Validation:
- InboxCore: 64 passed, 3 opt-in live tests skipped; includes the recovery-replay regression.
- Physical iPhone history XCTest passed for both receipts after relaunch; screenshots inspected. Earlier live observations cover Running and completion. The full fresh live test still fails on the documented backend recovery bug.
- Signed iPhone build passed after integration with the remote-screen changes; repository spelling and diff checks passed.
- Production web retained output and exits 0/7 after reload, with elapsed times 121.316 s and 30.868 s.
