### PR TITLE
fix(managed): hide explicit unlimited shell limits

### DIFF
--- a/js/nanocodex-tools/tools/bash.mjs
+++ b/js/nanocodex-tools/tools/bash.mjs
@@ -298,7 +298,9 @@ function describeRuntime({
     commands: Object.freeze([...bash.commands.keys()].sort()),
     customCommands: Object.freeze(customCommandNames.sort()),
     cwd,
-    limits: Object.freeze(Object.fromEntries(Object.entries(executionLimits).filter(([, value]) => value !== PRACTICALLY_UNBOUNDED))),
+    limits: Object.freeze(Object.fromEntries(Object.entries(executionLimits).filter(
+      ([, value]) => Number.isFinite(value) && value !== PRACTICALLY_UNBOUNDED,
+    ))),
     network: Object.freeze({
       enabled: networkEnabled,
       mode: networkMode ?? (networkEnabled ? "http" : "disabled"),


### PR DESCRIPTION
## Summary

- preserve the runtime descriptor contract for caller-supplied `Infinity` execution limits
- continue hiding the new `Number.MAX_SAFE_INTEGER` host-owned defaults
- repair the post-merge Node/browser CI failure from #305

## Validation

- `node --test js/nanocodex/test/bash.test.mjs` (12 passed)
- `pnpm --filter nanocodex-tools typecheck`
- `git diff --check`

The failing master assertion expected `{}` for explicit unlimited limits but saw `{ maxStringLength: Infinity, maxOutputSize: Infinity }`; this restores the prior descriptor filtering while retaining the safe-integer runtime fix.