### PR TITLE
fix(managed): include Chrome in the Cloudflare sandbox image

### DIFF
--- a/js/managed/Dockerfile
+++ b/js/managed/Dockerfile
@@ -81,6 +81,17 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
+# Ubuntu 22.04's chromium-browser package requires Snap, which is unavailable
+# in the Sandbox container. Install Google's native AMD64 Debian package.
+RUN curl --fail --location --proto '=https' --tlsv1.2 \
+        https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
+        -o /tmp/google-chrome.deb \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends /tmp/google-chrome.deb \
+    && google-chrome --version \
+    && apt-get clean \
+    && rm -rf /tmp/google-chrome.deb /var/cache/apt/* /var/lib/apt/lists/*
+
 RUN ln -s /usr/bin/fdfind /usr/local/bin/fd \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
         | sh -s -- -y --profile minimal --default-toolchain stable \

--- a/js/managed/README.md
+++ b/js/managed/README.md
@@ -295,3 +295,19 @@ Session deletion fences new work, cancels body readers, drains pending writes,
 and aborts incomplete uploads before the existing `/brain` cleanup. The
 `attachments.test.ts` Worker tests exercise real local R2 multipart behavior,
 reconstruction, retries, filesystem reads, deletion fencing, and account isolation.
+
+## Browser on the Cloudflare sandbox desktop
+
+The AMD64 Sandbox image includes Google Chrome. From the remote desktop's
+terminal, open a visible browser with:
+
+```sh
+google-chrome --no-sandbox --ozone-platform=wayland --disable-dev-shm-usage \
+  --no-first-run --start-maximized about:blank
+```
+
+The terminal inherits the running desktop's Wayland environment. A separate
+shell execution does not automatically inherit that environment. The Sandbox
+runs as root, so this command disables Chrome's process sandbox; use it only
+inside the isolated Sandbox container. It does not disable TLS verification.
+The Debian server Hand image separately provides `chromium`.


### PR DESCRIPTION
Cloudflare sandbox desktops currently have no browser, so opening a visible browser requires downloading Chrome and installing its dependencies during the session.

Install Google's native AMD64 Chrome package in `js/managed/Dockerfile`, check the binary during the build, and remove package caches. Document the Wayland launch command and the root container's process-sandbox requirement. The separate Debian server Hand image already includes Chromium.

Validation: installed Chrome in a live Cloudflare sandbox and confirmed a maximized headed browser rendered its New Tab page on the remote desktop. The Dockerfile install command passes `sh -n`; changed files pass whitespace checks. A full Docker image build was not run because Docker is unavailable in the execution sandbox. The live installation used apt's default recommendations; the image installs only required dependencies. An HTTPS test page encountered a certificate-authority error; TLS verification remains enabled.

The Chrome package follows Google's current stable release at build time, like the image's existing unpinned apt packages.