### PR TITLE
Keep mobile tabs recent and add an expanded draft editor

### DIFF
--- a/apple/InboxCore/Sources/InboxCore/InboxPolicy.swift
+++ b/apple/InboxCore/Sources/InboxCore/InboxPolicy.swift
@@ -173,3 +173,26 @@ public struct InboxDeck: Equatable, Sendable {
     public mutating func back() { if let id = previous.popLast() { focusedID = id } }
     public var canGoBack: Bool { !previous.isEmpty }
 }
+
+/// The mobile tab window uses server activity timestamps in milliseconds.
+public enum ConversationWindow {
+    public static let pageSize = 24
+    public static let duration: TimeInterval = 24 * 60 * 60
+
+    public static func includes(_ card: AgentCard, focusedID: String? = nil,
+                                openedIDs: Set<String> = [], now: Date = Date()) -> Bool {
+        card.isRunning || card.id == focusedID || openedIDs.contains(card.id)
+            || (card.updatedAt.isFinite && card.updatedAt >= (now.timeIntervalSince1970 - duration) * 1000)
+    }
+
+    public static func overview(_ cards: [AgentCard], focusedID: String? = nil,
+                                openedIDs: Set<String> = [], olderLimit: Int = 0,
+                                now: Date = Date()) -> [AgentCard] {
+        let ordered = cards.sorted(by: AgentCard.mostRecentFirst)
+        let current = Set(ordered.filter {
+            includes($0, focusedID: focusedID, openedIDs: openedIDs, now: now)
+        }.map(\.id))
+        let older = Set(ordered.filter { !current.contains($0.id) }.prefix(max(0, olderLimit)).map(\.id))
+        return ordered.filter { current.contains($0.id) || older.contains($0.id) }
+    }
+}

--- a/apple/InboxCore/Tests/InboxCoreTests/ConversationWindowTests.swift
+++ b/apple/InboxCore/Tests/InboxCoreTests/ConversationWindowTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import InboxCore
+
+final class ConversationWindowTests: XCTestCase {
+    let now = Date(timeIntervalSince1970: 200_000)
+    func testWindowBoundaryAndExplicitExceptions() {
+        let boundary = (now.timeIntervalSince1970 - ConversationWindow.duration) * 1000
+        let recent = AgentCard(id: "recent", title: "", updatedAt: boundary)
+        var old = AgentCard(id: "old", title: "", updatedAt: boundary - 1)
+        XCTAssertTrue(ConversationWindow.includes(recent, now: now))
+        XCTAssertFalse(ConversationWindow.includes(old, now: now))
+        XCTAssertTrue(ConversationWindow.includes(old, focusedID: "old", now: now))
+        XCTAssertTrue(ConversationWindow.includes(old, openedIDs: ["old"], now: now))
+        old.activeTurns = ["running"]
+        XCTAssertTrue(ConversationWindow.includes(old, now: now))
+    }
+    func testOlderOverviewIsLazyStableAndDoesNotOpenTabs() {
+        let cards = (0..<50).map { AgentCard(id: String($0), title: "", updatedAt: Double($0)) }
+        XCTAssertTrue(ConversationWindow.overview(cards, now: now).isEmpty)
+        let page = ConversationWindow.overview(cards, olderLimit: 24, now: now)
+        XCTAssertEqual(page.count, 24)
+        XCTAssertEqual(page.first?.id, "49")
+        XCTAssertFalse(ConversationWindow.includes(page[0], now: now))
+        XCTAssertEqual(ConversationWindow.overview(cards, olderLimit: 48, now: now).count, 48)
+        XCTAssertEqual(ConversationWindow.overview(cards, openedIDs: ["0"], olderLimit: 24, now: now).count, 25)
+    }
+}

--- a/apple/NanocodexInbox/InboxModel.swift
+++ b/apple/NanocodexInbox/InboxModel.swift
@@ -30,6 +30,8 @@ final class InboxModel: ObservableObject {
     @Published var threadError: String?
     private var observedAgentID: String?
     private var tabOrder: [String] = []
+    @Published private var openedConversations = Set<String>()
+    @Published private var olderConversationLimit = 0
     private struct TabHistory {
         var events: [AgentEvent]
         var cursor: Cursor
@@ -196,6 +198,16 @@ final class InboxModel: ObservableObject {
         let byID = Dictionary(uniqueKeysWithValues: cards.map { ($0.id, $0) })
         return tabOrder.compactMap { byID[$0] }
     }
+    private var recentConversationIDs: Set<String> {
+        Set(cards.filter { ConversationWindow.includes($0, focusedID: deck.focusedID,
+            openedIDs: openedConversations) }.map(\.id))
+    }
+    var overviewCards: [AgentCard] {
+        ConversationWindow.overview(cards, focusedID: deck.focusedID,
+            openedIDs: openedConversations, olderLimit: olderConversationLimit)
+    }
+    var hasOlderConversations: Bool { overviewCards.count < cards.count }
+    func loadOlderConversations() { olderConversationLimit += ConversationWindow.pageSize }
     var creationError: String? { focused.flatMap { creationErrors[$0.id] } }
     private func resolvedAgentID(_ id: String) -> String { createdAgentIDs[id] ?? id }
     var attentionCount: Int { cards.filter { $0.isInInbox(seen: seenCursor($0.id), deferred: deferred[$0.id]) && $0.needsAttention(seen: seenCursor($0.id)) }.count }
@@ -593,6 +605,7 @@ final class InboxModel: ObservableObject {
         agentNotificationUpdate?.cancel(); agentNotificationUpdate = nil
         stopOverview()
         overviewTranscripts = [:]; tabHistories = [:]; recentTabs = []; tabOrder = []
+        openedConversations = []; olderConversationLimit = 0
         handTasks.endAllObservations()
         schedulesTask?.cancel(); schedulesTask = nil; schedulesFailures = [:]
         scheduledJobs = []; scheduledJobAgents = [:]; schedulesLoading = false; schedulesLoaded = false; schedulesError = nil
@@ -805,9 +818,8 @@ final class InboxModel: ObservableObject {
             } + created
             if cards != merged { cards = merged }
             reconcile()
-            // Keep all agents covered: roster timestamps do not version replies
-            // or settings. Prioritize interactive work without waiting for an
-            // entire four-agent batch before publishing completed results.
+            // Keep state coverage for running work, but fetch older history only
+            // when the user opens the conversation or reveals its overview.
             let pendingIDs = Set(pending.map(\.agentID) + cancellations.map(\.agentID)).union(busy)
             let byID = Dictionary(uniqueKeysWithValues: cards.map { ($0.id, $0) })
             let updateCards = listing.map { byID[$0.id] ?? $0 }
@@ -831,6 +843,11 @@ final class InboxModel: ObservableObject {
         // The focused observer owns history. Evaluate this when the operation
         // starts rather than capturing the old tab at the start of the sweep.
         if id == observedAgentID && streaming != nil { return AgentRefreshHistory.stateOnly }
+        let interactive = pending.contains { $0.agentID == id }
+            || cancellations.contains { $0.agentID == id } || busy.contains(id)
+            || voice.conversationID == id || overviewVisible.contains(id)
+        guard interactive || ConversationWindow.includes(card, focusedID: deck.focusedID,
+            openedIDs: openedConversations) else { return .stateOnly }
         return card.checked && card.error == nil ? .changed(after: historyCursors[id] ?? .zero) : .initial
     }
     private func applyRefresh(_ result: Result<AgentRefreshResult, Error>, id: String, epoch: UUID) async {
@@ -877,13 +894,15 @@ final class InboxModel: ObservableObject {
         reconcile()
     }
     private func reconcile() {
-        let available = Set(cards.map(\.id))
+        openedConversations.formIntersection(Set(cards.map(\.id)))
+        let available = recentConversationIDs
         var unique = Set<String>()
         tabOrder.removeAll { !available.contains($0) || !unique.insert($0).inserted }
         let known = Set(tabOrder)
-        tabOrder.append(contentsOf: cards.map(\.id).filter { !known.contains($0) })
+        tabOrder.append(contentsOf: cards.sorted(by: AgentCard.mostRecentFirst).map(\.id).filter { available.contains($0) && !known.contains($0) })
         let previous = deck.focusedID
         let eligible = cards.filter { card in
+            guard available.contains(card.id) else { return false }
             if card.id == pinnedThreadID { return true }
             switch filter {
             case .inbox: return card.isInInbox(seen: seenCursor(card.id), deferred: deferred[card.id])
@@ -1039,6 +1058,7 @@ final class InboxModel: ObservableObject {
 
     func select(_ id: String) {
         guard cards.contains(where: { $0.id == id }) else { return }
+        openedConversations.insert(id)
         if let card = focused, card.id != id {
             navigation.append((card.id, seen[card.id], deferred[card.id], filter))
             if navigation.count > 50 { navigation.removeFirst() }
@@ -1949,6 +1969,7 @@ final class InboxModel: ObservableObject {
     private func bindCreatedAgent(_ localID: String, to id: String) {
         let wasFocused = deck.focusedID == localID
         createdAgentIDs[localID] = id
+        if openedConversations.remove(localID) != nil { openedConversations.insert(id) }
         // A concurrent roster can list the real agent before create returns.
         // Keep the placeholder's position and avoid duplicate SwiftUI identities.
         tabOrder = tabOrder.filter { $0 != id }.map { $0 == localID ? id : $0 }

--- a/apple/NanocodexInbox/InboxView.swift
+++ b/apple/NanocodexInbox/InboxView.swift
@@ -271,12 +271,12 @@ struct InboxView: View {
                 guard !draggingTabs else { return }
                 composerFocused = false; showOverview = true
             } label: {
-                Text(String(model.cards.count)).font(.system(size: 13, weight: .semibold)).monospacedDigit()
+                Text(String(model.tabCards.count)).font(.system(size: 13, weight: .semibold)).monospacedDigit()
                     .frame(minWidth: 23, minHeight: 25)
                     .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(Ink.text, lineWidth: 1.5))
                     .frame(width: 44, height: 44)
             }
-            .accessibilityLabel("Conversation overview").accessibilityValue("\(model.cards.count) conversations")
+            .accessibilityLabel("Conversation overview").accessibilityValue("\(model.tabCards.count) active conversations")
             .accessibilityHint("Tap to show windows. Drag left or right to move through tabs; hold at an edge to keep scrolling.")
             .accessibilityIdentifier("tab-overview")
             .highPriorityGesture(tabScrubGesture)
@@ -453,12 +453,12 @@ private struct ConversationOverview: View {
     init(model: InboxModel, select: @escaping (String) -> Void) {
         self.model = model
         self.select = select
-        _order = State(initialValue: model.cards.sorted(by: AgentCard.mostRecentFirst).map(\.id))
+        _order = State(initialValue: model.overviewCards.sorted(by: AgentCard.mostRecentFirst).map(\.id))
     }
 
     private var visibleCards: [AgentCard] {
         let text = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        let cards = Dictionary(uniqueKeysWithValues: model.cards.map { ($0.id, $0) })
+        let cards = Dictionary(uniqueKeysWithValues: model.overviewCards.map { ($0.id, $0) })
         return order.compactMap { cards[$0] }.filter { card in
             (!runningOnly || card.isRunning) && (text.isEmpty || card.title.localizedCaseInsensitiveContains(text)
                 || card.id.localizedCaseInsensitiveContains(text) || card.preview.localizedCaseInsensitiveContains(text))
@@ -515,13 +515,19 @@ private struct ConversationOverview: View {
                 }.padding(16)
                 if visibleCards.isEmpty {
                     ContentUnavailableView(model.cards.isEmpty ? "No conversations" : "No matching conversations", systemImage: "bubble.left.and.bubble.right",
-                                           description: Text(model.cards.isEmpty ? "Use + to start a conversation." : "Try another search or show all conversations."))
+                                           description: Text(model.cards.isEmpty ? "Use + to start a conversation." : "Try another search or load older conversations below."))
+                }
+                if model.hasOlderConversations {
+                    Button("Load older conversations") { model.loadOlderConversations() }
+                        .buttonStyle(.bordered)
+                        .padding(.bottom, 20)
+                        .accessibilityIdentifier("load-older-conversations")
                 }
             }.scrollDismissesKeyboard(.interactively).accessibilityIdentifier("conversation-overview")
             }
             .searchable(text: $query, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search conversations")
             .background(Ink.background)
-            .navigationTitle("Conversations (\(model.cards.count))")
+            .navigationTitle("Conversations")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItemGroup(placement: .bottomBar) {
@@ -536,7 +542,7 @@ private struct ConversationOverview: View {
             }
         }
         .presentationDetents([.large]).presentationDragIndicator(.visible)
-        .onChange(of: model.cards.map(\.id)) { _, ids in
+        .onChange(of: model.overviewCards.map(\.id)) { _, ids in
             // Live history updates must not move another window under a tap.
             let available = Set(ids)
             order.removeAll { !available.contains($0) }
@@ -638,6 +644,7 @@ private struct AgentComposerView: View {
     @ObservedObject var model: InboxModel
     @FocusState.Binding var focused: Bool
     var onVoiceChat: @MainActor () -> Void = {}
+    @State private var showExpandedEditor = false
     @State private var showPhotos = false
     @State private var showFiles = false
     @State private var selectedPhotos: [PhotosPickerItem] = []
@@ -785,9 +792,17 @@ private struct AgentComposerView: View {
                     Image(systemName: "plus").frame(width: 44, height: 44).contentShape(Rectangle())
                 }.menuStyle(.borderlessButton).accessibilityLabel("Add attachments").accessibilityIdentifier("add-attachments")
                 TextField("Ask Nanocodex", text: $model.draft, axis: .vertical)
-                    .lineLimit(1...4).textFieldStyle(.plain).font(.body).focused($focused)
-                    .fixedSize(horizontal: false, vertical: true)
+                    .lineLimit(1...6).textFieldStyle(.plain).font(.body).focused($focused)
                     .padding(.vertical, 8).accessibilityIdentifier("composer")
+                Button {
+                    focused = false
+                    showExpandedEditor = true
+                } label: {
+                    Image(systemName: "arrow.up.left.and.arrow.down.right")
+                        .frame(width: 44, height: 44).contentShape(Rectangle())
+                }.buttonStyle(.plain).foregroundStyle(Ink.muted)
+                    .accessibilityLabel("Expand message editor")
+                    .accessibilityIdentifier("expand-composer")
                 if let agentID = model.focused?.id {
                     NanocodexVoiceControl(session: model.voice, onReturnToChat: onVoiceChat) {
                         focused = false
@@ -823,7 +838,27 @@ private struct AgentComposerView: View {
             .overlay(RoundedRectangle(cornerRadius: 28).strokeBorder(Color.primary.opacity(focused ? 0.18 : 0.1)))
             .shadow(color: .black.opacity(0.035), radius: 8, y: 2)
             .padding(.horizontal, 12).padding(.top, 6).padding(.bottom, 8).background(Ink.background)
-            .onChange(of: model.focusedConversationIdentity) { _, _ in focused = false }
+            .onChange(of: model.focusedConversationIdentity) { _, _ in
+                showExpandedEditor = false
+                focused = false
+            }
+            .sheet(isPresented: $showExpandedEditor) {
+                ExpandedAgentComposer(
+                    draft: $model.draft,
+                    canSend: model.canSend,
+                    attachmentCount: model.focusedAttachments.count,
+                    onCollapse: {
+                        showExpandedEditor = false
+                        focused = true
+                    },
+                    onSend: {
+                        if model.send() {
+                            showExpandedEditor = false
+                            focused = false
+                        }
+                    }
+                )
+            }
             #if os(iOS)
             .fullScreenCover(isPresented: $showCamera, onDismiss: { cameraTarget = nil }) {
                 CameraPicker { image in
@@ -868,6 +903,61 @@ private struct AgentComposerView: View {
         cameraTarget = target; focused = false; showCamera = true
     }
     #endif
+}
+
+private struct ExpandedAgentComposer: View {
+    @Binding var draft: String
+    let canSend: Bool
+    let attachmentCount: Int
+    let onCollapse: () -> Void
+    let onSend: () -> Void
+    @FocusState private var editorFocused: Bool
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: 8) {
+                TextEditor(text: $draft)
+                    .font(.body)
+                    .scrollContentBackground(.hidden)
+                    .focused($editorFocused)
+                    .accessibilityLabel("Message")
+                    .accessibilityIdentifier("expanded-composer")
+                    .overlay(alignment: .topLeading) {
+                        if draft.isEmpty {
+                            Text("Ask Nanocodex")
+                                .foregroundStyle(.secondary)
+                                .padding(.horizontal, 5).padding(.top, 8)
+                                .allowsHitTesting(false)
+                                .accessibilityHidden(true)
+                        }
+                    }
+                if attachmentCount > 0 {
+                    Label("Attachments: \(attachmentCount)", systemImage: "paperclip")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+            }
+            .padding(16)
+            .background(Ink.background)
+            .navigationTitle("Message")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(action: onCollapse) {
+                        Label("Collapse", systemImage: "arrow.down.right.and.arrow.up.left")
+                    }.accessibilityLabel("Collapse message editor")
+                        .accessibilityIdentifier("collapse-composer")
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Send", action: onSend)
+                        .disabled(!canSend)
+                        .keyboardShortcut(.return, modifiers: .command)
+                        .accessibilityIdentifier("expanded-composer-send")
+                }
+            }
+            .task { editorFocused = true }
+        }
+        .presentationDetents([.large])
+        .presentationDragIndicator(.visible)
+    }
 }
 
 #if os(iOS)

--- a/apple/README.md
+++ b/apple/README.md
@@ -22,6 +22,14 @@ HighlightSwift in light and dark mode. Unsupported languages remain readable
 as plain code. Desktop pane
 arrangement, tiling, navigation shortcuts, and per-agent state remain owned by
 the existing workspace.
+The mobile tab strip and switcher count default to conversations touched in the last
+24 hours, plus running, focused, and explicitly opened conversations. The overview
+loads older conversations in batches of 24 with **Load older conversations**; browsing
+older previews does not add them to the tab strip. Roster and state checks continue
+for background work, while older transcripts load only when opened or visible.
+The composer grows up to six lines, then scrolls; its expand button opens a larger
+editor sharing the same draft and attachments.
+
 Each tab opens the full conversation directly. Overview cards render miniature
 transcripts with the same message components and latest available content.
 Unchanged Markdown stays behind an equality boundary, so typing, scrolling, and


### PR DESCRIPTION
Mobile currently puts the entire conversation roster into the tab strip and bottom-right count. Default active tabs now include sessions touched in the last 24 hours, plus running, focused, and explicitly opened conversations. Older conversations are revealed 24 at a time from the overview; browsing previews does not add them to active tabs. Roster and state checks remain active to discover running work, while old transcript history is fetched only when opened or visible.

The composer grows to six lines before scrolling and gains an expand/collapse editor for long drafts, sharing the same draft, attachments, and send behavior.

Validation:
- InboxCore baseline: 121 tests, four skipped, zero failures.
- Two new ConversationWindow regression tests pass: cutoff boundary, running/focused/opened exceptions, bounded older pages, and preview browsing without tab promotion.
- Swift frontend parse of both edited app files and git diff --check pass.
- Full Xcode build and simulator interaction remain unverified: fresh checkout lacks the generated NanocodexVoiceCore.xcframework required during dependency resolution.
