### PR TITLE
fix(agents): mark browser X requests as same-origin

### DIFF
--- a/js/nanocodex/test/browser-harness.test.mjs
+++ b/js/nanocodex/test/browser-harness.test.mjs
@@ -295,6 +295,8 @@ test("browser browseX reaches the app origin for profiles and posts without X au
     "https://demo.test/api/tools/x/convert?url=https%3A%2F%2Fx.com%2Fjack%2Fstatus%2F20&format=json",
   ]);
   assert.ok(requests.every((request) => request.credentials === "same-origin"));
+  assert.ok(requests.every((request) => request.headers.get("x-nanocodex-request") === "1"));
+  assert.ok(requests.every((request) => request.headers.get("accept") === "application/json"));
   const aborted = AbortSignal.abort();
   await assert.rejects(tool.handler({ action: "profile", handle: "gakonst" }, { ...context, signal: aborted }));
   assert.equal(requests.length, 2, "cancelled tool calls must not fetch");

--- a/js/nanocodex/tools/browser/index.mjs
+++ b/js/nanocodex/tools/browser/index.mjs
@@ -138,7 +138,9 @@ export function bindBrowser(prepared, options = {}) {
           const source = new URL(input);
           const url = new URL(`/api/tools/x/${source.pathname.slice("/api/".length)}`, prepared.origin);
           url.search = source.search;
-          return fetch(url, { ...init, credentials: "same-origin" });
+          const headers = new Headers(init?.headers);
+          headers.set("x-nanocodex-request", "1");
+          return fetch(url, { ...init, headers, credentials: "same-origin" });
         },
       }),
       standard.web(web),


### PR DESCRIPTION
Browser chat can discover `browseX`, but GET requests from its Worker can omit Origin and Referer and receive 403 from the account proxy. Add the existing `X-Nanocodex-Request` marker; the server still requires the browser-controlled `Sec-Fetch-Site: same-origin` check.

Verified all 11 browser contract tests and the production app build. After deployment, a fresh production homepage chat called `accountInfo`, reported the native `browseX` entry, and successfully called `browseX({action:"profile",handle:"gakonst",limit:1})`, returning the post URL. No alternate tools or provider fallback were used.
