### PR TITLE
feat(sandbox): add Swift and the CI development stack

### DIFF
--- a/.github/workflows/sandbox-image.yml
+++ b/.github/workflows/sandbox-image.yml
@@ -1,0 +1,31 @@
+name: Sandbox development image
+on:
+  pull_request:
+    paths:
+      - 'js/managed/Dockerfile'
+      - 'js/managed/scripts/check-dev-stack.sh'
+      - 'js/managed/scripts/prepare-hand-image.mjs'
+      - 'js/managed/scripts/bundle-hand-desktop.sh'
+      - 'hands/remote/**'
+      - '.github/workflows/sandbox-image.yml'
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: sandbox-image-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - name: Prepare Hand sources
+        run: node js/managed/scripts/prepare-hand-image.mjs
+      - name: Build sandbox and exercise development tools
+        run: docker buildx build --platform linux/amd64 --load --tag nanocodex-sandbox:dev --file js/managed/Dockerfile js/managed
+      - name: Verify tools in the final image
+        run: docker run --rm --network none --entrypoint sh nanocodex-sandbox:dev /usr/local/bin/nanocodex-check-dev-stack

--- a/.github/workflows/sandbox-image.yml
+++ b/.github/workflows/sandbox-image.yml
@@ -26,6 +26,18 @@ jobs:
       - name: Prepare Hand sources
         run: node js/managed/scripts/prepare-hand-image.mjs
       - name: Build sandbox and exercise development tools
-        run: docker buildx build --platform linux/amd64 --load --tag nanocodex-sandbox:dev --file js/managed/Dockerfile js/managed
+        shell: bash
+        run: |
+          set -o pipefail
+          if ! docker buildx build --progress plain --platform linux/amd64 --load --tag nanocodex-sandbox:dev --file js/managed/Dockerfile js/managed 2>&1 | tee "$RUNNER_TEMP/sandbox-build.log"; then
+            python3 - <<'PY'
+          import os
+          from pathlib import Path
+          message = "\\n".join(Path(os.environ["RUNNER_TEMP"], "sandbox-build.log").read_text().splitlines()[-40:])
+          message = message.replace("%", "%25").replace("\\r", "%0D").replace("\\n", "%0A")
+          print(f"::error title=Sandbox image build failed::{message}")
+          PY
+            exit 1
+          fi
       - name: Verify tools in the final image
         run: docker run --rm --network none --entrypoint sh nanocodex-sandbox:dev /usr/local/bin/nanocodex-check-dev-stack

--- a/js/managed/Dockerfile
+++ b/js/managed/Dockerfile
@@ -37,7 +37,16 @@ COPY --from=waymote /src/waymote/zig-out/bin/waymote-streamd /src/waymote/zig-ou
 COPY scripts/bundle-hand-desktop.sh /tmp/bundle-hand-desktop.sh
 RUN sh /tmp/bundle-hand-desktop.sh
 
+# Linux toolchains; Apple SDKs and xcodebuild remain on macOS CI.
+FROM golang:1.26.5-bookworm AS go-toolchain
+FROM swift:6.3.3-jammy AS swift-toolchain
+FROM node:24.19.0-bookworm-slim AS node-toolchain
+
 FROM docker.io/cloudflare/sandbox:0.12.4
+COPY --from=swift-toolchain /usr /opt/swift/usr
+COPY --from=node-toolchain /usr/local/bin/node /usr/local/bin/node
+COPY --from=node-toolchain /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=go-toolchain /usr/local/go /usr/local/go
 
 COPY --from=ghcr.io/astral-sh/uv:0.8.11 /uv /uvx /usr/local/bin/
 
@@ -45,7 +54,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     RUSTUP_HOME=/opt/rustup \
     CARGO_HOME=/opt/cargo \
     CARGO_TARGET_DIR=/tmp/nanocodex-cargo-target \
-    PATH=/opt/cargo/bin:${PATH}
+    PATH=/opt/cargo/bin:/opt/swift/usr/bin:/usr/local/go/bin:${PATH}
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -62,6 +71,18 @@ RUN apt-get update \
         less \
         fonts-dejavu-core \
         libssl-dev \
+        libcurl4-openssl-dev \
+        libedit2 \
+        libgcc-11-dev \
+        libpython3-dev \
+        libsqlite3-0 \
+        libstdc++-11-dev \
+        libxml2-dev \
+        libz3-dev \
+        python3-lldb-13 \
+        tzdata \
+        zlib1g-dev \
+        musl-tools \
         ninja-build \
         openssh-client \
         pkg-config \
@@ -94,13 +115,21 @@ RUN curl --fail --location --proto '=https' --tlsv1.2 \
 
 RUN ln -s /usr/bin/fdfind /usr/local/bin/fd \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-        | sh -s -- -y --profile minimal --default-toolchain stable \
+        | sh -s -- -y --profile minimal --default-toolchain 1.97.0 \
     && rustup component add clippy rustfmt \
+    && rustup target add wasm32-unknown-unknown x86_64-unknown-linux-musl \
+    && cargo install --locked wasm-bindgen-cli --version 0.2.126 \
+    && rm -rf "$CARGO_TARGET_DIR" \
+    && ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -sf ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
     && npm install --global pnpm@11.25.0 \
     && cargo --version \
     && rustc --version \
     && pnpm --version \
     && uv --version
+
+COPY scripts/check-dev-stack.sh /usr/local/bin/nanocodex-check-dev-stack
+RUN sh /usr/local/bin/nanocodex-check-dev-stack
 
 COPY --from=hand /out/nanocodex-remote /usr/local/bin/nanocodex-remote
 COPY --from=desktop /opt/nanocodex-desktop /opt/nanocodex-desktop

--- a/js/managed/Dockerfile
+++ b/js/managed/Dockerfile
@@ -41,11 +41,11 @@ RUN sh /tmp/bundle-hand-desktop.sh
 FROM golang:1.26.5-bookworm AS go-toolchain
 FROM swift:6.3.3-jammy AS swift-toolchain
 FROM node:24.19.0-bookworm-slim AS node-toolchain
+RUN npm install --global pnpm@11.25.0
 
 FROM docker.io/cloudflare/sandbox:0.12.4
 COPY --from=swift-toolchain /usr /opt/swift/usr
-COPY --from=node-toolchain /usr/local/bin/node /usr/local/bin/node
-COPY --from=node-toolchain /usr/local/lib/node_modules /usr/local/lib/node_modules
+COPY --from=node-toolchain /usr/local /opt/node
 COPY --from=go-toolchain /usr/local/go /usr/local/go
 
 COPY --from=ghcr.io/astral-sh/uv:0.8.11 /uv /uvx /usr/local/bin/
@@ -54,7 +54,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     RUSTUP_HOME=/opt/rustup \
     CARGO_HOME=/opt/cargo \
     CARGO_TARGET_DIR=/tmp/nanocodex-cargo-target \
-    PATH=/opt/cargo/bin:/opt/swift/usr/bin:/usr/local/go/bin:${PATH}
+    PATH=/opt/node/bin:/opt/cargo/bin:/opt/swift/usr/bin:/usr/local/go/bin:${PATH}
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -120,9 +120,6 @@ RUN ln -s /usr/bin/fdfind /usr/local/bin/fd \
     && rustup target add wasm32-unknown-unknown x86_64-unknown-linux-musl \
     && cargo install --locked wasm-bindgen-cli --version 0.2.126 \
     && rm -rf "$CARGO_TARGET_DIR" \
-    && ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
-    && ln -sf ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
-    && npm install --global pnpm@11.25.0 \
     && cargo --version \
     && rustc --version \
     && pnpm --version \

--- a/js/managed/README.md
+++ b/js/managed/README.md
@@ -278,6 +278,29 @@ deployment order, secret handling, and required browser evidence in
 [`../../AGENTS.md`](../../AGENTS.md). The package scripts provide its focused
 typecheck, test, and Wrangler dry-run build when that boundary changes.
 
+### Sandbox development tools
+
+New Cloudflare Sandbox images include Swift 6.3.3 (Ubuntu 22.04), Go 1.26.5,
+Node 24.19.0, pnpm 11.25.0, and Rust 1.97.0 with rustfmt, Clippy, the
+`wasm32-unknown-unknown` and `x86_64-unknown-linux-musl` targets, and
+wasm-bindgen-cli 0.2.126. Rust, Go, Node, pnpm, and wasm-bindgen versions align
+with the repository CI configuration; Swift is a pinned Linux toolchain, while
+Apple CI uses the Swift bundled with its Xcode runner. Python, uv, C/C++ build
+tools, CMake, Ninja, and musl-tools are also available.
+
+Run `sh /usr/local/bin/nanocodex-check-dev-stack` in a sandbox to check the
+installed tools and compile small Swift/Foundation, Go, Rust, musl, and WASM
+programs without fetching package dependencies. The image build runs the same
+check and fails if a compiler or required runtime library is missing.
+
+Linux Swift supports portable Swift packages. AppKit, SwiftUI, iOS simulators,
+Apple SDKs, and `xcodebuild` still require a Mac Hand or Apple CI; installing
+Swift does not make all `apple/` packages Linux compatible.
+
+These tools become available after the managed container image is built and
+rolled out. Existing running sandboxes need recreation with the updated image.
+When changing tool versions in CI, update the corresponding image pins too.
+
 ### Original video attachments
 
 The authenticated `/v1/agents/:id/attachments/:uuid` route stores original

--- a/js/managed/scripts/check-dev-stack.sh
+++ b/js/managed/scripts/check-dev-stack.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Offline compilation checks, run during the image build and on demand.
+set -eu
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+cd "$work"
+node --version
+npm --version
+pnpm --version
+uv --version
+go version
+swift --version
+rustc --version
+cargo --version
+wasm-bindgen --version
+cargo clippy --version
+cargo fmt --version
+printf 'console.log("node ok")\n' > hello.js
+node hello.js
+printf 'import Foundation\nprint("swift ok")\n' > hello.swift
+swiftc hello.swift -o swift-hello
+./swift-hello
+printf 'package main\nimport "fmt"\nfunc main() { fmt.Println("go ok") }\n' > hello.go
+GOCACHE="$work/go-cache" go build -o go-hello hello.go
+./go-hello
+printf 'fn main() { println!("rust ok"); }\n' > hello.rs
+rustc hello.rs -o rust-hello
+./rust-hello
+rustc --target x86_64-unknown-linux-musl hello.rs -o musl-hello
+./musl-hello
+printf '#[no_mangle] pub extern "C" fn answer() -> u32 { 42 }\n' > wasm.rs
+rustc --crate-type cdylib --target wasm32-unknown-unknown wasm.rs -o hello.wasm
+test -s hello.wasm
+python3 -c 'import ssl, sqlite3; print("python ok")'


### PR DESCRIPTION
Cloudflare sandboxes currently lack Swift, Go, and the WASM tools used by repository CI. Add Swift 6.3.3 for Ubuntu 22.04, Go 1.26.5, Node 24.19.0, Rust 1.97.0 with Clippy/rustfmt and WASM/musl targets, and wasm-bindgen-cli 0.2.126; retain pnpm 11.25.0 and the existing Python/uv and native build tools. Node and pnpm are installed together in an isolated prefix to avoid mixing them with the base image's older npm installation.

The image build compiles small Swift/Foundation, Go, Rust, musl, and WASM programs. A dedicated PR workflow builds the complete AMD64 image and repeats the smoke check with networking disabled. Build failures include diagnostic annotations. Documentation explains usage, rollout/recreation, and the remaining Mac/Xcode requirement for Apple apps.

Validation on 741666feff4cba54a89a7dc2f742a49c10f0b448: full sandbox image build and offline compiler checks passed; main CI, Cloudflare validation, and JavaScript package preview passed. Shell syntax and ShellCheck passed for the smoke script. Swift is a pinned Linux toolchain; Apple CI uses runner-provided Xcode Swift.