### PR TITLE
fix(agents): expose native X browsing in browser chats

### DIFF
--- a/js/account/README.md
+++ b/js/account/README.md
@@ -8,7 +8,9 @@ or a second agent backend.
 
 ## User surfaces
 
-- **Home** shows an ephemeral browser-agent demo. **Durable Agent** retains a
+- **Home** shows an ephemeral browser-agent demo. Both browser chats and durable
+  agents include native `browseX` public X browsing, listed in `accountInfo.apis`
+  without an X connection. **Durable Agent** retains a
   thread only after the user connects their own ChatGPT or OpenAI credential.
 - **Attached Tools**, **Multiplayer**, and **World** demonstrate browser-hosted
   tools, a shared managed-agent room, and an agent-populated world.

--- a/js/account/worker/index.ts
+++ b/js/account/worker/index.ts
@@ -16,6 +16,7 @@ import { routeEvalRead } from "./evalReadApi.ts";
 import { handleGitRequest, type GitStorageEnv } from "./gitRoutes.ts";
 import { GitRepository } from "./gitRepository.ts";
 import { proxyDefaultMcp } from "./mcpProxy.ts";
+import { proxyX, type XProxyEnv } from "./xProxy.ts";
 import {
   handleThreadGitRequest,
   type ThreadGitStorageEnv,
@@ -101,6 +102,7 @@ const LOCAL_SPONSORED_TRIAL_RESET = typeof __NANOCODEX_LOCAL_SPONSORED_TRIAL_RES
   && __NANOCODEX_LOCAL_SPONSORED_TRIAL_RESET__;
 
 type WorkerEnv = GitStorageEnv & ThreadGitStorageEnv & EvalStorageEnv & ChatGptEgressEnv
+  & XProxyEnv
   & AccountFundingProxyEnv
   & ConnectDialogProxyEnv
   & LocalConnectApiEnv
@@ -172,6 +174,8 @@ export default {
       env.NANOCODEX_BACKEND,
     );
     if (mcpResponse != null) return mcpResponse;
+    const xResponse = await proxyX(request, env, sameOrigin(request, url, env));
+    if (xResponse != null) return xResponse;
 
     if (url.pathname === "/api/health" && request.method === "GET") {
       const managed = managedAccess(request, env);

--- a/js/account/worker/xProxy.test.ts
+++ b/js/account/worker/xProxy.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { proxyX, type XProxyEnv } from "./xProxy.ts";
+
+const url = "https://demo.test/api/tools/x/browse?resource=profile&handle=gakonst&format=json";
+
+test("browser X proxy forwards only the public query and propagates cancellation", async () => {
+  const controller = new AbortController();
+  let forwarded: Request | undefined;
+  const env = {
+    ENVIRONMENT: "development",
+    NANOCODEX_X: { fetch: async (request: Request) => {
+      forwarded = request;
+      return Response.json({ markdown: "public post" }, { headers: { "set-cookie": "private=1" } });
+    } } as Pick<Fetcher, "fetch">,
+  };
+  const response = await proxyX(new Request(url, {
+    headers: { authorization: "Bearer private", cookie: "private=1", "x-nanocodex-connector-connection": "private" },
+    signal: controller.signal,
+  }), env, true);
+  assert.equal(response?.status, 200);
+  assert.deepEqual(await response?.json(), { markdown: "public post" });
+  assert.equal(response?.headers.get("set-cookie"), null);
+  assert.equal(forwarded?.url, "https://x.internal/api/browse?resource=profile&handle=gakonst&format=json");
+  assert.deepEqual([...forwarded!.headers], [["accept", "application/json"]]);
+  controller.abort();
+  assert.equal(forwarded?.signal.aborted, true);
+});
+
+test("browser X proxy fences origins, routes, methods, and missing bindings", async () => {
+  const env = { ENVIRONMENT: "development", NANOCODEX_X: { fetch: async () => assert.fail("must not fetch") } };
+  assert.equal((await proxyX(new Request(url), env, false))?.status, 403);
+  assert.equal((await proxyX(new Request("https://demo.test/api/tools/x/arbitrary"), env, true))?.status, 404);
+  assert.equal((await proxyX(new Request(url, { method: "POST" }), env, true))?.status, 405);
+  assert.equal((await proxyX(new Request(url), { ENVIRONMENT: "development" }, true))?.status, 503);
+  assert.equal(await proxyX(new Request("https://demo.test/api/other"), env, true), undefined);
+});
+
+test("browser X proxy enforces production rate limits before the Worker call", async () => {
+  const keys: string[] = [];
+  const env: XProxyEnv = {
+    ENVIRONMENT: "production",
+    NANOCODEX_X: { fetch: async () => assert.fail("must not fetch") },
+    AGENT_TOOL_LIMIT: { limit: async ({ key }) => { keys.push(key); return { success: false }; } },
+  };
+  const response = await proxyX(new Request(url, { headers: { "cf-connecting-ip": "203.0.113.1" } }), env, true);
+  assert.equal(response?.status, 429);
+  assert.equal(response?.headers.get("retry-after"), "60");
+  assert.equal(keys.length, 1);
+  assert.doesNotMatch(keys[0]!, /203\.0\.113/);
+  assert.equal((await proxyX(new Request(url), { ...env, AGENT_TOOL_LIMIT: undefined }, true))?.status, 503);
+});
+
+test("browser X proxy preserves upstream failures and handles binding failures", async () => {
+  const env = {
+    ENVIRONMENT: "development",
+    NANOCODEX_X: { fetch: async () => Response.json({ error: "rate limited", retry_after: 60 }, {
+      status: 429, headers: { "retry-after": "60" },
+    }) },
+  };
+  const response = await proxyX(new Request(url), env, true);
+  assert.equal(response?.status, 429);
+  assert.equal(response?.headers.get("retry-after"), "60");
+  assert.deepEqual(await response?.json(), { error: "rate limited", retry_after: 60 });
+  assert.equal((await proxyX(new Request(url, { method: "HEAD" }), env, true))?.body, null);
+  env.NANOCODEX_X = { fetch: async () => { throw new Error("internal detail"); } };
+  const failed = await proxyX(new Request(url), env, true);
+  assert.equal(failed?.status, 502);
+  assert.deepEqual(await failed?.json(), { error: "X service unavailable" });
+});

--- a/js/account/worker/xProxy.ts
+++ b/js/account/worker/xProxy.ts
@@ -1,0 +1,50 @@
+import { limitAgentOperation, type PublicSecurityEnv } from "./publicSecurity.ts";
+
+export type XProxyEnv = PublicSecurityEnv & { NANOCODEX_X?: Pick<Fetcher, "fetch"> };
+
+/** Browser chats use the same private X Worker as durable agents. */
+export async function proxyX(
+  request: Request,
+  env: XProxyEnv,
+  sameOrigin: boolean,
+): Promise<Response | undefined> {
+  const url = new URL(request.url);
+  if (!url.pathname.startsWith("/api/tools/x/")) return undefined;
+  if (!sameOrigin) return error("forbidden", 403);
+  if (!["/api/tools/x/browse", "/api/tools/x/convert"].includes(url.pathname)) {
+    return error("not_found", 404);
+  }
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return error("method_not_allowed", 405, { allow: "GET, HEAD" });
+  }
+  if (!env.NANOCODEX_X) return error("X service unavailable", 503);
+  const limited = await limitAgentOperation(
+    env, `x:${request.headers.get("cf-connecting-ip") ?? "unknown-ip"}`, "search",
+  );
+  if (limited) return limited;
+  const upstream = new URL(url.pathname.replace("/api/tools/x/", "/api/"), "https://x.internal");
+  upstream.search = url.search;
+  try {
+    // Account, provider, and connector credentials never cross this boundary.
+    const response = await env.NANOCODEX_X.fetch(new Request(upstream, {
+      method: request.method,
+      headers: { accept: "application/json" },
+      signal: request.signal,
+    }));
+    const headers = new Headers({ "cache-control": "no-store", "x-content-type-options": "nosniff" });
+    for (const name of ["content-type", "retry-after"]) {
+      const value = response.headers.get(name);
+      if (value !== null) headers.set(name, value);
+    }
+    return new Response(request.method === "HEAD" ? null : response.body, { status: response.status, headers });
+  } catch {
+    return error("X service unavailable", 502);
+  }
+}
+
+function error(message: string, status: number, headers?: Record<string, string>): Response {
+  return Response.json({ error: message }, {
+    status,
+    headers: { "cache-control": "no-store", "x-content-type-options": "nosniff", ...headers },
+  });
+}

--- a/js/account/wrangler.jsonc
+++ b/js/account/wrangler.jsonc
@@ -51,6 +51,7 @@
     ]
   },
   "services": [
+    { "binding": "NANOCODEX_X", "service": "nanocodex-x" },
     {
       "binding": "NANOCODEX_BACKEND",
       "service": "nanocodex-durable-agent"
@@ -189,6 +190,7 @@
     "development": {
       "name": "nanocodex",
       "services": [
+        { "binding": "NANOCODEX_X", "service": "nanocodex-x", "remote": false },
         {
           "binding": "NANOCODEX_BACKEND",
           "service": "nanocodex-durable-agent",

--- a/js/nanocodex/README.md
+++ b/js/nanocodex/README.md
@@ -454,6 +454,11 @@ const agent = await Agent.create({
 use the individual factories in server-side Cloudflare Workers. Vite integration
 is provided separately by `nanocodex-vite`.
 
+The browser composition includes native `browseX` public X browsing, advertised
+by `accountInfo().apis` without an X connector. The embedding app serves
+`/api/tools/x/browse` and `/api/tools/x/convert`; Nanocodex's account app forwards
+these requests to the private X Worker.
+
 The browser composition includes `render_artifact` as a normal typed tool. For
 other hosts, compose the same factory with any workspace implementing the
 Nanocodex workspace contract:

--- a/js/nanocodex/test/browser-harness.test.mjs
+++ b/js/nanocodex/test/browser-harness.test.mjs
@@ -6,6 +6,7 @@ import { ToolRouter, toolMapSource } from "../runtime/tool-router.mjs";
 import * as datasets from "../tools/dataset.mjs";
 import { namedTool } from "../tools/namedTool.mjs";
 import * as standard from "../tools/standard.mjs";
+import { X_API } from "nanocodex-tools/x";
 
 const context = Object.freeze({
   callId: "browser-harness-call",
@@ -147,6 +148,7 @@ test("the account-action browser harness exposes one exact model-visible tool se
     "runtimeInfo",
     "accountInfo",
     "requestAccountConnection",
+    "browseX",
     "web__run",
     "image_gen__imagegen",
     "view_image",
@@ -164,6 +166,7 @@ test("the account-action browser harness exposes one exact model-visible tool se
   const accountInfo = await byName.accountInfo.handler({}, context);
   assert.deepEqual(accountInfo, {
     status: "ready",
+    apis: [X_API],
     authenticated: ["github", "gdrive", "gcalendar", "slack", "x"],
     accounts: {
       github: "Nano Cat (nanocat)",
@@ -273,6 +276,41 @@ test("the account-action browser harness exposes one exact model-visible tool se
   await router.reset();
 });
 
+test("browser browseX reaches the app origin for profiles and posts without X authorization", async () => {
+  const requests = [];
+  const result = { markdown: "Public X data", data: { posts: [] } };
+  const runtime = bindBrowser({
+    ...preparedBrowser(),
+    fetch: async (input, init) => {
+      requests.push(new Request(input, init));
+      return Response.json(result);
+    },
+  });
+  const tool = runtime.tools.find(({ name }) => name === "browseX");
+  assert.ok(tool, "the browser tool catalog must expose browseX");
+  assert.deepEqual(await tool.handler({ action: "profile", handle: "gakonst", limit: 1 }, context), result);
+  assert.deepEqual(await tool.handler({ action: "post", url: "https://x.com/jack/status/20" }, context), result);
+  assert.deepEqual(requests.map(({ url }) => url), [
+    "https://demo.test/api/tools/x/browse?resource=profile&handle=gakonst&limit=1&format=json",
+    "https://demo.test/api/tools/x/convert?url=https%3A%2F%2Fx.com%2Fjack%2Fstatus%2F20&format=json",
+  ]);
+  assert.ok(requests.every((request) => request.credentials === "same-origin"));
+  const aborted = AbortSignal.abort();
+  await assert.rejects(tool.handler({ action: "profile", handle: "gakonst" }, { ...context, signal: aborted }));
+  assert.equal(requests.length, 2, "cancelled tool calls must not fetch");
+});
+
+test("browser browseX preserves provider failure and retry information", async () => {
+  const runtime = bindBrowser({
+    ...preparedBrowser(),
+    fetch: async () => Response.json({ error: "rate limited", retry_after: 60 }, { status: 429 }),
+  });
+  const tool = runtime.tools.find(({ name }) => name === "browseX");
+  assert.deepEqual(await tool.handler({ action: "profile", handle: "gakonst" }, context), {
+    status: "unavailable", http_status: 429, error: "rate limited", retry_after: 60,
+  });
+});
+
 test("account connection links reject unexpected provider and callback URLs", async () => {
   for (const authorization_url of [
     "https://attacker.test/oauth?client_id=x&state=y&scope=z&redirect_uri=https%3A%2F%2Fdemo.test%2Fv1%2Fconnectors%2Fgoogle%2Fcallback",
@@ -379,6 +417,7 @@ test("accountInfo adds app authorization without forwarding unknown control-plan
 
   assert.deepEqual(await accountInfo.handler({}, context), {
     status: "ready",
+    apis: [X_API],
     authenticated: ["chatgpt"],
     accounts: { chatgpt: "Subscription" },
     connectorAccounts: {},
@@ -438,6 +477,7 @@ test("accountInfo projects a bounded host identity and hosted authorization", as
 
   assert.deepEqual(await accountInfo.handler({}, context), {
     status: "ready",
+    apis: [X_API],
     authenticated: ["github"],
     accounts: { github: "Host GitHub" },
     connectorAccounts: {},
@@ -505,6 +545,7 @@ test("accountInfo includes an empty required Vault field in login and unavailabl
 
     assert.deepEqual(await accountInfo.handler({}, context), {
       status: expectedStatus,
+      apis: [X_API],
       authenticated: [],
       accounts: {},
       connectorAccounts: {},

--- a/js/nanocodex/tools/browser/accountInfo.mjs
+++ b/js/nanocodex/tools/browser/accountInfo.mjs
@@ -1,4 +1,5 @@
 import { namedTool } from "../namedTool.mjs";
+import { X_API } from "nanocodex-tools/x";
 
 const CONNECTOR_IDS = [
   "github",
@@ -150,6 +151,15 @@ const VAULT_ENTRY_SCHEMA = {
 const ACCOUNT_INFO_SCHEMA = Object.freeze({
   type: "object",
   properties: {
+    apis: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: Object.fromEntries(Object.entries(X_API).map(([key, value]) => [key, { type: "string", const: value }])),
+        required: Object.keys(X_API),
+        additionalProperties: false,
+      },
+    },
     status: {
       type: "string",
       enum: ["ready", "requires_login", "unavailable"],
@@ -283,7 +293,7 @@ const ACCOUNT_INFO_SCHEMA = Object.freeze({
   },
   required: [
     "status", "authenticated", "accounts", "connectorAccounts", "identity",
-    "stablecoins", "authorizations", "vault",
+    "stablecoins", "authorizations", "vault", "apis",
   ],
   additionalProperties: false,
 });
@@ -311,7 +321,7 @@ const ACCOUNT_CONNECTION_REQUEST_SCHEMA = Object.freeze({
 
 export function browserAccountInfoTool(options) {
   return namedTool("accountInfo", {
-    description: "Report account authentication, safe Vault references, stablecoin balances, and app authorization boundaries. Vault references never include passwords, full card numbers, CVVs, expiry details, or billing ZIPs.",
+    description: "Report native public APIs, account authentication, safe Vault references, stablecoin balances, and app authorization boundaries. Native APIs in apis need no connector authorization; call their listed tools directly. Vault references never include passwords, full card numbers, CVVs, expiry details, or billing ZIPs.",
     parameters: { type: "object", additionalProperties: false },
     outputSchema: ACCOUNT_INFO_SCHEMA,
     handler: (_input, context) => browserAccountInfo(options, context?.signal),
@@ -509,6 +519,7 @@ export async function browserAccountInfo(options, signal) {
     }
     return {
       status: "ready",
+      apis: [X_API],
       authenticated,
       accounts,
       connectorAccounts,
@@ -526,6 +537,7 @@ export async function browserAccountInfo(options, signal) {
 function emptyInfo(status) {
   return {
     status,
+    apis: [X_API],
     authenticated: [],
     accounts: {},
     connectorAccounts: {},

--- a/js/nanocodex/tools/browser/index.mjs
+++ b/js/nanocodex/tools/browser/index.mjs
@@ -1,4 +1,5 @@
 import "./browserBuffer.mjs";
+import { browseX } from "nanocodex-tools/x";
 import {
   createBrowserEgressFetch,
   createBrowserRuntimeFetch,
@@ -132,6 +133,14 @@ export function bindBrowser(prepared, options = {}) {
       browserRuntimeInfoTool(account, shell.descriptor),
       browserAccountInfoTool(account),
       ...(options.accountConnectionRequests ? [browserAccountConnectionTool(account)] : []),
+      browseX({
+        fetch: (input, init) => {
+          const source = new URL(input);
+          const url = new URL(`/api/tools/x/${source.pathname.slice("/api/".length)}`, prepared.origin);
+          url.search = source.search;
+          return fetch(url, { ...init, credentials: "same-origin" });
+        },
+      }),
       standard.web(web),
       standard.imageGeneration({
         ...images,

--- a/js/x-api/README.md
+++ b/js/x-api/README.md
@@ -1,10 +1,13 @@
 # Nanocodex X API
 
 `nanocodex-x` is a private Cloudflare Worker for reading public X data. Managed
-agents call the native `browseX` tool; `accountInfo().apis` advertises it even
-when no X connector is authorized. The managed Worker reaches it through the
-`NANOCODEX_X` Service Binding. There is no public route, workers.dev endpoint,
-API key, or dependency on the x.md hosted service.
+agents and browser chats call the native `browseX` tool; `accountInfo().apis`
+advertises it even when no X connector is authorized. Managed agents use the
+`NANOCODEX_X` Service Binding directly. Browser chats use the account Worker's
+same-origin `/api/tools/x/browse` and `/api/tools/x/convert` routes, which apply
+rate limits and forward through the same binding without account credentials.
+The X Worker has no public route or workers.dev endpoint and requires no API
+key or dependency on the x.md hosted service.
 
 The shared tool and request contract live at `nanocodex-tools/x`. The Worker
 owns provider access, conversion, rendering, caching, and the HTTP interface.


### PR DESCRIPTION
The homepage chat had no `browseX` tool because the first integration only registered it in durable agents. Browser chats now expose the same native tool and list it in `accountInfo.apis`, including when no X account is connected.

The account Worker forwards the browser's two X routes to `nanocodex-x`. It enforces same-origin requests and the existing tool rate limit, passes cancellation through, and strips account credentials from the upstream request.

Reproduced the missing tool in production. Verified 11 browser contract tests, all 80 account tests, SDK type/package checks, and the full production app build. Production chat confirmed discovery and exposed the missing GET origin marker, fixed in #295. After that deployment, the same browser journey successfully retrieved @gakonst's latest post through `browseX`.
