### PR TITLE
fix(durability): checkpoint recovered cancellations

### DIFF
--- a/crates/nanocodex-agent/src/agent/driver/control.rs
+++ b/crates/nanocodex-agent/src/agent/driver/control.rs
@@ -109,7 +109,7 @@ impl DriverShutdown {
 pub(super) fn queued_execution_operation(
     queued_turns: &VecDeque<QueuedTurn>,
     target: TurnKey,
-) -> Option<(Option<String>, Prompt)> {
+) -> Option<(Option<ExecutionOperation>, Prompt)> {
     queued_turns.iter().find_map(|queued| match queued {
         QueuedTurn::Pending {
             key,
@@ -125,7 +125,7 @@ pub(super) fn queued_execution_operation(
 pub(super) fn queued_prompt(
     key: TurnKey,
     prompt: Prompt,
-    execution_operation: Option<String>,
+    execution_operation: Option<ExecutionOperation>,
     cancel_on_admission: bool,
     thinking: Thinking,
     fast_mode: bool,
@@ -135,6 +135,7 @@ pub(super) fn queued_prompt(
 ) -> QueuedTurn {
     if cancel_on_admission {
         QueuedTurn::Cancelled {
+            key,
             prompt,
             execution_operation,
             cancellation_committed: false,
@@ -173,6 +174,7 @@ pub(super) fn cancel_queued_turn(
         return false;
     };
     let QueuedTurn::Pending {
+        key,
         prompt,
         execution_operation,
         thinking,
@@ -188,6 +190,7 @@ pub(super) fn cancel_queued_turn(
     queued_turns.insert(
         position,
         QueuedTurn::Cancelled {
+            key,
             prompt,
             execution_operation,
             cancellation_committed,
@@ -205,6 +208,7 @@ pub(super) fn mark_all_queued_turns_cancelled(queued_turns: &mut VecDeque<Queued
     let accepted = std::mem::take(queued_turns);
     queued_turns.extend(accepted.into_iter().map(|queued| match queued {
         QueuedTurn::Pending {
+            key,
             prompt,
             execution_operation,
             thinking,
@@ -214,6 +218,7 @@ pub(super) fn mark_all_queued_turns_cancelled(queued_turns: &mut VecDeque<Queued
             result,
             ..
         } => QueuedTurn::Cancelled {
+            key,
             prompt,
             execution_operation,
             cancellation_committed: false,
@@ -256,7 +261,6 @@ pub(super) async fn begin_shutdown(
                 events,
                 result,
             } => {
-                let execution_operation = execution_operation.map(ExecutionOperation::into_id);
                 queued_turns.push_back(queued_prompt(
                     key,
                     prompt,

--- a/crates/nanocodex-agent/src/agent/driver/mod.rs
+++ b/crates/nanocodex-agent/src/agent/driver/mod.rs
@@ -1127,9 +1127,7 @@ where
             let (fork_snapshots, mut fork_snapshot_rx) = watch::channel(None);
             let mut fork_snapshots_open = true;
             let mut cancel = Some(cancel);
-            if cancel_on_admission
-                && let Some(cancel) = cancel.take()
-            {
+            if cancel_on_admission && let Some(cancel) = cancel.take() {
                 let _ = cancel.send(());
             }
             let mut cancel_result = None;

--- a/crates/nanocodex-agent/src/agent/driver/mod.rs
+++ b/crates/nanocodex-agent/src/agent/driver/mod.rs
@@ -113,8 +113,7 @@ where
                             break Command::Prompt {
                                 key,
                                 prompt,
-                                execution_operation: execution_operation
-                                    .map(ExecutionOperation::Admitted),
+                                execution_operation,
                                 accepted: None,
                                 cancel_on_admission: false,
                                 thinking: Some(thinking),
@@ -125,6 +124,7 @@ where
                             };
                         }
                         QueuedTurn::Cancelled {
+                            key,
                             prompt,
                             execution_operation,
                             cancellation_committed,
@@ -134,6 +134,23 @@ where
                             events,
                             result,
                         } => {
+                            if execution_operation
+                                .as_ref()
+                                .is_some_and(ExecutionOperation::is_recovered)
+                            {
+                                break Command::Prompt {
+                                    key,
+                                    prompt,
+                                    execution_operation,
+                                    accepted: None,
+                                    cancel_on_admission: true,
+                                    thinking: Some(thinking),
+                                    fast_mode: Some(fast_mode),
+                                    parent,
+                                    events,
+                                    result,
+                                };
+                            }
                             turn_index += 1;
                             let prompt_content = tracing::enabled!(
                                 target: "nanocodex",
@@ -170,8 +187,10 @@ where
                             let _guard = turn_span.enter();
                             let persisted = if cancellation_committed {
                                 Ok(())
-                            } else if let Some(operation_id) = &execution_operation {
-                                self.execution.cancel_operation(operation_id, &prompt).await
+                            } else if let Some(operation) = &execution_operation {
+                                self.execution
+                                    .cancel_operation(operation.id(), &prompt)
+                                    .await
                             } else {
                                 Ok(())
                             };
@@ -202,7 +221,10 @@ where
                             };
                             let outcome = self
                                 .execution
-                                .recover_failure(execution_operation.as_deref(), outcome)
+                                .recover_failure(
+                                    execution_operation.as_ref().map(ExecutionOperation::id),
+                                    outcome,
+                                )
                                 .await;
                             if !commands_open
                                 && let Err(error) = &outcome
@@ -469,7 +491,10 @@ where
                             continue;
                         }
                     };
-                    if !matches!(admission, AdmittedExecution::Execute) {
+                    if !matches!(
+                        admission,
+                        AdmittedExecution::Execute | AdmittedExecution::Resume
+                    ) {
                         let error = NanocodexError::InvalidExecutionPolicy(
                             "standalone compaction identity resolved to an unexpected terminal operation"
                                 .to_owned(),
@@ -577,8 +602,6 @@ where
                                         events,
                                         result,
                                     }) => {
-                                        let execution_operation =
-                                            execution_operation.map(ExecutionOperation::into_id);
                                         queued_turns.push_back(queued_prompt(
                                             key,
                                             prompt,
@@ -632,7 +655,7 @@ where
                                         queued_turns.push_back(queued_prompt(
                                             key,
                                             prompt,
-                                            execution_operation.map(ExecutionOperation::into_id),
+                                            execution_operation,
                                             cancel_on_admission,
                                             default_thinking,
                                             default_fast_mode,
@@ -654,23 +677,26 @@ where
                                             &queued_turns,
                                             key,
                                         ) {
-                                            Some((operation_id, prompt)) => {
-                                                let persisted = match operation_id {
-                                                    Some(operation_id) => {
+                                            Some((operation, prompt)) => {
+                                                let recovered = operation
+                                                    .as_ref()
+                                                    .is_some_and(ExecutionOperation::is_recovered);
+                                                let persisted = match operation.as_ref() {
+                                                    Some(operation) if !recovered => {
                                                         self.execution
                                                             .cancel_operation(
-                                                                &operation_id,
+                                                                operation.id(),
                                                                 &prompt,
                                                             )
                                                             .await
                                                     }
-                                                    None => Ok(()),
+                                                    Some(_) | None => Ok(()),
                                                 };
                                                 persisted.and_then(|()| {
                                                     if cancel_queued_turn(
                                                         &mut queued_turns,
                                                         key,
-                                                        true,
+                                                        !recovered,
                                                     ) {
                                                         Ok(())
                                                     } else {
@@ -974,6 +1000,9 @@ where
                 );
                 continue;
             };
+            let recovered_operation = execution_operation
+                .as_ref()
+                .is_some_and(ExecutionOperation::is_recovered);
             let execution_operation = execution_operation.map(ExecutionOperation::into_id);
             let thinking = thinking.unwrap_or(default_thinking);
             let fast_mode = fast_mode.unwrap_or(default_fast_mode);
@@ -988,11 +1017,11 @@ where
                 drop(result.send(outcome));
                 continue;
             }
-            if cancel_on_admission {
+            if cancel_on_admission && !recovered_operation {
                 queued_turns.push_front(queued_prompt(
                     key,
                     prompt,
-                    execution_operation,
+                    execution_operation.map(ExecutionOperation::Admitted),
                     true,
                     thinking,
                     fast_mode,
@@ -1098,6 +1127,11 @@ where
             let (fork_snapshots, mut fork_snapshot_rx) = watch::channel(None);
             let mut fork_snapshots_open = true;
             let mut cancel = Some(cancel);
+            if cancel_on_admission
+                && let Some(cancel) = cancel.take()
+            {
+                let _ = cancel.send(());
+            }
             let mut cancel_result = None;
             model.set_events(events);
             let mut execution = Box::pin(
@@ -1179,8 +1213,6 @@ where
                                 events,
                                 result,
                             }) => {
-                                let execution_operation =
-                                    execution_operation.map(ExecutionOperation::into_id);
                                 queued_turns.push_back(queued_prompt(
                                     key,
                                     prompt,
@@ -1303,20 +1335,23 @@ where
                                         &queued_turns,
                                         target,
                                     ) {
-                                        Some((operation_id, prompt)) => {
-                                            let persisted = match operation_id {
-                                                Some(operation_id) => {
+                                        Some((operation, prompt)) => {
+                                            let recovered = operation
+                                                .as_ref()
+                                                .is_some_and(ExecutionOperation::is_recovered);
+                                            let persisted = match operation.as_ref() {
+                                                Some(operation) if !recovered => {
                                                     self.execution
-                                                        .cancel_operation(&operation_id, &prompt)
+                                                        .cancel_operation(operation.id(), &prompt)
                                                         .await
                                                 }
-                                                None => Ok(()),
+                                                Some(_) | None => Ok(()),
                                             };
                                             persisted.and_then(|()| {
                                                 if cancel_queued_turn(
                                                     &mut queued_turns,
                                                     target,
-                                                    true,
+                                                    !recovered,
                                                 ) {
                                                     Ok(())
                                                 } else {
@@ -1889,6 +1924,9 @@ async fn accept_execution_command(
         ExecutionOperation::Admitted(operation_id) => {
             Ok((operation_id, AdmittedExecution::Execute))
         }
+        ExecutionOperation::Recovered(operation_id) => {
+            Ok((operation_id, AdmittedExecution::Resume))
+        }
     };
     match admission {
         Ok((operation_id, AdmittedExecution::Execute)) => {
@@ -1900,6 +1938,24 @@ async fn accept_execution_command(
                 key,
                 prompt,
                 execution_operation: Some(ExecutionOperation::Admitted(operation_id)),
+                accepted: None,
+                cancel_on_admission,
+                thinking,
+                fast_mode,
+                parent,
+                events,
+                result,
+            })
+        }
+        Ok((operation_id, AdmittedExecution::Resume)) => {
+            if accepted.send(Ok(operation_id.clone())).is_err() {
+                execution.release_claim(&operation_id).await;
+                return None;
+            }
+            Some(Command::Prompt {
+                key,
+                prompt,
+                execution_operation: Some(ExecutionOperation::Recovered(operation_id)),
                 accepted: None,
                 cancel_on_admission,
                 thinking,
@@ -2024,6 +2080,29 @@ async fn accept_idle_route(
                 key,
                 prompt,
                 execution_operation: Some(ExecutionOperation::Admitted(operation_id)),
+                accepted: None,
+                cancel_on_admission: false,
+                thinking: None,
+                fast_mode: None,
+                parent,
+                events,
+                result: turn_result,
+            })
+        }
+        Ok((operation_id, AdmittedExecution::Resume)) => {
+            if route_result
+                .send(Ok(PromptRouteKind::Started {
+                    request_id: Some(operation_id.clone()),
+                }))
+                .is_err()
+            {
+                execution.release_claim(&operation_id).await;
+                return None;
+            }
+            Some(Command::Prompt {
+                key,
+                prompt,
+                execution_operation: Some(ExecutionOperation::Recovered(operation_id)),
                 accepted: None,
                 cancel_on_admission: false,
                 thinking: None,

--- a/crates/nanocodex-agent/src/agent/execution/mod.rs
+++ b/crates/nanocodex-agent/src/agent/execution/mod.rs
@@ -29,8 +29,10 @@ pub type ExecutionFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 
 /// Result of admitting one identified execution into an attached policy.
 pub enum ExecutionAdmission {
-    /// Execute the newly accepted or previously interrupted operation.
+    /// Execute a newly accepted operation.
     Execute,
+    /// Resume an unfinished operation admitted by an earlier host instance.
+    Resume,
     /// Return an already completed operation without executing it again.
     Completed {
         /// Session boundary committed with the output.
@@ -535,6 +537,7 @@ pub(crate) struct Execution {
 
 pub(crate) enum AdmittedExecution {
     Execute,
+    Resume,
     Completed {
         output: ExecutionOutput,
         snapshot: SessionSnapshot,
@@ -792,6 +795,7 @@ impl Execution {
 fn map_admission(admission: ExecutionAdmission) -> AdmittedExecution {
     match admission {
         ExecutionAdmission::Execute => AdmittedExecution::Execute,
+        ExecutionAdmission::Resume => AdmittedExecution::Resume,
         ExecutionAdmission::Completed { snapshot, output } => {
             AdmittedExecution::Completed { output, snapshot }
         }
@@ -1124,7 +1128,7 @@ async fn cancel_with_reclaim(
         .await
         .map_err(reopen_after_cancel_retry)?;
     match admission {
-        ExecutionAdmission::Execute => {
+        ExecutionAdmission::Execute | ExecutionAdmission::Resume => {
             if snapshot.is_some() {
                 policy
                     .begin_attempt(operation_id.clone())

--- a/crates/nanocodex-agent/src/agent/turn.rs
+++ b/crates/nanocodex-agent/src/agent/turn.rs
@@ -490,10 +490,12 @@ pub(super) enum Command {
 }
 
 #[cfg(feature = "openai")]
+#[derive(Clone)]
 pub(super) enum ExecutionOperation {
     Caller(String),
     Automatic(String),
     Admitted(String),
+    Recovered(String),
 }
 
 #[cfg(feature = "openai")]
@@ -502,8 +504,22 @@ impl ExecutionOperation {
         match self {
             Self::Caller(operation_id)
             | Self::Automatic(operation_id)
-            | Self::Admitted(operation_id) => operation_id,
+            | Self::Admitted(operation_id)
+            | Self::Recovered(operation_id) => operation_id,
         }
+    }
+
+    pub(super) fn id(&self) -> &str {
+        match self {
+            Self::Caller(operation_id)
+            | Self::Automatic(operation_id)
+            | Self::Admitted(operation_id)
+            | Self::Recovered(operation_id) => operation_id,
+        }
+    }
+
+    pub(super) const fn is_recovered(&self) -> bool {
+        matches!(self, Self::Recovered(_))
     }
 }
 
@@ -518,7 +534,7 @@ pub(super) enum QueuedTurn {
     Pending {
         key: TurnKey,
         prompt: Prompt,
-        execution_operation: Option<String>,
+        execution_operation: Option<ExecutionOperation>,
         thinking: Thinking,
         fast_mode: bool,
         parent: Option<tracing::Span>,
@@ -526,8 +542,9 @@ pub(super) enum QueuedTurn {
         result: oneshot::Sender<Result<TurnResult>>,
     },
     Cancelled {
+        key: TurnKey,
         prompt: Prompt,
-        execution_operation: Option<String>,
+        execution_operation: Option<ExecutionOperation>,
         cancellation_committed: bool,
         thinking: Thinking,
         fast_mode: bool,

--- a/crates/nanocodex-durability/src/agent.rs
+++ b/crates/nanocodex-durability/src/agent.rs
@@ -534,7 +534,8 @@ async fn map_admission(
     admission: Admission<crate::context::Snapshot, ExecutionOutput>,
 ) -> AgentResult<ExecutionAdmission> {
     Ok(match admission {
-        Admission::Accepted | Admission::Pending => ExecutionAdmission::Execute,
+        Admission::Accepted => ExecutionAdmission::Execute,
+        Admission::Pending => ExecutionAdmission::Resume,
         Admission::Completed { checkpoint, output } => ExecutionAdmission::Completed {
             snapshot: crate::context::restore_snapshot(owner.into(), checkpoint)
                 .await

--- a/crates/nanocodex-durability/src/session.rs
+++ b/crates/nanocodex-durability/src/session.rs
@@ -722,15 +722,12 @@ impl Driver {
                                 Ok(()) => {
                                     let admissible = match checkpoint.as_ref() {
                                         Some(_) => self.require_running(&operation_id),
-                                        None
-                                            if self.running.contains(&operation_id)
-                                                || self
-                                                    .state
-                                                    .operation(&operation_id)
-                                                    .is_some_and(|operation| {
-                                                        operation
-                                                            .cancellation_requires_checkpoint()
-                                                    }) =>
+                                        None if self.running.contains(&operation_id)
+                                            || self.state.operation(&operation_id).is_some_and(
+                                                |operation| {
+                                                    operation.cancellation_requires_checkpoint()
+                                                },
+                                            ) =>
                                         {
                                             Err(Error::CancellationCheckpointRequired {
                                                 operation_id: operation_id.clone(),

--- a/crates/nanocodex-durability/src/session.rs
+++ b/crates/nanocodex-durability/src/session.rs
@@ -722,7 +722,16 @@ impl Driver {
                                 Ok(()) => {
                                     let admissible = match checkpoint.as_ref() {
                                         Some(_) => self.require_running(&operation_id),
-                                        None if self.running.contains(&operation_id) => {
+                                        None
+                                            if self.running.contains(&operation_id)
+                                                || self
+                                                    .state
+                                                    .operation(&operation_id)
+                                                    .is_some_and(|operation| {
+                                                        operation
+                                                            .cancellation_requires_checkpoint()
+                                                    }) =>
+                                        {
                                             Err(Error::CancellationCheckpointRequired {
                                                 operation_id: operation_id.clone(),
                                             })

--- a/crates/nanocodex-durability/src/state.rs
+++ b/crates/nanocodex-durability/src/state.rs
@@ -382,6 +382,13 @@ pub struct OperationState {
 }
 
 impl OperationState {
+    pub(crate) fn cancellation_requires_checkpoint(&self) -> bool {
+        self.continuation.is_some()
+            || self.retired_model_calls != 0
+            || !self.steps.is_empty()
+            || !self.steers.is_empty()
+    }
+
     fn retire_steps(&mut self) {
         for (id, step) in &self.steps {
             if step.kind == "model_call"
@@ -664,9 +671,7 @@ impl DurableState {
             if matches!(
                 &operation.status,
                 OperationStatus::Cancelled { checkpoint: None }
-            ) && (operation.retired_model_calls != 0
-                || !operation.steps.is_empty()
-                || !operation.steers.is_empty())
+            ) && operation.cancellation_requires_checkpoint()
             {
                 return Err(Error::InvalidState(format!(
                     "started operation `{operation_id}` was cancelled without a checkpoint"
@@ -957,11 +962,7 @@ impl DurableState {
                 let operation = self.pending_operation(operation_id)?;
                 if checkpoint.is_some() {
                     self.ensure_prior_operations_terminal(operation_id)?;
-                } else if operation.continuation.is_some()
-                    || operation.retired_model_calls != 0
-                    || !operation.steps.is_empty()
-                    || !operation.steers.is_empty()
-                {
+                } else if operation.cancellation_requires_checkpoint() {
                     return Err(Error::InvalidState(format!(
                         "started operation `{operation_id}` was cancelled without a checkpoint"
                     )));

--- a/crates/nanocodex-durability/tests/agent.rs
+++ b/crates/nanocodex-durability/tests/agent.rs
@@ -2050,6 +2050,84 @@ async fn cold_reopen_recovers_idle_routed_prompt_without_a_second_model_call() -
 }
 
 #[tokio::test]
+async fn cold_reopened_started_prompt_cancels_with_a_checkpoint_without_model_replay() -> Result<()> {
+    let store = crate::MemoryStore::new()?;
+    let failing_store = FailReplaceOnce {
+        inner: store.clone(),
+        expected_revision: 7,
+        failed: Arc::new(AtomicBool::new(false)),
+    };
+    let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let openai = || {
+        let generations = Arc::clone(&generations);
+        OpenAi::builder("test-key")
+            .service(move || DurableReplayService {
+                generations: Arc::clone(&generations),
+            })
+            .build()
+    };
+    let workspace = temporary_workspace("cancel-durability-cold-reopen")?;
+    let request = || {
+        PromptRequest::new("cancel recovered input").request_id("recovered-cancel")
+    };
+
+    let state = crate::DurableSession::open(failing_store, "cancel-cold-reopen").await?;
+    let (first, first_events) = Nanocodex::builder(openai()?)
+        .workspace(&workspace)
+        .session_id(test_session_id())
+        .durability(state)
+        .await?
+        .build()?;
+    let first_error = first
+        .prompt(request())
+        .await?
+        .result()
+        .await
+        .expect_err("the injected terminal replacement must leave a pending operation");
+    assert!(
+        first_error
+            .to_string()
+            .contains("injected replacement failure")
+    );
+    first.shutdown().await?;
+    drop((first, first_events));
+
+    let state = crate::DurableSession::open(store, "cancel-cold-reopen").await?;
+    let (reopened, reopened_events) = Nanocodex::builder(openai()?)
+        .workspace(&workspace)
+        .session_id(test_session_id())
+        .durability(state.clone())
+        .await?
+        .build()?;
+    let cancelled = reopened
+        .prompt(request().cancel_on_admission())
+        .await?
+        .result()
+        .await;
+    assert!(matches!(cancelled, Err(NanocodexError::TurnCancelled)));
+    assert_eq!(
+        generations.load(Ordering::SeqCst),
+        1,
+        "cancelling recovered work must not dispatch another model call",
+    );
+    let retained = state.state().await?;
+    assert!(matches!(
+        &retained
+            .operation("recovered-cancel")
+            .expect("cancelled operation remains retained")
+            .status,
+        OperationStatus::Cancelled {
+            checkpoint: Some(_)
+        }
+    ));
+
+    reopened.shutdown().await?;
+    drop((reopened, reopened_events));
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn active_routed_input_is_retained_in_the_durable_checkpoint() -> Result<()> {
     let store = crate::MemoryStore::new()?;
     let state = crate::DurableSession::open(store, "active-routed-input").await?;

--- a/crates/nanocodex-durability/tests/agent.rs
+++ b/crates/nanocodex-durability/tests/agent.rs
@@ -2050,7 +2050,8 @@ async fn cold_reopen_recovers_idle_routed_prompt_without_a_second_model_call() -
 }
 
 #[tokio::test]
-async fn cold_reopened_started_prompt_cancels_with_a_checkpoint_without_model_replay() -> Result<()> {
+async fn cold_reopened_started_prompt_cancels_with_a_checkpoint_without_model_replay() -> Result<()>
+{
     let store = crate::MemoryStore::new()?;
     let failing_store = FailReplaceOnce {
         inner: store.clone(),
@@ -2067,9 +2068,7 @@ async fn cold_reopened_started_prompt_cancels_with_a_checkpoint_without_model_re
             .build()
     };
     let workspace = temporary_workspace("cancel-durability-cold-reopen")?;
-    let request = || {
-        PromptRequest::new("cancel recovered input").request_id("recovered-cancel")
-    };
+    let request = || PromptRequest::new("cancel recovered input").request_id("recovered-cancel");
 
     let state = crate::DurableSession::open(failing_store, "cancel-cold-reopen").await?;
     let (first, first_events) = Nanocodex::builder(openai()?)

--- a/crates/nanocodex-durability/tests/session.rs
+++ b/crates/nanocodex-durability/tests/session.rs
@@ -932,6 +932,44 @@ async fn active_operation_cancellation_requires_a_checkpoint() {
 }
 
 #[tokio::test]
+async fn cold_reopened_started_operation_cancellation_requires_a_checkpoint() {
+    let store = MemoryStore::new().unwrap();
+    let session = DurableSession::open(store.clone(), "cold-active-cancel-checkpoint")
+        .await
+        .unwrap();
+    session.admit("turn-1", &"one").await.unwrap();
+    session.begin_attempt("turn-1").await.unwrap();
+    session
+        .begin_step("turn-1", "model-1", "model_call", &"request")
+        .await
+        .unwrap();
+    session.release("turn-1").await.unwrap();
+    drop(session);
+
+    let reopened = DurableSession::open(store, "cold-active-cancel-checkpoint")
+        .await
+        .unwrap();
+    assert!(matches!(
+        reopened.admit("turn-1", &"one").await,
+        Ok(Admission::Pending)
+    ));
+    assert!(matches!(
+        reopened.cancel("turn-1").await,
+        Err(Error::CancellationCheckpointRequired { operation_id }) if operation_id == "turn-1"
+    ));
+    assert!(matches!(
+        reopened
+            .state()
+            .await
+            .unwrap()
+            .operation("turn-1")
+            .unwrap()
+            .status,
+        nanocodex_durability::OperationStatus::Pending
+    ));
+}
+
+#[tokio::test]
 async fn definitely_uncommitted_terminal_replace_reopens_the_exact_claim_for_retry() {
     let store = MemoryStore::new().unwrap();
     let failed = Arc::new(AtomicBool::new(false));


### PR DESCRIPTION
## Root cause

Durable admission collapsed newly accepted and previously pending operations into the same `Execute` result. After a Durable Object restart, the in-memory `running` set is empty even when the persisted operation already contains model/tool progress. A cancel-on-admission request therefore took the never-started cancellation path and attempted to terminalize the recovered operation without a checkpoint, producing `invalid durability state: started operation ... was cancelled without a checkpoint`.

## Fix

- distinguish newly accepted executions from recovered pending executions
- preserve recovered identity while turns are queued
- restore recovered state and pre-trigger active cancellation, producing a safe checkpoint without dispatching another model request
- make checkpoint-free cancellation consult durable progress as well as the ephemeral running set
- add cold-reopen regressions at the durability and full-agent boundaries

## Validation

CI exercises the full Rust workspace, clippy/docs, WASM bindings, and the new regressions.