### PR TITLE
Add browser-style mobile tab overview and swipe-to-close

### DIFF
--- a/apple/NanocodexInbox/DemoContent.swift
+++ b/apple/NanocodexInbox/DemoContent.swift
@@ -273,7 +273,8 @@ private final class StartupFixtureProtocol: URLProtocol, @unchecked Sendable {
             if path == "/v1/agents" {
                 delay = 6
                 if ProcessInfo.processInfo.environment["NANOCODEX_STARTUP_REJECT"] == "1" { status = 401 }
-                body = #"{"data":["saved","other","slow"],"summaries":{"saved":{"title":"Saved conversation","updated_at":3,"turn_count":1,"may_have_scheduled_jobs":true},"other":{"title":"Other conversation","updated_at":2,"turn_count":1,"may_have_scheduled_jobs":true},"slow":{"title":"Background conversation","updated_at":1,"turn_count":1,"may_have_scheduled_jobs":true}}}"#
+            let now = Date().timeIntervalSince1970 * 1000
+                body = #"{"data":["saved","other","slow"],"summaries":{"saved":{"title":"Saved conversation","updated_at":\#(now),"turn_count":1,"may_have_scheduled_jobs":true},"other":{"title":"Other conversation","updated_at":\#(now - 1),"turn_count":1,"may_have_scheduled_jobs":true},"slow":{"title":"Background conversation","updated_at":\#(now - 2),"turn_count":1,"may_have_scheduled_jobs":true}}}"#
             } else if path.hasSuffix("/events/history") {
                 delay = id == "slow" ? 20 : 10
                 body = "{\"data\":[{\"cursor\":\"1\",\"type\":\"turn_completed\",\"turn_id\":\"t\",\"final_message\":\"Loaded \(id) conversation.\"}],\"has_more\":false,\"latest_cursor\":\"1\"}"

--- a/apple/NanocodexInbox/InboxModel.swift
+++ b/apple/NanocodexInbox/InboxModel.swift
@@ -30,6 +30,7 @@ final class InboxModel: ObservableObject {
     @Published var threadError: String?
     private var observedAgentID: String?
     private var tabOrder: [String] = []
+    @Published private(set) var closedConversationIDs = Set<String>()
     @Published private var openedConversations = Set<String>()
     @Published private var olderConversationLimit = 0
     private struct TabHistory {
@@ -196,17 +197,20 @@ final class InboxModel: ObservableObject {
     }
     var tabCards: [AgentCard] {
         let byID = Dictionary(uniqueKeysWithValues: cards.map { ($0.id, $0) })
-        return tabOrder.compactMap { byID[$0] }
+        return tabOrder.filter { !closedConversationIDs.contains($0) }.compactMap { byID[$0] }
     }
     private var recentConversationIDs: Set<String> {
-        Set(cards.filter { ConversationWindow.includes($0, focusedID: deck.focusedID,
+        Set(cards.filter { !closedConversationIDs.contains($0.id) && ConversationWindow.includes($0, focusedID: deck.focusedID,
             openedIDs: openedConversations) }.map(\.id))
     }
     var overviewCards: [AgentCard] {
-        ConversationWindow.overview(cards, focusedID: deck.focusedID,
+        ConversationWindow.overview(cards.filter { !closedConversationIDs.contains($0.id) }, focusedID: deck.focusedID,
             openedIDs: openedConversations, olderLimit: olderConversationLimit)
     }
-    var hasOlderConversations: Bool { overviewCards.count < cards.count }
+    var closedConversationCards: [AgentCard] {
+        cards.filter { closedConversationIDs.contains($0.id) }.sorted(by: AgentCard.mostRecentFirst)
+    }
+    var hasOlderConversations: Bool { overviewCards.count < cards.filter { !closedConversationIDs.contains($0.id) }.count }
     func loadOlderConversations() { olderConversationLimit += ConversationWindow.pageSize }
     var creationError: String? { focused.flatMap { creationErrors[$0.id] } }
     private func resolvedAgentID(_ id: String) -> String { createdAgentIDs[id] ?? id }
@@ -567,6 +571,7 @@ final class InboxModel: ObservableObject {
             request.setValue("Bearer " + credential.apiKey, forHTTPHeaderField: "Authorization")
         }
         scope = accountScope
+        closedConversationIDs = Set(UserDefaults.standard.stringArray(forKey: "inbox.closedTabs." + scope) ?? [])
         configureDeviceHand(credential)
         activateContext()
         drafts = UserDefaults.standard.dictionary(forKey: "inbox.drafts." + scope) as? [String: String] ?? [:]
@@ -584,8 +589,8 @@ final class InboxModel: ObservableObject {
         }
         cards = initial
         restoreCreations()
-        if let previousID, cards.contains(where: { $0.id == previousID }) {
-            deck.reconcile(cards.map(\.id)); deck.focus(previousID)
+        if let previousID, !closedConversationIDs.contains(previousID), cards.contains(where: { $0.id == previousID }) {
+            deck.reconcile(cards.filter { !closedConversationIDs.contains($0.id) }.map(\.id)); deck.focus(previousID)
             if let openingRequest {
                 openingHistory = (previousID, openingRequest)
                 handedOff = true
@@ -605,7 +610,7 @@ final class InboxModel: ObservableObject {
         agentNotificationUpdate?.cancel(); agentNotificationUpdate = nil
         stopOverview()
         overviewTranscripts = [:]; tabHistories = [:]; recentTabs = []; tabOrder = []
-        openedConversations = []; olderConversationLimit = 0
+        openedConversations = []; closedConversationIDs = []; olderConversationLimit = 0
         handTasks.endAllObservations()
         schedulesTask?.cancel(); schedulesTask = nil; schedulesFailures = [:]
         scheduledJobs = []; scheduledJobAgents = [:]; schedulesLoading = false; schedulesLoaded = false; schedulesError = nil
@@ -902,7 +907,7 @@ final class InboxModel: ObservableObject {
         tabOrder.append(contentsOf: cards.sorted(by: AgentCard.mostRecentFirst).map(\.id).filter { available.contains($0) && !known.contains($0) })
         let previous = deck.focusedID
         let eligible = cards.filter { card in
-            guard available.contains(card.id) else { return false }
+            guard !closedConversationIDs.contains(card.id), available.contains(card.id) else { return false }
             if card.id == pinnedThreadID { return true }
             switch filter {
             case .inbox: return card.isInInbox(seen: seenCursor(card.id), deferred: deferred[card.id])
@@ -950,6 +955,8 @@ final class InboxModel: ObservableObject {
     func back() {
         while let previous = navigation.popLast() {
             guard previous.id != focused?.id, cards.contains(where: { $0.id == previous.id }) else { continue }
+            closedConversationIDs.remove(previous.id)
+            openedConversations.insert(previous.id)
             pinnedThreadID = previous.id
             seen[previous.id] = previous.seen; deferred[previous.id] = previous.deferred
             persist(); filter = previous.filter
@@ -1056,8 +1063,34 @@ final class InboxModel: ObservableObject {
         select(id)
     }
 
+    // Closing a browser tab only hides it locally; work, drafts and history remain intact.
+    func closeConversationTab(_ id: String) {
+        let id = resolvedAgentID(id)
+        guard cards.contains(where: { $0.id == id }), !closedConversationIDs.contains(id) else { return }
+        let order = tabCards.map(\.id)
+        let neighbor: String? = order.firstIndex(of: id).flatMap { index in
+            if index + 1 < order.count { return order[index + 1] }
+            return index > 0 ? order[index - 1] : nil
+        }
+        let wasFocused = deck.focusedID == id
+        closedConversationIDs.insert(id)
+        if pinnedThreadID == id { pinnedThreadID = nil }
+        persist()
+        if wasFocused, let neighbor {
+            select(neighbor)
+        } else {
+            if wasFocused, let card = focused {
+                navigation.append((card.id, seen[card.id], deferred[card.id], filter))
+                if navigation.count > 50 { navigation.removeFirst() }
+            }
+            reconcile()
+        }
+    }
+
     func select(_ id: String) {
+        let id = resolvedAgentID(id)
         guard cards.contains(where: { $0.id == id }) else { return }
+        if closedConversationIDs.remove(id) != nil { persist() }
         openedConversations.insert(id)
         if let card = focused, card.id != id {
             navigation.append((card.id, seen[card.id], deferred[card.id], filter))
@@ -1969,6 +2002,7 @@ final class InboxModel: ObservableObject {
     private func bindCreatedAgent(_ localID: String, to id: String) {
         let wasFocused = deck.focusedID == localID
         createdAgentIDs[localID] = id
+        if closedConversationIDs.remove(localID) != nil { closedConversationIDs.insert(id) }
         if openedConversations.remove(localID) != nil { openedConversations.insert(id) }
         // A concurrent roster can list the real agent before create returns.
         // Keep the placeholder's position and avoid duplicate SwiftUI identities.
@@ -2000,8 +2034,8 @@ final class InboxModel: ObservableObject {
         pendingCreations.remove(localID); creationErrors[localID] = nil
         unlistedAgents.insert(id)
         // Rebind without navigating: a late response must never steal focus.
-        deck.reconcile(deck.order.map { $0 == localID ? id : $0 })
-        if wasFocused { deck.focus(id) }
+        deck.reconcile(deck.order.map { $0 == localID ? id : $0 }.filter { !closedConversationIDs.contains($0) })
+        if wasFocused, !closedConversationIDs.contains(id) { deck.focus(id) }
         persist(); observeFocused()
     }
     private func restoreCreations() {
@@ -2011,11 +2045,13 @@ final class InboxModel: ObservableObject {
     private func persist() {
         guard !scope.isEmpty else { return }
         let scope = scope, drafts = drafts, attachmentDrafts = attachmentDrafts, seen = seen
+        let closedConversationIDs = closedConversationIDs
         let selectedContext = selectedContext, excludedContext = excludedContext
         let pending = pending, cancellations = cancellations, pendingCreations = pendingCreations
         let isDemo = isDemo, demoRows = demoRows
         let demoTurns = isDemo ? Dictionary(uniqueKeysWithValues: cards.map { ($0.id, $0.activeTurns) }) : [:]
         preferences.enqueue { defaults in
+            defaults.set(Array(closedConversationIDs).sorted(), forKey: "inbox.closedTabs." + scope)
             defaults.set(drafts, forKey: "inbox.drafts." + scope)
             if let data = try? JSONEncoder().encode(attachmentDrafts) { defaults.set(data, forKey: "inbox.attachments." + scope) }
             defaults.set(seen, forKey: "inbox.seen." + scope)
@@ -2045,6 +2081,7 @@ final class InboxModel: ObservableObject {
             remoteService = try? RemoteService(origin: URL(string: "http://127.0.0.1:18965")!) { _ in }
         }
         scope = "demo." + (ProcessInfo.processInfo.environment["NANOCODEX_DEMO_PROFILE"] ?? "default")
+        closedConversationIDs = Set(UserDefaults.standard.stringArray(forKey: "inbox.closedTabs." + scope) ?? [])
         cards = DemoContent.cards()
         if let profile = ProcessInfo.processInfo.environment["NANOCODEX_DEMO_PROFILE"] {
             scope = "demo." + profile

--- a/apple/NanocodexInbox/InboxView.swift
+++ b/apple/NanocodexInbox/InboxView.swift
@@ -77,7 +77,7 @@ struct InboxView: View {
         }
         .foregroundStyle(Ink.text)
         .tint(Ink.accent)
-        .sheet(isPresented: $showOverview) {
+        .fullScreenCover(isPresented: $showOverview) {
             ConversationOverview(model: model) { id in
                 selectConversation(id)
                 showOverview = false
@@ -448,6 +448,8 @@ private struct ConversationOverview: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var query = ""
     @State private var runningOnly = false
+    @State private var showingClosed = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var order: [String]
 
     init(model: InboxModel, select: @escaping (String) -> Void) {
@@ -458,8 +460,10 @@ private struct ConversationOverview: View {
 
     private var visibleCards: [AgentCard] {
         let text = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        let cards = Dictionary(uniqueKeysWithValues: model.overviewCards.map { ($0.id, $0) })
-        return order.compactMap { cards[$0] }.filter { card in
+        let source = showingClosed ? model.closedConversationCards : model.overviewCards
+        let cards = Dictionary(uniqueKeysWithValues: source.map { ($0.id, $0) })
+        let ordered = showingClosed ? source : order.compactMap { cards[$0] }
+        return ordered.filter { card in
             (!runningOnly || card.isRunning) && (text.isEmpty || card.title.localizedCaseInsensitiveContains(text)
                 || card.id.localizedCaseInsensitiveContains(text) || card.preview.localizedCaseInsensitiveContains(text))
         }
@@ -484,40 +488,24 @@ private struct ConversationOverview: View {
             ScrollView {
                 LazyVGrid(columns: [GridItem(.adaptive(minimum: dynamicTypeSize.isAccessibilitySize ? 280 : 155), spacing: 14)], spacing: 18) {
                     ForEach(visibleCards) { card in
-                        Button { select(card.id) } label: {
-                            VStack(alignment: .leading, spacing: 9) {
-                                Text(card.title).font(.system(size: 15, weight: .semibold)).lineLimit(2, reservesSpace: true)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                ConversationMiniature(model: model, card: card, rows: model.overviewRows(for: card.id)).equatable()
-                                    .frame(height: 230)
-                                    .background(Ink.background)
-                                    .clipShape(RoundedRectangle(cornerRadius: 16))
-                                    .overlay {
-                                        RoundedRectangle(cornerRadius: 16)
-                                            .strokeBorder(card.isRunning ? Color.green : model.focused?.id == card.id ? Ink.text : Ink.border,
-                                                          lineWidth: card.isRunning || model.focused?.id == card.id ? 2 : 0.75)
-                                    }
-                                    .accessibilityIdentifier("overview-preview:" + card.id)
-                            }
-                            .contentShape(Rectangle())
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityRepresentation {
-                            Button(card.title) { select(card.id) }
-                                .accessibilityValue(overviewDescription(card))
-                                .accessibilityHint("Open conversation")
-                                .accessibilityAddTraits(model.deck.focusedID == card.id ? [.isSelected] : [])
-                                .accessibilityIdentifier("overview-card:" + card.id)
-                        }
+                        ConversationOverviewCard(model: model, card: card,
+                            description: overviewDescription(card), canClose: !showingClosed,
+                            select: { select(card.id) }, close: {
+                                withAnimation(reduceMotion ? nil : .spring(response: 0.32, dampingFraction: 0.86)) {
+                                    model.closeConversationTab(card.id)
+                                }
+                            })
+                            .transition(reduceMotion ? .opacity : .scale(scale: 0.9).combined(with: .opacity))
                         .onAppear { model.setOverviewVisible(card.id, visible: true) }
                         .onDisappear { model.setOverviewVisible(card.id, visible: false) }
                     }
                 }.padding(16)
+                    .animation(reduceMotion ? nil : .spring(response: 0.32, dampingFraction: 0.86), value: visibleCards.map(\.id))
                 if visibleCards.isEmpty {
                     ContentUnavailableView(model.cards.isEmpty ? "No conversations" : "No matching conversations", systemImage: "bubble.left.and.bubble.right",
                                            description: Text(model.cards.isEmpty ? "Use + to start a conversation." : "Try another search or load older conversations below."))
                 }
-                if model.hasOlderConversations {
+                if !showingClosed && model.hasOlderConversations {
                     Button("Load older conversations") { model.loadOlderConversations() }
                         .buttonStyle(.bordered)
                         .padding(.bottom, 20)
@@ -527,10 +515,17 @@ private struct ConversationOverview: View {
             }
             .searchable(text: $query, placement: .navigationBarDrawer(displayMode: .always), prompt: "Search conversations")
             .background(Ink.background)
-            .navigationTitle("Conversations")
+            .navigationTitle(showingClosed ? "Closed tabs" : "Conversations")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItemGroup(placement: .bottomBar) {
+                    Menu {
+                        Button(showingClosed ? "Show open tabs" : "Closed tabs", systemImage: "clock") {
+                            showingClosed.toggle()
+                        }
+                    } label: { Text("More") }
+                    .accessibilityIdentifier("overview-more")
+                    Spacer()
                     Button {
                         model.newAgent()
                         dismiss()
@@ -541,7 +536,6 @@ private struct ConversationOverview: View {
                 }
             }
         }
-        .presentationDetents([.large]).presentationDragIndicator(.visible)
         .onChange(of: model.overviewCards.map(\.id)) { _, ids in
             // Live history updates must not move another window under a tap.
             let available = Set(ids)
@@ -550,6 +544,79 @@ private struct ConversationOverview: View {
             order.append(contentsOf: ids.filter { !known.contains($0) })
         }
         .onDisappear { model.stopOverview() }
+    }
+}
+
+private struct ConversationOverviewCard: View {
+    @ObservedObject var model: InboxModel
+    let card: AgentCard
+    let description: String
+    let canClose: Bool
+    var select: () -> Void
+    var close: () -> Void
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @GestureState private var swipe: CGFloat = 0
+
+    private var selected: Bool { model.deck.focusedID == card.id }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 6) {
+                Image(systemName: "bubble.left.fill")
+                    .foregroundStyle(card.isRunning ? Color.green : Color.secondary)
+                    .accessibilityHidden(true)
+                Text(card.title).font(.subheadline.weight(.medium)).lineLimit(1)
+                    .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+                    .contentShape(Rectangle())
+                    .onTapGesture(perform: select)
+                    .accessibilityRepresentation { Button("Open " + card.title, action: select) }
+                if canClose {
+                    Button(action: close) {
+                        Image(systemName: "xmark").font(.system(size: 12, weight: .medium))
+                            .frame(width: 44, height: 44).contentShape(Rectangle())
+                    }
+                    .accessibilityLabel("Close " + card.title)
+                    .accessibilityHint("Keeps the conversation and any running work")
+                    .accessibilityIdentifier("overview-close:" + card.id)
+                }
+            }.padding(.leading, 12)
+            ConversationMiniature(model: model, card: card, rows: model.overviewRows(for: card.id)).equatable()
+                    .frame(height: 230)
+                    .frame(maxWidth: .infinity)
+                    .background(Ink.background)
+                    .contentShape(Rectangle())
+                    // A tap recognizer fails when dragging; a plain Button can
+                    // activate on release after a simultaneous swipe gesture.
+                    .onTapGesture(perform: select)
+                    .accessibilityRepresentation {
+                        Button(card.title, action: select)
+                            .accessibilityValue(description)
+                            .accessibilityHint("Open conversation")
+                            .accessibilityAddTraits(selected ? [.isSelected] : [])
+                            .accessibilityIdentifier("overview-card:" + card.id)
+                    }
+        }
+        .buttonStyle(.plain)
+        .background(Ink.card)
+        .clipShape(RoundedRectangle(cornerRadius: 18))
+        .overlay {
+            RoundedRectangle(cornerRadius: 18)
+                .strokeBorder(selected ? Color.accentColor : Ink.border, lineWidth: selected ? 2 : 0.5)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("overview-preview:" + card.id)
+        .offset(x: reduceMotion ? 0 : swipe)
+        .opacity(1 - min(abs(swipe) / 300, 0.65))
+        .simultaneousGesture(DragGesture(minimumDistance: 24)
+            .updating($swipe) { value, offset, _ in
+                guard canClose, abs(value.translation.width) > abs(value.translation.height) * 1.5 else { return }
+                offset = value.translation.width
+            }
+            .onEnded { value in
+                guard canClose, abs(value.translation.width) > 90,
+                      abs(value.translation.width) > abs(value.translation.height) * 1.5 else { return }
+                close()
+            })
     }
 }
 

--- a/apple/NanocodexInboxUITests/InboxUITests.swift
+++ b/apple/NanocodexInboxUITests/InboxUITests.swift
@@ -48,6 +48,61 @@ final class InboxUITests: XCTestCase {
         XCTAssertFalse(app.staticTexts["Loaded saved conversation."].exists)
         XCTAssertTrue(app.buttons["browser-tab:other"].isSelected)
     }
+    func testOverviewClosesAndReopensTabWithoutDeletingConversation() {
+        let app = startupFixture()
+        XCTAssertTrue(app.buttons["browser-tab:saved"].waitForExistence(timeout: 20))
+        app.buttons["tab-overview"].tap()
+        let overview = app.descendants(matching: .any)["conversation-overview"].firstMatch
+        XCTAssertTrue(overview.waitForExistence(timeout: 10))
+        let close = app.buttons["overview-close:saved"]
+        XCTAssertTrue(close.waitForExistence(timeout: 10))
+        close.tap()
+        gone(close)
+        XCTAssertTrue(overview.exists, "Closing a card must keep the overview open")
+        app.buttons["Done"].tap()
+        XCTAssertFalse(app.buttons["browser-tab:saved"].exists)
+        XCTAssertTrue(app.buttons["browser-tab:other"].isSelected)
+        XCUIDevice.shared.press(.home)
+        app.terminate(); app.launch()
+        XCTAssertTrue(app.buttons["browser-tab:other"].waitForExistence(timeout: 20))
+        XCTAssertFalse(app.buttons["browser-tab:saved"].exists, "Closed tabs must stay closed after relaunch")
+        app.buttons["tab-overview"].tap()
+        app.buttons["overview-more"].tap()
+        app.buttons["Closed tabs"].tap()
+        let saved = app.buttons["overview-card:saved"]
+        XCTAssertTrue(saved.waitForExistence(timeout: 10))
+        saved.tap()
+        XCTAssertTrue(app.buttons["browser-tab:saved"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.buttons["browser-tab:saved"].isSelected)
+        XCTAssertTrue(app.staticTexts["Loaded saved conversation."].waitForExistence(timeout: 20))
+    }
+
+    func testOverviewSwipeClosesLastTabAndCanReopen() {
+        let app = startupFixture()
+        XCTAssertTrue(app.buttons["browser-tab:saved"].waitForExistence(timeout: 20))
+        app.buttons["tab-overview"].tap()
+        let overview = app.descendants(matching: .any)["conversation-overview"].firstMatch
+        XCTAssertTrue(overview.waitForExistence(timeout: 10))
+        capture(app, "browser-tabs-overview")
+        for id in ["other", "slow"] {
+            let close = app.buttons["overview-close:" + id]
+            XCTAssertTrue(close.waitForExistence(timeout: 10))
+            close.tap(); gone(close)
+        }
+        app.buttons["overview-card:saved"].swipeLeft()
+        gone(app.buttons["overview-card:saved"])
+        XCTAssertTrue(overview.exists)
+        capture(app, "browser-tabs-all-closed")
+        app.buttons["Done"].tap()
+        XCTAssertFalse(app.buttons.matching(NSPredicate(format: "identifier BEGINSWITH %@", "browser-tab:")).firstMatch.exists)
+        app.buttons["tab-overview"].tap()
+        app.buttons["overview-more"].tap()
+        app.buttons["Closed tabs"].tap()
+        app.buttons["overview-card:saved"].tap()
+        XCTAssertTrue(app.buttons["browser-tab:saved"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.buttons["browser-tab:saved"].isSelected)
+    }
+
     func testStartupRejectsUnauthorizedRoster() {
         let app = startupFixture(reject: true)
         XCTAssertTrue(app.textFields["phone-number"].waitForExistence(timeout: 15))

--- a/apple/README.md
+++ b/apple/README.md
@@ -30,8 +30,14 @@ for background work, while older transcripts load only when opened or visible.
 The composer grows up to six lines, then scrolls; its expand button opens a larger
 editor sharing the same draft and attachments.
 
-Each tab opens the full conversation directly. Overview cards render miniature
-transcripts with the same message components and latest available content.
+Each tab opens the full conversation directly. The full-screen overview shows
+searchable cards with miniature transcripts and an outline around the selected tab.
+Close a card with its × button or a horizontal swipe; the overview stays open while
+the remaining cards rearrange. Closing the selected tab selects its neighbor.
+Closed tabs remain closed across launches on this device and can be reopened from
+**More → Closed tabs**. Closing preserves conversation history, drafts, and running work.
+Overview cards render miniature transcripts with the same message components and
+latest available content.
 Unchanged Markdown stays behind an equality boundary, so typing, scrolling, and
 another row's streamed updates do not reparse completed messages. Parsing runs on
 a background actor with a bounded cache; streamed changes coalesce for 32 ms,


### PR DESCRIPTION
The mobile tab overview now follows the supplied browser interaction: full-screen searchable preview cards, an active-tab outline, close buttons, horizontal swipe-to-close, and animated rearrangement while the overview remains open.

Closing the selected tab selects its neighbor. Closed tabs persist per account on the device and reopen through More → Closed tabs; history, drafts, and running work are preserved. Reduce Motion and accessible open/close actions are supported.

Validation: Xcode 26.6 build and two iOS 26.5 simulator UI tests passed. Tests cover close, neighboring selection, persistence across relaunch, reopening intact history, swipe-to-close, and closing/reopening the last tab. Updated startup fixture timestamps so its recent conversations remain recent.
