### PR TITLE
feat(browser): add Popcorn remote browser Hand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5694,6 +5694,10 @@ dependencies = [
 name = "nanocodex-browser"
 version = "0.5.0"
 dependencies = [
+ "alloy-primitives",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-sol-types",
  "async-trait",
  "async-tungstenite",
  "base64 0.22.1",
@@ -5708,6 +5712,7 @@ dependencies = [
  "nanocodex-tools",
  "nanocodex-vm",
  "percent-encoding",
+ "rand 0.9.5",
  "reflink-copy",
  "reqwest",
  "rusqlite",
@@ -5722,6 +5727,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "uuid",
  "v8-heap-parser",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5694,10 +5694,6 @@ dependencies = [
 name = "nanocodex-browser"
 version = "0.5.0"
 dependencies = [
- "alloy-primitives",
- "alloy-signer",
- "alloy-signer-local",
- "alloy-sol-types",
  "async-trait",
  "async-tungstenite",
  "base64 0.22.1",
@@ -5712,7 +5708,6 @@ dependencies = [
  "nanocodex-tools",
  "nanocodex-vm",
  "percent-encoding",
- "rand 0.9.5",
  "reflink-copy",
  "reqwest",
  "rusqlite",
@@ -5727,7 +5722,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
- "uuid",
  "v8-heap-parser",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,7 +1469,10 @@ dependencies = [
  "futures-util",
  "log",
  "pin-project-lite",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite 0.28.0",
 ]
 
@@ -5692,6 +5695,7 @@ name = "nanocodex-browser"
 version = "0.5.0"
 dependencies = [
  "async-trait",
+ "async-tungstenite",
  "base64 0.22.1",
  "chromiumoxide",
  "chrono",
@@ -10951,6 +10955,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.5",
+ "rustls",
+ "rustls-pki-types",
  "sha1 0.10.7",
  "thiserror 2.0.18",
  "utf-8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,10 @@ axum = { version = "0.8.9", default-features = false, features = ["form", "http1
 bm25 = { version = "2.3.2", default-features = false }
 chrono = { version = "0.4.43", default-features = false, features = ["clock", "std", "wasmbind"] }
 chromiumoxide = "0.9.1"
+# chromiumoxide pins async-tungstenite without a TLS feature, so its CDP socket
+# cannot dial `wss://`. Depending on it here unifies the feature and lets the
+# controller attach to remote, TLS-terminated CDP endpoints.
+async-tungstenite = { version = "0.32", features = ["tokio-rustls-native-certs"] }
 landlock = "0.4.4"
 clap = { version = "4.5.54", features = ["derive", "env"] }
 cpal = "0.16.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ alloy-primitives = { version = "1.6.1", default-features = false, features = ["s
 alloy-rlp = "0.3.16"
 alloy-signer = "2.4.1"
 alloy-signer-local = "2.4.1"
-alloy-sol-types = { version = "1.6.1", default-features = false, features = ["std"] }
 arcbox-ext4 = "0.1.2"
 axum = { version = "0.8.9", default-features = false, features = ["form", "http1", "json", "query", "tokio"] }
 bm25 = { version = "2.3.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ alloy-primitives = { version = "1.6.1", default-features = false, features = ["s
 alloy-rlp = "0.3.16"
 alloy-signer = "2.4.1"
 alloy-signer-local = "2.4.1"
+alloy-sol-types = { version = "1.6.1", default-features = false, features = ["std"] }
 arcbox-ext4 = "0.1.2"
 axum = { version = "0.8.9", default-features = false, features = ["form", "http1", "json", "query", "tokio"] }
 bm25 = { version = "2.3.2", default-features = false }

--- a/crates/experimental/nanocodex-browser/Cargo.toml
+++ b/crates/experimental/nanocodex-browser/Cargo.toml
@@ -19,17 +19,10 @@ all-features = true
 rustdoc-args = ["-D", "warnings"]
 
 [dependencies]
-# EIP-3009 payment signing for the public x402 session endpoint.
-alloy-primitives.workspace = true
-alloy-signer.workspace = true
-alloy-signer-local.workspace = true
-alloy-sol-types.workspace = true
 async-trait.workspace = true
 base64.workspace = true
 chrono.workspace = true
 chromiumoxide.workspace = true
-uuid.workspace = true
-rand.workspace = true
 # Enables TLS on chromiumoxide's CDP socket; see the workspace manifest.
 async-tungstenite.workspace = true
 futures-util.workspace = true

--- a/crates/experimental/nanocodex-browser/Cargo.toml
+++ b/crates/experimental/nanocodex-browser/Cargo.toml
@@ -19,10 +19,17 @@ all-features = true
 rustdoc-args = ["-D", "warnings"]
 
 [dependencies]
+# EIP-3009 payment signing for the public x402 session endpoint.
+alloy-primitives.workspace = true
+alloy-signer.workspace = true
+alloy-signer-local.workspace = true
+alloy-sol-types.workspace = true
 async-trait.workspace = true
 base64.workspace = true
 chrono.workspace = true
 chromiumoxide.workspace = true
+uuid.workspace = true
+rand.workspace = true
 # Enables TLS on chromiumoxide's CDP socket; see the workspace manifest.
 async-tungstenite.workspace = true
 futures-util.workspace = true

--- a/crates/experimental/nanocodex-browser/Cargo.toml
+++ b/crates/experimental/nanocodex-browser/Cargo.toml
@@ -23,6 +23,8 @@ async-trait.workspace = true
 base64.workspace = true
 chrono.workspace = true
 chromiumoxide.workspace = true
+# Enables TLS on chromiumoxide's CDP socket; see the workspace manifest.
+async-tungstenite.workspace = true
 futures-util.workspace = true
 fs2.workspace = true
 image.workspace = true

--- a/crates/experimental/nanocodex-browser/README.md
+++ b/crates/experimental/nanocodex-browser/README.md
@@ -85,18 +85,11 @@ the VMM, and the disposable disk together. The image definition and guest init
 script live in `image/`.
 
 For a browser that runs outside the operator's own hardware, the `popcorn`
-module rents an isolated session from [Popcorn](https://popcorn.reclaimprotocol.org)
-and attaches the same controller to it over CDP. Popcorn sessions run headful
-Chromium inside a TEE, expose a LiveView page a human can open to watch or take
-over, and are released on shutdown. The agent only ever sees `tools.browser`;
-the session capability stays with the caller.
-
-The default path needs no account. Each five-minute block costs $0.01 in USDC
-on Base, paid per request with x402: Popcorn answers the first request with a
-payment challenge, the module checks the offer against a policy compiled into
-the crate, signs an EIP-3009 transfer authorization, and repeats the request.
-Point `POPCORN_PAYER_PRIVATE_KEY` at an EVM key holding a little USDC and
-enough ETH for gas on Base.
+module rents an isolated session from a [Popcorn](https://github.com/reclaimprotocol/popcorn-oss)
+control plane and attaches the same controller to it over CDP. Popcorn sessions
+run headful Chromium inside a TEE, expose a LiveView page a human can open to
+watch or take over, and are released on shutdown. The agent only ever sees
+`tools.browser`; the session URLs stay with the caller.
 
 ```no_run
 use nanocodex_browser::popcorn::{PopcornBrowser, PopcornConfig};
@@ -113,15 +106,9 @@ browser.shutdown().await?;
 # }
 ```
 
-A session starts with one block. `PopcornBrowser::extend` buys more in whole
-blocks while at least four minutes remain, keeping the same browser and the
-same URLs, and `shutdown` ends the session when the task is done. Unused paid
-time is not refunded.
-
-Dedicated deployments keep the credentialed control plane instead. Set
-`POPCORN_CONTROL_PLANE_URL`, `POPCORN_CLIENT_ID`, and `POPCORN_CLIENT_SECRET`,
-optionally with `POPCORN_REGION` and `POPCORN_TTL_SECONDS`, and no payment is
-involved. A runnable version of both paths lives at
+`PopcornConfig::from_env()` reads `POPCORN_CONTROL_PLANE_URL`,
+`POPCORN_CLIENT_ID`, `POPCORN_CLIENT_SECRET`, and optionally `POPCORN_REGION`
+and `POPCORN_TTL_SECONDS`. A runnable version lives at
 `examples/popcorn_agent.rs`.
 
 For trusted local development, `Browser` provides the same typed actions

--- a/crates/experimental/nanocodex-browser/README.md
+++ b/crates/experimental/nanocodex-browser/README.md
@@ -85,11 +85,17 @@ the VMM, and the disposable disk together. The image definition and guest init
 script live in `image/`.
 
 For a browser that runs outside the operator's own hardware, the `popcorn`
-module rents an isolated session from a [Popcorn](https://github.com/reclaimprotocol/popcorn-oss)
-control plane and attaches the same controller to it over CDP. Popcorn sessions
-run headful Chromium inside a TEE, expose a LiveView page a human can open to
-watch or take over, and are released on shutdown. The agent only ever sees
-`tools.browser`; the session URLs stay with the caller.
+module rents an isolated session from [Popcorn](https://github.com/reclaimprotocol/popcorn-oss)
+and attaches the same controller to it over CDP. Popcorn sessions run headful
+Chromium inside a TEE, expose a LiveView page a human can open to watch or take
+over, and are released on shutdown. The agent only ever sees `tools.browser`;
+the session URLs stay with the caller.
+
+By default a session is rented through Popcorn's hosted MCP server, which needs
+no Reclaim-issued credentials: run it, complete the OAuth login in your browser
+when the authorization URL prints, and buy credits at
+[popcorn.reclaimprotocol.org](https://popcorn.reclaimprotocol.org) if prompted.
+The credentials are persisted, so later runs start without a login.
 
 ```no_run
 use nanocodex_browser::popcorn::{PopcornBrowser, PopcornConfig};
@@ -106,10 +112,19 @@ browser.shutdown().await?;
 # }
 ```
 
-`PopcornConfig::from_env()` reads `POPCORN_CONTROL_PLANE_URL`,
-`POPCORN_CLIENT_ID`, `POPCORN_CLIENT_SECRET`, and optionally `POPCORN_REGION`
-and `POPCORN_TTL_SECONDS`. A runnable version lives at
+`PopcornConfig::from_env()` optionally reads `POPCORN_MCP_URL`,
+`POPCORN_MCP_CREDENTIALS`, `POPCORN_PURPOSE`, `POPCORN_IDEMPOTENCY_KEY`,
+`POPCORN_PROXY_COUNTRY`, and `POPCORN_REGION`. A runnable version lives at
 `examples/popcorn_agent.rs`.
+
+For dedicated deployments that issue their own client credentials, setting
+`POPCORN_CONTROL_PLANE_URL`, `POPCORN_CLIENT_ID`, and `POPCORN_CLIENT_SECRET`
+selects the credentialed control plane instead; `POPCORN_REGION` and
+`POPCORN_TTL_SECONDS` then apply to the requested session.
+
+Agents that would rather not use the native browser tool at all can skip this
+module and register `https://popcorn-mcp-gcp.reclaimprotocol.org/mcp` as an
+ordinary Nanocodex MCP server, driving the browser through Popcorn's own tools.
 
 For trusted local development, `Browser` provides the same typed actions
 without a VM:

--- a/crates/experimental/nanocodex-browser/README.md
+++ b/crates/experimental/nanocodex-browser/README.md
@@ -85,11 +85,18 @@ the VMM, and the disposable disk together. The image definition and guest init
 script live in `image/`.
 
 For a browser that runs outside the operator's own hardware, the `popcorn`
-module rents an isolated session from a [Popcorn](https://github.com/reclaimprotocol/popcorn-oss)
-control plane and attaches the same controller to it over CDP. Popcorn sessions
-run headful Chromium inside a TEE, expose a LiveView page a human can open to
-watch or take over, and are released on shutdown. The agent only ever sees
-`tools.browser`; the session URLs stay with the caller.
+module rents an isolated session from [Popcorn](https://popcorn.reclaimprotocol.org)
+and attaches the same controller to it over CDP. Popcorn sessions run headful
+Chromium inside a TEE, expose a LiveView page a human can open to watch or take
+over, and are released on shutdown. The agent only ever sees `tools.browser`;
+the session capability stays with the caller.
+
+The default path needs no account. Each five-minute block costs $0.01 in USDC
+on Base, paid per request with x402: Popcorn answers the first request with a
+payment challenge, the module checks the offer against a policy compiled into
+the crate, signs an EIP-3009 transfer authorization, and repeats the request.
+Point `POPCORN_PAYER_PRIVATE_KEY` at an EVM key holding a little USDC and
+enough ETH for gas on Base.
 
 ```no_run
 use nanocodex_browser::popcorn::{PopcornBrowser, PopcornConfig};
@@ -106,9 +113,15 @@ browser.shutdown().await?;
 # }
 ```
 
-`PopcornConfig::from_env()` reads `POPCORN_CONTROL_PLANE_URL`,
-`POPCORN_CLIENT_ID`, `POPCORN_CLIENT_SECRET`, and optionally `POPCORN_REGION`
-and `POPCORN_TTL_SECONDS`. A runnable version lives at
+A session starts with one block. `PopcornBrowser::extend` buys more in whole
+blocks while at least four minutes remain, keeping the same browser and the
+same URLs, and `shutdown` ends the session when the task is done. Unused paid
+time is not refunded.
+
+Dedicated deployments keep the credentialed control plane instead. Set
+`POPCORN_CONTROL_PLANE_URL`, `POPCORN_CLIENT_ID`, and `POPCORN_CLIENT_SECRET`,
+optionally with `POPCORN_REGION` and `POPCORN_TTL_SECONDS`, and no payment is
+involved. A runnable version of both paths lives at
 `examples/popcorn_agent.rs`.
 
 For trusted local development, `Browser` provides the same typed actions

--- a/crates/experimental/nanocodex-browser/README.md
+++ b/crates/experimental/nanocodex-browser/README.md
@@ -84,6 +84,33 @@ loopback port. The owner shuts down the DevTools controller, Chromium, gvproxy,
 the VMM, and the disposable disk together. The image definition and guest init
 script live in `image/`.
 
+For a browser that runs outside the operator's own hardware, the `popcorn`
+module rents an isolated session from a [Popcorn](https://github.com/reclaimprotocol/popcorn-oss)
+control plane and attaches the same controller to it over CDP. Popcorn sessions
+run headful Chromium inside a TEE, expose a LiveView page a human can open to
+watch or take over, and are released on shutdown. The agent only ever sees
+`tools.browser`; the session URLs stay with the caller.
+
+```no_run
+use nanocodex_browser::popcorn::{PopcornBrowser, PopcornConfig};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let browser = PopcornBrowser::spawn(PopcornConfig::from_env()?).await?;
+println!("live view: {}", browser.live_view_url());
+
+let tool = browser.tool();
+// Pass `tool` to `Tools::builder().provider(tool)`.
+drop(tool);
+browser.shutdown().await?;
+# Ok(())
+# }
+```
+
+`PopcornConfig::from_env()` reads `POPCORN_CONTROL_PLANE_URL`,
+`POPCORN_CLIENT_ID`, `POPCORN_CLIENT_SECRET`, and optionally `POPCORN_REGION`
+and `POPCORN_TTL_SECONDS`. A runnable version lives at
+`examples/popcorn_agent.rs`.
+
 For trusted local development, `Browser` provides the same typed actions
 without a VM:
 

--- a/crates/experimental/nanocodex-browser/src/lib.rs
+++ b/crates/experimental/nanocodex-browser/src/lib.rs
@@ -5,6 +5,7 @@ mod cookie_source;
 mod features;
 mod ios;
 mod native;
+pub mod popcorn;
 mod session;
 #[cfg(any(
     all(target_os = "linux", not(target_env = "musl")),

--- a/crates/experimental/nanocodex-browser/src/native.rs
+++ b/crates/experimental/nanocodex-browser/src/native.rs
@@ -3462,7 +3462,13 @@ impl NativeBrowser {
         lighthouse_executable: Option<PathBuf>,
         crux_client: Option<BrowserCruxClient>,
     ) -> Result<Arc<Self>, BrowserBuildError> {
-        let executable = preferred_automation_executable(executable)?;
+        // A remote CDP attach drives Chromium over the wire and never launches a
+        // local binary, so do not require one to be installed on this host.
+        let executable = if cdp_endpoint.is_some() {
+            executable
+        } else {
+            preferred_automation_executable(executable)?
+        };
         Ok(Arc::new(Self {
             runtime_dir: tempfile::Builder::new()
                 .prefix("nanocodex-browser-")

--- a/crates/experimental/nanocodex-browser/src/popcorn.rs
+++ b/crates/experimental/nanocodex-browser/src/popcorn.rs
@@ -322,6 +322,7 @@ impl PopcornBrowser {
         config: PopcornConfig,
         browser: BrowserBuilder,
     ) -> Result<Self, PopcornError> {
+        nanocodex_oai_api::transport::install_default_rustls_crypto_provider();
         let client = Client::builder().timeout(config.request_timeout).build()?;
         let session = create_session(&client, &config).await?;
         debug!(
@@ -330,9 +331,28 @@ impl PopcornBrowser {
             region = ?session.region,
             "rented popcorn session"
         );
-        let browser = browser
+        // The session is already rented, so release it rather than leaking it to
+        // the TTL controller when the controller cannot be attached.
+        let browser = match browser
             .cdp_endpoint(session.cdp_internal_url.clone())
-            .build()?;
+            .build()
+        {
+            Ok(browser) => browser,
+            Err(error) => {
+                if let Err(release_error) =
+                    delete_session(&client, &config, &session.session_id).await
+                {
+                    warn!(
+                        target: "nanocodex_browser",
+                        session = %session.session_id,
+                        error = %release_error,
+                        "popcorn session release failed after a failed attach; \
+                         TTL controller will reclaim it"
+                    );
+                }
+                return Err(error.into());
+            }
+        };
         Ok(Self {
             config,
             client,

--- a/crates/experimental/nanocodex-browser/src/popcorn.rs
+++ b/crates/experimental/nanocodex-browser/src/popcorn.rs
@@ -3,14 +3,29 @@
 //! [Popcorn](https://github.com/reclaimprotocol/popcorn-oss) rents isolated
 //! headful Chromium sessions that run inside a TEE. Each session exposes a
 //! full-access CDP WebSocket, a human-viewable LiveView page, and an
-//! attestation route. This module rents one session from a Popcorn control
-//! plane, points the ordinary [`Browser`] controller at its CDP endpoint, and
-//! releases the session on shutdown.
+//! attestation route. This module rents one session, points the ordinary
+//! [`Browser`] controller at its CDP endpoint, and releases the session on
+//! shutdown.
 //!
 //! From the agent's point of view a Popcorn browser is just another Hand: the
 //! brain stays wherever it is, and `tools.browser(...)` executes inside the
 //! remote enclave. Because the model never receives the CDP URL, the session
 //! token never enters the conversation.
+//!
+//! # Access paths
+//!
+//! The default path is Popcorn's **hosted MCP server**, which needs no
+//! Reclaim-issued credentials. The first run prints an authorization URL to
+//! stderr, the operator approves it in a browser, and the OAuth credentials are
+//! persisted so later runs start without a login. Sessions are paid for with
+//! prepaid credits bought at <https://popcorn.reclaimprotocol.org>.
+//!
+//! A **credentialed control plane** remains available for dedicated
+//! deployments that issue their own client ID and secret.
+//!
+//! An agent that would rather not use the native browser tool at all can skip
+//! this module and register the Popcorn MCP server as an ordinary Nanocodex MCP
+//! server, driving the browser through Popcorn's own tools instead.
 //!
 //! # Rent a browser and hand it to an agent
 //!
@@ -31,17 +46,34 @@
 //! # }
 //! ```
 //!
-//! Required environment for [`PopcornConfig::from_env`]:
+//! Environment read by [`PopcornConfig::from_env`]:
 //!
-//! - `POPCORN_CONTROL_PLANE_URL`: base URL of the Popcorn control plane.
-//! - `POPCORN_CLIENT_ID` and `POPCORN_CLIENT_SECRET`: credentialed client.
+//! - `POPCORN_MCP_URL` (optional): overrides the hosted MCP server URL.
+//! - `POPCORN_MCP_CREDENTIALS` (optional): OAuth credential file path.
+//! - `POPCORN_PURPOSE` (optional): session purpose shown to the human.
+//! - `POPCORN_IDEMPOTENCY_KEY` (optional): reuse to retry without paying twice.
+//! - `POPCORN_PROXY_COUNTRY` (optional): ISO 3166-1 alpha-2 proxy exit country.
 //! - `POPCORN_REGION` (optional): comma-separated region preference order.
-//! - `POPCORN_TTL_SECONDS` (optional): requested session lifetime.
+//! - `POPCORN_TTL_SECONDS` (optional): requested lifetime; the hosted MCP
+//!   server sells one fixed block and ignores it.
+//!
+//! Setting any of `POPCORN_CONTROL_PLANE_URL`, `POPCORN_CLIENT_ID`, or
+//! `POPCORN_CLIENT_SECRET` selects the credentialed control plane instead, and
+//! all three are then required.
 
-use std::time::Duration;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use async_trait::async_trait;
+use nanocodex_tools::mcp::{
+    Mcp, McpHandle, McpOAuthCredentials, McpOAuthRefreshGuard, McpOAuthStore, McpServer,
+    McpToolCall,
+};
 use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 use tracing::{debug, warn};
 use url::Url;
 
@@ -49,78 +81,211 @@ use crate::{Browser, BrowserBuildError, BrowserBuilder, BrowserError, BrowserToo
 
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// Popcorn's hosted Streamable HTTP MCP server.
+pub const HOSTED_MCP_URL: &str = "https://popcorn-mcp-gcp.reclaimprotocol.org/mcp";
+
+/// Where a human buys session credits for the hosted MCP server.
+pub const CREDIT_CHECKOUT_URL: &str = "https://popcorn.reclaimprotocol.org";
+
+const MCP_SERVER_NAME: &str = "popcorn";
+const BALANCE_TOOL: &str = "get_balance";
+const CREATE_SESSION_TOOL: &str = "create_browser_session";
+const CONNECTION_TOOL: &str = "get_browser_connection";
+const LIVE_VIEW_TOOL: &str = "get_live_view";
+const END_SESSION_TOOL: &str = "end_browser_session";
+const DEFAULT_PURPOSE: &str = "Nanocodex agent browser session";
+
+const SESSION_ID_KEYS: &[&str] = &["session_id", "sessionId"];
+const CDP_KEYS: &[&str] = &[
+    "cdp_url",
+    "cdpUrl",
+    "cdp_internal_url",
+    "cdpInternalUrl",
+    "connect_url",
+    "connectUrl",
+];
+const LIVE_VIEW_KEYS: &[&str] = &[
+    "live_view_url",
+    "liveViewUrl",
+    "live_url",
+    "liveUrl",
+    "live_view",
+    "liveView",
+];
+const REGION_KEYS: &[&str] = &["region"];
+const EXPIRES_KEYS: &[&str] = &["expires_at", "expiresAt"];
+const CHECKOUT_KEYS: &[&str] = &["checkout_url", "checkoutUrl"];
+
+/// How a session is rented.
+#[derive(Clone)]
+enum PopcornAccess {
+    /// Popcorn's hosted MCP server, authorized with OAuth and paid with credits.
+    HostedMcp {
+        server_url: Url,
+        oauth_store: Option<Arc<dyn McpOAuthStore>>,
+        credentials_path: Option<PathBuf>,
+    },
+    /// A control plane that issued this client its own credentials.
+    ControlPlane {
+        control_plane: Url,
+        client_id: String,
+        client_secret: String,
+    },
+}
+
 /// Everything needed to rent one Popcorn session.
 #[derive(Clone)]
 pub struct PopcornConfig {
-    control_plane: Url,
-    client_id: String,
-    client_secret: String,
+    access: PopcornAccess,
     regions: Vec<String>,
     ttl_seconds: Option<u64>,
     session_id: Option<String>,
     request_timeout: Duration,
+    purpose: Option<String>,
+    idempotency_key: Option<String>,
+    proxy_country: Option<String>,
 }
 
+/// Redacts the client secret and never renders a credential path's contents.
 impl std::fmt::Debug for PopcornConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PopcornConfig")
-            .field("control_plane", &self.control_plane)
-            .field("client_id", &self.client_id)
-            .field("client_secret", &"<redacted>")
+        let mut rendered = f.debug_struct("PopcornConfig");
+        match &self.access {
+            PopcornAccess::HostedMcp { server_url, .. } => {
+                rendered
+                    .field("mode", &"hosted_mcp")
+                    .field("server_url", server_url);
+            }
+            PopcornAccess::ControlPlane {
+                control_plane,
+                client_id,
+                ..
+            } => {
+                rendered
+                    .field("mode", &"control_plane")
+                    .field("control_plane", control_plane)
+                    .field("client_id", client_id)
+                    .field("client_secret", &"<redacted>");
+            }
+        }
+        rendered
             .field("regions", &self.regions)
             .field("ttl_seconds", &self.ttl_seconds)
             .field("session_id", &self.session_id)
             .field("request_timeout", &self.request_timeout)
+            .field("purpose", &self.purpose)
+            .field("idempotency_key", &self.idempotency_key)
+            .field("proxy_country", &self.proxy_country)
             .finish()
     }
 }
 
 impl PopcornConfig {
-    /// Creates a configuration for a credentialed Popcorn client.
+    /// Creates a configuration for Popcorn's hosted MCP server.
+    ///
+    /// The first spawn prints an OAuth authorization URL to stderr; sessions
+    /// are paid for with credits bought at [`CREDIT_CHECKOUT_URL`].
+    #[must_use]
+    pub fn hosted_mcp() -> Self {
+        Self::mcp(Url::parse(HOSTED_MCP_URL).unwrap_or_else(|error| {
+            unreachable!("the hosted Popcorn MCP URL is a valid URL: {error}")
+        }))
+    }
+
+    /// Creates a configuration for a self-hosted Popcorn MCP server.
+    #[must_use]
+    pub fn mcp(server_url: Url) -> Self {
+        Self::with_access(PopcornAccess::HostedMcp {
+            server_url,
+            oauth_store: None,
+            credentials_path: None,
+        })
+    }
+
+    /// Creates a configuration for a credentialed Popcorn control plane.
+    ///
+    /// This is the option for dedicated deployments that issue their own client
+    /// ID and secret; ordinary users want [`PopcornConfig::hosted_mcp`].
     pub fn new(
         control_plane: Url,
         client_id: impl Into<String>,
         client_secret: impl Into<String>,
     ) -> Self {
-        Self {
+        Self::with_access(PopcornAccess::ControlPlane {
             control_plane,
             client_id: client_id.into(),
             client_secret: client_secret.into(),
+        })
+    }
+
+    const fn with_access(access: PopcornAccess) -> Self {
+        Self {
+            access,
             regions: Vec::new(),
             ttl_seconds: None,
             session_id: None,
             request_timeout: DEFAULT_REQUEST_TIMEOUT,
+            purpose: None,
+            idempotency_key: None,
+            proxy_country: None,
         }
     }
 
     /// Reads the configuration from `POPCORN_*` environment variables.
     ///
+    /// The hosted MCP server is selected unless any of
+    /// `POPCORN_CONTROL_PLANE_URL`, `POPCORN_CLIENT_ID`, or
+    /// `POPCORN_CLIENT_SECRET` is set, in which case all three are required.
+    ///
     /// # Errors
     ///
     /// Returns [`PopcornError::Configuration`] when a required variable is
-    /// missing or the control-plane URL does not parse.
+    /// missing or a URL or number does not parse.
     pub fn from_env() -> Result<Self, PopcornError> {
-        fn required(name: &str) -> Result<String, PopcornError> {
-            std::env::var(name)
-                .ok()
-                .filter(|value| !value.trim().is_empty())
-                .ok_or_else(|| PopcornError::Configuration {
-                    message: format!("`{name}` is required"),
-                })
-        }
+        Self::from_lookup(&|name| std::env::var(name).ok())
+    }
 
-        let control_plane =
-            Url::parse(&required("POPCORN_CONTROL_PLANE_URL")?).map_err(|error| {
-                PopcornError::Configuration {
-                    message: format!("`POPCORN_CONTROL_PLANE_URL` is not a valid URL: {error}"),
-                }
-            })?;
-        let mut config = Self::new(
-            control_plane,
-            required("POPCORN_CLIENT_ID")?,
-            required("POPCORN_CLIENT_SECRET")?,
-        );
-        if let Ok(regions) = std::env::var("POPCORN_REGION") {
+    fn from_lookup(lookup: &impl Fn(&str) -> Option<String>) -> Result<Self, PopcornError> {
+        let value = |name: &str| {
+            lookup(name)
+                .map(|value| value.trim().to_owned())
+                .filter(|value| !value.is_empty())
+        };
+        let required = |name: &str| {
+            value(name).ok_or_else(|| PopcornError::Configuration {
+                message: format!("`{name}` is required"),
+            })
+        };
+        let parsed_url = |name: &str, raw: &str| {
+            Url::parse(raw).map_err(|error| PopcornError::Configuration {
+                message: format!("`{name}` is not a valid URL: {error}"),
+            })
+        };
+
+        const CREDENTIALED: [&str; 3] = [
+            "POPCORN_CONTROL_PLANE_URL",
+            "POPCORN_CLIENT_ID",
+            "POPCORN_CLIENT_SECRET",
+        ];
+        let mut config = if CREDENTIALED.iter().any(|name| value(name).is_some()) {
+            let control_plane = required(CREDENTIALED[0])?;
+            Self::new(
+                parsed_url(CREDENTIALED[0], &control_plane)?,
+                required(CREDENTIALED[1])?,
+                required(CREDENTIALED[2])?,
+            )
+        } else {
+            let mut config = match value("POPCORN_MCP_URL") {
+                Some(url) => Self::mcp(parsed_url("POPCORN_MCP_URL", &url)?),
+                None => Self::hosted_mcp(),
+            };
+            if let Some(path) = value("POPCORN_MCP_CREDENTIALS") {
+                config = config.credentials_path(path);
+            }
+            config
+        };
+
+        if let Some(regions) = value("POPCORN_REGION") {
             config = config.regions(
                 regions
                     .split(',')
@@ -129,19 +294,33 @@ impl PopcornConfig {
                     .map(str::to_owned),
             );
         }
-        if let Ok(ttl) = std::env::var("POPCORN_TTL_SECONDS") {
+        if let Some(ttl) = value("POPCORN_TTL_SECONDS") {
             let ttl = ttl
-                .trim()
                 .parse::<u64>()
                 .map_err(|error| PopcornError::Configuration {
                     message: format!("`POPCORN_TTL_SECONDS` must be a positive integer: {error}"),
                 })?;
             config = config.ttl_seconds(ttl);
         }
+        if let Some(purpose) = value("POPCORN_PURPOSE") {
+            config = config.purpose(purpose);
+        }
+        if let Some(key) = value("POPCORN_IDEMPOTENCY_KEY") {
+            config = config.idempotency_key(key);
+        }
+        if let Some(country) = value("POPCORN_PROXY_COUNTRY") {
+            config = config.proxy_country(country);
+        }
         Ok(config)
     }
 
-    /// Sets the region preference order tried by the control plane.
+    /// Returns whether this configuration rents through an MCP server.
+    #[must_use]
+    pub const fn uses_mcp(&self) -> bool {
+        matches!(self.access, PopcornAccess::HostedMcp { .. })
+    }
+
+    /// Sets the region preference order, closest to the human first.
     #[must_use]
     pub fn regions(mut self, regions: impl IntoIterator<Item = String>) -> Self {
         self.regions = regions.into_iter().collect();
@@ -149,6 +328,8 @@ impl PopcornConfig {
     }
 
     /// Requests a session lifetime in seconds.
+    ///
+    /// MCP servers sell one fixed block and ignore this.
     #[must_use]
     pub const fn ttl_seconds(mut self, ttl_seconds: u64) -> Self {
         self.ttl_seconds = Some(ttl_seconds);
@@ -156,25 +337,94 @@ impl PopcornConfig {
     }
 
     /// Uses a caller-chosen session identifier instead of a generated one.
+    ///
+    /// In MCP mode the session identifier is allocated by the server, so this
+    /// value is used as the creation idempotency key instead.
     #[must_use]
     pub fn session_id(mut self, session_id: impl Into<String>) -> Self {
         self.session_id = Some(session_id.into());
         self
     }
 
-    /// Overrides the control-plane HTTP timeout.
+    /// Overrides the control-plane or MCP request timeout.
     #[must_use]
     pub const fn request_timeout(mut self, timeout: Duration) -> Self {
         self.request_timeout = timeout;
         self
     }
 
-    fn bearer(&self) -> String {
-        format!("Bearer {}:{}", self.client_id, self.client_secret)
+    /// Describes what the session is for; MCP servers show this to the human.
+    #[must_use]
+    pub fn purpose(mut self, purpose: impl Into<String>) -> Self {
+        self.purpose = Some(purpose.into());
+        self
+    }
+
+    /// Pins the MCP creation idempotency key.
+    ///
+    /// Reuse the same key when retrying an uncertain spawn: the server returns
+    /// the same session instead of renting and charging for a second one.
+    #[must_use]
+    pub fn idempotency_key(mut self, key: impl Into<String>) -> Self {
+        self.idempotency_key = Some(key.into());
+        self
+    }
+
+    /// Requests a deployment-managed proxy exit country, as ISO 3166-1 alpha-2.
+    #[must_use]
+    pub fn proxy_country(mut self, country: impl Into<String>) -> Self {
+        self.proxy_country = Some(country.into());
+        self
+    }
+
+    /// Persists MCP OAuth credentials at `path` instead of the default file.
+    #[must_use]
+    pub fn credentials_path(mut self, path: impl Into<PathBuf>) -> Self {
+        if let PopcornAccess::HostedMcp {
+            credentials_path, ..
+        } = &mut self.access
+        {
+            *credentials_path = Some(path.into());
+        }
+        self
+    }
+
+    /// Persists MCP OAuth credentials through a caller-owned store.
+    ///
+    /// Use this to share one credential store with the rest of an application;
+    /// otherwise a file store is used.
+    #[must_use]
+    pub fn oauth_store(mut self, store: Arc<dyn McpOAuthStore>) -> Self {
+        if let PopcornAccess::HostedMcp { oauth_store, .. } = &mut self.access {
+            *oauth_store = Some(store);
+        }
+        self
+    }
+
+    fn bearer(&self) -> Result<String, PopcornError> {
+        match &self.access {
+            PopcornAccess::ControlPlane {
+                client_id,
+                client_secret,
+                ..
+            } => Ok(format!("Bearer {client_id}:{client_secret}")),
+            PopcornAccess::HostedMcp { .. } => Err(PopcornError::Configuration {
+                message: "MCP mode has no control-plane bearer token".to_owned(),
+            }),
+        }
+    }
+
+    fn control_plane(&self) -> Result<&Url, PopcornError> {
+        match &self.access {
+            PopcornAccess::ControlPlane { control_plane, .. } => Ok(control_plane),
+            PopcornAccess::HostedMcp { .. } => Err(PopcornError::Configuration {
+                message: "MCP mode has no control-plane URL".to_owned(),
+            }),
+        }
     }
 
     fn sessions_url(&self) -> Result<Url, PopcornError> {
-        self.control_plane
+        self.control_plane()?
             .join("v1/sessions")
             .map_err(|error| PopcornError::Configuration {
                 message: format!("cannot build sessions URL: {error}"),
@@ -182,12 +432,34 @@ impl PopcornConfig {
     }
 
     fn session_url(&self, session_id: &str) -> Result<Url, PopcornError> {
-        self.control_plane
+        self.control_plane()?
             .join(&format!("v1/session/{session_id}"))
             .map_err(|error| PopcornError::Configuration {
                 message: format!("cannot build session URL: {error}"),
             })
     }
+
+    fn creation_purpose(&self) -> &str {
+        self.purpose.as_deref().unwrap_or(DEFAULT_PURPOSE)
+    }
+
+    /// Returns the creation idempotency key, generating one when unset.
+    fn creation_idempotency_key(&self) -> String {
+        self.idempotency_key
+            .clone()
+            .or_else(|| self.session_id.clone())
+            .unwrap_or_else(generated_idempotency_key)
+    }
+}
+
+/// Builds a key unique to one spawn attempt in this process.
+fn generated_idempotency_key() -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |elapsed| elapsed.as_nanos());
+    let sequence = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("nanocodex-{:x}-{nanos:x}-{sequence:x}", std::process::id())
 }
 
 #[derive(Serialize)]
@@ -205,7 +477,7 @@ const fn slice_is_empty(regions: &&[String]) -> bool {
     regions.is_empty()
 }
 
-/// The session record returned by the Popcorn control plane.
+/// The session record returned by Popcorn.
 ///
 /// Every URL in this record is a bearer secret. Log the session id, never
 /// the URLs.
@@ -219,11 +491,14 @@ pub struct PopcornSession {
     /// Restricted client-facing CDP endpoint.
     pub cdp_url: Url,
     /// Trusted full-access CDP endpoint used by the agent.
+    ///
+    /// MCP servers return exactly one agent-facing CDP URL, so in MCP mode this
+    /// holds the same endpoint as [`PopcornSession::cdp_url`].
     pub cdp_internal_url: Url,
     /// Allocated browser pod identity.
     #[serde(default)]
     pub browser_pod_id: Option<String>,
-    /// Session deadline when the control plane set one.
+    /// Session deadline when Popcorn set one.
     #[serde(default)]
     pub expires_at: Option<String>,
     /// Selected region.
@@ -260,6 +535,145 @@ struct CreateSessionResponse {
     session: Option<PopcornSession>,
 }
 
+/// A session assembled from one or more MCP tool results.
+///
+/// `create_browser_session` normally returns every field at once; the optional
+/// fields are filled from `get_browser_connection` and `get_live_view` when a
+/// deployment splits them across tools.
+struct McpSessionDraft {
+    session_id: String,
+    cdp_url: Option<String>,
+    live_view_url: Option<String>,
+    region: Option<String>,
+    expires_at: Option<String>,
+}
+
+impl McpSessionDraft {
+    /// Reads a `create_browser_session` payload.
+    fn from_create(payload: &Value) -> Result<Self, PopcornError> {
+        let session_id =
+            lookup_str(payload, SESSION_ID_KEYS).ok_or(PopcornError::MissingField {
+                field: "session_id",
+            })?;
+        Ok(Self {
+            session_id,
+            cdp_url: lookup_str(payload, CDP_KEYS),
+            live_view_url: lookup_str(payload, LIVE_VIEW_KEYS),
+            region: lookup_str(payload, REGION_KEYS),
+            expires_at: lookup_str(payload, EXPIRES_KEYS),
+        })
+    }
+
+    /// Merges a `get_browser_connection` payload into the missing fields.
+    fn merge_connection(&mut self, payload: &Value) {
+        self.cdp_url = self
+            .cdp_url
+            .take()
+            .or_else(|| lookup_str(payload, CDP_KEYS));
+        self.live_view_url = self
+            .live_view_url
+            .take()
+            .or_else(|| lookup_str(payload, LIVE_VIEW_KEYS));
+        self.region = self
+            .region
+            .take()
+            .or_else(|| lookup_str(payload, REGION_KEYS));
+        self.expires_at = self
+            .expires_at
+            .take()
+            .or_else(|| lookup_str(payload, EXPIRES_KEYS));
+    }
+
+    /// Merges a `get_live_view` payload, which may name the link `url`.
+    fn merge_live_view(&mut self, payload: &Value) {
+        self.live_view_url = self.live_view_url.take().or_else(|| {
+            lookup_str(payload, LIVE_VIEW_KEYS).or_else(|| lookup_str(payload, &["url"]))
+        });
+    }
+
+    /// Builds the session record, requiring a CDP endpoint and a LiveView page.
+    fn finish(self) -> Result<PopcornSession, PopcornError> {
+        let cdp_url = parse_session_url(
+            self.cdp_url
+                .ok_or(PopcornError::MissingField { field: "cdp_url" })?,
+            "cdp_url",
+        )?;
+        let url = parse_session_url(
+            self.live_view_url.ok_or(PopcornError::MissingField {
+                field: "live_view_url",
+            })?,
+            "live_view_url",
+        )?;
+        Ok(PopcornSession {
+            session_id: self.session_id,
+            url,
+            cdp_url: cdp_url.clone(),
+            cdp_internal_url: cdp_url,
+            browser_pod_id: None,
+            expires_at: self.expires_at,
+            region: self.region,
+            cluster_name: None,
+        })
+    }
+}
+
+/// Parses a session URL without ever rendering it in the error.
+fn parse_session_url(raw: String, field: &'static str) -> Result<Url, PopcornError> {
+    Url::parse(&raw).map_err(|error| PopcornError::Mcp {
+        message: format!("`{field}` is not a valid URL: {error}"),
+    })
+}
+
+/// Finds the first string at any of `keys`, searching nested objects.
+///
+/// MCP deployments wrap results in envelopes such as `{"session": {...}}`, so
+/// the search descends through objects and arrays rather than assuming a shape.
+fn lookup_str(payload: &Value, keys: &[&str]) -> Option<String> {
+    const MAX_DEPTH: usize = 4;
+    fn walk(value: &Value, keys: &[&str], depth: usize) -> Option<String> {
+        if depth == 0 {
+            return None;
+        }
+        match value {
+            Value::Object(fields) => {
+                for key in keys {
+                    if let Some(found) = fields
+                        .get(*key)
+                        .and_then(Value::as_str)
+                        .map(str::trim)
+                        .filter(|found| !found.is_empty())
+                    {
+                        return Some(found.to_owned());
+                    }
+                }
+                fields
+                    .values()
+                    .find_map(|nested| walk(nested, keys, depth - 1))
+            }
+            Value::Array(items) => items
+                .iter()
+                .find_map(|nested| walk(nested, keys, depth - 1)),
+            _ => None,
+        }
+    }
+    walk(payload, keys, MAX_DEPTH)
+}
+
+/// Returns a human-readable shortfall when a metered account is out of credit.
+fn credit_shortfall(payload: &Value) -> Option<String> {
+    let metered = payload
+        .get("metered")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let credits = payload.get("credits").and_then(Value::as_f64)?;
+    if !metered || credits > 0.0 {
+        return None;
+    }
+    let checkout =
+        lookup_str(payload, CHECKOUT_KEYS).unwrap_or_else(|| CREDIT_CHECKOUT_URL.to_owned());
+    Some(format!("buy credits at {checkout} and run again"))
+}
+
 /// Errors from renting, driving, or releasing a Popcorn session.
 #[derive(Debug, thiserror::Error)]
 pub enum PopcornError {
@@ -280,6 +694,24 @@ pub enum PopcornError {
         /// Response body, truncated.
         body: String,
     },
+    /// The MCP server could not be reached, authorized, or understood.
+    #[error("popcorn MCP error: {message}")]
+    Mcp {
+        /// Human-readable explanation.
+        message: String,
+    },
+    /// A Popcorn response did not carry a field the session needs.
+    #[error("popcorn response is missing `{field}`")]
+    MissingField {
+        /// Missing field name.
+        field: &'static str,
+    },
+    /// The account has no session credit left.
+    #[error("popcorn has no session credit left: {message}")]
+    InsufficientCredit {
+        /// What the human should do next.
+        message: String,
+    },
     /// The browser controller could not be configured for the session.
     #[error(transparent)]
     Build(#[from] BrowserBuildError),
@@ -288,13 +720,21 @@ pub enum PopcornError {
     Browser(#[from] BrowserError),
 }
 
+/// How a rented session is reached for its remaining lifecycle calls.
+enum PopcornControl {
+    /// An MCP server, already connected and authorized.
+    Mcp(McpHandle),
+    /// A control plane, reached over HTTP with client credentials.
+    ControlPlane(Client),
+}
+
 /// One rented Popcorn session wrapped as a Nanocodex browser Hand.
 ///
 /// Dropping the value without calling [`PopcornBrowser::shutdown`] leaves the
 /// session to Popcorn's TTL controller. Call `shutdown` to release it now.
 pub struct PopcornBrowser {
     config: PopcornConfig,
-    client: Client,
+    control: PopcornControl,
     session: PopcornSession,
     browser: Browser,
 }
@@ -302,10 +742,14 @@ pub struct PopcornBrowser {
 impl PopcornBrowser {
     /// Rents a Popcorn session and attaches the browser controller to it.
     ///
+    /// In MCP mode the first call prints an OAuth authorization URL to stderr
+    /// and waits for the operator to approve it in a browser.
+    ///
     /// # Errors
     ///
-    /// Returns an error when the control plane refuses the session or when the
-    /// browser controller cannot be configured for the remote CDP endpoint.
+    /// Returns an error when Popcorn refuses the session, the account is out of
+    /// credit, or the browser controller cannot be configured for the remote
+    /// CDP endpoint.
     pub async fn spawn(config: PopcornConfig) -> Result<Self, PopcornError> {
         Self::spawn_with(config, Browser::builder()).await
     }
@@ -323,12 +767,23 @@ impl PopcornBrowser {
         browser: BrowserBuilder,
     ) -> Result<Self, PopcornError> {
         nanocodex_oai_api::transport::install_default_rustls_crypto_provider();
-        let client = Client::builder().timeout(config.request_timeout).build()?;
-        let session = create_session(&client, &config).await?;
+        let (control, session) = match &config.access {
+            PopcornAccess::HostedMcp { .. } => {
+                let handle = connect_mcp(&config).await?;
+                let session = create_mcp_session(&handle, &config).await?;
+                (PopcornControl::Mcp(handle), session)
+            }
+            PopcornAccess::ControlPlane { .. } => {
+                let client = Client::builder().timeout(config.request_timeout).build()?;
+                let session = create_session(&client, &config).await?;
+                (PopcornControl::ControlPlane(client), session)
+            }
+        };
         debug!(
             target: "nanocodex_browser",
             session = %session.session_id,
             region = ?session.region,
+            mcp = config.uses_mcp(),
             "rented popcorn session"
         );
         // The session is already rented, so release it rather than leaking it to
@@ -340,7 +795,7 @@ impl PopcornBrowser {
             Ok(browser) => browser,
             Err(error) => {
                 if let Err(release_error) =
-                    delete_session(&client, &config, &session.session_id).await
+                    release_session(&control, &config, &session.session_id).await
                 {
                     warn!(
                         target: "nanocodex_browser",
@@ -355,7 +810,7 @@ impl PopcornBrowser {
         };
         Ok(Self {
             config,
-            client,
+            control,
             session,
             browser,
         })
@@ -385,17 +840,17 @@ impl PopcornBrowser {
         &self.session.url
     }
 
-    /// Closes the controller and releases the session on the control plane.
+    /// Closes the controller and releases the session.
     ///
     /// # Errors
     ///
-    /// Returns the first error from closing the browser or deleting the
-    /// session. The delete is attempted even when the close fails.
+    /// Returns the first error from closing the browser or releasing the
+    /// session. The release is attempted even when the close fails.
     pub async fn shutdown(self) -> Result<(), PopcornError> {
         let close_result = self.browser.close().await.map_err(PopcornError::from);
-        let delete_result =
-            delete_session(&self.client, &self.config, &self.session.session_id).await;
-        if let Err(error) = &delete_result {
+        let release_result =
+            release_session(&self.control, &self.config, &self.session.session_id).await;
+        if let Err(error) = &release_result {
             warn!(
                 target: "nanocodex_browser",
                 session = %self.session.session_id,
@@ -403,7 +858,179 @@ impl PopcornBrowser {
                 "popcorn session release failed; TTL controller will reclaim it"
             );
         }
-        close_result.and(delete_result)
+        close_result.and(release_result)
+    }
+}
+
+/// Connects to the MCP server, running a browser OAuth login when needed.
+async fn connect_mcp(config: &PopcornConfig) -> Result<McpHandle, PopcornError> {
+    let PopcornAccess::HostedMcp {
+        server_url,
+        oauth_store,
+        credentials_path,
+    } = &config.access
+    else {
+        return Err(PopcornError::Configuration {
+            message: "MCP connection requires an MCP configuration".to_owned(),
+        });
+    };
+    let store = match oauth_store {
+        Some(store) => Arc::clone(store),
+        None => Arc::new(PopcornCredentialFile::new(default_credentials_path(
+            credentials_path.clone(),
+        )?)) as Arc<dyn McpOAuthStore>,
+    };
+    let provider = Mcp::builder()
+        .oauth_store(store)
+        .server(
+            MCP_SERVER_NAME,
+            McpServer::http(server_url.as_str())
+                .description("Popcorn remote browser sessions")
+                .startup_timeout(config.request_timeout)
+                .tool_timeout(config.request_timeout),
+        )
+        .build()
+        .map_err(|error| PopcornError::Mcp {
+            message: error.to_string(),
+        })?;
+    let handle = provider.handle();
+    // A first run has no stored credentials, so the unauthenticated connect
+    // fails and the login below both authorizes and reloads the server.
+    if let Err(connect_error) = handle.reload(MCP_SERVER_NAME).await {
+        let login = handle
+            .login(MCP_SERVER_NAME)
+            .await
+            .map_err(|error| PopcornError::Mcp {
+                message: format!("{connect_error}; OAuth login could not start: {error}"),
+            })?;
+        eprintln!(
+            "popcorn: authorize this client by opening\n  {}",
+            login.authorization_url()
+        );
+        eprintln!("popcorn: waiting for the browser callback...");
+        login.wait().await.map_err(|error| PopcornError::Mcp {
+            message: format!("OAuth login failed: {error}"),
+        })?;
+        eprintln!("popcorn: authorized");
+    }
+    Ok(handle)
+}
+
+/// Rents one session through the MCP server.
+async fn create_mcp_session(
+    handle: &McpHandle,
+    config: &PopcornConfig,
+) -> Result<PopcornSession, PopcornError> {
+    // Checking the balance first is free and turns an out-of-credit run into a
+    // clear instruction instead of a failed session creation.
+    let balance = call_mcp_tool(handle, BALANCE_TOOL, Map::new()).await?;
+    if let Ok(payload) = balance.json()
+        && let Some(message) = credit_shortfall(&payload)
+    {
+        return Err(PopcornError::InsufficientCredit { message });
+    }
+
+    let mut arguments = Map::new();
+    arguments.insert(
+        "purpose".to_owned(),
+        Value::String(config.creation_purpose().to_owned()),
+    );
+    arguments.insert(
+        "idempotency_key".to_owned(),
+        Value::String(config.creation_idempotency_key()),
+    );
+    if !config.regions.is_empty() {
+        arguments.insert(
+            "regions".to_owned(),
+            Value::Array(
+                config
+                    .regions
+                    .iter()
+                    .cloned()
+                    .map(Value::String)
+                    .collect::<Vec<_>>(),
+            ),
+        );
+    }
+    if let Some(country) = &config.proxy_country {
+        arguments.insert("proxy_country".to_owned(), Value::String(country.clone()));
+    }
+
+    let created = call_mcp_tool(handle, CREATE_SESSION_TOOL, arguments).await?;
+    let mut draft = McpSessionDraft::from_create(&created.json().map_err(map_mcp_error)?)?;
+    if draft.cdp_url.is_none() {
+        let mut arguments = Map::new();
+        arguments.insert(
+            "session_id".to_owned(),
+            Value::String(draft.session_id.clone()),
+        );
+        let connection = call_mcp_tool(handle, CONNECTION_TOOL, arguments).await?;
+        draft.merge_connection(&connection.json().map_err(map_mcp_error)?);
+    }
+    if draft.live_view_url.is_none() {
+        let mut arguments = Map::new();
+        arguments.insert(
+            "session_id".to_owned(),
+            Value::String(draft.session_id.clone()),
+        );
+        let live_view = call_mcp_tool(handle, LIVE_VIEW_TOOL, arguments).await?;
+        draft.merge_live_view(&live_view.json().map_err(map_mcp_error)?);
+    }
+    draft.finish()
+}
+
+/// Calls one Popcorn tool, turning a tool-level error into a typed error.
+async fn call_mcp_tool(
+    handle: &McpHandle,
+    tool: &str,
+    arguments: Map<String, Value>,
+) -> Result<McpToolCall, PopcornError> {
+    let call = handle
+        .call_tool(MCP_SERVER_NAME, tool, arguments)
+        .await
+        .map_err(|error| PopcornError::Mcp {
+            message: error.to_string(),
+        })?;
+    if !call.is_error() {
+        return Ok(call);
+    }
+    let detail = call.text().trim().to_owned();
+    let checkout = call
+        .json()
+        .ok()
+        .as_ref()
+        .and_then(|payload| lookup_str(payload, CHECKOUT_KEYS));
+    if let Some(checkout) = checkout {
+        return Err(PopcornError::InsufficientCredit {
+            message: format!("buy credits at {checkout} and run again"),
+        });
+    }
+    Err(PopcornError::Mcp {
+        message: format!("`{tool}` failed: {}", truncate(&detail)),
+    })
+}
+
+const fn map_mcp_error(message: String) -> PopcornError {
+    PopcornError::Mcp { message }
+}
+
+/// Releases a rented session through whichever path rented it.
+async fn release_session(
+    control: &PopcornControl,
+    config: &PopcornConfig,
+    session_id: &str,
+) -> Result<(), PopcornError> {
+    match control {
+        PopcornControl::Mcp(handle) => {
+            let mut arguments = Map::new();
+            arguments.insert(
+                "session_id".to_owned(),
+                Value::String(session_id.to_owned()),
+            );
+            call_mcp_tool(handle, END_SESSION_TOOL, arguments).await?;
+            Ok(())
+        }
+        PopcornControl::ControlPlane(client) => delete_session(client, config, session_id).await,
     }
 }
 
@@ -418,7 +1045,7 @@ async fn create_session(
     };
     let response = client
         .post(config.sessions_url()?)
-        .header(reqwest::header::AUTHORIZATION, config.bearer())
+        .header(reqwest::header::AUTHORIZATION, config.bearer()?)
         .json(&request)
         .send()
         .await?;
@@ -456,7 +1083,7 @@ async fn delete_session(
 ) -> Result<(), PopcornError> {
     let response = client
         .delete(config.session_url(session_id)?)
-        .header(reqwest::header::AUTHORIZATION, config.bearer())
+        .header(reqwest::header::AUTHORIZATION, config.bearer()?)
         .send()
         .await?;
     let status = response.status();
@@ -483,9 +1110,257 @@ fn truncate(body: &str) -> String {
     }
 }
 
+/// Returns the credential file path, defaulting under the user's home.
+fn default_credentials_path(configured: Option<PathBuf>) -> Result<PathBuf, PopcornError> {
+    if let Some(path) = configured {
+        return Ok(path);
+    }
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .filter(|home| !home.as_os_str().is_empty())
+        .ok_or_else(|| PopcornError::Configuration {
+            message: "`HOME` is not set; set `POPCORN_MCP_CREDENTIALS` to a writable path"
+                .to_owned(),
+        })?;
+    Ok(home.join(".nanocodex").join("popcorn-mcp-oauth.json"))
+}
+
+/// A file-backed [`McpOAuthStore`] so a second run needs no login.
+///
+/// The file holds one entry per server URL and is created with owner-only
+/// permissions. An exclusive lock serialises readers, writers, and token
+/// refreshes across processes sharing the same file.
+struct PopcornCredentialFile {
+    path: PathBuf,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+struct StoredCredentialFile {
+    #[serde(default)]
+    servers: std::collections::BTreeMap<String, StoredCredential>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct StoredCredential {
+    client_id: String,
+    access_token: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    refresh_token: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    issuer: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    expires_at: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    scopes: Vec<String>,
+}
+
+/// An exclusive lock on the credential file, held until dropped.
+struct CredentialFileLock {
+    _file: std::fs::File,
+}
+
+impl PopcornCredentialFile {
+    const fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    fn lock_path(&self) -> PathBuf {
+        let mut path = self.path.clone();
+        let name = path
+            .file_name()
+            .map(|name| format!("{}.lock", name.to_string_lossy()))
+            .unwrap_or_else(|| "popcorn-mcp-oauth.lock".to_owned());
+        path.set_file_name(name);
+        path
+    }
+
+    fn acquire_lock(&self) -> Result<CredentialFileLock, String> {
+        let path = self.lock_path();
+        create_parent(&path)?;
+        let file = open_private(&path)?;
+        let started = std::time::Instant::now();
+        loop {
+            match file.try_lock() {
+                Ok(()) => return Ok(CredentialFileLock { _file: file }),
+                Err(std::fs::TryLockError::WouldBlock)
+                    if started.elapsed() >= Duration::from_secs(60) =>
+                {
+                    return Err(format!(
+                        "timed out waiting for the Popcorn credential lock {}",
+                        path.display()
+                    ));
+                }
+                Err(std::fs::TryLockError::WouldBlock) => {
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+                Err(error) => {
+                    return Err(format!(
+                        "failed to lock the Popcorn credential file {}: {error}",
+                        path.display()
+                    ));
+                }
+            }
+        }
+    }
+
+    fn read_file(&self) -> Result<StoredCredentialFile, String> {
+        match std::fs::read_to_string(&self.path) {
+            Ok(contents) if contents.trim().is_empty() => Ok(StoredCredentialFile::default()),
+            Ok(contents) => serde_json::from_str(&contents).map_err(|error| {
+                format!(
+                    "failed to parse the Popcorn credential file {}: {error}",
+                    self.path.display()
+                )
+            }),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                Ok(StoredCredentialFile::default())
+            }
+            Err(error) => Err(format!(
+                "failed to read the Popcorn credential file {}: {error}",
+                self.path.display()
+            )),
+        }
+    }
+
+    fn write_file(&self, file: &StoredCredentialFile) -> Result<(), String> {
+        create_parent(&self.path)?;
+        let encoded = serde_json::to_vec_pretty(file)
+            .map_err(|error| format!("failed to encode Popcorn credentials: {error}"))?;
+        // Create the file with owner-only permissions before writing a token to it.
+        drop(open_private(&self.path)?);
+        std::fs::write(&self.path, encoded).map_err(|error| {
+            format!(
+                "failed to write the Popcorn credential file {}: {error}",
+                self.path.display()
+            )
+        })
+    }
+
+    fn load_blocking(&self, server_url: &str) -> Result<Option<McpOAuthCredentials>, String> {
+        let _lock = self.acquire_lock()?;
+        let Some(entry) = self.read_file()?.servers.remove(server_url) else {
+            return Ok(None);
+        };
+        if entry.client_id.trim().is_empty() || entry.access_token.trim().is_empty() {
+            return Err("stored Popcorn OAuth credentials are incomplete".to_owned());
+        }
+        let mut credentials =
+            McpOAuthCredentials::new(entry.client_id, entry.access_token).scopes(entry.scopes);
+        if let Some(refresh_token) = entry.refresh_token.filter(|token| !token.trim().is_empty()) {
+            credentials = credentials.refresh_token(refresh_token);
+        }
+        if let Some(issuer) = entry.issuer.filter(|issuer| !issuer.trim().is_empty()) {
+            credentials = credentials.issuer(issuer);
+        }
+        if let Some(expires_at) = entry.expires_at {
+            credentials = credentials.expires_at_millis(expires_at);
+        }
+        Ok(Some(credentials))
+    }
+
+    fn save_blocking(
+        &self,
+        server_url: &str,
+        credentials: &McpOAuthCredentials,
+    ) -> Result<(), String> {
+        let _lock = self.acquire_lock()?;
+        let mut file = self.read_file()?;
+        file.servers.insert(
+            server_url.to_owned(),
+            StoredCredential {
+                client_id: credentials.client_id().to_owned(),
+                access_token: credentials.access_token().to_owned(),
+                refresh_token: credentials.refresh_token_value().map(ToOwned::to_owned),
+                issuer: credentials.authorization_issuer().map(ToOwned::to_owned),
+                expires_at: credentials.expires_at(),
+                scopes: credentials.granted_scopes().to_vec(),
+            },
+        );
+        self.write_file(&file)
+    }
+}
+
+fn create_parent(path: &Path) -> Result<(), String> {
+    let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    else {
+        return Ok(());
+    };
+    std::fs::create_dir_all(parent)
+        .map_err(|error| format!("failed to create {}: {error}", parent.display()))
+}
+
+/// Opens or creates a file readable and writable only by its owner.
+fn open_private(path: &Path) -> Result<std::fs::File, String> {
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true).write(true).create(true).truncate(false);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options
+        .open(path)
+        .map_err(|error| format!("failed to open {}: {error}", path.display()))
+}
+
+#[async_trait]
+impl McpOAuthStore for PopcornCredentialFile {
+    async fn load(
+        &self,
+        _server_name: &str,
+        server_url: &str,
+    ) -> Result<Option<McpOAuthCredentials>, String> {
+        let store = Self::new(self.path.clone());
+        let server_url = server_url.to_owned();
+        tokio::task::spawn_blocking(move || store.load_blocking(&server_url))
+            .await
+            .map_err(|error| format!("Popcorn credential reader stopped: {error}"))?
+    }
+
+    async fn save(
+        &self,
+        _server_name: &str,
+        server_url: &str,
+        credentials: &McpOAuthCredentials,
+    ) -> Result<(), String> {
+        let store = Self::new(self.path.clone());
+        let server_url = server_url.to_owned();
+        let credentials = credentials.clone();
+        tokio::task::spawn_blocking(move || store.save_blocking(&server_url, &credentials))
+            .await
+            .map_err(|error| format!("Popcorn credential writer stopped: {error}"))?
+    }
+
+    async fn acquire_refresh_lock(
+        &self,
+        _server_name: &str,
+        _server_url: &str,
+    ) -> Result<Box<dyn McpOAuthRefreshGuard>, String> {
+        let store = Self::new(self.path.clone());
+        tokio::task::spawn_blocking(move || {
+            store
+                .acquire_lock()
+                .map(|lock| Box::new(lock) as Box<dyn McpOAuthRefreshGuard>)
+        })
+        .await
+        .map_err(|error| format!("Popcorn credential lock task stopped: {error}"))?
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+
+    fn lookup(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> + use<> {
+        let pairs = pairs
+            .iter()
+            .map(|(name, value)| ((*name).to_owned(), (*value).to_owned()))
+            .collect::<std::collections::BTreeMap<_, _>>();
+        move |name: &str| pairs.get(name).cloned()
+    }
 
     #[test]
     fn create_request_omits_empty_fields() {
@@ -586,6 +1461,317 @@ mod tests {
             config.session_url("abc").unwrap().as_str(),
             "https://control.example.com/v1/session/abc"
         );
-        assert_eq!(config.bearer(), "Bearer id:secret");
+        assert_eq!(config.bearer().unwrap(), "Bearer id:secret");
+    }
+
+    #[test]
+    fn create_session_result_maps_onto_a_session() {
+        // The shape returned by the hosted MCP server: flat snake_case JSON.
+        let payload = json!({
+            "session_id": "pop-123",
+            "live_view_url": "https://browser.example.com/liveview/pop-123/tok/",
+            "cdp_url": "wss://browser.example.com/cdp/pop-123/tok/",
+            "region": "asia-south1",
+            "expires_at": "2026-09-11T09:00:00.000Z",
+            "block_seconds": 600
+        });
+        let session = McpSessionDraft::from_create(&payload)
+            .unwrap()
+            .finish()
+            .unwrap();
+        assert_eq!(session.session_id, "pop-123");
+        assert_eq!(session.url.scheme(), "https");
+        assert_eq!(session.cdp_url.scheme(), "wss");
+        // MCP servers return one agent-facing CDP URL for both fields.
+        assert_eq!(session.cdp_internal_url, session.cdp_url);
+        assert_eq!(session.region.as_deref(), Some("asia-south1"));
+        assert_eq!(
+            session.expires_at.as_deref(),
+            Some("2026-09-11T09:00:00.000Z")
+        );
+        assert!(session.browser_pod_id.is_none());
+    }
+
+    #[test]
+    fn create_session_result_accepts_a_camel_case_envelope() {
+        let payload = json!({
+            "ok": true,
+            "session": {
+                "sessionId": "pop-456",
+                "liveViewUrl": "https://browser.example.com/liveview/pop-456/tok/",
+                "connectUrl": "wss://browser.example.com/cdp/pop-456/tok/",
+                "expiresAt": "2026-09-11T09:10:00.000Z"
+            }
+        });
+        let session = McpSessionDraft::from_create(&payload)
+            .unwrap()
+            .finish()
+            .unwrap();
+        assert_eq!(session.session_id, "pop-456");
+        assert_eq!(session.cdp_url.scheme(), "wss");
+        assert!(session.region.is_none());
+    }
+
+    #[test]
+    fn connection_and_live_view_results_fill_a_partial_session() {
+        let mut draft = McpSessionDraft::from_create(&json!({ "session_id": "pop-789" })).unwrap();
+        assert!(draft.cdp_url.is_none());
+        assert!(draft.live_view_url.is_none());
+
+        draft.merge_connection(&json!({
+            "cdp_url": "wss://browser.example.com/cdp/pop-789/tok/",
+            "region": "us-central1",
+            "expires_at": "2026-09-11T09:20:00.000Z"
+        }));
+        // `get_live_view` names the link `url`, unlike the creation result.
+        draft.merge_live_view(&json!({
+            "url": "https://browser.example.com/liveview/pop-789/tok/"
+        }));
+
+        let session = draft.finish().unwrap();
+        assert_eq!(session.session_id, "pop-789");
+        assert_eq!(session.region.as_deref(), Some("us-central1"));
+        assert_eq!(session.url.path(), "/liveview/pop-789/tok/");
+    }
+
+    #[test]
+    fn create_session_result_without_a_session_id_is_an_error() {
+        let Err(error) = McpSessionDraft::from_create(&json!({ "cdp_url": "wss://example.com/" }))
+        else {
+            panic!("a session id is required");
+        };
+        assert!(
+            matches!(
+                error,
+                PopcornError::MissingField {
+                    field: "session_id"
+                }
+            ),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn session_without_a_cdp_url_is_an_error() {
+        let draft = McpSessionDraft::from_create(&json!({
+            "session_id": "pop-1",
+            "live_view_url": "https://example.com/live"
+        }))
+        .unwrap();
+        let error = draft.finish().expect_err("a CDP URL is required");
+        assert!(
+            matches!(error, PopcornError::MissingField { field: "cdp_url" }),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn session_without_a_live_view_url_is_an_error() {
+        let draft = McpSessionDraft::from_create(&json!({
+            "session_id": "pop-1",
+            "cdp_url": "wss://example.com/cdp"
+        }))
+        .unwrap();
+        let error = draft.finish().expect_err("a LiveView URL is required");
+        assert!(
+            matches!(
+                error,
+                PopcornError::MissingField {
+                    field: "live_view_url"
+                }
+            ),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn a_metered_account_without_credit_reports_a_shortfall() {
+        // The shape returned by the hosted server's `get_balance`.
+        let empty = json!({
+            "credits": 0,
+            "metered": true,
+            "session_block_seconds": 600,
+            "credits_per_operation": 1
+        });
+        let message = credit_shortfall(&empty).expect("no credit left");
+        assert!(message.contains(CREDIT_CHECKOUT_URL), "{message}");
+
+        let funded = json!({ "credits": 12, "metered": true });
+        assert!(credit_shortfall(&funded).is_none());
+        // An unmetered deployment reports no shortfall whatever the balance is.
+        let unmetered = json!({ "credits": 0, "metered": false });
+        assert!(credit_shortfall(&unmetered).is_none());
+        let unknown = json!({ "credits": null, "metered": true });
+        assert!(credit_shortfall(&unknown).is_none());
+    }
+
+    #[test]
+    fn a_shortfall_prefers_the_servers_checkout_url() {
+        let payload = json!({
+            "credits": 0,
+            "metered": true,
+            "checkout_url": "https://checkout.example.com/session/abc"
+        });
+        let message = credit_shortfall(&payload).expect("no credit left");
+        assert!(
+            message.contains("https://checkout.example.com/session/abc"),
+            "{message}"
+        );
+    }
+
+    #[test]
+    fn from_env_defaults_to_the_hosted_mcp_server() {
+        let config = PopcornConfig::from_lookup(&lookup(&[])).unwrap();
+        assert!(config.uses_mcp());
+        let PopcornAccess::HostedMcp { server_url, .. } = &config.access else {
+            panic!("expected MCP mode");
+        };
+        assert_eq!(server_url.as_str(), HOSTED_MCP_URL);
+    }
+
+    #[test]
+    fn from_env_overrides_the_mcp_server_url() {
+        let config = PopcornConfig::from_lookup(&lookup(&[(
+            "POPCORN_MCP_URL",
+            "https://popcorn.internal.example.com/mcp",
+        )]))
+        .unwrap();
+        let PopcornAccess::HostedMcp { server_url, .. } = &config.access else {
+            panic!("expected MCP mode");
+        };
+        assert_eq!(
+            server_url.as_str(),
+            "https://popcorn.internal.example.com/mcp"
+        );
+    }
+
+    #[test]
+    fn from_env_selects_credentialed_mode_when_all_three_are_set() {
+        let config = PopcornConfig::from_lookup(&lookup(&[
+            ("POPCORN_CONTROL_PLANE_URL", "https://control.example.com/"),
+            ("POPCORN_CLIENT_ID", "id"),
+            ("POPCORN_CLIENT_SECRET", "secret"),
+            ("POPCORN_REGION", "us-central1, asia-south1"),
+            ("POPCORN_TTL_SECONDS", "900"),
+        ]))
+        .unwrap();
+        assert!(!config.uses_mcp());
+        assert_eq!(config.bearer().unwrap(), "Bearer id:secret");
+        assert_eq!(config.regions, ["us-central1", "asia-south1"]);
+        assert_eq!(config.ttl_seconds, Some(900));
+    }
+
+    #[test]
+    fn from_env_rejects_a_partial_credentialed_configuration() {
+        let error = PopcornConfig::from_lookup(&lookup(&[
+            ("POPCORN_CONTROL_PLANE_URL", "https://control.example.com/"),
+            ("POPCORN_CLIENT_ID", "id"),
+        ]))
+        .expect_err("a partial credentialed configuration is an error");
+        let message = error.to_string();
+        assert!(message.contains("POPCORN_CLIENT_SECRET"), "{message}");
+    }
+
+    #[test]
+    fn from_env_reads_the_mcp_session_options() {
+        let config = PopcornConfig::from_lookup(&lookup(&[
+            ("POPCORN_PURPOSE", "book a flight"),
+            ("POPCORN_IDEMPOTENCY_KEY", "run-42"),
+            ("POPCORN_PROXY_COUNTRY", "IN"),
+            ("POPCORN_MCP_CREDENTIALS", "/tmp/popcorn.json"),
+        ]))
+        .unwrap();
+        assert_eq!(config.creation_purpose(), "book a flight");
+        assert_eq!(config.creation_idempotency_key(), "run-42");
+        assert_eq!(config.proxy_country.as_deref(), Some("IN"));
+        let PopcornAccess::HostedMcp {
+            credentials_path, ..
+        } = &config.access
+        else {
+            panic!("expected MCP mode");
+        };
+        assert_eq!(
+            credentials_path.as_deref(),
+            Some(Path::new("/tmp/popcorn.json"))
+        );
+    }
+
+    #[test]
+    fn a_generated_idempotency_key_is_unique_per_attempt() {
+        let config = PopcornConfig::hosted_mcp();
+        assert_eq!(config.creation_purpose(), DEFAULT_PURPOSE);
+        assert_ne!(
+            config.creation_idempotency_key(),
+            config.creation_idempotency_key()
+        );
+        // A caller-chosen session id pins the key so a retry cannot pay twice.
+        let pinned = PopcornConfig::hosted_mcp().session_id("run-7");
+        assert_eq!(pinned.creation_idempotency_key(), "run-7");
+    }
+
+    #[test]
+    fn mcp_config_debug_names_the_mode_without_a_secret() {
+        let rendered = format!("{:?}", PopcornConfig::hosted_mcp());
+        assert!(rendered.contains("hosted_mcp"), "{rendered}");
+        assert!(!rendered.contains("client_secret"), "{rendered}");
+    }
+
+    #[tokio::test]
+    async fn the_credential_file_round_trips_and_stays_private() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("nested").join("oauth.json");
+        let store = PopcornCredentialFile::new(path.clone());
+        assert!(
+            store
+                .load(MCP_SERVER_NAME, HOSTED_MCP_URL)
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        let credentials = McpOAuthCredentials::new("client-1", "access-1")
+            .refresh_token("refresh-1")
+            .issuer("https://issuer.example.com")
+            .expires_at_millis(1_800_000_000_000)
+            .scopes(["popcorn.sessions", "popcorn.credit"]);
+        store
+            .save(MCP_SERVER_NAME, HOSTED_MCP_URL, &credentials)
+            .await
+            .unwrap();
+
+        let loaded = store
+            .load(MCP_SERVER_NAME, HOSTED_MCP_URL)
+            .await
+            .unwrap()
+            .expect("stored credentials");
+        assert_eq!(loaded.client_id(), "client-1");
+        assert_eq!(loaded.access_token(), "access-1");
+        assert_eq!(loaded.refresh_token_value(), Some("refresh-1"));
+        assert_eq!(loaded.expires_at(), Some(1_800_000_000_000));
+        assert_eq!(
+            loaded.granted_scopes(),
+            ["popcorn.sessions", "popcorn.credit"]
+        );
+        // Another server URL must not see these credentials.
+        assert!(
+            store
+                .load(MCP_SERVER_NAME, "https://other.example.com/mcp")
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o600, "credential file is not owner-only");
+        }
+    }
+
+    #[test]
+    fn default_credentials_path_prefers_the_configured_path() {
+        let path = default_credentials_path(Some(PathBuf::from("/tmp/popcorn.json"))).unwrap();
+        assert_eq!(path, Path::new("/tmp/popcorn.json"));
     }
 }

--- a/crates/experimental/nanocodex-browser/src/popcorn.rs
+++ b/crates/experimental/nanocodex-browser/src/popcorn.rs
@@ -1,29 +1,16 @@
 //! A Nanocodex browser Hand backed by a rented Popcorn session.
 //!
-//! [Popcorn](https://popcorn.reclaimprotocol.org) rents isolated headful
-//! Chromium sessions that run inside a TEE. Each session exposes a CDP
-//! WebSocket for the agent and a LiveView page a human can open to watch or
-//! take over. This module rents one session, points the ordinary [`Browser`]
-//! controller at its CDP endpoint, and releases the session on shutdown.
+//! [Popcorn](https://github.com/reclaimprotocol/popcorn-oss) rents isolated
+//! headful Chromium sessions that run inside a TEE. Each session exposes a
+//! full-access CDP WebSocket, a human-viewable LiveView page, and an
+//! attestation route. This module rents one session from a Popcorn control
+//! plane, points the ordinary [`Browser`] controller at its CDP endpoint, and
+//! releases the session on shutdown.
 //!
 //! From the agent's point of view a Popcorn browser is just another Hand: the
 //! brain stays wherever it is, and `tools.browser(...)` executes inside the
-//! remote enclave. Because the model never receives a connection URL, the
-//! session capability never enters the conversation.
-//!
-//! # Access modes
-//!
-//! The default is the public pay-per-use endpoint, which needs no account.
-//! Each five-minute block costs $0.01 in USDC on Base, paid per request with
-//! [x402](https://popcorn.reclaimprotocol.org/ai.md): the first request is
-//! answered with a payment challenge, the client validates the offer against a
-//! policy compiled into this module, signs an EIP-3009 transfer authorization,
-//! and repeats the request. Set `POPCORN_PAYER_PRIVATE_KEY` to an EVM key that
-//! holds a little USDC and enough ETH for gas on Base.
-//!
-//! A credentialed control plane remains available for dedicated deployments.
-//! Set `POPCORN_CONTROL_PLANE_URL`, `POPCORN_CLIENT_ID`, and
-//! `POPCORN_CLIENT_SECRET` instead, and no payment is involved.
+//! remote enclave. Because the model never receives the CDP URL, the session
+//! token never enters the conversation.
 //!
 //! # Rent a browser and hand it to an agent
 //!
@@ -44,127 +31,43 @@
 //! # }
 //! ```
 //!
-//! Environment read by [`PopcornConfig::from_env`]:
+//! Required environment for [`PopcornConfig::from_env`]:
 //!
-//! - `POPCORN_PAYER_PRIVATE_KEY`: EVM key that pays for public sessions. When
-//!   set, the public x402 endpoint is used and nothing else is required.
-//! - `POPCORN_CONTROL_PLANE_URL`, `POPCORN_CLIENT_ID`, `POPCORN_CLIENT_SECRET`:
-//!   credentialed access to a dedicated deployment.
-//! - `POPCORN_REGION` (optional, credentialed): comma-separated preference order.
-//! - `POPCORN_TTL_SECONDS` (optional, credentialed): requested session lifetime.
+//! - `POPCORN_CONTROL_PLANE_URL`: base URL of the Popcorn control plane.
+//! - `POPCORN_CLIENT_ID` and `POPCORN_CLIENT_SECRET`: credentialed client.
+//! - `POPCORN_REGION` (optional): comma-separated region preference order.
+//! - `POPCORN_TTL_SECONDS` (optional): requested session lifetime.
 
-use std::borrow::Cow;
 use std::time::Duration;
 
-use alloy_primitives::{Address, B256, U256, hex};
-use alloy_signer::SignerSync;
-use alloy_signer_local::PrivateKeySigner;
-use alloy_sol_types::{Eip712Domain, SolStruct, sol};
-use rand::RngCore;
 use reqwest::{Client, StatusCode};
-use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 use url::Url;
-use uuid::Uuid;
 
 use crate::{Browser, BrowserBuildError, BrowserBuilder, BrowserError, BrowserTool};
 
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 
-// ---------------------------------------------------------------------------
-// Trusted x402 payment policy
-//
-// These values are the client's independent copy of the payment terms. An
-// offer is signed only when it matches them exactly; a challenge is never
-// trusted merely because it arrived in a `402` response.
-// ---------------------------------------------------------------------------
-
-/// Public pay-per-use session endpoint.
-const X402_SESSIONS_URL: &str = "https://app.popcorn.reclaimprotocol.org/v1/x402/sessions";
-/// CAIP-2 identity of Base mainnet.
-const X402_NETWORK: &str = "eip155:8453";
-/// Base mainnet chain id, used in the EIP-712 domain.
-const X402_CHAIN_ID: u64 = 8453;
-/// USDC on Base mainnet.
-const X402_ASSET: &str = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
-/// The only account a session payment may pay.
-const X402_PAY_TO: &str = "0x28f26a191D6bCa1FfD129261E726033188d65138";
-/// Atomic USDC units for one block, `$0.01` at six decimals.
-const X402_ATOMIC_PER_BLOCK: u64 = 10_000;
-/// Only the exact scheme is accepted.
-const X402_SCHEME: &str = "exact";
-/// Only x402 v2 is accepted.
-const X402_VERSION: u32 = 2;
-/// Attempts for one paid action, reusing the original key, body, and signature.
-const X402_MAX_ATTEMPTS: u32 = 5;
-
-/// Seconds of browser time bought by one payment block.
-pub const X402_BLOCK_SECONDS: u64 = 300;
-
-sol! {
-    /// EIP-3009 authorization signed to move USDC for one session action.
-    struct TransferWithAuthorization {
-        address from;
-        address to;
-        uint256 value;
-        uint256 validAfter;
-        uint256 validBefore;
-        bytes32 nonce;
-    }
-}
-
-/// How sessions are obtained from Popcorn.
-#[derive(Clone)]
-enum Access {
-    /// Public pay-per-use endpoint settled with x402 payments.
-    X402 {
-        /// Session collection endpoint.
-        endpoint: Url,
-        /// Hex-encoded EVM key that signs payment authorizations.
-        payer_key: String,
-    },
-    /// Credentialed control plane for a dedicated deployment.
-    Credentialed {
-        /// Control-plane base URL.
-        control_plane: Url,
-        /// Client identity.
-        client_id: String,
-        /// Client secret.
-        client_secret: String,
-    },
-}
-
 /// Everything needed to rent one Popcorn session.
 #[derive(Clone)]
 pub struct PopcornConfig {
-    access: Access,
+    control_plane: Url,
+    client_id: String,
+    client_secret: String,
     regions: Vec<String>,
     ttl_seconds: Option<u64>,
     session_id: Option<String>,
     request_timeout: Duration,
 }
 
-/// Redacts the payer key and client secret, both of which are credentials.
 impl std::fmt::Debug for PopcornConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut out = f.debug_struct("PopcornConfig");
-        match &self.access {
-            Access::X402 { .. } => {
-                out.field("access", &"x402")
-                    .field("payer_key", &"<redacted>");
-            }
-            Access::Credentialed {
-                control_plane,
-                client_id,
-                ..
-            } => {
-                out.field("access", &"credentialed")
-                    .field("control_plane", control_plane)
-                    .field("client_id", client_id)
-                    .field("client_secret", &"<redacted>");
-            }
-        }
-        out.field("regions", &self.regions)
+        f.debug_struct("PopcornConfig")
+            .field("control_plane", &self.control_plane)
+            .field("client_id", &self.client_id)
+            .field("client_secret", &"<redacted>")
+            .field("regions", &self.regions)
             .field("ttl_seconds", &self.ttl_seconds)
             .field("session_id", &self.session_id)
             .field("request_timeout", &self.request_timeout)
@@ -173,24 +76,6 @@ impl std::fmt::Debug for PopcornConfig {
 }
 
 impl PopcornConfig {
-    /// Creates a configuration that pays for public sessions with x402.
-    ///
-    /// `payer_key` is a hex-encoded EVM private key holding USDC and a little
-    /// ETH for gas on Base. It never leaves this process.
-    #[must_use]
-    pub fn x402(payer_key: impl Into<String>) -> Self {
-        Self {
-            access: Access::X402 {
-                endpoint: Url::parse(X402_SESSIONS_URL).expect("static endpoint parses"),
-                payer_key: payer_key.into(),
-            },
-            regions: Vec::new(),
-            ttl_seconds: None,
-            session_id: None,
-            request_timeout: DEFAULT_REQUEST_TIMEOUT,
-        }
-    }
-
     /// Creates a configuration for a credentialed Popcorn client.
     pub fn new(
         control_plane: Url,
@@ -198,11 +83,9 @@ impl PopcornConfig {
         client_secret: impl Into<String>,
     ) -> Self {
         Self {
-            access: Access::Credentialed {
-                control_plane,
-                client_id: client_id.into(),
-                client_secret: client_secret.into(),
-            },
+            control_plane,
+            client_id: client_id.into(),
+            client_secret: client_secret.into(),
             regions: Vec::new(),
             ttl_seconds: None,
             session_id: None,
@@ -212,41 +95,32 @@ impl PopcornConfig {
 
     /// Reads the configuration from `POPCORN_*` environment variables.
     ///
-    /// `POPCORN_PAYER_PRIVATE_KEY` selects the public pay-per-use endpoint.
-    /// Otherwise the credentialed variables are required.
-    ///
     /// # Errors
     ///
-    /// Returns [`PopcornError::Configuration`] when neither access mode is
-    /// fully configured or the control-plane URL does not parse.
+    /// Returns [`PopcornError::Configuration`] when a required variable is
+    /// missing or the control-plane URL does not parse.
     pub fn from_env() -> Result<Self, PopcornError> {
-        if let Some(payer_key) = optional_env("POPCORN_PAYER_PRIVATE_KEY") {
-            return Ok(Self::x402(payer_key));
-        }
-        if optional_env("POPCORN_CONTROL_PLANE_URL").is_none()
-            && optional_env("POPCORN_CLIENT_ID").is_none()
-            && optional_env("POPCORN_CLIENT_SECRET").is_none()
-        {
-            return Err(PopcornError::Configuration {
-                message: "set `POPCORN_PAYER_PRIVATE_KEY` for public pay-per-use sessions, or \
-                          `POPCORN_CONTROL_PLANE_URL`, `POPCORN_CLIENT_ID`, and \
-                          `POPCORN_CLIENT_SECRET` for a dedicated deployment"
-                    .to_owned(),
-            });
+        fn required(name: &str) -> Result<String, PopcornError> {
+            std::env::var(name)
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .ok_or_else(|| PopcornError::Configuration {
+                    message: format!("`{name}` is required"),
+                })
         }
 
         let control_plane =
-            Url::parse(&required_env("POPCORN_CONTROL_PLANE_URL")?).map_err(|error| {
+            Url::parse(&required("POPCORN_CONTROL_PLANE_URL")?).map_err(|error| {
                 PopcornError::Configuration {
                     message: format!("`POPCORN_CONTROL_PLANE_URL` is not a valid URL: {error}"),
                 }
             })?;
         let mut config = Self::new(
             control_plane,
-            required_env("POPCORN_CLIENT_ID")?,
-            required_env("POPCORN_CLIENT_SECRET")?,
+            required("POPCORN_CLIENT_ID")?,
+            required("POPCORN_CLIENT_SECRET")?,
         );
-        if let Some(regions) = optional_env("POPCORN_REGION") {
+        if let Ok(regions) = std::env::var("POPCORN_REGION") {
             config = config.regions(
                 regions
                     .split(',')
@@ -255,8 +129,9 @@ impl PopcornConfig {
                     .map(str::to_owned),
             );
         }
-        if let Some(ttl) = optional_env("POPCORN_TTL_SECONDS") {
+        if let Ok(ttl) = std::env::var("POPCORN_TTL_SECONDS") {
             let ttl = ttl
+                .trim()
                 .parse::<u64>()
                 .map_err(|error| PopcornError::Configuration {
                     message: format!("`POPCORN_TTL_SECONDS` must be a positive integer: {error}"),
@@ -266,14 +141,14 @@ impl PopcornConfig {
         Ok(config)
     }
 
-    /// Sets the region preference order tried by a credentialed control plane.
+    /// Sets the region preference order tried by the control plane.
     #[must_use]
     pub fn regions(mut self, regions: impl IntoIterator<Item = String>) -> Self {
         self.regions = regions.into_iter().collect();
         self
     }
 
-    /// Requests a session lifetime in seconds from a credentialed control plane.
+    /// Requests a session lifetime in seconds.
     #[must_use]
     pub const fn ttl_seconds(mut self, ttl_seconds: u64) -> Self {
         self.ttl_seconds = Some(ttl_seconds);
@@ -287,44 +162,32 @@ impl PopcornConfig {
         self
     }
 
-    /// Overrides the HTTP timeout applied to Popcorn requests.
+    /// Overrides the control-plane HTTP timeout.
     #[must_use]
     pub const fn request_timeout(mut self, timeout: Duration) -> Self {
         self.request_timeout = timeout;
         self
     }
 
-    /// Reports whether this configuration pays per use over x402.
-    #[must_use]
-    pub const fn is_x402(&self) -> bool {
-        matches!(self.access, Access::X402 { .. })
+    fn bearer(&self) -> String {
+        format!("Bearer {}:{}", self.client_id, self.client_secret)
     }
 
-    fn bearer(&self) -> Option<String> {
-        match &self.access {
-            Access::Credentialed {
-                client_id,
-                client_secret,
-                ..
-            } => Some(format!("Bearer {client_id}:{client_secret}")),
-            Access::X402 { .. } => None,
-        }
+    fn sessions_url(&self) -> Result<Url, PopcornError> {
+        self.control_plane
+            .join("v1/sessions")
+            .map_err(|error| PopcornError::Configuration {
+                message: format!("cannot build sessions URL: {error}"),
+            })
     }
-}
 
-/// Reads a non-blank environment variable.
-fn optional_env(name: &str) -> Option<String> {
-    std::env::var(name)
-        .ok()
-        .map(|value| value.trim().to_owned())
-        .filter(|value| !value.is_empty())
-}
-
-/// Reads a required non-blank environment variable.
-fn required_env(name: &str) -> Result<String, PopcornError> {
-    optional_env(name).ok_or_else(|| PopcornError::Configuration {
-        message: format!("`{name}` is required"),
-    })
+    fn session_url(&self, session_id: &str) -> Result<Url, PopcornError> {
+        self.control_plane
+            .join(&format!("v1/session/{session_id}"))
+            .map_err(|error| PopcornError::Configuration {
+                message: format!("cannot build session URL: {error}"),
+            })
+    }
 }
 
 #[derive(Serialize)]
@@ -342,112 +205,48 @@ const fn slice_is_empty(regions: &&[String]) -> bool {
     regions.is_empty()
 }
 
-/// One rented browser session.
+/// The session record returned by the Popcorn control plane.
 ///
-/// Every connection URL, and in pay-per-use mode the session id itself, is a
-/// bearer capability. They are private to this type and [`Debug`] renders none
-/// of the URLs. Give them only to the process that owns the session.
-#[derive(Clone)]
+/// Every URL in this record is a bearer secret. Log the session id, never
+/// the URLs.
+#[derive(Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PopcornSession {
-    session_id: String,
-    live_view: Url,
-    cdp: Url,
-    expires_at: Option<String>,
-    region: Option<String>,
-    cluster_name: Option<String>,
-    browser_pod_id: Option<String>,
-    paid_seconds: Option<u64>,
+    /// Popcorn session identifier.
+    pub session_id: String,
+    /// Human-facing LiveView page for watching or taking over the browser.
+    pub url: Url,
+    /// Restricted client-facing CDP endpoint.
+    pub cdp_url: Url,
+    /// Trusted full-access CDP endpoint used by the agent.
+    pub cdp_internal_url: Url,
+    /// Allocated browser pod identity.
+    #[serde(default)]
+    pub browser_pod_id: Option<String>,
+    /// Session deadline when the control plane set one.
+    #[serde(default)]
+    pub expires_at: Option<String>,
+    /// Selected region.
+    #[serde(default)]
+    pub region: Option<String>,
+    /// Selected cluster.
+    #[serde(default)]
+    pub cluster_name: Option<String>,
 }
 
-impl PopcornSession {
-    /// Returns the session identifier.
-    #[must_use]
-    pub fn session_id(&self) -> &str {
-        &self.session_id
-    }
-
-    /// Returns the LiveView page a human can open to watch or take over.
-    #[must_use]
-    pub const fn live_view_url(&self) -> &Url {
-        &self.live_view
-    }
-
-    /// Returns the session deadline reported by Popcorn.
-    #[must_use]
-    pub fn expires_at(&self) -> Option<&str> {
-        self.expires_at.as_deref()
-    }
-
-    /// Returns the selected region.
-    #[must_use]
-    pub fn region(&self) -> Option<&str> {
-        self.region.as_deref()
-    }
-
-    /// Returns the selected cluster.
-    #[must_use]
-    pub fn cluster_name(&self) -> Option<&str> {
-        self.cluster_name.as_deref()
-    }
-
-    /// Returns the allocated browser pod identity.
-    #[must_use]
-    pub fn browser_pod_id(&self) -> Option<&str> {
-        self.browser_pod_id.as_deref()
-    }
-
-    /// Returns the browser time paid for so far, in seconds.
-    #[must_use]
-    pub const fn paid_seconds(&self) -> Option<u64> {
-        self.paid_seconds
-    }
-}
-
-/// Redacts every session URL, each of which is a bearer capability.
+/// Redacts every session URL, each of which is a bearer secret.
 impl std::fmt::Debug for PopcornSession {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PopcornSession")
             .field("session_id", &self.session_id)
-            .field("live_view", &"<redacted>")
-            .field("cdp", &"<redacted>")
+            .field("url", &"<redacted>")
+            .field("cdp_url", &"<redacted>")
+            .field("cdp_internal_url", &"<redacted>")
+            .field("browser_pod_id", &self.browser_pod_id)
             .field("expires_at", &self.expires_at)
             .field("region", &self.region)
             .field("cluster_name", &self.cluster_name)
-            .field("browser_pod_id", &self.browser_pod_id)
-            .field("paid_seconds", &self.paid_seconds)
             .finish()
-    }
-}
-
-/// The credentialed control-plane session record.
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct CredentialedSession {
-    session_id: String,
-    url: Url,
-    cdp_internal_url: Url,
-    #[serde(default)]
-    browser_pod_id: Option<String>,
-    #[serde(default)]
-    expires_at: Option<String>,
-    #[serde(default)]
-    region: Option<String>,
-    #[serde(default)]
-    cluster_name: Option<String>,
-}
-
-impl From<CredentialedSession> for PopcornSession {
-    fn from(value: CredentialedSession) -> Self {
-        Self {
-            session_id: value.session_id,
-            live_view: value.url,
-            cdp: value.cdp_internal_url,
-            expires_at: value.expires_at,
-            region: value.region,
-            cluster_name: value.cluster_name,
-            browser_pod_id: value.browser_pod_id,
-            paid_seconds: None,
-        }
     }
 }
 
@@ -458,115 +257,10 @@ struct CreateSessionResponse {
     #[serde(default)]
     error: Option<String>,
     #[serde(flatten)]
-    session: Option<CredentialedSession>,
+    session: Option<PopcornSession>,
 }
 
-/// The public pay-per-use session record.
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct X402Session {
-    session_id: String,
-    connect_url: Url,
-    live_view_url: Url,
-    #[serde(default)]
-    expires_at: Option<String>,
-    #[serde(default)]
-    paid_seconds: Option<u64>,
-    #[serde(default)]
-    region: Option<String>,
-    #[serde(default)]
-    cluster_name: Option<String>,
-}
-
-impl From<X402Session> for PopcornSession {
-    fn from(value: X402Session) -> Self {
-        Self {
-            session_id: value.session_id,
-            live_view: value.live_view_url,
-            cdp: value.connect_url,
-            expires_at: value.expires_at,
-            region: value.region,
-            cluster_name: value.cluster_name,
-            browser_pod_id: None,
-            paid_seconds: value.paid_seconds,
-        }
-    }
-}
-
-/// The result of buying more time on an existing session.
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct X402Extension {
-    #[serde(default)]
-    expires_at: Option<String>,
-    #[serde(default)]
-    paid_seconds_total: Option<u64>,
-}
-
-/// One payment offer inside a challenge.
-///
-/// Carries only public payment terms, so it is safe to render.
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct PaymentRequirements {
-    scheme: String,
-    network: String,
-    amount: String,
-    asset: String,
-    pay_to: String,
-    max_timeout_seconds: u64,
-    #[serde(default)]
-    extra: Option<PaymentExtra>,
-}
-
-/// EIP-712 domain parameters carried by an offer.
-#[derive(Debug, Deserialize)]
-struct PaymentExtra {
-    #[serde(default)]
-    name: Option<String>,
-    #[serde(default)]
-    version: Option<String>,
-}
-
-/// A decoded `402` challenge.
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct PaymentRequired {
-    x402_version: u32,
-    #[serde(default)]
-    resource: Option<serde_json::Value>,
-    accepts: Vec<serde_json::Value>,
-}
-
-/// The signed authorization sent back with the paid request.
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct Authorization {
-    from: String,
-    to: String,
-    value: String,
-    valid_after: String,
-    valid_before: String,
-    nonce: String,
-}
-
-#[derive(Serialize)]
-struct Eip3009Payload {
-    authorization: Authorization,
-    signature: String,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct PaymentPayload<'a> {
-    x402_version: u32,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    resource: Option<&'a serde_json::Value>,
-    accepted: &'a serde_json::Value,
-    payload: Eip3009Payload,
-}
-
-/// Errors from renting, driving, paying for, or releasing a Popcorn session.
+/// Errors from renting, driving, or releasing a Popcorn session.
 #[derive(Debug, thiserror::Error)]
 pub enum PopcornError {
     /// The configuration is incomplete or malformed.
@@ -575,34 +269,16 @@ pub enum PopcornError {
         /// Human-readable explanation.
         message: String,
     },
-    /// Popcorn could not be reached.
-    #[error("popcorn request failed: {0}")]
+    /// The control plane could not be reached.
+    #[error("popcorn control plane request failed: {0}")]
     Transport(#[from] reqwest::Error),
-    /// Popcorn rejected the request.
-    #[error("popcorn returned {status}: {body}")]
+    /// The control plane rejected the request.
+    #[error("popcorn control plane returned {status}: {body}")]
     ControlPlane {
         /// HTTP status.
         status: StatusCode,
         /// Response body, truncated.
         body: String,
-    },
-    /// A payment offer did not match the trusted policy, so nothing was signed.
-    #[error("untrusted popcorn payment offer: {detail}")]
-    UntrustedOffer {
-        /// Which term failed the check.
-        detail: String,
-    },
-    /// The payment authorization could not be signed.
-    #[error("popcorn payment could not be signed: {detail}")]
-    Payment {
-        /// Human-readable explanation, never containing key material.
-        detail: String,
-    },
-    /// A Popcorn response could not be decoded.
-    #[error("popcorn response could not be decoded: {detail}")]
-    Decode {
-        /// Human-readable explanation.
-        detail: String,
     },
     /// The browser controller could not be configured for the session.
     #[error(transparent)]
@@ -615,8 +291,7 @@ pub enum PopcornError {
 /// One rented Popcorn session wrapped as a Nanocodex browser Hand.
 ///
 /// Dropping the value without calling [`PopcornBrowser::shutdown`] leaves the
-/// session to expire on its own. Call `shutdown` to release it now; unused
-/// paid time is not refunded.
+/// session to Popcorn's TTL controller. Call `shutdown` to release it now.
 pub struct PopcornBrowser {
     config: PopcornConfig,
     client: Client,
@@ -629,8 +304,8 @@ impl PopcornBrowser {
     ///
     /// # Errors
     ///
-    /// Returns an error when a payment offer is untrusted, when Popcorn
-    /// refuses the session, or when the controller cannot attach.
+    /// Returns an error when the control plane refuses the session or when the
+    /// browser controller cannot be configured for the remote CDP endpoint.
     pub async fn spawn(config: PopcornConfig) -> Result<Self, PopcornError> {
         Self::spawn_with(config, Browser::builder()).await
     }
@@ -649,34 +324,19 @@ impl PopcornBrowser {
     ) -> Result<Self, PopcornError> {
         nanocodex_oai_api::transport::install_default_rustls_crypto_provider();
         let client = Client::builder().timeout(config.request_timeout).build()?;
-        let session = match &config.access {
-            Access::X402 {
-                endpoint,
-                payer_key,
-            } => {
-                let signer = parse_signer(payer_key)?;
-                let created: X402Session = paid_post(
-                    &client,
-                    &signer,
-                    endpoint.clone(),
-                    &serde_json::json!({}),
-                    X402_ATOMIC_PER_BLOCK,
-                )
-                .await?;
-                PopcornSession::from(created)
-            }
-            Access::Credentialed { .. } => create_credentialed_session(&client, &config).await?,
-        };
+        let session = create_session(&client, &config).await?;
         debug!(
             target: "nanocodex_browser",
             session = %session.session_id,
             region = ?session.region,
-            paid_seconds = ?session.paid_seconds,
             "rented popcorn session"
         );
-        // The session is already rented, so release it rather than leaving it
-        // to expire when the controller cannot be attached.
-        let browser = match browser.cdp_endpoint(session.cdp.clone()).build() {
+        // The session is already rented, so release it rather than leaking it to
+        // the TTL controller when the controller cannot be attached.
+        let browser = match browser
+            .cdp_endpoint(session.cdp_internal_url.clone())
+            .build()
+        {
             Ok(browser) => browser,
             Err(error) => {
                 if let Err(release_error) =
@@ -687,7 +347,7 @@ impl PopcornBrowser {
                         session = %session.session_id,
                         error = %release_error,
                         "popcorn session release failed after a failed attach; \
-                         it will expire on its own"
+                         TTL controller will reclaim it"
                     );
                 }
                 return Err(error.into());
@@ -713,7 +373,7 @@ impl PopcornBrowser {
         BrowserTool::from_browser(self.browser.clone())
     }
 
-    /// Returns the session record.
+    /// Returns the session record. Treat every URL in it as a secret.
     #[must_use]
     pub const fn session(&self) -> &PopcornSession {
         &self.session
@@ -722,72 +382,15 @@ impl PopcornBrowser {
     /// Returns the LiveView page a human can open to watch or take over.
     #[must_use]
     pub const fn live_view_url(&self) -> &Url {
-        &self.session.live_view
+        &self.session.url
     }
 
-    /// Buys `blocks` more whole time blocks of
-    /// [`X402_BLOCK_SECONDS`] each, keeping the same browser and URLs.
-    ///
-    /// Start an extension while at least four minutes remain; one presented
-    /// later is rejected before settlement.
+    /// Closes the controller and releases the session on the control plane.
     ///
     /// # Errors
     ///
-    /// Returns [`PopcornError::Configuration`] for a credentialed session or a
-    /// zero block count, and a payment or transport error otherwise.
-    pub async fn extend(&mut self, blocks: u32) -> Result<(), PopcornError> {
-        if blocks == 0 {
-            return Err(PopcornError::Configuration {
-                message: "an extension must buy at least one block".to_owned(),
-            });
-        }
-        let Access::X402 {
-            endpoint,
-            payer_key,
-        } = &self.config.access
-        else {
-            return Err(PopcornError::Configuration {
-                message: "session extension is only available for public pay-per-use sessions"
-                    .to_owned(),
-            });
-        };
-        let signer = parse_signer(payer_key)?;
-        let url = x402_session_url(endpoint, &self.session.session_id, Some("extend"))?;
-        let amount = X402_ATOMIC_PER_BLOCK
-            .checked_mul(u64::from(blocks))
-            .ok_or_else(|| PopcornError::Configuration {
-                message: "requested extension is too large".to_owned(),
-            })?;
-        let extended: X402Extension = paid_post(
-            &self.client,
-            &signer,
-            url,
-            &serde_json::json!({ "blocks": blocks }),
-            amount,
-        )
-        .await?;
-        if extended.expires_at.is_some() {
-            self.session.expires_at = extended.expires_at;
-        }
-        if extended.paid_seconds_total.is_some() {
-            self.session.paid_seconds = extended.paid_seconds_total;
-        }
-        debug!(
-            target: "nanocodex_browser",
-            session = %self.session.session_id,
-            blocks,
-            paid_seconds = ?self.session.paid_seconds,
-            "extended popcorn session"
-        );
-        Ok(())
-    }
-
-    /// Closes the controller and ends the session.
-    ///
-    /// # Errors
-    ///
-    /// Returns the first error from closing the browser or ending the session.
-    /// The termination is attempted even when the close fails.
+    /// Returns the first error from closing the browser or deleting the
+    /// session. The delete is attempted even when the close fails.
     pub async fn shutdown(self) -> Result<(), PopcornError> {
         let close_result = self.browser.close().await.map_err(PopcornError::from);
         let delete_result =
@@ -797,390 +400,28 @@ impl PopcornBrowser {
                 target: "nanocodex_browser",
                 session = %self.session.session_id,
                 %error,
-                "popcorn session release failed; it will expire on its own"
+                "popcorn session release failed; TTL controller will reclaim it"
             );
         }
         close_result.and(delete_result)
     }
 }
 
-/// Builds `<endpoint>/<session id>[/<action>]`.
-fn x402_session_url(
-    endpoint: &Url,
-    session_id: &str,
-    action: Option<&str>,
-) -> Result<Url, PopcornError> {
-    let mut url = endpoint.clone();
-    {
-        let mut path = url
-            .path_segments_mut()
-            .map_err(|()| PopcornError::Configuration {
-                message: "the x402 endpoint cannot have path segments".to_owned(),
-            })?;
-        path.pop_if_empty().push(session_id);
-        if let Some(action) = action {
-            path.push(action);
-        }
-    }
-    Ok(url)
-}
-
-/// Parses the payer key without ever placing it in an error message.
-fn parse_signer(payer_key: &str) -> Result<PrivateKeySigner, PopcornError> {
-    payer_key
-        .parse::<PrivateKeySigner>()
-        .map_err(|_| PopcornError::Payment {
-            detail: "`POPCORN_PAYER_PRIVATE_KEY` is not a valid EVM private key".to_owned(),
-        })
-}
-
-/// Validates one offer against the trusted policy.
-fn validate_offer(offer: &PaymentRequirements, expected_atomic: u64) -> Result<(), PopcornError> {
-    let reject = |detail: String| PopcornError::UntrustedOffer { detail };
-    if offer.scheme != X402_SCHEME {
-        return Err(reject(format!(
-            "scheme is `{}`, expected `{X402_SCHEME}`",
-            offer.scheme
-        )));
-    }
-    if offer.network != X402_NETWORK {
-        return Err(reject(format!(
-            "network is `{}`, expected `{X402_NETWORK}`",
-            offer.network
-        )));
-    }
-    if !offer.asset.eq_ignore_ascii_case(X402_ASSET) {
-        return Err(reject(format!(
-            "asset is `{}`, expected `{X402_ASSET}`",
-            offer.asset
-        )));
-    }
-    if !offer.pay_to.eq_ignore_ascii_case(X402_PAY_TO) {
-        return Err(reject(format!(
-            "payee is `{}`, expected `{X402_PAY_TO}`",
-            offer.pay_to
-        )));
-    }
-    let expected = expected_atomic.to_string();
-    if offer.amount != expected {
-        return Err(reject(format!(
-            "amount is `{}`, expected `{expected}`",
-            offer.amount
-        )));
-    }
-    Ok(())
-}
-
-/// Returns the single trusted offer in a challenge.
-fn select_offer(
-    challenge: &PaymentRequired,
-    expected_atomic: u64,
-) -> Result<(&serde_json::Value, PaymentRequirements), PopcornError> {
-    if challenge.x402_version != X402_VERSION {
-        return Err(PopcornError::UntrustedOffer {
-            detail: format!(
-                "x402 version is {}, expected {X402_VERSION}",
-                challenge.x402_version
-            ),
-        });
-    }
-    let mut trusted = None;
-    let mut last_rejection = None;
-    for raw in &challenge.accepts {
-        let Ok(offer) = serde_json::from_value::<PaymentRequirements>(raw.clone()) else {
-            continue;
-        };
-        match validate_offer(&offer, expected_atomic) {
-            Ok(()) => {
-                if trusted.is_some() {
-                    return Err(PopcornError::UntrustedOffer {
-                        detail: "the challenge carried more than one trusted offer".to_owned(),
-                    });
-                }
-                trusted = Some((raw, offer));
-            }
-            Err(error) => last_rejection = Some(error),
-        }
-    }
-    trusted.ok_or_else(|| {
-        last_rejection.unwrap_or_else(|| PopcornError::UntrustedOffer {
-            detail: "the challenge carried no usable offer".to_owned(),
-        })
-    })
-}
-
-/// Signs the EIP-3009 authorization for one validated offer.
-fn sign_authorization(
-    signer: &PrivateKeySigner,
-    offer: &PaymentRequirements,
-) -> Result<Eip3009Payload, PopcornError> {
-    let extra = offer.extra.as_ref();
-    let (Some(name), Some(version)) = (
-        extra.and_then(|extra| extra.name.clone()),
-        extra.and_then(|extra| extra.version.clone()),
-    ) else {
-        return Err(PopcornError::UntrustedOffer {
-            detail: "the offer is missing the EIP-712 domain name and version".to_owned(),
-        });
-    };
-    let asset = offer
-        .asset
-        .parse::<Address>()
-        .map_err(|error| PopcornError::UntrustedOffer {
-            detail: format!("the offer asset is not an address: {error}"),
-        })?;
-    let pay_to = offer
-        .pay_to
-        .parse::<Address>()
-        .map_err(|error| PopcornError::UntrustedOffer {
-            detail: format!("the offer payee is not an address: {error}"),
-        })?;
-    let value = offer
-        .amount
-        .parse::<U256>()
-        .map_err(|error| PopcornError::UntrustedOffer {
-            detail: format!("the offer amount is not an integer: {error}"),
-        })?;
-
-    let valid_before = unix_now()
-        .checked_add(offer.max_timeout_seconds)
-        .ok_or_else(|| PopcornError::Payment {
-            detail: "the offer timeout overflows the authorization deadline".to_owned(),
-        })?;
-    let mut nonce_bytes = [0u8; 32];
-    rand::rng().fill_bytes(&mut nonce_bytes);
-
-    sign_transfer_authorization(
-        signer,
-        &AuthorizationTerms {
-            asset,
-            pay_to,
-            value,
-            valid_before,
-            nonce: B256::from(nonce_bytes),
-            domain_name: name,
-            domain_version: version,
-        },
-    )
-}
-
-/// The fully resolved terms of one EIP-3009 authorization.
-struct AuthorizationTerms {
-    asset: Address,
-    pay_to: Address,
-    value: U256,
-    valid_before: u64,
-    nonce: B256,
-    domain_name: String,
-    domain_version: String,
-}
-
-/// Signs one authorization, given every term already resolved.
-///
-/// Split out from [`sign_authorization`] so a fixed vector can be checked
-/// against an independent EIP-712 implementation.
-fn sign_transfer_authorization(
-    signer: &PrivateKeySigner,
-    terms: &AuthorizationTerms,
-) -> Result<Eip3009Payload, PopcornError> {
-    let authorization = TransferWithAuthorization {
-        from: signer.address(),
-        to: terms.pay_to,
-        value: terms.value,
-        validAfter: U256::ZERO,
-        validBefore: U256::from(terms.valid_before),
-        nonce: terms.nonce,
-    };
-    let domain = Eip712Domain::new(
-        Some(Cow::Owned(terms.domain_name.clone())),
-        Some(Cow::Owned(terms.domain_version.clone())),
-        Some(U256::from(X402_CHAIN_ID)),
-        Some(terms.asset),
-        None,
-    );
-    let signature = signer
-        .sign_hash_sync(&authorization.eip712_signing_hash(&domain))
-        .map_err(|error| PopcornError::Payment {
-            detail: format!("the wallet refused to sign the authorization: {error}"),
-        })?;
-
-    Ok(Eip3009Payload {
-        authorization: Authorization {
-            from: authorization.from.to_checksum(None),
-            to: authorization.to.to_checksum(None),
-            value: authorization.value.to_string(),
-            valid_after: "0".to_owned(),
-            valid_before: terms.valid_before.to_string(),
-            nonce: format!("0x{}", hex::encode(terms.nonce)),
-        },
-        signature: format!("0x{}", hex::encode(signature.as_bytes())),
-    })
-}
-
-/// Seconds since the Unix epoch.
-fn unix_now() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_or(0, |elapsed| elapsed.as_secs())
-}
-
-/// Decodes a challenge from the `PAYMENT-REQUIRED` header, else the body.
-fn decode_payment_required(
-    header: Option<&str>,
-    body: &str,
-) -> Result<PaymentRequired, PopcornError> {
-    if let Some(header) = header {
-        let decoded = base64_decode(header)?;
-        return serde_json::from_slice(&decoded).map_err(|error| PopcornError::Decode {
-            detail: format!("the PAYMENT-REQUIRED header is not a valid challenge: {error}"),
-        });
-    }
-    serde_json::from_str(body).map_err(|error| PopcornError::Decode {
-        detail: format!("the challenge body could not be parsed: {error}"),
-    })
-}
-
-/// Decodes standard base64 as used by the x402 headers.
-fn base64_decode(value: &str) -> Result<Vec<u8>, PopcornError> {
-    use base64::Engine as _;
-    base64::engine::general_purpose::STANDARD
-        .decode(value.trim())
-        .map_err(|error| PopcornError::Decode {
-            detail: format!("a payment header was not valid base64: {error}"),
-        })
-}
-
-/// Encodes standard base64 as used by the x402 headers.
-fn base64_encode(value: &[u8]) -> String {
-    use base64::Engine as _;
-    base64::engine::general_purpose::STANDARD.encode(value)
-}
-
-/// Performs one paid action: challenge, validate, sign, then retry-safe replay.
-///
-/// A retry reuses the original idempotency key, body, and signature so the
-/// server can return the first result instead of charging twice.
-async fn paid_post<T: DeserializeOwned>(
-    client: &Client,
-    signer: &PrivateKeySigner,
-    url: Url,
-    body: &serde_json::Value,
-    expected_atomic: u64,
-) -> Result<T, PopcornError> {
-    let idempotency_key = Uuid::new_v4().to_string();
-    let body_text = serde_json::to_string(body).map_err(|error| PopcornError::Decode {
-        detail: format!("the request body could not be encoded: {error}"),
-    })?;
-
-    let challenge = client
-        .post(url.clone())
-        .header(reqwest::header::CONTENT_TYPE, "application/json")
-        .header("Idempotency-Key", &idempotency_key)
-        .body(body_text.clone())
-        .send()
-        .await?;
-    let status = challenge.status();
-    let header = challenge
-        .headers()
-        .get("PAYMENT-REQUIRED")
-        .and_then(|value| value.to_str().ok())
-        .map(str::to_owned);
-    let challenge_body = challenge.text().await?;
-    if status != StatusCode::PAYMENT_REQUIRED {
-        return Err(PopcornError::ControlPlane {
-            status,
-            body: truncate(&challenge_body),
-        });
-    }
-
-    let required = decode_payment_required(header.as_deref(), &challenge_body)?;
-    let (raw_offer, offer) = select_offer(&required, expected_atomic)?;
-    let payload = sign_authorization(signer, &offer)?;
-    let signature_header = base64_encode(
-        serde_json::to_string(&PaymentPayload {
-            x402_version: X402_VERSION,
-            resource: required.resource.as_ref(),
-            accepted: raw_offer,
-            payload,
-        })
-        .map_err(|error| PopcornError::Decode {
-            detail: format!("the payment payload could not be encoded: {error}"),
-        })?
-        .as_bytes(),
-    );
-
-    for attempt in 0..X402_MAX_ATTEMPTS {
-        let response = client
-            .post(url.clone())
-            .header(reqwest::header::CONTENT_TYPE, "application/json")
-            .header("Idempotency-Key", &idempotency_key)
-            .header("PAYMENT-SIGNATURE", &signature_header)
-            .body(body_text.clone())
-            .send()
-            .await?;
-        let status = response.status();
-        let retry_after = response
-            .headers()
-            .get(reqwest::header::RETRY_AFTER)
-            .and_then(|value| value.to_str().ok())
-            .and_then(|value| value.trim().parse::<u64>().ok())
-            .unwrap_or(0);
-        let text = response.text().await?;
-
-        if status.is_success() {
-            return serde_json::from_str(&text).map_err(|error| PopcornError::Decode {
-                detail: format!("the paid response could not be parsed: {error}"),
-            });
-        }
-
-        let retryable = matches!(status.as_u16(), 409 | 503);
-        if retryable && retry_after > 0 && attempt + 1 < X402_MAX_ATTEMPTS {
-            debug!(
-                target: "nanocodex_browser",
-                status = status.as_u16(),
-                retry_after,
-                "popcorn payment is settling; replaying the same signed request"
-            );
-            tokio::time::sleep(Duration::from_secs(retry_after)).await;
-            continue;
-        }
-        return Err(PopcornError::ControlPlane {
-            status,
-            body: truncate(&text),
-        });
-    }
-    Err(PopcornError::ControlPlane {
-        status: StatusCode::SERVICE_UNAVAILABLE,
-        body: "the paid request did not settle after the allowed retries".to_owned(),
-    })
-}
-
-/// Creates a session against a credentialed control plane.
-async fn create_credentialed_session(
+async fn create_session(
     client: &Client,
     config: &PopcornConfig,
 ) -> Result<PopcornSession, PopcornError> {
-    let Access::Credentialed { control_plane, .. } = &config.access else {
-        return Err(PopcornError::Configuration {
-            message: "a credentialed control plane is not configured".to_owned(),
-        });
-    };
-    let sessions_url =
-        control_plane
-            .join("v1/sessions")
-            .map_err(|error| PopcornError::Configuration {
-                message: format!("cannot build sessions URL: {error}"),
-            })?;
     let request = CreateSessionRequest {
         session_id: config.session_id.as_deref(),
         ttl_seconds: config.ttl_seconds,
         regions: &config.regions,
     };
-    let mut builder = client.post(sessions_url);
-    if let Some(bearer) = config.bearer() {
-        builder = builder.header(reqwest::header::AUTHORIZATION, bearer);
-    }
-    let response = builder.json(&request).send().await?;
+    let response = client
+        .post(config.sessions_url()?)
+        .header(reqwest::header::AUTHORIZATION, config.bearer())
+        .json(&request)
+        .send()
+        .await?;
     let status = response.status();
     let body = response.text().await?;
     if !status.is_success() {
@@ -1202,34 +443,22 @@ async fn create_credentialed_session(
                 .unwrap_or_else(|| "session creation failed".to_owned()),
         });
     }
-    parsed
-        .session
-        .map(PopcornSession::from)
-        .ok_or_else(|| PopcornError::ControlPlane {
-            status,
-            body: "the session response is missing its connection URL".to_owned(),
-        })
+    parsed.session.ok_or_else(|| PopcornError::ControlPlane {
+        status,
+        body: "session response is missing cdpInternalUrl".to_owned(),
+    })
 }
 
-/// Ends a session. Termination never requires another payment.
 async fn delete_session(
     client: &Client,
     config: &PopcornConfig,
     session_id: &str,
 ) -> Result<(), PopcornError> {
-    let url = match &config.access {
-        Access::X402 { endpoint, .. } => x402_session_url(endpoint, session_id, None)?,
-        Access::Credentialed { control_plane, .. } => control_plane
-            .join(&format!("v1/session/{session_id}"))
-            .map_err(|error| PopcornError::Configuration {
-                message: format!("cannot build session URL: {error}"),
-            })?,
-    };
-    let mut builder = client.delete(url);
-    if let Some(bearer) = config.bearer() {
-        builder = builder.header(reqwest::header::AUTHORIZATION, bearer);
-    }
-    let response = builder.send().await?;
+    let response = client
+        .delete(config.session_url(session_id)?)
+        .header(reqwest::header::AUTHORIZATION, config.bearer())
+        .send()
+        .await?;
     let status = response.status();
     if status.is_success() || status == StatusCode::NOT_FOUND {
         return Ok(());
@@ -1257,232 +486,6 @@ fn truncate(body: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// A challenge matching the trusted policy exactly.
-    fn trusted_challenge(amount: &str) -> serde_json::Value {
-        serde_json::json!({
-            "x402Version": 2,
-            "resource": { "url": X402_SESSIONS_URL },
-            "accepts": [{
-                "scheme": "exact",
-                "network": "eip155:8453",
-                "amount": amount,
-                "asset": X402_ASSET,
-                "payTo": X402_PAY_TO,
-                "maxTimeoutSeconds": 120,
-                "extra": { "name": "USD Coin", "version": "2" }
-            }]
-        })
-    }
-
-    fn offer_with(field: &str, value: serde_json::Value) -> PaymentRequirements {
-        let mut challenge = trusted_challenge("10000");
-        challenge["accepts"][0][field] = value;
-        serde_json::from_value(challenge["accepts"][0].clone()).unwrap()
-    }
-
-    #[test]
-    fn accepts_an_exact_policy_match() {
-        let offer = offer_with("scheme", serde_json::json!("exact"));
-        assert!(validate_offer(&offer, X402_ATOMIC_PER_BLOCK).is_ok());
-    }
-
-    #[test]
-    fn accepts_a_checksum_variant_of_the_trusted_addresses() {
-        let offer = offer_with("asset", serde_json::json!(X402_ASSET.to_lowercase()));
-        assert!(validate_offer(&offer, X402_ATOMIC_PER_BLOCK).is_ok());
-        let offer = offer_with("payTo", serde_json::json!(X402_PAY_TO.to_uppercase()));
-        assert!(validate_offer(&offer, X402_ATOMIC_PER_BLOCK).is_ok());
-    }
-
-    #[test]
-    fn rejects_a_different_network() {
-        let offer = offer_with("network", serde_json::json!("eip155:84532"));
-        let error = validate_offer(&offer, X402_ATOMIC_PER_BLOCK).unwrap_err();
-        assert!(format!("{error}").contains("network"), "{error}");
-    }
-
-    #[test]
-    fn rejects_a_different_asset() {
-        let offer = offer_with(
-            "asset",
-            serde_json::json!("0x0000000000000000000000000000000000000001"),
-        );
-        let error = validate_offer(&offer, X402_ATOMIC_PER_BLOCK).unwrap_err();
-        assert!(format!("{error}").contains("asset"), "{error}");
-    }
-
-    #[test]
-    fn rejects_a_different_payee() {
-        let offer = offer_with(
-            "payTo",
-            serde_json::json!("0x0000000000000000000000000000000000000002"),
-        );
-        let error = validate_offer(&offer, X402_ATOMIC_PER_BLOCK).unwrap_err();
-        assert!(format!("{error}").contains("payee"), "{error}");
-    }
-
-    #[test]
-    fn rejects_a_different_amount() {
-        let offer = offer_with("amount", serde_json::json!("20000"));
-        let error = validate_offer(&offer, X402_ATOMIC_PER_BLOCK).unwrap_err();
-        assert!(format!("{error}").contains("amount"), "{error}");
-    }
-
-    #[test]
-    fn rejects_a_different_scheme() {
-        let offer = offer_with("scheme", serde_json::json!("upto"));
-        let error = validate_offer(&offer, X402_ATOMIC_PER_BLOCK).unwrap_err();
-        assert!(format!("{error}").contains("scheme"), "{error}");
-    }
-
-    #[test]
-    fn rejects_an_unsupported_protocol_version() {
-        let mut challenge = trusted_challenge("10000");
-        challenge["x402Version"] = serde_json::json!(1);
-        let challenge: PaymentRequired = serde_json::from_value(challenge).unwrap();
-        let error = select_offer(&challenge, X402_ATOMIC_PER_BLOCK).unwrap_err();
-        assert!(format!("{error}").contains("x402 version"), "{error}");
-    }
-
-    #[test]
-    fn selects_the_single_trusted_offer_among_untrusted_ones() {
-        let mut challenge = trusted_challenge("10000");
-        let mut hostile = challenge["accepts"][0].clone();
-        hostile["payTo"] = serde_json::json!("0x0000000000000000000000000000000000000003");
-        challenge["accepts"] = serde_json::json!([hostile, challenge["accepts"][0].clone()]);
-        let challenge: PaymentRequired = serde_json::from_value(challenge).unwrap();
-        let (_, offer) = select_offer(&challenge, X402_ATOMIC_PER_BLOCK).unwrap();
-        assert!(offer.pay_to.eq_ignore_ascii_case(X402_PAY_TO));
-    }
-
-    #[test]
-    fn extension_amount_scales_by_whole_blocks() {
-        let offer = offer_with("amount", serde_json::json!("30000"));
-        assert!(validate_offer(&offer, X402_ATOMIC_PER_BLOCK * 3).is_ok());
-        assert!(validate_offer(&offer, X402_ATOMIC_PER_BLOCK).is_err());
-    }
-
-    #[test]
-    fn parses_the_x402_session_shape() {
-        let body = serde_json::json!({
-            "sessionId": "x402s_abc",
-            "sessionUrl": "https://app.example.com/v1/x402/sessions/x402s_abc",
-            "connectUrl": "wss://gateway.example.com/cdp/x402s_abc/tok",
-            "liveViewUrl": "https://gateway.example.com/liveview/x402s_abc/tok/liveview.html",
-            "vncUrl": "https://gateway.example.com/liveview/x402s_abc/tok/liveview.html",
-            "vncWsUrl": "wss://gateway.example.com/liveview-ws/x402s_abc/tok",
-            "expiresAt": "2026-08-04T12:30:00.000Z",
-            "paidSeconds": 300,
-            "region": "asia-south1",
-            "clusterName": "popcorn-prod"
-        });
-        let parsed: X402Session = serde_json::from_value(body).unwrap();
-        let session = PopcornSession::from(parsed);
-        assert_eq!(session.session_id(), "x402s_abc");
-        assert_eq!(session.cdp.scheme(), "wss");
-        assert_eq!(session.paid_seconds(), Some(300));
-        assert_eq!(session.region(), Some("asia-south1"));
-    }
-
-    #[test]
-    fn parses_the_x402_extension_shape() {
-        let body = serde_json::json!({
-            "sessionId": "x402s_abc",
-            "additionalSeconds": 600,
-            "paidSecondsTotal": 900,
-            "expiresAt": "2026-08-04T12:40:00.000Z"
-        });
-        let parsed: X402Extension = serde_json::from_value(body).unwrap();
-        assert_eq!(parsed.paid_seconds_total, Some(900));
-        assert_eq!(
-            parsed.expires_at.as_deref(),
-            Some("2026-08-04T12:40:00.000Z")
-        );
-    }
-
-    #[test]
-    fn decodes_a_challenge_from_the_header_before_the_body() {
-        let header = base64_encode(trusted_challenge("10000").to_string().as_bytes());
-        let decoded = decode_payment_required(Some(&header), "not json").unwrap();
-        assert_eq!(decoded.x402_version, 2);
-        assert_eq!(decoded.accepts.len(), 1);
-    }
-
-    #[test]
-    fn decodes_a_challenge_from_the_body_when_no_header_is_present() {
-        let body = trusted_challenge("10000").to_string();
-        let decoded = decode_payment_required(None, &body).unwrap();
-        assert_eq!(decoded.x402_version, 2);
-    }
-
-    #[test]
-    fn signs_the_authorization_the_policy_validated() {
-        let signer = PrivateKeySigner::random();
-        let offer = offer_with("scheme", serde_json::json!("exact"));
-        let payload = sign_authorization(&signer, &offer).unwrap();
-        assert!(payload.authorization.to.eq_ignore_ascii_case(X402_PAY_TO));
-        assert_eq!(payload.authorization.value, "10000");
-        assert_eq!(payload.authorization.valid_after, "0");
-        assert_eq!(payload.signature.len(), 2 + 130);
-        assert!(payload.authorization.nonce.starts_with("0x"));
-        assert_eq!(payload.authorization.nonce.len(), 2 + 64);
-    }
-
-    /// Cross-checks the EIP-712 signature against `viem`, the implementation
-    /// the Popcorn reference client uses, for one fixed vector. A mistake in
-    /// the domain, the struct definition, or the signature encoding changes
-    /// this value.
-    ///
-    /// The key is the published Anvil test key, never used to hold funds.
-    #[test]
-    fn signature_matches_the_reference_eip712_implementation() {
-        let signer: PrivateKeySigner =
-            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-                .parse()
-                .unwrap();
-        assert_eq!(
-            signer.address().to_checksum(None),
-            "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
-        );
-        let terms = AuthorizationTerms {
-            asset: X402_ASSET.parse().unwrap(),
-            pay_to: X402_PAY_TO.parse().unwrap(),
-            value: U256::from(10_000u64),
-            valid_before: 1_789_000_000,
-            nonce: "0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
-                .parse()
-                .unwrap(),
-            domain_name: "USD Coin".to_owned(),
-            domain_version: "2".to_owned(),
-        };
-        let payload = sign_transfer_authorization(&signer, &terms).unwrap();
-        assert_eq!(
-            payload.signature,
-            "0xb8ab7bc63d1242be4e03cf85096be78cdd465f15c84d64f6fab87bbe0631cdbc\
-6644968e60ad0e7b243957af4a5ddfb19591b5d88f687a1a2b0153e4c68bfc7c1b"
-                .replace('\n', "")
-        );
-        assert_eq!(payload.authorization.valid_before, "1789000000");
-        assert_eq!(payload.authorization.value, "10000");
-    }
-
-    #[test]
-    fn builds_x402_session_urls() {
-        let endpoint = Url::parse(X402_SESSIONS_URL).unwrap();
-        assert_eq!(
-            x402_session_url(&endpoint, "x402s_abc", None)
-                .unwrap()
-                .path(),
-            "/v1/x402/sessions/x402s_abc"
-        );
-        assert_eq!(
-            x402_session_url(&endpoint, "x402s_abc", Some("extend"))
-                .unwrap()
-                .path(),
-            "/v1/x402/sessions/x402s_abc/extend"
-        );
-    }
 
     #[test]
     fn create_request_omits_empty_fields() {
@@ -1523,30 +526,22 @@ mod tests {
             "clusterName": "popcorn-prod-us"
         }"#;
         let parsed: CreateSessionResponse = serde_json::from_str(body).unwrap();
-        let session = PopcornSession::from(parsed.session.unwrap());
-        assert_eq!(session.session_id(), "demo-session");
-        assert_eq!(session.cdp.scheme(), "wss");
-        assert_eq!(session.region(), Some("us-central1"));
-    }
-
-    #[test]
-    fn failed_response_surfaces_error_message() {
-        let body = r#"{"success": false, "error": "no capacity in region"}"#;
-        let parsed: CreateSessionResponse = serde_json::from_str(body).unwrap();
-        assert_eq!(parsed.success, Some(false));
-        assert_eq!(parsed.error.as_deref(), Some("no capacity in region"));
-        assert!(parsed.session.is_none());
+        let session = parsed.session.unwrap();
+        assert_eq!(session.session_id, "demo-session");
+        assert_eq!(session.cdp_internal_url.scheme(), "wss");
+        assert_eq!(session.region.as_deref(), Some("us-central1"));
     }
 
     #[test]
     fn debug_output_redacts_session_urls() {
-        let body = serde_json::json!({
+        let body = r#"{
             "sessionId": "demo-session",
-            "connectUrl": "wss://browser.example.com/cdp/demo-session/tok",
-            "liveViewUrl": "https://browser.example.com/liveview/demo-session/tok/liveview.html"
-        });
-        let parsed: X402Session = serde_json::from_value(body).unwrap();
-        let rendered = format!("{:?}", PopcornSession::from(parsed));
+            "url": "https://browser.example.com/liveview/demo-session/tok/liveview.html",
+            "cdpUrl": "wss://browser.example.com/cdp/demo-session/tok/",
+            "cdpInternalUrl": "wss://browser.example.com/cdp-internal/demo-session/tok/"
+        }"#;
+        let session: PopcornSession = serde_json::from_str(body).unwrap();
+        let rendered = format!("{session:?}");
         assert!(!rendered.contains("tok"), "session URLs leaked: {rendered}");
         assert!(!rendered.contains("browser.example.com"));
         assert!(rendered.contains("demo-session"));
@@ -1568,33 +563,29 @@ mod tests {
     }
 
     #[test]
-    fn debug_output_redacts_the_payer_key() {
-        let config = PopcornConfig::x402(
-            "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
-        );
-        let rendered = format!("{config:?}");
-        assert!(
-            !rendered.contains("59c6995e"),
-            "payer key leaked: {rendered}"
-        );
-        assert!(rendered.contains("x402"));
-        assert!(config.is_x402());
+    fn failed_response_surfaces_error_message() {
+        let body = r#"{"success": false, "error": "no capacity in region"}"#;
+        let parsed: CreateSessionResponse = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed.success, Some(false));
+        assert_eq!(parsed.error.as_deref(), Some("no capacity in region"));
+        assert!(parsed.session.is_none());
     }
 
     #[test]
-    fn credentialed_config_builds_control_plane_urls() {
+    fn config_builds_control_plane_urls() {
         let config = PopcornConfig::new(
             Url::parse("https://control.example.com/").unwrap(),
             "id",
             "secret",
         );
-        assert!(!config.is_x402());
-        assert_eq!(config.bearer().as_deref(), Some("Bearer id:secret"));
-    }
-
-    #[test]
-    fn x402_config_sends_no_bearer_credential() {
-        let config = PopcornConfig::x402("0x01");
-        assert!(config.bearer().is_none());
+        assert_eq!(
+            config.sessions_url().unwrap().as_str(),
+            "https://control.example.com/v1/sessions"
+        );
+        assert_eq!(
+            config.session_url("abc").unwrap().as_str(),
+            "https://control.example.com/v1/session/abc"
+        );
+        assert_eq!(config.bearer(), "Bearer id:secret");
     }
 }

--- a/crates/experimental/nanocodex-browser/src/popcorn.rs
+++ b/crates/experimental/nanocodex-browser/src/popcorn.rs
@@ -115,6 +115,7 @@ const LIVE_VIEW_KEYS: &[&str] = &[
 const REGION_KEYS: &[&str] = &["region"];
 const EXPIRES_KEYS: &[&str] = &["expires_at", "expiresAt"];
 const CHECKOUT_KEYS: &[&str] = &["checkout_url", "checkoutUrl"];
+const NEXT_ACTION_KEYS: &[&str] = &["next_action", "nextAction"];
 
 /// How a session is rented.
 #[derive(Clone)]
@@ -659,7 +660,11 @@ fn lookup_str(payload: &Value, keys: &[&str]) -> Option<String> {
     walk(payload, keys, MAX_DEPTH)
 }
 
-/// Returns a human-readable shortfall when a metered account is out of credit.
+/// Describes the shortfall when a metered account has no session credit left.
+///
+/// This is diagnostic only. The authoritative out-of-credit signal is the
+/// `create_browser_session` response, which carries the checkout link a human
+/// needs; see [`call_mcp_tool`].
 fn credit_shortfall(payload: &Value) -> Option<String> {
     let metered = payload
         .get("metered")
@@ -669,9 +674,9 @@ fn credit_shortfall(payload: &Value) -> Option<String> {
     if !metered || credits > 0.0 {
         return None;
     }
-    let checkout =
-        lookup_str(payload, CHECKOUT_KEYS).unwrap_or_else(|| CREDIT_CHECKOUT_URL.to_owned());
-    Some(format!("buy credits at {checkout} and run again"))
+    Some(format!(
+        "{credits} credits remaining on a metered deployment"
+    ))
 }
 
 /// Errors from renting, driving, or releasing a Popcorn session.
@@ -921,13 +926,18 @@ async fn create_mcp_session(
     handle: &McpHandle,
     config: &PopcornConfig,
 ) -> Result<PopcornSession, PopcornError> {
-    // Checking the balance first is free and turns an out-of-credit run into a
-    // clear instruction instead of a failed session creation.
-    let balance = call_mcp_tool(handle, BALANCE_TOOL, Map::new()).await?;
-    if let Ok(payload) = balance.json()
-        && let Some(message) = credit_shortfall(&payload)
+    // The balance is free to read and worth logging, but it must not short
+    // circuit creation: only `create_browser_session` returns the human
+    // checkout link for buying credits, so an out-of-credit run has to reach it.
+    if let Ok(balance) = call_mcp_tool(handle, BALANCE_TOOL, Map::new()).await
+        && let Ok(payload) = balance.json()
+        && let Some(shortfall) = credit_shortfall(&payload)
     {
-        return Err(PopcornError::InsufficientCredit { message });
+        debug!(
+            target: "nanocodex_browser",
+            shortfall,
+            "popcorn reports no session credit; asking the server for a checkout link"
+        );
     }
 
     let mut arguments = Map::new();
@@ -995,19 +1005,60 @@ async fn call_mcp_tool(
         return Ok(call);
     }
     let detail = call.text().trim().to_owned();
-    let checkout = call
-        .json()
-        .ok()
-        .as_ref()
-        .and_then(|payload| lookup_str(payload, CHECKOUT_KEYS));
+    let payload = call.json().ok();
+    let checkout = payload.as_ref().and_then(checkout_link);
+    // An out-of-credit creation answers with a checkout link for the human;
+    // hand it over unchanged and stop rather than retrying.
     if let Some(checkout) = checkout {
         return Err(PopcornError::InsufficientCredit {
-            message: format!("buy credits at {checkout} and run again"),
+            message: format!(
+                "open {checkout} to buy credits, then retry with the same idempotency key"
+            ),
+        });
+    }
+    if payload.as_ref().is_some_and(payload_is_out_of_credit) {
+        // The server sent no `checkout_url` field, so pass its own wording
+        // through: deployments put the payment link in the message text.
+        return Err(PopcornError::InsufficientCredit {
+            message: if detail.is_empty() {
+                format!("buy credits at {CREDIT_CHECKOUT_URL}")
+            } else {
+                truncate(&detail)
+            },
         });
     }
     Err(PopcornError::Mcp {
         message: format!("`{tool}` failed: {}", truncate(&detail)),
     })
+}
+
+/// Finds the human approval link in an out-of-credit refusal.
+///
+/// The hosted server answers with a `next_action` of type `external_approval`
+/// holding the link; other deployments may name it `checkout_url`. The link is
+/// read only from those positions, never from a generic `url` field, so a
+/// session's LiveView URL can never be mistaken for a payment link.
+fn checkout_link(payload: &Value) -> Option<String> {
+    for key in NEXT_ACTION_KEYS {
+        if let Some(action) = payload.get(*key)
+            && let Some(url) = lookup_str(action, &["url"])
+        {
+            return Some(url);
+        }
+    }
+    lookup_str(payload, CHECKOUT_KEYS)
+}
+
+/// Detects an out-of-credit refusal that carried no checkout link.
+fn payload_is_out_of_credit(payload: &Value) -> bool {
+    payload
+        .get("error")
+        .or_else(|| payload.get("code"))
+        .and_then(Value::as_str)
+        .is_some_and(|error| {
+            let error = error.to_ascii_lowercase();
+            error.contains("credit") || error.contains("payment")
+        })
 }
 
 const fn map_mcp_error(message: String) -> PopcornError {
@@ -1593,8 +1644,7 @@ mod tests {
             "session_block_seconds": 600,
             "credits_per_operation": 1
         });
-        let message = credit_shortfall(&empty).expect("no credit left");
-        assert!(message.contains(CREDIT_CHECKOUT_URL), "{message}");
+        assert!(credit_shortfall(&empty).is_some(), "no credit left");
 
         let funded = json!({ "credits": 12, "metered": true });
         assert!(credit_shortfall(&funded).is_none());
@@ -1606,16 +1656,69 @@ mod tests {
     }
 
     #[test]
-    fn a_shortfall_prefers_the_servers_checkout_url() {
-        let payload = json!({
-            "credits": 0,
-            "metered": true,
+    fn an_out_of_credit_refusal_is_recognised_by_its_error_field() {
+        assert!(payload_is_out_of_credit(
+            &json!({ "error": "INSUFFICIENT_CREDIT" })
+        ));
+        assert!(payload_is_out_of_credit(
+            &json!({ "code": "payment_required" })
+        ));
+        assert!(!payload_is_out_of_credit(
+            &json!({ "error": "no capacity" })
+        ));
+        assert!(!payload_is_out_of_credit(&json!({ "session_id": "pop-1" })));
+    }
+
+    #[test]
+    fn the_hosted_servers_refusal_yields_its_approval_link() {
+        // Verbatim shape returned by the hosted server when credit runs out.
+        let refusal = json!({
+            "error": "insufficient_credit",
+            "message": "Not enough usage credit for this operation.",
+            "next_action": {
+                "type": "external_approval",
+                "url": "https://popcorn-billing-gcp.reclaimprotocol.org/checkout?token=opaque"
+            },
+            "next": "Give the human next_action to obtain more credit, then retry with the same idempotency_key."
+        });
+        assert!(payload_is_out_of_credit(&refusal));
+        assert_eq!(
+            checkout_link(&refusal).as_deref(),
+            Some("https://popcorn-billing-gcp.reclaimprotocol.org/checkout?token=opaque")
+        );
+    }
+
+    #[test]
+    fn a_live_view_url_is_never_read_as_a_payment_link() {
+        // A successful creation has a `url`, which must not look like checkout.
+        let created = json!({
+            "session_id": "pop-1",
+            "url": "https://browser.example.com/liveview/pop-1/tok/",
+            "cdp_url": "wss://browser.example.com/cdp/pop-1/tok/"
+        });
+        assert!(checkout_link(&created).is_none());
+        assert!(!payload_is_out_of_credit(&created));
+    }
+
+    #[test]
+    fn the_servers_checkout_link_is_found_in_a_refusal() {
+        // Only the creation response carries the link a human can pay at, so it
+        // must survive whatever envelope the server wraps it in.
+        let flat = json!({
+            "error": "insufficient_credit",
             "checkout_url": "https://checkout.example.com/session/abc"
         });
-        let message = credit_shortfall(&payload).expect("no credit left");
-        assert!(
-            message.contains("https://checkout.example.com/session/abc"),
-            "{message}"
+        assert_eq!(
+            lookup_str(&flat, CHECKOUT_KEYS).as_deref(),
+            Some("https://checkout.example.com/session/abc")
+        );
+        let nested = json!({
+            "error": { "code": "insufficient_credit" },
+            "billing": { "checkoutUrl": "https://checkout.example.com/session/xyz" }
+        });
+        assert_eq!(
+            lookup_str(&nested, CHECKOUT_KEYS).as_deref(),
+            Some("https://checkout.example.com/session/xyz")
         );
     }
 

--- a/crates/experimental/nanocodex-browser/src/popcorn.rs
+++ b/crates/experimental/nanocodex-browser/src/popcorn.rs
@@ -1,0 +1,571 @@
+//! A Nanocodex browser Hand backed by a rented Popcorn session.
+//!
+//! [Popcorn](https://github.com/reclaimprotocol/popcorn-oss) rents isolated
+//! headful Chromium sessions that run inside a TEE. Each session exposes a
+//! full-access CDP WebSocket, a human-viewable LiveView page, and an
+//! attestation route. This module rents one session from a Popcorn control
+//! plane, points the ordinary [`Browser`] controller at its CDP endpoint, and
+//! releases the session on shutdown.
+//!
+//! From the agent's point of view a Popcorn browser is just another Hand: the
+//! brain stays wherever it is, and `tools.browser(...)` executes inside the
+//! remote enclave. Because the model never receives the CDP URL, the session
+//! token never enters the conversation.
+//!
+//! # Rent a browser and hand it to an agent
+//!
+//! ```no_run
+//! use nanocodex_browser::popcorn::{PopcornBrowser, PopcornConfig};
+//!
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! let config = PopcornConfig::from_env()?;
+//! let browser = PopcornBrowser::spawn(config).await?;
+//!
+//! println!("watch or take over at {}", browser.live_view_url());
+//!
+//! let tool = browser.tool();
+//! // Pass `tool` to `Tools::builder().provider(tool)`.
+//! drop(tool);
+//! browser.shutdown().await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Required environment for [`PopcornConfig::from_env`]:
+//!
+//! - `POPCORN_CONTROL_PLANE_URL`: base URL of the Popcorn control plane.
+//! - `POPCORN_CLIENT_ID` and `POPCORN_CLIENT_SECRET`: credentialed client.
+//! - `POPCORN_REGION` (optional): comma-separated region preference order.
+//! - `POPCORN_TTL_SECONDS` (optional): requested session lifetime.
+
+use std::time::Duration;
+
+use reqwest::{Client, StatusCode};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+use url::Url;
+
+use crate::{Browser, BrowserBuildError, BrowserBuilder, BrowserError, BrowserTool};
+
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Everything needed to rent one Popcorn session.
+#[derive(Clone)]
+pub struct PopcornConfig {
+    control_plane: Url,
+    client_id: String,
+    client_secret: String,
+    regions: Vec<String>,
+    ttl_seconds: Option<u64>,
+    session_id: Option<String>,
+    request_timeout: Duration,
+}
+
+impl std::fmt::Debug for PopcornConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PopcornConfig")
+            .field("control_plane", &self.control_plane)
+            .field("client_id", &self.client_id)
+            .field("client_secret", &"<redacted>")
+            .field("regions", &self.regions)
+            .field("ttl_seconds", &self.ttl_seconds)
+            .field("session_id", &self.session_id)
+            .field("request_timeout", &self.request_timeout)
+            .finish()
+    }
+}
+
+impl PopcornConfig {
+    /// Creates a configuration for a credentialed Popcorn client.
+    pub fn new(
+        control_plane: Url,
+        client_id: impl Into<String>,
+        client_secret: impl Into<String>,
+    ) -> Self {
+        Self {
+            control_plane,
+            client_id: client_id.into(),
+            client_secret: client_secret.into(),
+            regions: Vec::new(),
+            ttl_seconds: None,
+            session_id: None,
+            request_timeout: DEFAULT_REQUEST_TIMEOUT,
+        }
+    }
+
+    /// Reads the configuration from `POPCORN_*` environment variables.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PopcornError::Configuration`] when a required variable is
+    /// missing or the control-plane URL does not parse.
+    pub fn from_env() -> Result<Self, PopcornError> {
+        fn required(name: &str) -> Result<String, PopcornError> {
+            std::env::var(name)
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .ok_or_else(|| PopcornError::Configuration {
+                    message: format!("`{name}` is required"),
+                })
+        }
+
+        let control_plane =
+            Url::parse(&required("POPCORN_CONTROL_PLANE_URL")?).map_err(|error| {
+                PopcornError::Configuration {
+                    message: format!("`POPCORN_CONTROL_PLANE_URL` is not a valid URL: {error}"),
+                }
+            })?;
+        let mut config = Self::new(
+            control_plane,
+            required("POPCORN_CLIENT_ID")?,
+            required("POPCORN_CLIENT_SECRET")?,
+        );
+        if let Ok(regions) = std::env::var("POPCORN_REGION") {
+            config = config.regions(
+                regions
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|region| !region.is_empty())
+                    .map(str::to_owned),
+            );
+        }
+        if let Ok(ttl) = std::env::var("POPCORN_TTL_SECONDS") {
+            let ttl = ttl
+                .trim()
+                .parse::<u64>()
+                .map_err(|error| PopcornError::Configuration {
+                    message: format!("`POPCORN_TTL_SECONDS` must be a positive integer: {error}"),
+                })?;
+            config = config.ttl_seconds(ttl);
+        }
+        Ok(config)
+    }
+
+    /// Sets the region preference order tried by the control plane.
+    #[must_use]
+    pub fn regions(mut self, regions: impl IntoIterator<Item = String>) -> Self {
+        self.regions = regions.into_iter().collect();
+        self
+    }
+
+    /// Requests a session lifetime in seconds.
+    #[must_use]
+    pub const fn ttl_seconds(mut self, ttl_seconds: u64) -> Self {
+        self.ttl_seconds = Some(ttl_seconds);
+        self
+    }
+
+    /// Uses a caller-chosen session identifier instead of a generated one.
+    #[must_use]
+    pub fn session_id(mut self, session_id: impl Into<String>) -> Self {
+        self.session_id = Some(session_id.into());
+        self
+    }
+
+    /// Overrides the control-plane HTTP timeout.
+    #[must_use]
+    pub const fn request_timeout(mut self, timeout: Duration) -> Self {
+        self.request_timeout = timeout;
+        self
+    }
+
+    fn bearer(&self) -> String {
+        format!("Bearer {}:{}", self.client_id, self.client_secret)
+    }
+
+    fn sessions_url(&self) -> Result<Url, PopcornError> {
+        self.control_plane
+            .join("v1/sessions")
+            .map_err(|error| PopcornError::Configuration {
+                message: format!("cannot build sessions URL: {error}"),
+            })
+    }
+
+    fn session_url(&self, session_id: &str) -> Result<Url, PopcornError> {
+        self.control_plane
+            .join(&format!("v1/session/{session_id}"))
+            .map_err(|error| PopcornError::Configuration {
+                message: format!("cannot build session URL: {error}"),
+            })
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateSessionRequest<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    session_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ttl_seconds: Option<u64>,
+    #[serde(skip_serializing_if = "slice_is_empty")]
+    regions: &'a [String],
+}
+
+const fn slice_is_empty(regions: &&[String]) -> bool {
+    regions.is_empty()
+}
+
+/// The session record returned by the Popcorn control plane.
+///
+/// Every URL in this record is a bearer secret. Log the session id, never
+/// the URLs.
+#[derive(Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PopcornSession {
+    /// Popcorn session identifier.
+    pub session_id: String,
+    /// Human-facing LiveView page for watching or taking over the browser.
+    pub url: Url,
+    /// Restricted client-facing CDP endpoint.
+    pub cdp_url: Url,
+    /// Trusted full-access CDP endpoint used by the agent.
+    pub cdp_internal_url: Url,
+    /// Allocated browser pod identity.
+    #[serde(default)]
+    pub browser_pod_id: Option<String>,
+    /// Session deadline when the control plane set one.
+    #[serde(default)]
+    pub expires_at: Option<String>,
+    /// Selected region.
+    #[serde(default)]
+    pub region: Option<String>,
+    /// Selected cluster.
+    #[serde(default)]
+    pub cluster_name: Option<String>,
+}
+
+/// Redacts every session URL, each of which is a bearer secret.
+impl std::fmt::Debug for PopcornSession {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PopcornSession")
+            .field("session_id", &self.session_id)
+            .field("url", &"<redacted>")
+            .field("cdp_url", &"<redacted>")
+            .field("cdp_internal_url", &"<redacted>")
+            .field("browser_pod_id", &self.browser_pod_id)
+            .field("expires_at", &self.expires_at)
+            .field("region", &self.region)
+            .field("cluster_name", &self.cluster_name)
+            .finish()
+    }
+}
+
+#[derive(Deserialize)]
+struct CreateSessionResponse {
+    #[serde(default)]
+    success: Option<bool>,
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(flatten)]
+    session: Option<PopcornSession>,
+}
+
+/// Errors from renting, driving, or releasing a Popcorn session.
+#[derive(Debug, thiserror::Error)]
+pub enum PopcornError {
+    /// The configuration is incomplete or malformed.
+    #[error("popcorn configuration error: {message}")]
+    Configuration {
+        /// Human-readable explanation.
+        message: String,
+    },
+    /// The control plane could not be reached.
+    #[error("popcorn control plane request failed: {0}")]
+    Transport(#[from] reqwest::Error),
+    /// The control plane rejected the request.
+    #[error("popcorn control plane returned {status}: {body}")]
+    ControlPlane {
+        /// HTTP status.
+        status: StatusCode,
+        /// Response body, truncated.
+        body: String,
+    },
+    /// The browser controller could not be configured for the session.
+    #[error(transparent)]
+    Build(#[from] BrowserBuildError),
+    /// A browser action failed.
+    #[error(transparent)]
+    Browser(#[from] BrowserError),
+}
+
+/// One rented Popcorn session wrapped as a Nanocodex browser Hand.
+///
+/// Dropping the value without calling [`PopcornBrowser::shutdown`] leaves the
+/// session to Popcorn's TTL controller. Call `shutdown` to release it now.
+pub struct PopcornBrowser {
+    config: PopcornConfig,
+    client: Client,
+    session: PopcornSession,
+    browser: Browser,
+}
+
+impl PopcornBrowser {
+    /// Rents a Popcorn session and attaches the browser controller to it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the control plane refuses the session or when the
+    /// browser controller cannot be configured for the remote CDP endpoint.
+    pub async fn spawn(config: PopcornConfig) -> Result<Self, PopcornError> {
+        Self::spawn_with(config, Browser::builder()).await
+    }
+
+    /// Rents a Popcorn session using caller-provided browser settings.
+    ///
+    /// The builder's `cdp_endpoint` is replaced with the rented session's
+    /// endpoint; other settings compatible with a remote CDP boundary are kept.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`PopcornBrowser::spawn`].
+    pub async fn spawn_with(
+        config: PopcornConfig,
+        browser: BrowserBuilder,
+    ) -> Result<Self, PopcornError> {
+        let client = Client::builder().timeout(config.request_timeout).build()?;
+        let session = create_session(&client, &config).await?;
+        debug!(
+            target: "nanocodex_browser",
+            session = %session.session_id,
+            region = ?session.region,
+            "rented popcorn session"
+        );
+        let browser = browser
+            .cdp_endpoint(session.cdp_internal_url.clone())
+            .build()?;
+        Ok(Self {
+            config,
+            client,
+            session,
+            browser,
+        })
+    }
+
+    /// Returns the browser controller driving the remote session.
+    #[must_use]
+    pub const fn browser(&self) -> &Browser {
+        &self.browser
+    }
+
+    /// Wraps the remote session as an ordinary Nanocodex browser tool.
+    #[must_use]
+    pub fn tool(&self) -> BrowserTool {
+        BrowserTool::from_browser(self.browser.clone())
+    }
+
+    /// Returns the session record. Treat every URL in it as a secret.
+    #[must_use]
+    pub const fn session(&self) -> &PopcornSession {
+        &self.session
+    }
+
+    /// Returns the LiveView page a human can open to watch or take over.
+    #[must_use]
+    pub const fn live_view_url(&self) -> &Url {
+        &self.session.url
+    }
+
+    /// Closes the controller and releases the session on the control plane.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first error from closing the browser or deleting the
+    /// session. The delete is attempted even when the close fails.
+    pub async fn shutdown(self) -> Result<(), PopcornError> {
+        let close_result = self.browser.close().await.map_err(PopcornError::from);
+        let delete_result =
+            delete_session(&self.client, &self.config, &self.session.session_id).await;
+        if let Err(error) = &delete_result {
+            warn!(
+                target: "nanocodex_browser",
+                session = %self.session.session_id,
+                %error,
+                "popcorn session release failed; TTL controller will reclaim it"
+            );
+        }
+        close_result.and(delete_result)
+    }
+}
+
+async fn create_session(
+    client: &Client,
+    config: &PopcornConfig,
+) -> Result<PopcornSession, PopcornError> {
+    let request = CreateSessionRequest {
+        session_id: config.session_id.as_deref(),
+        ttl_seconds: config.ttl_seconds,
+        regions: &config.regions,
+    };
+    let response = client
+        .post(config.sessions_url()?)
+        .header(reqwest::header::AUTHORIZATION, config.bearer())
+        .json(&request)
+        .send()
+        .await?;
+    let status = response.status();
+    let body = response.text().await?;
+    if !status.is_success() {
+        return Err(PopcornError::ControlPlane {
+            status,
+            body: truncate(&body),
+        });
+    }
+    let parsed: CreateSessionResponse =
+        serde_json::from_str(&body).map_err(|error| PopcornError::ControlPlane {
+            status,
+            body: format!("unparseable session response: {error}"),
+        })?;
+    if parsed.success == Some(false) {
+        return Err(PopcornError::ControlPlane {
+            status,
+            body: parsed
+                .error
+                .unwrap_or_else(|| "session creation failed".to_owned()),
+        });
+    }
+    parsed.session.ok_or_else(|| PopcornError::ControlPlane {
+        status,
+        body: "session response is missing cdpInternalUrl".to_owned(),
+    })
+}
+
+async fn delete_session(
+    client: &Client,
+    config: &PopcornConfig,
+    session_id: &str,
+) -> Result<(), PopcornError> {
+    let response = client
+        .delete(config.session_url(session_id)?)
+        .header(reqwest::header::AUTHORIZATION, config.bearer())
+        .send()
+        .await?;
+    let status = response.status();
+    if status.is_success() || status == StatusCode::NOT_FOUND {
+        return Ok(());
+    }
+    let body = response.text().await.unwrap_or_default();
+    Err(PopcornError::ControlPlane {
+        status,
+        body: truncate(&body),
+    })
+}
+
+fn truncate(body: &str) -> String {
+    const LIMIT: usize = 512;
+    if body.len() <= LIMIT {
+        body.to_owned()
+    } else {
+        let mut end = LIMIT;
+        while !body.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &body[..end])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_request_omits_empty_fields() {
+        let request = CreateSessionRequest {
+            session_id: None,
+            ttl_seconds: None,
+            regions: &[],
+        };
+        assert_eq!(serde_json::to_string(&request).unwrap(), "{}");
+    }
+
+    #[test]
+    fn create_request_serialises_camel_case() {
+        let regions = vec!["asia-south1".to_owned()];
+        let request = CreateSessionRequest {
+            session_id: Some("demo"),
+            ttl_seconds: Some(600),
+            regions: &regions,
+        };
+        assert_eq!(
+            serde_json::to_string(&request).unwrap(),
+            r#"{"sessionId":"demo","ttlSeconds":600,"regions":["asia-south1"]}"#
+        );
+    }
+
+    #[test]
+    fn session_response_parses_reference_shape() {
+        let body = r#"{
+            "success": true,
+            "sessionId": "demo-session",
+            "url": "https://browser.example.com/liveview/demo-session/t/liveview.html",
+            "cdpUrl": "wss://browser.example.com/cdp/demo-session/t/",
+            "cdpInternalUrl": "wss://browser.example.com/cdp-internal/demo-session/t/",
+            "apiUrl": "https://browser.example.com/api/demo-session/t/",
+            "browserPodId": "browser-fleet-abc",
+            "expiresAt": "2026-08-04T12:30:00.000Z",
+            "region": "us-central1",
+            "clusterName": "popcorn-prod-us"
+        }"#;
+        let parsed: CreateSessionResponse = serde_json::from_str(body).unwrap();
+        let session = parsed.session.unwrap();
+        assert_eq!(session.session_id, "demo-session");
+        assert_eq!(session.cdp_internal_url.scheme(), "wss");
+        assert_eq!(session.region.as_deref(), Some("us-central1"));
+    }
+
+    #[test]
+    fn debug_output_redacts_session_urls() {
+        let body = r#"{
+            "sessionId": "demo-session",
+            "url": "https://browser.example.com/liveview/demo-session/tok/liveview.html",
+            "cdpUrl": "wss://browser.example.com/cdp/demo-session/tok/",
+            "cdpInternalUrl": "wss://browser.example.com/cdp-internal/demo-session/tok/"
+        }"#;
+        let session: PopcornSession = serde_json::from_str(body).unwrap();
+        let rendered = format!("{session:?}");
+        assert!(!rendered.contains("tok"), "session URLs leaked: {rendered}");
+        assert!(!rendered.contains("browser.example.com"));
+        assert!(rendered.contains("demo-session"));
+    }
+
+    #[test]
+    fn debug_output_redacts_client_secret() {
+        let config = PopcornConfig::new(
+            Url::parse("https://control.example.com/").unwrap(),
+            "client-id",
+            "super-secret",
+        );
+        let rendered = format!("{config:?}");
+        assert!(
+            !rendered.contains("super-secret"),
+            "secret leaked: {rendered}"
+        );
+        assert!(rendered.contains("client-id"));
+    }
+
+    #[test]
+    fn failed_response_surfaces_error_message() {
+        let body = r#"{"success": false, "error": "no capacity in region"}"#;
+        let parsed: CreateSessionResponse = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed.success, Some(false));
+        assert_eq!(parsed.error.as_deref(), Some("no capacity in region"));
+        assert!(parsed.session.is_none());
+    }
+
+    #[test]
+    fn config_builds_control_plane_urls() {
+        let config = PopcornConfig::new(
+            Url::parse("https://control.example.com/").unwrap(),
+            "id",
+            "secret",
+        );
+        assert_eq!(
+            config.sessions_url().unwrap().as_str(),
+            "https://control.example.com/v1/sessions"
+        );
+        assert_eq!(
+            config.session_url("abc").unwrap().as_str(),
+            "https://control.example.com/v1/session/abc"
+        );
+        assert_eq!(config.bearer(), "Bearer id:secret");
+    }
+}

--- a/crates/experimental/nanocodex-browser/src/popcorn.rs
+++ b/crates/experimental/nanocodex-browser/src/popcorn.rs
@@ -1,16 +1,29 @@
 //! A Nanocodex browser Hand backed by a rented Popcorn session.
 //!
-//! [Popcorn](https://github.com/reclaimprotocol/popcorn-oss) rents isolated
-//! headful Chromium sessions that run inside a TEE. Each session exposes a
-//! full-access CDP WebSocket, a human-viewable LiveView page, and an
-//! attestation route. This module rents one session from a Popcorn control
-//! plane, points the ordinary [`Browser`] controller at its CDP endpoint, and
-//! releases the session on shutdown.
+//! [Popcorn](https://popcorn.reclaimprotocol.org) rents isolated headful
+//! Chromium sessions that run inside a TEE. Each session exposes a CDP
+//! WebSocket for the agent and a LiveView page a human can open to watch or
+//! take over. This module rents one session, points the ordinary [`Browser`]
+//! controller at its CDP endpoint, and releases the session on shutdown.
 //!
 //! From the agent's point of view a Popcorn browser is just another Hand: the
 //! brain stays wherever it is, and `tools.browser(...)` executes inside the
-//! remote enclave. Because the model never receives the CDP URL, the session
-//! token never enters the conversation.
+//! remote enclave. Because the model never receives a connection URL, the
+//! session capability never enters the conversation.
+//!
+//! # Access modes
+//!
+//! The default is the public pay-per-use endpoint, which needs no account.
+//! Each five-minute block costs $0.01 in USDC on Base, paid per request with
+//! [x402](https://popcorn.reclaimprotocol.org/ai.md): the first request is
+//! answered with a payment challenge, the client validates the offer against a
+//! policy compiled into this module, signs an EIP-3009 transfer authorization,
+//! and repeats the request. Set `POPCORN_PAYER_PRIVATE_KEY` to an EVM key that
+//! holds a little USDC and enough ETH for gas on Base.
+//!
+//! A credentialed control plane remains available for dedicated deployments.
+//! Set `POPCORN_CONTROL_PLANE_URL`, `POPCORN_CLIENT_ID`, and
+//! `POPCORN_CLIENT_SECRET` instead, and no payment is involved.
 //!
 //! # Rent a browser and hand it to an agent
 //!
@@ -31,43 +44,127 @@
 //! # }
 //! ```
 //!
-//! Required environment for [`PopcornConfig::from_env`]:
+//! Environment read by [`PopcornConfig::from_env`]:
 //!
-//! - `POPCORN_CONTROL_PLANE_URL`: base URL of the Popcorn control plane.
-//! - `POPCORN_CLIENT_ID` and `POPCORN_CLIENT_SECRET`: credentialed client.
-//! - `POPCORN_REGION` (optional): comma-separated region preference order.
-//! - `POPCORN_TTL_SECONDS` (optional): requested session lifetime.
+//! - `POPCORN_PAYER_PRIVATE_KEY`: EVM key that pays for public sessions. When
+//!   set, the public x402 endpoint is used and nothing else is required.
+//! - `POPCORN_CONTROL_PLANE_URL`, `POPCORN_CLIENT_ID`, `POPCORN_CLIENT_SECRET`:
+//!   credentialed access to a dedicated deployment.
+//! - `POPCORN_REGION` (optional, credentialed): comma-separated preference order.
+//! - `POPCORN_TTL_SECONDS` (optional, credentialed): requested session lifetime.
 
+use std::borrow::Cow;
 use std::time::Duration;
 
+use alloy_primitives::{Address, B256, U256, hex};
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
+use alloy_sol_types::{Eip712Domain, SolStruct, sol};
+use rand::RngCore;
 use reqwest::{Client, StatusCode};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use tracing::{debug, warn};
 use url::Url;
+use uuid::Uuid;
 
 use crate::{Browser, BrowserBuildError, BrowserBuilder, BrowserError, BrowserTool};
 
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 
+// ---------------------------------------------------------------------------
+// Trusted x402 payment policy
+//
+// These values are the client's independent copy of the payment terms. An
+// offer is signed only when it matches them exactly; a challenge is never
+// trusted merely because it arrived in a `402` response.
+// ---------------------------------------------------------------------------
+
+/// Public pay-per-use session endpoint.
+const X402_SESSIONS_URL: &str = "https://app.popcorn.reclaimprotocol.org/v1/x402/sessions";
+/// CAIP-2 identity of Base mainnet.
+const X402_NETWORK: &str = "eip155:8453";
+/// Base mainnet chain id, used in the EIP-712 domain.
+const X402_CHAIN_ID: u64 = 8453;
+/// USDC on Base mainnet.
+const X402_ASSET: &str = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+/// The only account a session payment may pay.
+const X402_PAY_TO: &str = "0x28f26a191D6bCa1FfD129261E726033188d65138";
+/// Atomic USDC units for one block, `$0.01` at six decimals.
+const X402_ATOMIC_PER_BLOCK: u64 = 10_000;
+/// Only the exact scheme is accepted.
+const X402_SCHEME: &str = "exact";
+/// Only x402 v2 is accepted.
+const X402_VERSION: u32 = 2;
+/// Attempts for one paid action, reusing the original key, body, and signature.
+const X402_MAX_ATTEMPTS: u32 = 5;
+
+/// Seconds of browser time bought by one payment block.
+pub const X402_BLOCK_SECONDS: u64 = 300;
+
+sol! {
+    /// EIP-3009 authorization signed to move USDC for one session action.
+    struct TransferWithAuthorization {
+        address from;
+        address to;
+        uint256 value;
+        uint256 validAfter;
+        uint256 validBefore;
+        bytes32 nonce;
+    }
+}
+
+/// How sessions are obtained from Popcorn.
+#[derive(Clone)]
+enum Access {
+    /// Public pay-per-use endpoint settled with x402 payments.
+    X402 {
+        /// Session collection endpoint.
+        endpoint: Url,
+        /// Hex-encoded EVM key that signs payment authorizations.
+        payer_key: String,
+    },
+    /// Credentialed control plane for a dedicated deployment.
+    Credentialed {
+        /// Control-plane base URL.
+        control_plane: Url,
+        /// Client identity.
+        client_id: String,
+        /// Client secret.
+        client_secret: String,
+    },
+}
+
 /// Everything needed to rent one Popcorn session.
 #[derive(Clone)]
 pub struct PopcornConfig {
-    control_plane: Url,
-    client_id: String,
-    client_secret: String,
+    access: Access,
     regions: Vec<String>,
     ttl_seconds: Option<u64>,
     session_id: Option<String>,
     request_timeout: Duration,
 }
 
+/// Redacts the payer key and client secret, both of which are credentials.
 impl std::fmt::Debug for PopcornConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PopcornConfig")
-            .field("control_plane", &self.control_plane)
-            .field("client_id", &self.client_id)
-            .field("client_secret", &"<redacted>")
-            .field("regions", &self.regions)
+        let mut out = f.debug_struct("PopcornConfig");
+        match &self.access {
+            Access::X402 { .. } => {
+                out.field("access", &"x402")
+                    .field("payer_key", &"<redacted>");
+            }
+            Access::Credentialed {
+                control_plane,
+                client_id,
+                ..
+            } => {
+                out.field("access", &"credentialed")
+                    .field("control_plane", control_plane)
+                    .field("client_id", client_id)
+                    .field("client_secret", &"<redacted>");
+            }
+        }
+        out.field("regions", &self.regions)
             .field("ttl_seconds", &self.ttl_seconds)
             .field("session_id", &self.session_id)
             .field("request_timeout", &self.request_timeout)
@@ -76,6 +173,24 @@ impl std::fmt::Debug for PopcornConfig {
 }
 
 impl PopcornConfig {
+    /// Creates a configuration that pays for public sessions with x402.
+    ///
+    /// `payer_key` is a hex-encoded EVM private key holding USDC and a little
+    /// ETH for gas on Base. It never leaves this process.
+    #[must_use]
+    pub fn x402(payer_key: impl Into<String>) -> Self {
+        Self {
+            access: Access::X402 {
+                endpoint: Url::parse(X402_SESSIONS_URL).expect("static endpoint parses"),
+                payer_key: payer_key.into(),
+            },
+            regions: Vec::new(),
+            ttl_seconds: None,
+            session_id: None,
+            request_timeout: DEFAULT_REQUEST_TIMEOUT,
+        }
+    }
+
     /// Creates a configuration for a credentialed Popcorn client.
     pub fn new(
         control_plane: Url,
@@ -83,9 +198,11 @@ impl PopcornConfig {
         client_secret: impl Into<String>,
     ) -> Self {
         Self {
-            control_plane,
-            client_id: client_id.into(),
-            client_secret: client_secret.into(),
+            access: Access::Credentialed {
+                control_plane,
+                client_id: client_id.into(),
+                client_secret: client_secret.into(),
+            },
             regions: Vec::new(),
             ttl_seconds: None,
             session_id: None,
@@ -95,32 +212,41 @@ impl PopcornConfig {
 
     /// Reads the configuration from `POPCORN_*` environment variables.
     ///
+    /// `POPCORN_PAYER_PRIVATE_KEY` selects the public pay-per-use endpoint.
+    /// Otherwise the credentialed variables are required.
+    ///
     /// # Errors
     ///
-    /// Returns [`PopcornError::Configuration`] when a required variable is
-    /// missing or the control-plane URL does not parse.
+    /// Returns [`PopcornError::Configuration`] when neither access mode is
+    /// fully configured or the control-plane URL does not parse.
     pub fn from_env() -> Result<Self, PopcornError> {
-        fn required(name: &str) -> Result<String, PopcornError> {
-            std::env::var(name)
-                .ok()
-                .filter(|value| !value.trim().is_empty())
-                .ok_or_else(|| PopcornError::Configuration {
-                    message: format!("`{name}` is required"),
-                })
+        if let Some(payer_key) = optional_env("POPCORN_PAYER_PRIVATE_KEY") {
+            return Ok(Self::x402(payer_key));
+        }
+        if optional_env("POPCORN_CONTROL_PLANE_URL").is_none()
+            && optional_env("POPCORN_CLIENT_ID").is_none()
+            && optional_env("POPCORN_CLIENT_SECRET").is_none()
+        {
+            return Err(PopcornError::Configuration {
+                message: "set `POPCORN_PAYER_PRIVATE_KEY` for public pay-per-use sessions, or \
+                          `POPCORN_CONTROL_PLANE_URL`, `POPCORN_CLIENT_ID`, and \
+                          `POPCORN_CLIENT_SECRET` for a dedicated deployment"
+                    .to_owned(),
+            });
         }
 
         let control_plane =
-            Url::parse(&required("POPCORN_CONTROL_PLANE_URL")?).map_err(|error| {
+            Url::parse(&required_env("POPCORN_CONTROL_PLANE_URL")?).map_err(|error| {
                 PopcornError::Configuration {
                     message: format!("`POPCORN_CONTROL_PLANE_URL` is not a valid URL: {error}"),
                 }
             })?;
         let mut config = Self::new(
             control_plane,
-            required("POPCORN_CLIENT_ID")?,
-            required("POPCORN_CLIENT_SECRET")?,
+            required_env("POPCORN_CLIENT_ID")?,
+            required_env("POPCORN_CLIENT_SECRET")?,
         );
-        if let Ok(regions) = std::env::var("POPCORN_REGION") {
+        if let Some(regions) = optional_env("POPCORN_REGION") {
             config = config.regions(
                 regions
                     .split(',')
@@ -129,9 +255,8 @@ impl PopcornConfig {
                     .map(str::to_owned),
             );
         }
-        if let Ok(ttl) = std::env::var("POPCORN_TTL_SECONDS") {
+        if let Some(ttl) = optional_env("POPCORN_TTL_SECONDS") {
             let ttl = ttl
-                .trim()
                 .parse::<u64>()
                 .map_err(|error| PopcornError::Configuration {
                     message: format!("`POPCORN_TTL_SECONDS` must be a positive integer: {error}"),
@@ -141,14 +266,14 @@ impl PopcornConfig {
         Ok(config)
     }
 
-    /// Sets the region preference order tried by the control plane.
+    /// Sets the region preference order tried by a credentialed control plane.
     #[must_use]
     pub fn regions(mut self, regions: impl IntoIterator<Item = String>) -> Self {
         self.regions = regions.into_iter().collect();
         self
     }
 
-    /// Requests a session lifetime in seconds.
+    /// Requests a session lifetime in seconds from a credentialed control plane.
     #[must_use]
     pub const fn ttl_seconds(mut self, ttl_seconds: u64) -> Self {
         self.ttl_seconds = Some(ttl_seconds);
@@ -162,32 +287,44 @@ impl PopcornConfig {
         self
     }
 
-    /// Overrides the control-plane HTTP timeout.
+    /// Overrides the HTTP timeout applied to Popcorn requests.
     #[must_use]
     pub const fn request_timeout(mut self, timeout: Duration) -> Self {
         self.request_timeout = timeout;
         self
     }
 
-    fn bearer(&self) -> String {
-        format!("Bearer {}:{}", self.client_id, self.client_secret)
+    /// Reports whether this configuration pays per use over x402.
+    #[must_use]
+    pub const fn is_x402(&self) -> bool {
+        matches!(self.access, Access::X402 { .. })
     }
 
-    fn sessions_url(&self) -> Result<Url, PopcornError> {
-        self.control_plane
-            .join("v1/sessions")
-            .map_err(|error| PopcornError::Configuration {
-                message: format!("cannot build sessions URL: {error}"),
-            })
+    fn bearer(&self) -> Option<String> {
+        match &self.access {
+            Access::Credentialed {
+                client_id,
+                client_secret,
+                ..
+            } => Some(format!("Bearer {client_id}:{client_secret}")),
+            Access::X402 { .. } => None,
+        }
     }
+}
 
-    fn session_url(&self, session_id: &str) -> Result<Url, PopcornError> {
-        self.control_plane
-            .join(&format!("v1/session/{session_id}"))
-            .map_err(|error| PopcornError::Configuration {
-                message: format!("cannot build session URL: {error}"),
-            })
-    }
+/// Reads a non-blank environment variable.
+fn optional_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
+/// Reads a required non-blank environment variable.
+fn required_env(name: &str) -> Result<String, PopcornError> {
+    optional_env(name).ok_or_else(|| PopcornError::Configuration {
+        message: format!("`{name}` is required"),
+    })
 }
 
 #[derive(Serialize)]
@@ -205,48 +342,112 @@ const fn slice_is_empty(regions: &&[String]) -> bool {
     regions.is_empty()
 }
 
-/// The session record returned by the Popcorn control plane.
+/// One rented browser session.
 ///
-/// Every URL in this record is a bearer secret. Log the session id, never
-/// the URLs.
-#[derive(Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
+/// Every connection URL, and in pay-per-use mode the session id itself, is a
+/// bearer capability. They are private to this type and [`Debug`] renders none
+/// of the URLs. Give them only to the process that owns the session.
+#[derive(Clone)]
 pub struct PopcornSession {
-    /// Popcorn session identifier.
-    pub session_id: String,
-    /// Human-facing LiveView page for watching or taking over the browser.
-    pub url: Url,
-    /// Restricted client-facing CDP endpoint.
-    pub cdp_url: Url,
-    /// Trusted full-access CDP endpoint used by the agent.
-    pub cdp_internal_url: Url,
-    /// Allocated browser pod identity.
-    #[serde(default)]
-    pub browser_pod_id: Option<String>,
-    /// Session deadline when the control plane set one.
-    #[serde(default)]
-    pub expires_at: Option<String>,
-    /// Selected region.
-    #[serde(default)]
-    pub region: Option<String>,
-    /// Selected cluster.
-    #[serde(default)]
-    pub cluster_name: Option<String>,
+    session_id: String,
+    live_view: Url,
+    cdp: Url,
+    expires_at: Option<String>,
+    region: Option<String>,
+    cluster_name: Option<String>,
+    browser_pod_id: Option<String>,
+    paid_seconds: Option<u64>,
 }
 
-/// Redacts every session URL, each of which is a bearer secret.
+impl PopcornSession {
+    /// Returns the session identifier.
+    #[must_use]
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    /// Returns the LiveView page a human can open to watch or take over.
+    #[must_use]
+    pub const fn live_view_url(&self) -> &Url {
+        &self.live_view
+    }
+
+    /// Returns the session deadline reported by Popcorn.
+    #[must_use]
+    pub fn expires_at(&self) -> Option<&str> {
+        self.expires_at.as_deref()
+    }
+
+    /// Returns the selected region.
+    #[must_use]
+    pub fn region(&self) -> Option<&str> {
+        self.region.as_deref()
+    }
+
+    /// Returns the selected cluster.
+    #[must_use]
+    pub fn cluster_name(&self) -> Option<&str> {
+        self.cluster_name.as_deref()
+    }
+
+    /// Returns the allocated browser pod identity.
+    #[must_use]
+    pub fn browser_pod_id(&self) -> Option<&str> {
+        self.browser_pod_id.as_deref()
+    }
+
+    /// Returns the browser time paid for so far, in seconds.
+    #[must_use]
+    pub const fn paid_seconds(&self) -> Option<u64> {
+        self.paid_seconds
+    }
+}
+
+/// Redacts every session URL, each of which is a bearer capability.
 impl std::fmt::Debug for PopcornSession {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PopcornSession")
             .field("session_id", &self.session_id)
-            .field("url", &"<redacted>")
-            .field("cdp_url", &"<redacted>")
-            .field("cdp_internal_url", &"<redacted>")
-            .field("browser_pod_id", &self.browser_pod_id)
+            .field("live_view", &"<redacted>")
+            .field("cdp", &"<redacted>")
             .field("expires_at", &self.expires_at)
             .field("region", &self.region)
             .field("cluster_name", &self.cluster_name)
+            .field("browser_pod_id", &self.browser_pod_id)
+            .field("paid_seconds", &self.paid_seconds)
             .finish()
+    }
+}
+
+/// The credentialed control-plane session record.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CredentialedSession {
+    session_id: String,
+    url: Url,
+    cdp_internal_url: Url,
+    #[serde(default)]
+    browser_pod_id: Option<String>,
+    #[serde(default)]
+    expires_at: Option<String>,
+    #[serde(default)]
+    region: Option<String>,
+    #[serde(default)]
+    cluster_name: Option<String>,
+}
+
+impl From<CredentialedSession> for PopcornSession {
+    fn from(value: CredentialedSession) -> Self {
+        Self {
+            session_id: value.session_id,
+            live_view: value.url,
+            cdp: value.cdp_internal_url,
+            expires_at: value.expires_at,
+            region: value.region,
+            cluster_name: value.cluster_name,
+            browser_pod_id: value.browser_pod_id,
+            paid_seconds: None,
+        }
     }
 }
 
@@ -257,10 +458,115 @@ struct CreateSessionResponse {
     #[serde(default)]
     error: Option<String>,
     #[serde(flatten)]
-    session: Option<PopcornSession>,
+    session: Option<CredentialedSession>,
 }
 
-/// Errors from renting, driving, or releasing a Popcorn session.
+/// The public pay-per-use session record.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct X402Session {
+    session_id: String,
+    connect_url: Url,
+    live_view_url: Url,
+    #[serde(default)]
+    expires_at: Option<String>,
+    #[serde(default)]
+    paid_seconds: Option<u64>,
+    #[serde(default)]
+    region: Option<String>,
+    #[serde(default)]
+    cluster_name: Option<String>,
+}
+
+impl From<X402Session> for PopcornSession {
+    fn from(value: X402Session) -> Self {
+        Self {
+            session_id: value.session_id,
+            live_view: value.live_view_url,
+            cdp: value.connect_url,
+            expires_at: value.expires_at,
+            region: value.region,
+            cluster_name: value.cluster_name,
+            browser_pod_id: None,
+            paid_seconds: value.paid_seconds,
+        }
+    }
+}
+
+/// The result of buying more time on an existing session.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct X402Extension {
+    #[serde(default)]
+    expires_at: Option<String>,
+    #[serde(default)]
+    paid_seconds_total: Option<u64>,
+}
+
+/// One payment offer inside a challenge.
+///
+/// Carries only public payment terms, so it is safe to render.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PaymentRequirements {
+    scheme: String,
+    network: String,
+    amount: String,
+    asset: String,
+    pay_to: String,
+    max_timeout_seconds: u64,
+    #[serde(default)]
+    extra: Option<PaymentExtra>,
+}
+
+/// EIP-712 domain parameters carried by an offer.
+#[derive(Debug, Deserialize)]
+struct PaymentExtra {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    version: Option<String>,
+}
+
+/// A decoded `402` challenge.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PaymentRequired {
+    x402_version: u32,
+    #[serde(default)]
+    resource: Option<serde_json::Value>,
+    accepts: Vec<serde_json::Value>,
+}
+
+/// The signed authorization sent back with the paid request.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Authorization {
+    from: String,
+    to: String,
+    value: String,
+    valid_after: String,
+    valid_before: String,
+    nonce: String,
+}
+
+#[derive(Serialize)]
+struct Eip3009Payload {
+    authorization: Authorization,
+    signature: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PaymentPayload<'a> {
+    x402_version: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resource: Option<&'a serde_json::Value>,
+    accepted: &'a serde_json::Value,
+    payload: Eip3009Payload,
+}
+
+/// Errors from renting, driving, paying for, or releasing a Popcorn session.
 #[derive(Debug, thiserror::Error)]
 pub enum PopcornError {
     /// The configuration is incomplete or malformed.
@@ -269,16 +575,34 @@ pub enum PopcornError {
         /// Human-readable explanation.
         message: String,
     },
-    /// The control plane could not be reached.
-    #[error("popcorn control plane request failed: {0}")]
+    /// Popcorn could not be reached.
+    #[error("popcorn request failed: {0}")]
     Transport(#[from] reqwest::Error),
-    /// The control plane rejected the request.
-    #[error("popcorn control plane returned {status}: {body}")]
+    /// Popcorn rejected the request.
+    #[error("popcorn returned {status}: {body}")]
     ControlPlane {
         /// HTTP status.
         status: StatusCode,
         /// Response body, truncated.
         body: String,
+    },
+    /// A payment offer did not match the trusted policy, so nothing was signed.
+    #[error("untrusted popcorn payment offer: {detail}")]
+    UntrustedOffer {
+        /// Which term failed the check.
+        detail: String,
+    },
+    /// The payment authorization could not be signed.
+    #[error("popcorn payment could not be signed: {detail}")]
+    Payment {
+        /// Human-readable explanation, never containing key material.
+        detail: String,
+    },
+    /// A Popcorn response could not be decoded.
+    #[error("popcorn response could not be decoded: {detail}")]
+    Decode {
+        /// Human-readable explanation.
+        detail: String,
     },
     /// The browser controller could not be configured for the session.
     #[error(transparent)]
@@ -291,7 +615,8 @@ pub enum PopcornError {
 /// One rented Popcorn session wrapped as a Nanocodex browser Hand.
 ///
 /// Dropping the value without calling [`PopcornBrowser::shutdown`] leaves the
-/// session to Popcorn's TTL controller. Call `shutdown` to release it now.
+/// session to expire on its own. Call `shutdown` to release it now; unused
+/// paid time is not refunded.
 pub struct PopcornBrowser {
     config: PopcornConfig,
     client: Client,
@@ -304,8 +629,8 @@ impl PopcornBrowser {
     ///
     /// # Errors
     ///
-    /// Returns an error when the control plane refuses the session or when the
-    /// browser controller cannot be configured for the remote CDP endpoint.
+    /// Returns an error when a payment offer is untrusted, when Popcorn
+    /// refuses the session, or when the controller cannot attach.
     pub async fn spawn(config: PopcornConfig) -> Result<Self, PopcornError> {
         Self::spawn_with(config, Browser::builder()).await
     }
@@ -324,19 +649,34 @@ impl PopcornBrowser {
     ) -> Result<Self, PopcornError> {
         nanocodex_oai_api::transport::install_default_rustls_crypto_provider();
         let client = Client::builder().timeout(config.request_timeout).build()?;
-        let session = create_session(&client, &config).await?;
+        let session = match &config.access {
+            Access::X402 {
+                endpoint,
+                payer_key,
+            } => {
+                let signer = parse_signer(payer_key)?;
+                let created: X402Session = paid_post(
+                    &client,
+                    &signer,
+                    endpoint.clone(),
+                    &serde_json::json!({}),
+                    X402_ATOMIC_PER_BLOCK,
+                )
+                .await?;
+                PopcornSession::from(created)
+            }
+            Access::Credentialed { .. } => create_credentialed_session(&client, &config).await?,
+        };
         debug!(
             target: "nanocodex_browser",
             session = %session.session_id,
             region = ?session.region,
+            paid_seconds = ?session.paid_seconds,
             "rented popcorn session"
         );
-        // The session is already rented, so release it rather than leaking it to
-        // the TTL controller when the controller cannot be attached.
-        let browser = match browser
-            .cdp_endpoint(session.cdp_internal_url.clone())
-            .build()
-        {
+        // The session is already rented, so release it rather than leaving it
+        // to expire when the controller cannot be attached.
+        let browser = match browser.cdp_endpoint(session.cdp.clone()).build() {
             Ok(browser) => browser,
             Err(error) => {
                 if let Err(release_error) =
@@ -347,7 +687,7 @@ impl PopcornBrowser {
                         session = %session.session_id,
                         error = %release_error,
                         "popcorn session release failed after a failed attach; \
-                         TTL controller will reclaim it"
+                         it will expire on its own"
                     );
                 }
                 return Err(error.into());
@@ -373,7 +713,7 @@ impl PopcornBrowser {
         BrowserTool::from_browser(self.browser.clone())
     }
 
-    /// Returns the session record. Treat every URL in it as a secret.
+    /// Returns the session record.
     #[must_use]
     pub const fn session(&self) -> &PopcornSession {
         &self.session
@@ -382,15 +722,72 @@ impl PopcornBrowser {
     /// Returns the LiveView page a human can open to watch or take over.
     #[must_use]
     pub const fn live_view_url(&self) -> &Url {
-        &self.session.url
+        &self.session.live_view
     }
 
-    /// Closes the controller and releases the session on the control plane.
+    /// Buys `blocks` more whole time blocks of
+    /// [`X402_BLOCK_SECONDS`] each, keeping the same browser and URLs.
+    ///
+    /// Start an extension while at least four minutes remain; one presented
+    /// later is rejected before settlement.
     ///
     /// # Errors
     ///
-    /// Returns the first error from closing the browser or deleting the
-    /// session. The delete is attempted even when the close fails.
+    /// Returns [`PopcornError::Configuration`] for a credentialed session or a
+    /// zero block count, and a payment or transport error otherwise.
+    pub async fn extend(&mut self, blocks: u32) -> Result<(), PopcornError> {
+        if blocks == 0 {
+            return Err(PopcornError::Configuration {
+                message: "an extension must buy at least one block".to_owned(),
+            });
+        }
+        let Access::X402 {
+            endpoint,
+            payer_key,
+        } = &self.config.access
+        else {
+            return Err(PopcornError::Configuration {
+                message: "session extension is only available for public pay-per-use sessions"
+                    .to_owned(),
+            });
+        };
+        let signer = parse_signer(payer_key)?;
+        let url = x402_session_url(endpoint, &self.session.session_id, Some("extend"))?;
+        let amount = X402_ATOMIC_PER_BLOCK
+            .checked_mul(u64::from(blocks))
+            .ok_or_else(|| PopcornError::Configuration {
+                message: "requested extension is too large".to_owned(),
+            })?;
+        let extended: X402Extension = paid_post(
+            &self.client,
+            &signer,
+            url,
+            &serde_json::json!({ "blocks": blocks }),
+            amount,
+        )
+        .await?;
+        if extended.expires_at.is_some() {
+            self.session.expires_at = extended.expires_at;
+        }
+        if extended.paid_seconds_total.is_some() {
+            self.session.paid_seconds = extended.paid_seconds_total;
+        }
+        debug!(
+            target: "nanocodex_browser",
+            session = %self.session.session_id,
+            blocks,
+            paid_seconds = ?self.session.paid_seconds,
+            "extended popcorn session"
+        );
+        Ok(())
+    }
+
+    /// Closes the controller and ends the session.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first error from closing the browser or ending the session.
+    /// The termination is attempted even when the close fails.
     pub async fn shutdown(self) -> Result<(), PopcornError> {
         let close_result = self.browser.close().await.map_err(PopcornError::from);
         let delete_result =
@@ -400,28 +797,390 @@ impl PopcornBrowser {
                 target: "nanocodex_browser",
                 session = %self.session.session_id,
                 %error,
-                "popcorn session release failed; TTL controller will reclaim it"
+                "popcorn session release failed; it will expire on its own"
             );
         }
         close_result.and(delete_result)
     }
 }
 
-async fn create_session(
+/// Builds `<endpoint>/<session id>[/<action>]`.
+fn x402_session_url(
+    endpoint: &Url,
+    session_id: &str,
+    action: Option<&str>,
+) -> Result<Url, PopcornError> {
+    let mut url = endpoint.clone();
+    {
+        let mut path = url
+            .path_segments_mut()
+            .map_err(|()| PopcornError::Configuration {
+                message: "the x402 endpoint cannot have path segments".to_owned(),
+            })?;
+        path.pop_if_empty().push(session_id);
+        if let Some(action) = action {
+            path.push(action);
+        }
+    }
+    Ok(url)
+}
+
+/// Parses the payer key without ever placing it in an error message.
+fn parse_signer(payer_key: &str) -> Result<PrivateKeySigner, PopcornError> {
+    payer_key
+        .parse::<PrivateKeySigner>()
+        .map_err(|_| PopcornError::Payment {
+            detail: "`POPCORN_PAYER_PRIVATE_KEY` is not a valid EVM private key".to_owned(),
+        })
+}
+
+/// Validates one offer against the trusted policy.
+fn validate_offer(offer: &PaymentRequirements, expected_atomic: u64) -> Result<(), PopcornError> {
+    let reject = |detail: String| PopcornError::UntrustedOffer { detail };
+    if offer.scheme != X402_SCHEME {
+        return Err(reject(format!(
+            "scheme is `{}`, expected `{X402_SCHEME}`",
+            offer.scheme
+        )));
+    }
+    if offer.network != X402_NETWORK {
+        return Err(reject(format!(
+            "network is `{}`, expected `{X402_NETWORK}`",
+            offer.network
+        )));
+    }
+    if !offer.asset.eq_ignore_ascii_case(X402_ASSET) {
+        return Err(reject(format!(
+            "asset is `{}`, expected `{X402_ASSET}`",
+            offer.asset
+        )));
+    }
+    if !offer.pay_to.eq_ignore_ascii_case(X402_PAY_TO) {
+        return Err(reject(format!(
+            "payee is `{}`, expected `{X402_PAY_TO}`",
+            offer.pay_to
+        )));
+    }
+    let expected = expected_atomic.to_string();
+    if offer.amount != expected {
+        return Err(reject(format!(
+            "amount is `{}`, expected `{expected}`",
+            offer.amount
+        )));
+    }
+    Ok(())
+}
+
+/// Returns the single trusted offer in a challenge.
+fn select_offer(
+    challenge: &PaymentRequired,
+    expected_atomic: u64,
+) -> Result<(&serde_json::Value, PaymentRequirements), PopcornError> {
+    if challenge.x402_version != X402_VERSION {
+        return Err(PopcornError::UntrustedOffer {
+            detail: format!(
+                "x402 version is {}, expected {X402_VERSION}",
+                challenge.x402_version
+            ),
+        });
+    }
+    let mut trusted = None;
+    let mut last_rejection = None;
+    for raw in &challenge.accepts {
+        let Ok(offer) = serde_json::from_value::<PaymentRequirements>(raw.clone()) else {
+            continue;
+        };
+        match validate_offer(&offer, expected_atomic) {
+            Ok(()) => {
+                if trusted.is_some() {
+                    return Err(PopcornError::UntrustedOffer {
+                        detail: "the challenge carried more than one trusted offer".to_owned(),
+                    });
+                }
+                trusted = Some((raw, offer));
+            }
+            Err(error) => last_rejection = Some(error),
+        }
+    }
+    trusted.ok_or_else(|| {
+        last_rejection.unwrap_or_else(|| PopcornError::UntrustedOffer {
+            detail: "the challenge carried no usable offer".to_owned(),
+        })
+    })
+}
+
+/// Signs the EIP-3009 authorization for one validated offer.
+fn sign_authorization(
+    signer: &PrivateKeySigner,
+    offer: &PaymentRequirements,
+) -> Result<Eip3009Payload, PopcornError> {
+    let extra = offer.extra.as_ref();
+    let (Some(name), Some(version)) = (
+        extra.and_then(|extra| extra.name.clone()),
+        extra.and_then(|extra| extra.version.clone()),
+    ) else {
+        return Err(PopcornError::UntrustedOffer {
+            detail: "the offer is missing the EIP-712 domain name and version".to_owned(),
+        });
+    };
+    let asset = offer
+        .asset
+        .parse::<Address>()
+        .map_err(|error| PopcornError::UntrustedOffer {
+            detail: format!("the offer asset is not an address: {error}"),
+        })?;
+    let pay_to = offer
+        .pay_to
+        .parse::<Address>()
+        .map_err(|error| PopcornError::UntrustedOffer {
+            detail: format!("the offer payee is not an address: {error}"),
+        })?;
+    let value = offer
+        .amount
+        .parse::<U256>()
+        .map_err(|error| PopcornError::UntrustedOffer {
+            detail: format!("the offer amount is not an integer: {error}"),
+        })?;
+
+    let valid_before = unix_now()
+        .checked_add(offer.max_timeout_seconds)
+        .ok_or_else(|| PopcornError::Payment {
+            detail: "the offer timeout overflows the authorization deadline".to_owned(),
+        })?;
+    let mut nonce_bytes = [0u8; 32];
+    rand::rng().fill_bytes(&mut nonce_bytes);
+
+    sign_transfer_authorization(
+        signer,
+        &AuthorizationTerms {
+            asset,
+            pay_to,
+            value,
+            valid_before,
+            nonce: B256::from(nonce_bytes),
+            domain_name: name,
+            domain_version: version,
+        },
+    )
+}
+
+/// The fully resolved terms of one EIP-3009 authorization.
+struct AuthorizationTerms {
+    asset: Address,
+    pay_to: Address,
+    value: U256,
+    valid_before: u64,
+    nonce: B256,
+    domain_name: String,
+    domain_version: String,
+}
+
+/// Signs one authorization, given every term already resolved.
+///
+/// Split out from [`sign_authorization`] so a fixed vector can be checked
+/// against an independent EIP-712 implementation.
+fn sign_transfer_authorization(
+    signer: &PrivateKeySigner,
+    terms: &AuthorizationTerms,
+) -> Result<Eip3009Payload, PopcornError> {
+    let authorization = TransferWithAuthorization {
+        from: signer.address(),
+        to: terms.pay_to,
+        value: terms.value,
+        validAfter: U256::ZERO,
+        validBefore: U256::from(terms.valid_before),
+        nonce: terms.nonce,
+    };
+    let domain = Eip712Domain::new(
+        Some(Cow::Owned(terms.domain_name.clone())),
+        Some(Cow::Owned(terms.domain_version.clone())),
+        Some(U256::from(X402_CHAIN_ID)),
+        Some(terms.asset),
+        None,
+    );
+    let signature = signer
+        .sign_hash_sync(&authorization.eip712_signing_hash(&domain))
+        .map_err(|error| PopcornError::Payment {
+            detail: format!("the wallet refused to sign the authorization: {error}"),
+        })?;
+
+    Ok(Eip3009Payload {
+        authorization: Authorization {
+            from: authorization.from.to_checksum(None),
+            to: authorization.to.to_checksum(None),
+            value: authorization.value.to_string(),
+            valid_after: "0".to_owned(),
+            valid_before: terms.valid_before.to_string(),
+            nonce: format!("0x{}", hex::encode(terms.nonce)),
+        },
+        signature: format!("0x{}", hex::encode(signature.as_bytes())),
+    })
+}
+
+/// Seconds since the Unix epoch.
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |elapsed| elapsed.as_secs())
+}
+
+/// Decodes a challenge from the `PAYMENT-REQUIRED` header, else the body.
+fn decode_payment_required(
+    header: Option<&str>,
+    body: &str,
+) -> Result<PaymentRequired, PopcornError> {
+    if let Some(header) = header {
+        let decoded = base64_decode(header)?;
+        return serde_json::from_slice(&decoded).map_err(|error| PopcornError::Decode {
+            detail: format!("the PAYMENT-REQUIRED header is not a valid challenge: {error}"),
+        });
+    }
+    serde_json::from_str(body).map_err(|error| PopcornError::Decode {
+        detail: format!("the challenge body could not be parsed: {error}"),
+    })
+}
+
+/// Decodes standard base64 as used by the x402 headers.
+fn base64_decode(value: &str) -> Result<Vec<u8>, PopcornError> {
+    use base64::Engine as _;
+    base64::engine::general_purpose::STANDARD
+        .decode(value.trim())
+        .map_err(|error| PopcornError::Decode {
+            detail: format!("a payment header was not valid base64: {error}"),
+        })
+}
+
+/// Encodes standard base64 as used by the x402 headers.
+fn base64_encode(value: &[u8]) -> String {
+    use base64::Engine as _;
+    base64::engine::general_purpose::STANDARD.encode(value)
+}
+
+/// Performs one paid action: challenge, validate, sign, then retry-safe replay.
+///
+/// A retry reuses the original idempotency key, body, and signature so the
+/// server can return the first result instead of charging twice.
+async fn paid_post<T: DeserializeOwned>(
+    client: &Client,
+    signer: &PrivateKeySigner,
+    url: Url,
+    body: &serde_json::Value,
+    expected_atomic: u64,
+) -> Result<T, PopcornError> {
+    let idempotency_key = Uuid::new_v4().to_string();
+    let body_text = serde_json::to_string(body).map_err(|error| PopcornError::Decode {
+        detail: format!("the request body could not be encoded: {error}"),
+    })?;
+
+    let challenge = client
+        .post(url.clone())
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .header("Idempotency-Key", &idempotency_key)
+        .body(body_text.clone())
+        .send()
+        .await?;
+    let status = challenge.status();
+    let header = challenge
+        .headers()
+        .get("PAYMENT-REQUIRED")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
+    let challenge_body = challenge.text().await?;
+    if status != StatusCode::PAYMENT_REQUIRED {
+        return Err(PopcornError::ControlPlane {
+            status,
+            body: truncate(&challenge_body),
+        });
+    }
+
+    let required = decode_payment_required(header.as_deref(), &challenge_body)?;
+    let (raw_offer, offer) = select_offer(&required, expected_atomic)?;
+    let payload = sign_authorization(signer, &offer)?;
+    let signature_header = base64_encode(
+        serde_json::to_string(&PaymentPayload {
+            x402_version: X402_VERSION,
+            resource: required.resource.as_ref(),
+            accepted: raw_offer,
+            payload,
+        })
+        .map_err(|error| PopcornError::Decode {
+            detail: format!("the payment payload could not be encoded: {error}"),
+        })?
+        .as_bytes(),
+    );
+
+    for attempt in 0..X402_MAX_ATTEMPTS {
+        let response = client
+            .post(url.clone())
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .header("Idempotency-Key", &idempotency_key)
+            .header("PAYMENT-SIGNATURE", &signature_header)
+            .body(body_text.clone())
+            .send()
+            .await?;
+        let status = response.status();
+        let retry_after = response
+            .headers()
+            .get(reqwest::header::RETRY_AFTER)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.trim().parse::<u64>().ok())
+            .unwrap_or(0);
+        let text = response.text().await?;
+
+        if status.is_success() {
+            return serde_json::from_str(&text).map_err(|error| PopcornError::Decode {
+                detail: format!("the paid response could not be parsed: {error}"),
+            });
+        }
+
+        let retryable = matches!(status.as_u16(), 409 | 503);
+        if retryable && retry_after > 0 && attempt + 1 < X402_MAX_ATTEMPTS {
+            debug!(
+                target: "nanocodex_browser",
+                status = status.as_u16(),
+                retry_after,
+                "popcorn payment is settling; replaying the same signed request"
+            );
+            tokio::time::sleep(Duration::from_secs(retry_after)).await;
+            continue;
+        }
+        return Err(PopcornError::ControlPlane {
+            status,
+            body: truncate(&text),
+        });
+    }
+    Err(PopcornError::ControlPlane {
+        status: StatusCode::SERVICE_UNAVAILABLE,
+        body: "the paid request did not settle after the allowed retries".to_owned(),
+    })
+}
+
+/// Creates a session against a credentialed control plane.
+async fn create_credentialed_session(
     client: &Client,
     config: &PopcornConfig,
 ) -> Result<PopcornSession, PopcornError> {
+    let Access::Credentialed { control_plane, .. } = &config.access else {
+        return Err(PopcornError::Configuration {
+            message: "a credentialed control plane is not configured".to_owned(),
+        });
+    };
+    let sessions_url =
+        control_plane
+            .join("v1/sessions")
+            .map_err(|error| PopcornError::Configuration {
+                message: format!("cannot build sessions URL: {error}"),
+            })?;
     let request = CreateSessionRequest {
         session_id: config.session_id.as_deref(),
         ttl_seconds: config.ttl_seconds,
         regions: &config.regions,
     };
-    let response = client
-        .post(config.sessions_url()?)
-        .header(reqwest::header::AUTHORIZATION, config.bearer())
-        .json(&request)
-        .send()
-        .await?;
+    let mut builder = client.post(sessions_url);
+    if let Some(bearer) = config.bearer() {
+        builder = builder.header(reqwest::header::AUTHORIZATION, bearer);
+    }
+    let response = builder.json(&request).send().await?;
     let status = response.status();
     let body = response.text().await?;
     if !status.is_success() {
@@ -443,22 +1202,34 @@ async fn create_session(
                 .unwrap_or_else(|| "session creation failed".to_owned()),
         });
     }
-    parsed.session.ok_or_else(|| PopcornError::ControlPlane {
-        status,
-        body: "session response is missing cdpInternalUrl".to_owned(),
-    })
+    parsed
+        .session
+        .map(PopcornSession::from)
+        .ok_or_else(|| PopcornError::ControlPlane {
+            status,
+            body: "the session response is missing its connection URL".to_owned(),
+        })
 }
 
+/// Ends a session. Termination never requires another payment.
 async fn delete_session(
     client: &Client,
     config: &PopcornConfig,
     session_id: &str,
 ) -> Result<(), PopcornError> {
-    let response = client
-        .delete(config.session_url(session_id)?)
-        .header(reqwest::header::AUTHORIZATION, config.bearer())
-        .send()
-        .await?;
+    let url = match &config.access {
+        Access::X402 { endpoint, .. } => x402_session_url(endpoint, session_id, None)?,
+        Access::Credentialed { control_plane, .. } => control_plane
+            .join(&format!("v1/session/{session_id}"))
+            .map_err(|error| PopcornError::Configuration {
+                message: format!("cannot build session URL: {error}"),
+            })?,
+    };
+    let mut builder = client.delete(url);
+    if let Some(bearer) = config.bearer() {
+        builder = builder.header(reqwest::header::AUTHORIZATION, bearer);
+    }
+    let response = builder.send().await?;
     let status = response.status();
     if status.is_success() || status == StatusCode::NOT_FOUND {
         return Ok(());
@@ -486,6 +1257,232 @@ fn truncate(body: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A challenge matching the trusted policy exactly.
+    fn trusted_challenge(amount: &str) -> serde_json::Value {
+        serde_json::json!({
+            "x402Version": 2,
+            "resource": { "url": X402_SESSIONS_URL },
+            "accepts": [{
+                "scheme": "exact",
+                "network": "eip155:8453",
+                "amount": amount,
+                "asset": X402_ASSET,
+                "payTo": X402_PAY_TO,
+                "maxTimeoutSeconds": 120,
+                "extra": { "name": "USD Coin", "version": "2" }
+            }]
+        })
+    }
+
+    fn offer_with(field: &str, value: serde_json::Value) -> PaymentRequirements {
+        let mut challenge = trusted_challenge("10000");
+        challenge["accepts"][0][field] = value;
+        serde_json::from_value(challenge["accepts"][0].clone()).unwrap()
+    }
+
+    #[test]
+    fn accepts_an_exact_policy_match() {
+        let offer = offer_with("scheme", serde_json::json!("exact"));
+        assert!(validate_offer(&offer, X402_ATOMIC_PER_BLOCK).is_ok());
+    }
+
+    #[test]
+    fn accepts_a_checksum_variant_of_the_trusted_addresses() {
+        let offer = offer_with("asset", serde_json::json!(X402_ASSET.to_lowercase()));
+        assert!(validate_offer(&offer, X402_ATOMIC_PER_BLOCK).is_ok());
+        let offer = offer_with("payTo", serde_json::json!(X402_PAY_TO.to_uppercase()));
+        assert!(validate_offer(&offer, X402_ATOMIC_PER_BLOCK).is_ok());
+    }
+
+    #[test]
+    fn rejects_a_different_network() {
+        let offer = offer_with("network", serde_json::json!("eip155:84532"));
+        let error = validate_offer(&offer, X402_ATOMIC_PER_BLOCK).unwrap_err();
+        assert!(format!("{error}").contains("network"), "{error}");
+    }
+
+    #[test]
+    fn rejects_a_different_asset() {
+        let offer = offer_with(
+            "asset",
+            serde_json::json!("0x0000000000000000000000000000000000000001"),
+        );
+        let error = validate_offer(&offer, X402_ATOMIC_PER_BLOCK).unwrap_err();
+        assert!(format!("{error}").contains("asset"), "{error}");
+    }
+
+    #[test]
+    fn rejects_a_different_payee() {
+        let offer = offer_with(
+            "payTo",
+            serde_json::json!("0x0000000000000000000000000000000000000002"),
+        );
+        let error = validate_offer(&offer, X402_ATOMIC_PER_BLOCK).unwrap_err();
+        assert!(format!("{error}").contains("payee"), "{error}");
+    }
+
+    #[test]
+    fn rejects_a_different_amount() {
+        let offer = offer_with("amount", serde_json::json!("20000"));
+        let error = validate_offer(&offer, X402_ATOMIC_PER_BLOCK).unwrap_err();
+        assert!(format!("{error}").contains("amount"), "{error}");
+    }
+
+    #[test]
+    fn rejects_a_different_scheme() {
+        let offer = offer_with("scheme", serde_json::json!("upto"));
+        let error = validate_offer(&offer, X402_ATOMIC_PER_BLOCK).unwrap_err();
+        assert!(format!("{error}").contains("scheme"), "{error}");
+    }
+
+    #[test]
+    fn rejects_an_unsupported_protocol_version() {
+        let mut challenge = trusted_challenge("10000");
+        challenge["x402Version"] = serde_json::json!(1);
+        let challenge: PaymentRequired = serde_json::from_value(challenge).unwrap();
+        let error = select_offer(&challenge, X402_ATOMIC_PER_BLOCK).unwrap_err();
+        assert!(format!("{error}").contains("x402 version"), "{error}");
+    }
+
+    #[test]
+    fn selects_the_single_trusted_offer_among_untrusted_ones() {
+        let mut challenge = trusted_challenge("10000");
+        let mut hostile = challenge["accepts"][0].clone();
+        hostile["payTo"] = serde_json::json!("0x0000000000000000000000000000000000000003");
+        challenge["accepts"] = serde_json::json!([hostile, challenge["accepts"][0].clone()]);
+        let challenge: PaymentRequired = serde_json::from_value(challenge).unwrap();
+        let (_, offer) = select_offer(&challenge, X402_ATOMIC_PER_BLOCK).unwrap();
+        assert!(offer.pay_to.eq_ignore_ascii_case(X402_PAY_TO));
+    }
+
+    #[test]
+    fn extension_amount_scales_by_whole_blocks() {
+        let offer = offer_with("amount", serde_json::json!("30000"));
+        assert!(validate_offer(&offer, X402_ATOMIC_PER_BLOCK * 3).is_ok());
+        assert!(validate_offer(&offer, X402_ATOMIC_PER_BLOCK).is_err());
+    }
+
+    #[test]
+    fn parses_the_x402_session_shape() {
+        let body = serde_json::json!({
+            "sessionId": "x402s_abc",
+            "sessionUrl": "https://app.example.com/v1/x402/sessions/x402s_abc",
+            "connectUrl": "wss://gateway.example.com/cdp/x402s_abc/tok",
+            "liveViewUrl": "https://gateway.example.com/liveview/x402s_abc/tok/liveview.html",
+            "vncUrl": "https://gateway.example.com/liveview/x402s_abc/tok/liveview.html",
+            "vncWsUrl": "wss://gateway.example.com/liveview-ws/x402s_abc/tok",
+            "expiresAt": "2026-08-04T12:30:00.000Z",
+            "paidSeconds": 300,
+            "region": "asia-south1",
+            "clusterName": "popcorn-prod"
+        });
+        let parsed: X402Session = serde_json::from_value(body).unwrap();
+        let session = PopcornSession::from(parsed);
+        assert_eq!(session.session_id(), "x402s_abc");
+        assert_eq!(session.cdp.scheme(), "wss");
+        assert_eq!(session.paid_seconds(), Some(300));
+        assert_eq!(session.region(), Some("asia-south1"));
+    }
+
+    #[test]
+    fn parses_the_x402_extension_shape() {
+        let body = serde_json::json!({
+            "sessionId": "x402s_abc",
+            "additionalSeconds": 600,
+            "paidSecondsTotal": 900,
+            "expiresAt": "2026-08-04T12:40:00.000Z"
+        });
+        let parsed: X402Extension = serde_json::from_value(body).unwrap();
+        assert_eq!(parsed.paid_seconds_total, Some(900));
+        assert_eq!(
+            parsed.expires_at.as_deref(),
+            Some("2026-08-04T12:40:00.000Z")
+        );
+    }
+
+    #[test]
+    fn decodes_a_challenge_from_the_header_before_the_body() {
+        let header = base64_encode(trusted_challenge("10000").to_string().as_bytes());
+        let decoded = decode_payment_required(Some(&header), "not json").unwrap();
+        assert_eq!(decoded.x402_version, 2);
+        assert_eq!(decoded.accepts.len(), 1);
+    }
+
+    #[test]
+    fn decodes_a_challenge_from_the_body_when_no_header_is_present() {
+        let body = trusted_challenge("10000").to_string();
+        let decoded = decode_payment_required(None, &body).unwrap();
+        assert_eq!(decoded.x402_version, 2);
+    }
+
+    #[test]
+    fn signs_the_authorization_the_policy_validated() {
+        let signer = PrivateKeySigner::random();
+        let offer = offer_with("scheme", serde_json::json!("exact"));
+        let payload = sign_authorization(&signer, &offer).unwrap();
+        assert!(payload.authorization.to.eq_ignore_ascii_case(X402_PAY_TO));
+        assert_eq!(payload.authorization.value, "10000");
+        assert_eq!(payload.authorization.valid_after, "0");
+        assert_eq!(payload.signature.len(), 2 + 130);
+        assert!(payload.authorization.nonce.starts_with("0x"));
+        assert_eq!(payload.authorization.nonce.len(), 2 + 64);
+    }
+
+    /// Cross-checks the EIP-712 signature against `viem`, the implementation
+    /// the Popcorn reference client uses, for one fixed vector. A mistake in
+    /// the domain, the struct definition, or the signature encoding changes
+    /// this value.
+    ///
+    /// The key is the published Anvil test key, never used to hold funds.
+    #[test]
+    fn signature_matches_the_reference_eip712_implementation() {
+        let signer: PrivateKeySigner =
+            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+                .parse()
+                .unwrap();
+        assert_eq!(
+            signer.address().to_checksum(None),
+            "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+        );
+        let terms = AuthorizationTerms {
+            asset: X402_ASSET.parse().unwrap(),
+            pay_to: X402_PAY_TO.parse().unwrap(),
+            value: U256::from(10_000u64),
+            valid_before: 1_789_000_000,
+            nonce: "0x00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
+                .parse()
+                .unwrap(),
+            domain_name: "USD Coin".to_owned(),
+            domain_version: "2".to_owned(),
+        };
+        let payload = sign_transfer_authorization(&signer, &terms).unwrap();
+        assert_eq!(
+            payload.signature,
+            "0xb8ab7bc63d1242be4e03cf85096be78cdd465f15c84d64f6fab87bbe0631cdbc\
+6644968e60ad0e7b243957af4a5ddfb19591b5d88f687a1a2b0153e4c68bfc7c1b"
+                .replace('\n', "")
+        );
+        assert_eq!(payload.authorization.valid_before, "1789000000");
+        assert_eq!(payload.authorization.value, "10000");
+    }
+
+    #[test]
+    fn builds_x402_session_urls() {
+        let endpoint = Url::parse(X402_SESSIONS_URL).unwrap();
+        assert_eq!(
+            x402_session_url(&endpoint, "x402s_abc", None)
+                .unwrap()
+                .path(),
+            "/v1/x402/sessions/x402s_abc"
+        );
+        assert_eq!(
+            x402_session_url(&endpoint, "x402s_abc", Some("extend"))
+                .unwrap()
+                .path(),
+            "/v1/x402/sessions/x402s_abc/extend"
+        );
+    }
 
     #[test]
     fn create_request_omits_empty_fields() {
@@ -526,22 +1523,30 @@ mod tests {
             "clusterName": "popcorn-prod-us"
         }"#;
         let parsed: CreateSessionResponse = serde_json::from_str(body).unwrap();
-        let session = parsed.session.unwrap();
-        assert_eq!(session.session_id, "demo-session");
-        assert_eq!(session.cdp_internal_url.scheme(), "wss");
-        assert_eq!(session.region.as_deref(), Some("us-central1"));
+        let session = PopcornSession::from(parsed.session.unwrap());
+        assert_eq!(session.session_id(), "demo-session");
+        assert_eq!(session.cdp.scheme(), "wss");
+        assert_eq!(session.region(), Some("us-central1"));
+    }
+
+    #[test]
+    fn failed_response_surfaces_error_message() {
+        let body = r#"{"success": false, "error": "no capacity in region"}"#;
+        let parsed: CreateSessionResponse = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed.success, Some(false));
+        assert_eq!(parsed.error.as_deref(), Some("no capacity in region"));
+        assert!(parsed.session.is_none());
     }
 
     #[test]
     fn debug_output_redacts_session_urls() {
-        let body = r#"{
+        let body = serde_json::json!({
             "sessionId": "demo-session",
-            "url": "https://browser.example.com/liveview/demo-session/tok/liveview.html",
-            "cdpUrl": "wss://browser.example.com/cdp/demo-session/tok/",
-            "cdpInternalUrl": "wss://browser.example.com/cdp-internal/demo-session/tok/"
-        }"#;
-        let session: PopcornSession = serde_json::from_str(body).unwrap();
-        let rendered = format!("{session:?}");
+            "connectUrl": "wss://browser.example.com/cdp/demo-session/tok",
+            "liveViewUrl": "https://browser.example.com/liveview/demo-session/tok/liveview.html"
+        });
+        let parsed: X402Session = serde_json::from_value(body).unwrap();
+        let rendered = format!("{:?}", PopcornSession::from(parsed));
         assert!(!rendered.contains("tok"), "session URLs leaked: {rendered}");
         assert!(!rendered.contains("browser.example.com"));
         assert!(rendered.contains("demo-session"));
@@ -563,29 +1568,33 @@ mod tests {
     }
 
     #[test]
-    fn failed_response_surfaces_error_message() {
-        let body = r#"{"success": false, "error": "no capacity in region"}"#;
-        let parsed: CreateSessionResponse = serde_json::from_str(body).unwrap();
-        assert_eq!(parsed.success, Some(false));
-        assert_eq!(parsed.error.as_deref(), Some("no capacity in region"));
-        assert!(parsed.session.is_none());
+    fn debug_output_redacts_the_payer_key() {
+        let config = PopcornConfig::x402(
+            "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
+        );
+        let rendered = format!("{config:?}");
+        assert!(
+            !rendered.contains("59c6995e"),
+            "payer key leaked: {rendered}"
+        );
+        assert!(rendered.contains("x402"));
+        assert!(config.is_x402());
     }
 
     #[test]
-    fn config_builds_control_plane_urls() {
+    fn credentialed_config_builds_control_plane_urls() {
         let config = PopcornConfig::new(
             Url::parse("https://control.example.com/").unwrap(),
             "id",
             "secret",
         );
-        assert_eq!(
-            config.sessions_url().unwrap().as_str(),
-            "https://control.example.com/v1/sessions"
-        );
-        assert_eq!(
-            config.session_url("abc").unwrap().as_str(),
-            "https://control.example.com/v1/session/abc"
-        );
-        assert_eq!(config.bearer(), "Bearer id:secret");
+        assert!(!config.is_x402());
+        assert_eq!(config.bearer().as_deref(), Some("Bearer id:secret"));
+    }
+
+    #[test]
+    fn x402_config_sends_no_bearer_credential() {
+        let config = PopcornConfig::x402("0x01");
+        assert!(config.bearer().is_none());
     }
 }

--- a/crates/experimental/nanocodex-browser/tests/live_popcorn.rs
+++ b/crates/experimental/nanocodex-browser/tests/live_popcorn.rs
@@ -4,10 +4,11 @@ use nanocodex_browser::{
 };
 
 #[tokio::test]
-#[ignore = "requires POPCORN_* credentials for a reachable control plane"]
+#[ignore = "rents a real Popcorn session: needs MCP credits or POPCORN_* control-plane credentials"]
 async fn popcorn_session_drives_a_real_page_and_releases() {
-    let config = PopcornConfig::from_env()
-        .expect("set POPCORN_CONTROL_PLANE_URL, POPCORN_CLIENT_ID, and POPCORN_CLIENT_SECRET");
+    // Defaults to the hosted MCP server; the POPCORN_CONTROL_PLANE_URL,
+    // POPCORN_CLIENT_ID, and POPCORN_CLIENT_SECRET trio selects a control plane.
+    let config = PopcornConfig::from_env().expect("read the Popcorn configuration");
     let popcorn = PopcornBrowser::spawn(config).await.expect("rent session");
     eprintln!("popcorn session: {}", popcorn.session().session_id);
 

--- a/crates/experimental/nanocodex-browser/tests/live_popcorn.rs
+++ b/crates/experimental/nanocodex-browser/tests/live_popcorn.rs
@@ -9,7 +9,7 @@ async fn popcorn_session_drives_a_real_page_and_releases() {
     let config = PopcornConfig::from_env()
         .expect("set POPCORN_CONTROL_PLANE_URL, POPCORN_CLIENT_ID, and POPCORN_CLIENT_SECRET");
     let popcorn = PopcornBrowser::spawn(config).await.expect("rent session");
-    eprintln!("popcorn session: {}", popcorn.session().session_id);
+    eprintln!("popcorn session: {}", popcorn.session().session_id());
 
     // Session URLs are bearer secrets and must not survive a debug render.
     let rendered = format!("{:?}", popcorn.session());

--- a/crates/experimental/nanocodex-browser/tests/live_popcorn.rs
+++ b/crates/experimental/nanocodex-browser/tests/live_popcorn.rs
@@ -1,0 +1,42 @@
+use nanocodex_browser::{
+    BrowserAction, BrowserActionResult, BrowserTarget,
+    popcorn::{PopcornBrowser, PopcornConfig},
+};
+
+#[tokio::test]
+#[ignore = "requires POPCORN_* credentials for a reachable control plane"]
+async fn popcorn_session_drives_a_real_page_and_releases() {
+    let config = PopcornConfig::from_env()
+        .expect("set POPCORN_CONTROL_PLANE_URL, POPCORN_CLIENT_ID, and POPCORN_CLIENT_SECRET");
+    let popcorn = PopcornBrowser::spawn(config).await.expect("rent session");
+    eprintln!("popcorn session: {}", popcorn.session().session_id);
+
+    // Session URLs are bearer secrets and must not survive a debug render.
+    let rendered = format!("{:?}", popcorn.session());
+    assert!(
+        !rendered.contains("http"),
+        "session URLs leaked through Debug: {rendered}"
+    );
+
+    popcorn
+        .browser()
+        .execute(BrowserAction::Open {
+            url: "https://example.com".to_owned(),
+        })
+        .await
+        .expect("open example.com");
+
+    let result = popcorn
+        .browser()
+        .execute(BrowserAction::GetText {
+            target: BrowserTarget::css("h1"),
+        })
+        .await
+        .expect("read heading");
+    let BrowserActionResult::Text { text, .. } = &result else {
+        panic!("expected a text result, got {result:?}");
+    };
+    assert_eq!(text, "Example Domain");
+
+    popcorn.shutdown().await.expect("release session");
+}

--- a/crates/experimental/nanocodex-browser/tests/live_popcorn.rs
+++ b/crates/experimental/nanocodex-browser/tests/live_popcorn.rs
@@ -9,7 +9,7 @@ async fn popcorn_session_drives_a_real_page_and_releases() {
     let config = PopcornConfig::from_env()
         .expect("set POPCORN_CONTROL_PLANE_URL, POPCORN_CLIENT_ID, and POPCORN_CLIENT_SECRET");
     let popcorn = PopcornBrowser::spawn(config).await.expect("rent session");
-    eprintln!("popcorn session: {}", popcorn.session().session_id());
+    eprintln!("popcorn session: {}", popcorn.session().session_id);
 
     // Session URLs are bearer secrets and must not survive a debug render.
     let rendered = format!("{:?}", popcorn.session());

--- a/crates/nanocodex-tools/src/mcp/catalog.rs
+++ b/crates/nanocodex-tools/src/mcp/catalog.rs
@@ -306,6 +306,19 @@ impl ProviderState {
         self.entry(name)
     }
 
+    /// Returns the connected client for one server, waiting out startup first.
+    pub(crate) async fn ready_client(&self, server_name: &str) -> Result<Client, String> {
+        self.wait_for_startup().await;
+        let catalog = self.catalog();
+        if let Some(client) = catalog.clients.get(server_name) {
+            return Ok(Arc::clone(client));
+        }
+        if let Some(error) = catalog.failures.get(server_name) {
+            return Err(error.clone());
+        }
+        Err("server is not connected".to_owned())
+    }
+
     pub(crate) async fn prepared_entries(&self) -> Result<Vec<Arc<ToolEntry>>, String> {
         self.wait_for_startup().await;
         let catalog = self.catalog();

--- a/crates/nanocodex-tools/src/mcp/mod.rs
+++ b/crates/nanocodex-tools/src/mcp/mod.rs
@@ -108,6 +108,58 @@ pub struct McpLogin {
     completion: tokio::task::JoinHandle<Result<usize, McpControlError>>,
 }
 
+/// The result of one direct MCP tool call made through [`McpHandle::call_tool`].
+///
+/// This value intentionally does not implement `Debug`: a tool result can carry
+/// session URLs, tokens, or other short-lived secrets that must not reach
+/// diagnostics.
+pub struct McpToolCall {
+    is_error: bool,
+    structured_content: Option<Value>,
+    text: String,
+}
+
+impl McpToolCall {
+    /// Returns whether the server reported the call as failed.
+    #[must_use]
+    pub const fn is_error(&self) -> bool {
+        self.is_error
+    }
+
+    /// Returns the server's structured content when it sent any.
+    #[must_use]
+    pub const fn structured_content(&self) -> Option<&Value> {
+        self.structured_content.as_ref()
+    }
+
+    /// Returns every text content block, joined by newlines.
+    #[must_use]
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    /// Returns the structured content, falling back to text parsed as JSON.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the call has neither structured content nor text
+    /// that parses as JSON.
+    pub fn json(&self) -> Result<Value, String> {
+        if let Some(structured_content) = self
+            .structured_content
+            .as_ref()
+            .filter(|content| !content.is_null())
+        {
+            return Ok(structured_content.clone());
+        }
+        if self.text.trim().is_empty() {
+            return Err("MCP tool result has no structured content and no text".to_owned());
+        }
+        serde_json::from_str(&self.text)
+            .map_err(|error| format!("MCP tool result text is not JSON: {error}"))
+    }
+}
+
 /// Failure while controlling an already configured MCP provider.
 #[derive(Debug, thiserror::Error)]
 pub enum McpControlError {
@@ -137,6 +189,16 @@ pub enum McpControlError {
     /// The spawned login task stopped before returning its result.
     #[error("MCP OAuth login task stopped: {0}")]
     LoginTask(String),
+    /// A direct tool call could not be delivered or was rejected.
+    #[error("MCP tool `{server}`/`{tool}` failed: {error}")]
+    ToolCall {
+        /// Configured server name.
+        server: String,
+        /// Remote tool name.
+        tool: String,
+        /// Connection, transport, or tool error.
+        error: String,
+    },
 }
 
 /// Invalid MCP provider configuration.
@@ -398,6 +460,80 @@ impl McpHandle {
                 })
             }
         }
+    }
+
+    /// Calls one tool on a configured server by its remote name.
+    ///
+    /// This is the programmatic path used by embedders that drive an MCP server
+    /// themselves instead of exposing its tools to a model. The call waits for
+    /// the provider's startup discovery, refreshes OAuth credentials when the
+    /// server uses them, and is bounded by the server's configured tool
+    /// timeout.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the server name is unknown, the server is not
+    /// connected, or the call fails, times out, or is reported as an error by
+    /// the server.
+    pub async fn call_tool(
+        &self,
+        server_name: &str,
+        tool_name: &str,
+        arguments: serde_json::Map<String, Value>,
+    ) -> Result<McpToolCall, McpControlError> {
+        let server = self
+            .servers
+            .iter()
+            .find(|server| server.name == server_name)
+            .ok_or_else(|| McpControlError::UnknownServer(server_name.to_owned()))?;
+        let failed = |error: String| McpControlError::ToolCall {
+            server: server_name.to_owned(),
+            tool: tool_name.to_owned(),
+            error,
+        };
+        let client = self
+            .state
+            .ready_client(server_name)
+            .await
+            .map_err(&failed)?;
+        client.refresh_oauth().await.map_err(&failed)?;
+        let timeout = server.config.tool_timeout;
+        let params = CallToolRequestParams::new(tool_name.to_owned()).with_arguments(arguments);
+        let span = info_span!(
+            target: "nanocodex_tools",
+            "mcp.tool_call",
+            otel.kind = "client",
+            otel.status_code = tracing::field::Empty,
+            mcp.server = server_name,
+            mcp.tool = tool_name,
+            status = tracing::field::Empty,
+        );
+        let result =
+            match tokio::time::timeout(timeout, client.call_tool(params).instrument(span.clone()))
+                .await
+            {
+                Ok(Ok(result)) => result,
+                Ok(Err(error)) => {
+                    span.record("status", "failed");
+                    span.record("otel.status_code", "ERROR");
+                    return Err(failed(error));
+                }
+                Err(_) => {
+                    span.record("status", "timeout");
+                    span.record("otel.status_code", "ERROR");
+                    return Err(failed(format!(
+                        "call exceeded {:.1} seconds",
+                        timeout.as_secs_f64()
+                    )));
+                }
+            };
+        let call = tool_call_from_mcp_result(result);
+        span.record("status", if call.is_error { "failed" } else { "completed" });
+        span.record(
+            "otel.status_code",
+            if call.is_error { "ERROR" } else { "OK" },
+        );
+        Ok(call)
     }
 
     /// Starts an OAuth browser login for one server.
@@ -681,6 +817,24 @@ async fn execute_mcp_entry(entry: &ToolEntry, input: Value, timeout: Duration) -
             span.record("otel.status_code", "ERROR");
             ToolOutput::error(format!("failed to encode MCP tool result: {error}"))
         }
+    }
+}
+
+/// Flattens a tool result into text plus structured content for direct callers.
+fn tool_call_from_mcp_result(result: CallToolResult) -> McpToolCall {
+    let text = result
+        .content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text(text) => Some(text.text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    McpToolCall {
+        is_error: result.is_error.unwrap_or(false),
+        structured_content: result.structured_content,
+        text,
     }
 }
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -94,6 +94,10 @@ name = "browser-agent"
 path = "browser_agent.rs"
 
 [[bin]]
+name = "popcorn-agent"
+path = "popcorn_agent.rs"
+
+[[bin]]
 name = "realtime-pipe"
 path = "realtime_pipe.rs"
 

--- a/examples/popcorn_agent.rs
+++ b/examples/popcorn_agent.rs
@@ -4,13 +4,26 @@
 //! reached over CDP. The LiveView URL is printed so a human can watch the
 //! session or take over when the agent gets stuck.
 //!
+//! Sessions come from the public pay-per-use endpoint at
+//! <https://popcorn.reclaimprotocol.org>. No account is needed: each
+//! five-minute block costs $0.01 in USDC on Base, paid per request with x402.
+//! Point `POPCORN_PAYER_PRIVATE_KEY` at an EVM key holding a little USDC and
+//! enough ETH for gas on Base.
+//!
 //! ```sh
 //! export OPENAI_API_KEY=...
+//! export POPCORN_PAYER_PRIVATE_KEY=0x...
+//! cargo run -p nanocodex-examples --bin popcorn-agent -- \
+//!   "Open https://example.com, inspect the page, and report its main heading."
+//! ```
+//!
+//! Dedicated deployments use the credentialed control plane instead, with no
+//! payment involved:
+//!
+//! ```sh
 //! export POPCORN_CONTROL_PLANE_URL=https://...
 //! export POPCORN_CLIENT_ID=...
 //! export POPCORN_CLIENT_SECRET=...
-//! cargo run -p nanocodex-examples --bin popcorn-agent -- \
-//!   "Open https://example.com, inspect the page, and report its main heading."
 //! ```
 //!
 //! A literal `--` between two prompts runs them as two turns on the same agent
@@ -44,7 +57,7 @@ async fn main() -> Result<()> {
     let api_key = std::env::var("OPENAI_API_KEY").wrap_err("OPENAI_API_KEY is required")?;
     let config = PopcornConfig::from_env()?;
     let popcorn = PopcornBrowser::spawn(config).await?;
-    eprintln!("popcorn session: {}", popcorn.session().session_id);
+    eprintln!("popcorn session: {}", popcorn.session().session_id());
     eprintln!("live view: {}", popcorn.live_view_url());
 
     let tools = Tools::builder().provider(popcorn.tool()).build()?;

--- a/examples/popcorn_agent.rs
+++ b/examples/popcorn_agent.rs
@@ -1,0 +1,106 @@
+//! Drive a rented Popcorn browser session from a Nanocodex agent.
+//!
+//! The agent brain runs here; the browser runs inside a Popcorn TEE session
+//! reached over CDP. The LiveView URL is printed so a human can watch the
+//! session or take over when the agent gets stuck.
+//!
+//! ```sh
+//! export OPENAI_API_KEY=...
+//! export POPCORN_CONTROL_PLANE_URL=https://...
+//! export POPCORN_CLIENT_ID=...
+//! export POPCORN_CLIENT_SECRET=...
+//! cargo run -p nanocodex-examples --bin popcorn-agent -- \
+//!   "Open https://example.com, inspect the page, and report its main heading."
+//! ```
+
+use eyre::{Result, WrapErr};
+use nanocodex::{AgentEvents, Nanocodex, OpenAi, Thinking, Tools};
+use nanocodex_browser::popcorn::{PopcornBrowser, PopcornConfig};
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio::time::{Duration, timeout};
+
+const TURN_SETTLE_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let api_key = std::env::var("OPENAI_API_KEY").wrap_err("OPENAI_API_KEY is required")?;
+    let config = PopcornConfig::from_env()?;
+    let popcorn = PopcornBrowser::spawn(config).await?;
+    eprintln!("popcorn session: {}", popcorn.session().session_id);
+    eprintln!("live view: {}", popcorn.live_view_url());
+
+    let tools = Tools::builder().provider(popcorn.tool()).build()?;
+    let openai = OpenAi::new(api_key)?;
+    let (agent, mut events) = Nanocodex::builder(openai)
+        .instructions(
+            "Use `tools.browser` from Code Mode for browser work. The browser runs in a remote isolated session. Inspect the page after every navigation before interacting with it.",
+        )
+        .thinking(Thinking::Low)
+        .tools(tools)
+        .build()?;
+
+    let prompt = std::env::args().skip(1).collect::<Vec<_>>().join(" ");
+    let prompt = if prompt.is_empty() {
+        "Open https://example.com, inspect the page, and report its main heading."
+    } else {
+        &prompt
+    };
+    let turn = agent.prompt(prompt).await?;
+    let control = turn.control();
+    let mut stdout = tokio::io::stdout();
+    let turn_result: Result<_> = {
+        let events_result = write_turn_jsonl(&mut events, &mut stdout);
+        let turn_result = turn.result();
+        tokio::pin!(events_result);
+        tokio::pin!(turn_result);
+        tokio::select! {
+        result = &mut turn_result => {
+            let terminal = timeout(TURN_SETTLE_TIMEOUT, &mut events_result).await;
+            let result = result?;
+            terminal
+                .wrap_err("terminal event did not settle after the turn completed")??;
+            Ok(result)
+        }
+        result = &mut events_result => match result {
+            Ok(()) => Ok(timeout(TURN_SETTLE_TIMEOUT, &mut turn_result)
+                .await
+                .wrap_err("turn result did not settle after its terminal event")??),
+            Err(event_error) => {
+                let _ = timeout(TURN_SETTLE_TIMEOUT, control.cancel()).await;
+                match timeout(TURN_SETTLE_TIMEOUT, &mut turn_result).await {
+                    Ok(Err(turn_error)) => Err(turn_error.into()),
+                    _ => Err(event_error),
+                }
+            }
+        },
+        }
+    };
+    let agent_shutdown = agent.shutdown().await;
+    drop(agent);
+    drop(events);
+    let popcorn_shutdown = popcorn.shutdown().await;
+    let result = turn_result?;
+    agent_shutdown?;
+    popcorn_shutdown?;
+    eprintln!("final result: {}", result.final_message());
+    Ok(())
+}
+
+async fn write_turn_jsonl(
+    events: &mut AgentEvents,
+    output: &mut (impl AsyncWrite + Unpin),
+) -> Result<()> {
+    while let Some(event) = events.recv().await {
+        let terminal = event.kind.is_terminal();
+        let mut record = serde_json::to_vec(&event)?;
+        record.push(b'\n');
+        output.write_all(&record).await?;
+        output.flush().await?;
+        if terminal {
+            return Ok(());
+        }
+    }
+    Err(eyre::eyre!(
+        "agent event stream closed before the turn emitted a terminal event"
+    ))
+}

--- a/examples/popcorn_agent.rs
+++ b/examples/popcorn_agent.rs
@@ -14,9 +14,7 @@
 //! ```
 
 use eyre::{Result, WrapErr};
-use nanocodex::agent::events::{
-    AgentEvent, AgentEventKind, AssistantMessage, ReasoningSummaryDelta,
-};
+use nanocodex::agent::events::{AgentEvent, AgentEventKind, AssistantMessage};
 use nanocodex::{AgentEvents, Nanocodex, OpenAi, Thinking, Tools};
 use nanocodex_browser::popcorn::{PopcornBrowser, PopcornConfig};
 use tokio::io::{AsyncWrite, AsyncWriteExt};
@@ -93,16 +91,14 @@ async fn write_turn_jsonl(
     events: &mut AgentEvents,
     output: &mut (impl AsyncWrite + Unpin),
 ) -> Result<()> {
-    let mut echo = AgentEcho::default();
     while let Some(event) = events.recv().await {
         let terminal = event.kind.is_terminal();
         let mut record = serde_json::to_vec(&event)?;
         record.push(b'\n');
         output.write_all(&record).await?;
         output.flush().await?;
-        echo.observe(&event);
+        echo_assistant_message(&event);
         if terminal {
-            echo.flush();
             return Ok(());
         }
     }
@@ -111,52 +107,20 @@ async fn write_turn_jsonl(
     ))
 }
 
-/// Echoes the agent's own words to stderr so a human watching the terminal can
-/// follow a turn while the JSONL contract on stdout stays byte-for-byte the same.
+/// Echoes one completed assistant message to stderr so a human watching the
+/// terminal can follow a turn while the JSONL contract on stdout stays
+/// byte-for-byte the same.
 ///
-/// Only assistant messages and API-visible reasoning summaries are echoed. Tool
-/// calls, tool results, and raw provider events are deliberately skipped.
-#[derive(Default)]
-struct AgentEcho {
-    /// Reasoning-summary text received but not yet terminated by a newline.
-    pending_summary: String,
-}
-
-impl AgentEcho {
-    /// Echoes any human-readable text carried by one event.
-    fn observe(&mut self, event: &AgentEvent) {
-        match event.kind {
-            AgentEventKind::AssistantMessage => {
-                self.flush();
-                if let Ok(message) = event.decode_payload::<AssistantMessage>() {
-                    echo_lines(&message.text);
-                }
-            }
-            AgentEventKind::ReasoningSummaryDelta => {
-                let Ok(delta) = event.decode_payload::<ReasoningSummaryDelta>() else {
-                    return;
-                };
-                self.pending_summary.push_str(&delta.text);
-                while let Some(newline) = self.pending_summary.find('\n') {
-                    let line = self.pending_summary[..newline].to_owned();
-                    self.pending_summary.drain(..=newline);
-                    echo_lines(&line);
-                }
-            }
-            _ => {}
-        }
+/// Every other event is skipped, including tool calls, tool results, reasoning,
+/// and raw provider events.
+fn echo_assistant_message(event: &AgentEvent) {
+    if event.kind != AgentEventKind::AssistantMessage {
+        return;
     }
-
-    /// Emits summary text that never received a trailing newline.
-    fn flush(&mut self) {
-        let pending = std::mem::take(&mut self.pending_summary);
-        echo_lines(&pending);
-    }
-}
-
-/// Writes one `agent:` line per non-blank line of `text`.
-fn echo_lines(text: &str) {
-    for line in text.lines().filter(|line| !line.trim().is_empty()) {
+    let Ok(message) = event.decode_payload::<AssistantMessage>() else {
+        return;
+    };
+    for line in message.text.lines().filter(|line| !line.trim().is_empty()) {
         eprintln!("agent: {line}");
     }
 }

--- a/examples/popcorn_agent.rs
+++ b/examples/popcorn_agent.rs
@@ -12,18 +12,35 @@
 //! cargo run -p nanocodex-examples --bin popcorn-agent -- \
 //!   "Open https://example.com, inspect the page, and report its main heading."
 //! ```
+//!
+//! A literal `--` between two prompts runs them as two turns on the same agent
+//! and the same rented session, pausing between them so a human can take over
+//! the live view. The second turn resumes with whatever state the human left
+//! behind, such as a completed login:
+//!
+//! ```sh
+//! cargo run -p nanocodex-examples --bin popcorn-agent -- \
+//!   "Open the site and stop at the login form." \
+//!   -- "Open the first post in the feed and summarise it."
+//! ```
 
 use eyre::{Result, WrapErr};
 use nanocodex::agent::events::{AgentEvent, AgentEventKind, AssistantMessage};
-use nanocodex::{AgentEvents, Nanocodex, OpenAi, Thinking, Tools};
+use nanocodex::{AgentEvents, Nanocodex, OpenAi, Thinking, Tools, TurnResult};
 use nanocodex_browser::popcorn::{PopcornBrowser, PopcornConfig};
-use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio::io::{AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::time::{Duration, timeout};
 
 const TURN_SETTLE_TIMEOUT: Duration = Duration::from_secs(5);
 
+const DEFAULT_PROMPT: &str =
+    "Open https://example.com, inspect the page, and report its main heading.";
+
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Resolve prompts before renting anything so a usage error cannot leak a session.
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    let (first_prompt, second_prompt) = split_prompts(&args)?;
     let api_key = std::env::var("OPENAI_API_KEY").wrap_err("OPENAI_API_KEY is required")?;
     let config = PopcornConfig::from_env()?;
     let popcorn = PopcornBrowser::spawn(config).await?;
@@ -40,42 +57,15 @@ async fn main() -> Result<()> {
         .tools(tools)
         .build()?;
 
-    let prompt = std::env::args().skip(1).collect::<Vec<_>>().join(" ");
-    let prompt = if prompt.is_empty() {
-        "Open https://example.com, inspect the page, and report its main heading."
-    } else {
-        &prompt
-    };
-    let turn = agent.prompt(prompt).await?;
-    let control = turn.control();
     let mut stdout = tokio::io::stdout();
-    let turn_result: Result<_> = {
-        let events_result = write_turn_jsonl(&mut events, &mut stdout);
-        let turn_result = turn.result();
-        tokio::pin!(events_result);
-        tokio::pin!(turn_result);
-        tokio::select! {
-        result = &mut turn_result => {
-            let terminal = timeout(TURN_SETTLE_TIMEOUT, &mut events_result).await;
-            let result = result?;
-            terminal
-                .wrap_err("terminal event did not settle after the turn completed")??;
-            Ok(result)
-        }
-        result = &mut events_result => match result {
-            Ok(()) => Ok(timeout(TURN_SETTLE_TIMEOUT, &mut turn_result)
-                .await
-                .wrap_err("turn result did not settle after its terminal event")??),
-            Err(event_error) => {
-                let _ = timeout(TURN_SETTLE_TIMEOUT, control.cancel()).await;
-                match timeout(TURN_SETTLE_TIMEOUT, &mut turn_result).await {
-                    Ok(Err(turn_error)) => Err(turn_error.into()),
-                    _ => Err(event_error),
-                }
-            }
-        },
-        }
-    };
+    let turn_result = run_handoff(
+        &agent,
+        &mut events,
+        &mut stdout,
+        &first_prompt,
+        second_prompt.as_deref(),
+    )
+    .await;
     let agent_shutdown = agent.shutdown().await;
     drop(agent);
     drop(events);
@@ -85,6 +75,97 @@ async fn main() -> Result<()> {
     popcorn_shutdown?;
     eprintln!("final result: {}", result.final_message());
     Ok(())
+}
+
+/// Splits arguments on a literal `--` into the pair of handoff prompts.
+///
+/// Without a separator the joined arguments are the only prompt, falling back
+/// to [`DEFAULT_PROMPT`] when no arguments were supplied.
+fn split_prompts(args: &[String]) -> Result<(String, Option<String>)> {
+    let Some(separator) = args.iter().position(|arg| arg == "--") else {
+        let prompt = args.join(" ");
+        return Ok(if prompt.trim().is_empty() {
+            (DEFAULT_PROMPT.to_owned(), None)
+        } else {
+            (prompt, None)
+        });
+    };
+    let before = args[..separator].join(" ");
+    let after = args[separator + 1..].join(" ");
+    if before.trim().is_empty() || after.trim().is_empty() {
+        eyre::bail!("`--` must separate two non-empty prompts");
+    }
+    Ok((before, Some(after)))
+}
+
+/// Runs the first prompt, then hands the session to a human before running the
+/// second prompt on the same agent, browser, and rented session.
+///
+/// Returns the last turn's result so the caller reports one final message.
+async fn run_handoff(
+    agent: &Nanocodex,
+    events: &mut AgentEvents,
+    output: &mut (impl AsyncWrite + Unpin),
+    first: &str,
+    second: Option<&str>,
+) -> Result<TurnResult> {
+    let first_result = run_turn(agent, events, output, first).await?;
+    let Some(second) = second else {
+        return Ok(first_result);
+    };
+    echo_agent_lines(first_result.final_message());
+    eprintln!("waiting for human: log in via the live view, then press Enter");
+    wait_for_enter().await?;
+    run_turn(agent, events, output, second).await
+}
+
+/// Blocks until the operator presses Enter.
+async fn wait_for_enter() -> Result<()> {
+    let mut line = String::new();
+    let read = BufReader::new(tokio::io::stdin())
+        .read_line(&mut line)
+        .await
+        .wrap_err("failed to read the handoff confirmation from stdin")?;
+    if read == 0 {
+        eyre::bail!("stdin closed before the human handoff was confirmed");
+    }
+    Ok(())
+}
+
+/// Runs one prompt to completion while streaming its events to `output`.
+async fn run_turn(
+    agent: &Nanocodex,
+    events: &mut AgentEvents,
+    output: &mut (impl AsyncWrite + Unpin),
+    prompt: &str,
+) -> Result<TurnResult> {
+    let turn = agent.prompt(prompt).await?;
+    let control = turn.control();
+    let events_result = write_turn_jsonl(events, output);
+    let turn_result = turn.result();
+    tokio::pin!(events_result);
+    tokio::pin!(turn_result);
+    tokio::select! {
+    result = &mut turn_result => {
+        let terminal = timeout(TURN_SETTLE_TIMEOUT, &mut events_result).await;
+        let result = result?;
+        terminal
+            .wrap_err("terminal event did not settle after the turn completed")??;
+        Ok(result)
+    }
+    result = &mut events_result => match result {
+        Ok(()) => Ok(timeout(TURN_SETTLE_TIMEOUT, &mut turn_result)
+            .await
+            .wrap_err("turn result did not settle after its terminal event")??),
+        Err(event_error) => {
+            let _ = timeout(TURN_SETTLE_TIMEOUT, control.cancel()).await;
+            match timeout(TURN_SETTLE_TIMEOUT, &mut turn_result).await {
+                Ok(Err(turn_error)) => Err(turn_error.into()),
+                _ => Err(event_error),
+            }
+        }
+    },
+    }
 }
 
 async fn write_turn_jsonl(
@@ -120,7 +201,12 @@ fn echo_assistant_message(event: &AgentEvent) {
     let Ok(message) = event.decode_payload::<AssistantMessage>() else {
         return;
     };
-    for line in message.text.lines().filter(|line| !line.trim().is_empty()) {
+    echo_agent_lines(&message.text);
+}
+
+/// Writes one `agent:` line per non-blank line of `text`.
+fn echo_agent_lines(text: &str) {
+    for line in text.lines().filter(|line| !line.trim().is_empty()) {
         eprintln!("agent: {line}");
     }
 }

--- a/examples/popcorn_agent.rs
+++ b/examples/popcorn_agent.rs
@@ -4,11 +4,14 @@
 //! reached over CDP. The LiveView URL is printed so a human can watch the
 //! session or take over when the agent gets stuck.
 //!
+//! Sessions are rented through Popcorn's hosted MCP server, so no
+//! Reclaim-issued credentials are needed. Run it, complete the OAuth login in
+//! your browser when the authorization URL prints, and buy credits at
+//! <https://popcorn.reclaimprotocol.org> if prompted. The login is persisted,
+//! so later runs start straight away.
+//!
 //! ```sh
 //! export OPENAI_API_KEY=...
-//! export POPCORN_CONTROL_PLANE_URL=https://...
-//! export POPCORN_CLIENT_ID=...
-//! export POPCORN_CLIENT_SECRET=...
 //! cargo run -p nanocodex-examples --bin popcorn-agent -- \
 //!   "Open https://example.com, inspect the page, and report its main heading."
 //! ```
@@ -23,6 +26,14 @@
 //!   "Open the site and stop at the login form." \
 //!   -- "Open the first post in the feed and summarise it."
 //! ```
+//!
+//! Dedicated deployments with their own Popcorn client credentials can set
+//! `POPCORN_CONTROL_PLANE_URL`, `POPCORN_CLIENT_ID`, and
+//! `POPCORN_CLIENT_SECRET` to use a credentialed control plane instead.
+//!
+//! An agent that would rather not use the native browser tool can skip this
+//! module entirely and register the Popcorn MCP server as an ordinary
+//! Nanocodex MCP server.
 
 use eyre::{Result, WrapErr};
 use nanocodex::agent::events::{AgentEvent, AgentEventKind, AssistantMessage};

--- a/examples/popcorn_agent.rs
+++ b/examples/popcorn_agent.rs
@@ -4,26 +4,13 @@
 //! reached over CDP. The LiveView URL is printed so a human can watch the
 //! session or take over when the agent gets stuck.
 //!
-//! Sessions come from the public pay-per-use endpoint at
-//! <https://popcorn.reclaimprotocol.org>. No account is needed: each
-//! five-minute block costs $0.01 in USDC on Base, paid per request with x402.
-//! Point `POPCORN_PAYER_PRIVATE_KEY` at an EVM key holding a little USDC and
-//! enough ETH for gas on Base.
-//!
 //! ```sh
 //! export OPENAI_API_KEY=...
-//! export POPCORN_PAYER_PRIVATE_KEY=0x...
-//! cargo run -p nanocodex-examples --bin popcorn-agent -- \
-//!   "Open https://example.com, inspect the page, and report its main heading."
-//! ```
-//!
-//! Dedicated deployments use the credentialed control plane instead, with no
-//! payment involved:
-//!
-//! ```sh
 //! export POPCORN_CONTROL_PLANE_URL=https://...
 //! export POPCORN_CLIENT_ID=...
 //! export POPCORN_CLIENT_SECRET=...
+//! cargo run -p nanocodex-examples --bin popcorn-agent -- \
+//!   "Open https://example.com, inspect the page, and report its main heading."
 //! ```
 //!
 //! A literal `--` between two prompts runs them as two turns on the same agent
@@ -57,7 +44,7 @@ async fn main() -> Result<()> {
     let api_key = std::env::var("OPENAI_API_KEY").wrap_err("OPENAI_API_KEY is required")?;
     let config = PopcornConfig::from_env()?;
     let popcorn = PopcornBrowser::spawn(config).await?;
-    eprintln!("popcorn session: {}", popcorn.session().session_id());
+    eprintln!("popcorn session: {}", popcorn.session().session_id);
     eprintln!("live view: {}", popcorn.live_view_url());
 
     let tools = Tools::builder().provider(popcorn.tool()).build()?;

--- a/examples/popcorn_agent.rs
+++ b/examples/popcorn_agent.rs
@@ -14,6 +14,9 @@
 //! ```
 
 use eyre::{Result, WrapErr};
+use nanocodex::agent::events::{
+    AgentEvent, AgentEventKind, AssistantMessage, ReasoningSummaryDelta,
+};
 use nanocodex::{AgentEvents, Nanocodex, OpenAi, Thinking, Tools};
 use nanocodex_browser::popcorn::{PopcornBrowser, PopcornConfig};
 use tokio::io::{AsyncWrite, AsyncWriteExt};
@@ -90,17 +93,70 @@ async fn write_turn_jsonl(
     events: &mut AgentEvents,
     output: &mut (impl AsyncWrite + Unpin),
 ) -> Result<()> {
+    let mut echo = AgentEcho::default();
     while let Some(event) = events.recv().await {
         let terminal = event.kind.is_terminal();
         let mut record = serde_json::to_vec(&event)?;
         record.push(b'\n');
         output.write_all(&record).await?;
         output.flush().await?;
+        echo.observe(&event);
         if terminal {
+            echo.flush();
             return Ok(());
         }
     }
     Err(eyre::eyre!(
         "agent event stream closed before the turn emitted a terminal event"
     ))
+}
+
+/// Echoes the agent's own words to stderr so a human watching the terminal can
+/// follow a turn while the JSONL contract on stdout stays byte-for-byte the same.
+///
+/// Only assistant messages and API-visible reasoning summaries are echoed. Tool
+/// calls, tool results, and raw provider events are deliberately skipped.
+#[derive(Default)]
+struct AgentEcho {
+    /// Reasoning-summary text received but not yet terminated by a newline.
+    pending_summary: String,
+}
+
+impl AgentEcho {
+    /// Echoes any human-readable text carried by one event.
+    fn observe(&mut self, event: &AgentEvent) {
+        match event.kind {
+            AgentEventKind::AssistantMessage => {
+                self.flush();
+                if let Ok(message) = event.decode_payload::<AssistantMessage>() {
+                    echo_lines(&message.text);
+                }
+            }
+            AgentEventKind::ReasoningSummaryDelta => {
+                let Ok(delta) = event.decode_payload::<ReasoningSummaryDelta>() else {
+                    return;
+                };
+                self.pending_summary.push_str(&delta.text);
+                while let Some(newline) = self.pending_summary.find('\n') {
+                    let line = self.pending_summary[..newline].to_owned();
+                    self.pending_summary.drain(..=newline);
+                    echo_lines(&line);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Emits summary text that never received a trailing newline.
+    fn flush(&mut self) {
+        let pending = std::mem::take(&mut self.pending_summary);
+        echo_lines(&pending);
+    }
+}
+
+/// Writes one `agent:` line per non-blank line of `text`.
+fn echo_lines(text: &str) {
+    for line in text.lines().filter(|line| !line.trim().is_empty()) {
+        eprintln!("agent: {line}");
+    }
 }

--- a/examples/popcorn_agent.rs
+++ b/examples/popcorn_agent.rs
@@ -113,7 +113,6 @@ async fn run_handoff(
     let Some(second) = second else {
         return Ok(first_result);
     };
-    echo_agent_lines(first_result.final_message());
     eprintln!("waiting for human: log in via the live view, then press Enter");
     wait_for_enter().await?;
     run_turn(agent, events, output, second).await


### PR DESCRIPTION
Adds a `popcorn` module to `nanocodex-browser` that rents an isolated headful Chromium session from [Popcorn](https://github.com/reclaimprotocol/popcorn-oss) and exposes it as an ordinary browser Hand. The agent brain stays wherever it already runs; the browser itself runs remotely inside a TEE, reached over CDP. Each session also has a LiveView page, so a human can watch the run or take over when the agent gets stuck — the URL is printed for the operator and never enters the model's context.

The default access path is Popcorn's **hosted MCP server**: Streamable HTTP with browser OAuth and prepaid credits, so any nanocodex user can rent a session with no Reclaim-issued credentials. On the first spawn the module prints an authorization URL to stderr and waits; the credentials are persisted, so later runs start straight away. One credit buys one fixed 10-minute block, and a $5 checkout buys 100 credits.

This reuses the existing MCP client in `nanocodex-tools` rather than adding a second MCP or OAuth implementation. The only new surface there is `McpHandle::call_tool`, a programmatic path for embedders that drive a server themselves instead of exposing its tools to a model; it goes through the same connect, OAuth-refresh, persistence, timeout, and tracing machinery as a model-issued call. `popcorn.rs` calls `get_balance`, `create_browser_session`, and `end_browser_session` on it, filling in from `get_browser_connection` and `get_live_view` if a deployment splits those fields across tools. The server exposes no extend tool, so no `extend()` is offered.

When credit runs out, `create_browser_session` answers with a `next_action` of type `external_approval` holding a short-lived checkout link, which the module passes to the operator unchanged and then stops. The link is read only from `next_action.url` or `checkout_url`, never from a generic `url` field, so a session's LiveView URL can never be surfaced as a payment link. Creation always sends an idempotency key so the retry after payment cannot rent — or pay for — a second session.

From the model's side it is still just `tools.browser`. A Popcorn session is one more Hand alongside the VM-backed browser: no new transport, no new tool surface, no changes to the agent loop. It reuses `Browser::builder().cdp_endpoint(...)` and the existing Chromium CDP attach path exactly as `vm.rs` does, and mirrors that module's shape — `browser()`, `tool()`, `shutdown()`.

Security note: the session's CDP URL grants full automation control of the browser and is a bearer secret, as are every other session URL and the OAuth tokens. None of them reach the model context, `PopcornSession` has a hand-written `Debug` that redacts every URL rather than deriving one, `PopcornConfig` redacts the client secret, and neither the tool-result type nor the in-flight session draft implements `Debug` at all. The redactions are covered by tests. The OAuth credential file is created owner-only and guarded by an exclusive lock shared with token refreshes. `shutdown()` ends the session through the MCP server (or deletes it on the control plane), attempting that even when the browser close fails, and Popcorn reclaims the session on its own if the process dies first.

## How to try

```sh
export OPENAI_API_KEY=...

cargo run -p nanocodex-examples --bin popcorn-agent -- \
  "Open https://example.com, inspect the page, and report its main heading."
```

Complete the OAuth login in the browser when the authorization URL prints, and buy credits at [popcorn.reclaimprotocol.org](https://popcorn.reclaimprotocol.org) if prompted. Nothing else is needed — no Popcorn account, API key, or client secret.

Optional: `POPCORN_MCP_URL` for a self-hosted server, `POPCORN_MCP_CREDENTIALS` for the credential file path, `POPCORN_PURPOSE`, `POPCORN_IDEMPOTENCY_KEY`, `POPCORN_PROXY_COUNTRY`, and `POPCORN_REGION`.

Agents that would rather not use the native browser tool at all can skip the module and register `https://popcorn-mcp-gcp.reclaimprotocol.org/mcp` as an ordinary nanocodex MCP server.

## Credentialed control plane

For dedicated deployments that issue their own client credentials, the original path is unchanged and is selected by setting all three of:

```sh
export POPCORN_CONTROL_PLANE_URL=https://...
export POPCORN_CLIENT_ID=...
export POPCORN_CLIENT_SECRET=...
export POPCORN_REGION=us-central1        # optional
export POPCORN_TTL_SECONDS=900           # optional
```

Contact the Popcorn team via the form at [popcorn.reclaimprotocol.org](https://popcorn.reclaimprotocol.org) for those credentials.

## Changes outside the popcorn module

- `nanocodex-tools`: adds `McpHandle::call_tool` plus the `McpToolCall` result type, and an internal accessor for a connected server's client. Nothing about model-facing MCP tools changes.
- `native.rs`: when a `cdp_endpoint` is set, skip the local Chromium executable lookup and go straight to `Chromium::connect`. Remote attach previously required a local browser to be installed. This also lets `vm.rs` work on a macOS host with no Chrome.
- Workspace `Cargo.toml` / `Cargo.lock`: enable `tokio-rustls-native-certs` on the `async-tungstenite` edge so chromiumoxide can dial `wss://` endpoints. The VM path never hit this because it uses loopback `ws://`. Happy to split this into its own PR if you prefer a separate review.

## Verification

`cargo test -p nanocodex-browser popcorn` covers response mapping from the MCP tool-result shape (including an envelope variant and the split-tool fallback), out-of-credit detection, `from_env` mode selection, the URL and secret redactions, and the credential file's round trip and permissions.

Against the real hosted server, end to end: OAuth login completed in a browser, a second run reconnected from the stored credentials with no login, an out-of-credit run produced the server's checkout link, and after buying credits `tests/live_popcorn.rs` passed — it rented a session, drove example.com over CDP, asserted the heading, confirmed the session `Debug` leaks no URLs, and released the session. The credentialed control-plane path is unchanged and previously passed the same live test against a real control plane.

