### PR TITLE
feat(hand): add a persistent Docker backend without KVM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,9 @@ jobs:
           RUSTDOCFLAGS: -D warnings
 
   vm-guest:
-    name: static Linux VM guest
+    name: static Linux guest and Docker Hand
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:
@@ -124,6 +124,21 @@ jobs:
           cargo build --locked --package nanocodex-vm
           --bin nanocodex-vm-guest --no-default-features
           --features guest-runtime --target x86_64-unknown-linux-musl
+
+      - name: Build the Docker Hand image
+        run: |
+          context=$(mktemp -d)
+          trap 'rm -rf "$context"' EXIT
+          cp target/x86_64-unknown-linux-musl/debug/nanocodex-vm-guest "$context/"
+          cp crates/experimental/nanocodex-vm/image/Dockerfile.hand "$context/Dockerfile"
+          docker build --tag nanocodex-hand:ci "$context"
+      - name: Test Docker tools, desktop, persistence, and cleanup without KVM
+        run: |
+          cargo test --locked -p nanocodex-vm --test docker_live -- --ignored --nocapture
+          cargo test --locked -p nanocodex2-bin --test nanocodex2_managed docker_hand_live -- --ignored --nocapture
+        env:
+          NANOCODEX_DOCKER_TEST_IMAGE: nanocodex-hand:ci
+          NANOCODEX_DOCKER_HOST_SENTINEL: must-not-enter-the-container
 
   policy:
     name: dependencies and spelling

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,18 @@ jobs:
         env:
           NANOCODEX_DOCKER_TEST_IMAGE: nanocodex-hand:ci
           NANOCODEX_DOCKER_HOST_SENTINEL: must-not-enter-the-container
+      - name: Verify missing KVM is explained before account setup
+        run: |
+          sudo unshare --mount --propagation private sh -eu -c '
+            if test -e /dev/kvm; then mount --bind /dev/null /dev/kvm; fi
+            if target/debug/nanocodex2 hand --vm /nonexistent-root.ext4 > /tmp/hand-kvm-error 2>&1; then
+              cat /tmp/hand-kvm-error
+              exit 1
+            fi
+            cat /tmp/hand-kvm-error
+            grep -F "VM backend is unavailable" /tmp/hand-kvm-error
+            grep -F "hand --docker IMAGE --volume NAME" /tmp/hand-kvm-error
+          '
 
   policy:
     name: dependencies and spelling

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6242,6 +6242,7 @@ dependencies = [
  "fs2",
  "futures-util",
  "image",
+ "kvm-ioctls",
  "nanocodex",
  "nanocodex-agent",
  "nanocodex-cli-auth",

--- a/bin/nanocodex/nanocodex2/Cargo.toml
+++ b/bin/nanocodex/nanocodex2/Cargo.toml
@@ -61,6 +61,7 @@ nanocodex-vm.workspace = true
 nanocodex-hand = { version = "0.5.0", path = "../../../crates/experimental/nanocodex-hand" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+kvm-ioctls = "0.24.0"
 nanocodex-vm = { workspace = true, features = ["desktop"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/bin/nanocodex/nanocodex2/README.md
+++ b/bin/nanocodex/nanocodex2/README.md
@@ -171,6 +171,80 @@ The immutable attachment snapshot publishes the guest workspace plus `vm`,
 attachment generation under the existing lease/fencing rules. Ctrl-C drains
 admitted calls, syncs the guest filesystem, and stops the VM.
 
+## Docker hand (no KVM)
+
+Use Docker on glibc Linux or Apple Silicon macOS with a Linux Docker daemon.
+Linux containers do not require `/dev/kvm`; Docker Desktop still needs its own
+Linux VM on macOS. This is an explicit container backend with a shared host
+kernel, not an automatic fallback from failed VM startup.
+
+Build the image for the selected Docker daemon's architecture from the repo root
+(the matching Rust musl target and linker must be installed):
+
+```bash
+pnpm build:hand-docker
+nanocodex2 hand \
+  --docker nanocodex-hand:local \
+  --docker-volume personal-hand-workspace \
+  --machine-id personal-hand \
+  --machine-name "Personal Docker Hand"
+```
+
+The existing account login supplies attachment authority. No account credential,
+Docker socket, or host directory is passed into the container. The bundled image
+contains the Rust guest runtime, shell, Git, Python, Node, and an X11 desktop.
+Images must already exist on the selected Docker daemon; launch never pulls.
+Use a pinned image digest when deploying an image from a registry.
+
+Docker Hands default to **offline**. `--docker-internet` explicitly enables
+ordinary Docker bridge networking, including any destinations that network can
+reach. This mode does not enforce broker-only egress. Account signaling and
+screen publication remain in the host process and work with an offline guest.
+A future broker-only mode must enforce its network boundary, not rely on proxy
+environment variables. `--docker-runtime runsc` selects an installed Docker
+runtime without fallback; gVisor/desktop compatibility must be checked on that
+host. The launcher does not install or configure gVisor.
+
+`--vm-workspace` (default `/app`), `--vm-cpus`, `--vm-memory-mib`, and
+`--vm-shell` apply to either backend. Docker Hands publish `container` instead
+of `vm` in the machine capability list. `--vm` and `--docker` are mutually
+exclusive; Docker images bundle their runtime and do not accept ext4 guest or
+firmware options.
+
+The named volume holds the workspace, including `$HOME` at `/app/.home` by
+default. Reuse the same volume and machine ID to resume files after a restart or
+image replacement. The root image is read-only; customize system packages in
+the Dockerfile and install project dependencies inside the workspace. Custom
+images must provide `/usr/local/bin/nanocodex-vm-guest`, `/bin/sh`, `/bin/sync`,
+and a workspace directory writable by UID/GID 1000. Runtime scratch data under
+`/run` and `/tmp` is temporary. Files on the volume are independent of the
+managed brain's durable application state.
+
+A deterministic container name reserves each workspace volume for one Hand.
+A duplicate launch fails without stopping the current owner. Ctrl-C/SIGTERM
+while attached drains work, syncs the guest, and removes the container; the
+volume is retained. Dropping the last tool capability also schedules bounded
+container cleanup. A killed host process or unreachable Docker daemon can leave
+a stale container. Inspect `docker ps -a --filter volume=personal-hand-workspace`
+and remove the exact stale container after confirming its Hand is stopped;
+then relaunch. The launcher never removes an existing owner's container.
+Back up volumes separately; container cleanup never deletes the named workspace.
+
+The design takes inspiration from [Meta's separation of the agent runtime from
+credential and permission services](https://research.meta.ai/blog/security-and-safety-for-ai-agents-our-approach-with-muse).
+It reuses Nanocodex's existing host-owned attachment and screen authority; it
+is not an implementation of Meta's Sentinel or a claim of VM-equivalent isolation.
+
+Run the Docker contract tests against the image:
+
+```bash
+NANOCODEX_DOCKER_TEST_IMAGE=nanocodex-hand:local \
+  cargo test --locked -p nanocodex-vm --test docker_live -- --ignored
+```
+
+The on-demand `host` pool remains libkrun-only; Docker is available through the
+single `hand` command and the `nanocodex_vm::docker` library API.
+
 ## On-demand VM hosts
 
 `nanocodex2 host` advertises bounded capacity instead of attaching one VM. The

--- a/bin/nanocodex/nanocodex2/README.md
+++ b/bin/nanocodex/nanocodex2/README.md
@@ -185,10 +185,12 @@ Build the image for the selected Docker daemon's architecture from the repo root
 pnpm build:hand-docker
 nanocodex2 hand \
   --docker nanocodex-hand:local \
-  --docker-volume personal-hand-workspace \
+  --volume personal-hand-workspace \
   --machine-id personal-hand \
   --machine-name "Personal Docker Hand"
 ```
+
+Startup checks backend support before account login or attachment. Missing Docker, a stopped or inaccessible daemon, non-Linux containers, missing images, mismatched image architecture, and unavailable OCI runtimes produce actionable errors.
 
 The existing account login supplies attachment authority. No account credential,
 Docker socket, or host directory is passed into the container. The bundled image
@@ -196,17 +198,17 @@ contains the Rust guest runtime, shell, Git, Python, Node, and an X11 desktop.
 Images must already exist on the selected Docker daemon; launch never pulls.
 Use a pinned image digest when deploying an image from a registry.
 
-Docker Hands default to **offline**. `--docker-internet` explicitly enables
+Docker Hands default to **offline**. `--network internet` explicitly enables
 ordinary Docker bridge networking, including any destinations that network can
 reach. This mode does not enforce broker-only egress. Account signaling and
 screen publication remain in the host process and work with an offline guest.
 A future broker-only mode must enforce its network boundary, not rely on proxy
-environment variables. `--docker-runtime runsc` selects an installed Docker
+environment variables. `--runtime runsc` selects an installed Docker
 runtime without fallback; gVisor/desktop compatibility must be checked on that
 host. The launcher does not install or configure gVisor.
 
-`--vm-workspace` (default `/app`), `--vm-cpus`, `--vm-memory-mib`, and
-`--vm-shell` apply to either backend. Docker Hands publish `container` instead
+`--workspace` (default `/app`), `--cpus`, `--memory`, and
+`--shell` apply to either backend. Docker Hands publish `container` instead
 of `vm` in the machine capability list. `--vm` and `--docker` are mutually
 exclusive; Docker images bundle their runtime and do not accept ext4 guest or
 firmware options.
@@ -241,6 +243,18 @@ Run the Docker contract tests against the image:
 NANOCODEX_DOCKER_TEST_IMAGE=nanocodex-hand:local \
   cargo test --locked -p nanocodex-vm --test docker_live -- --ignored
 ```
+
+The original `--docker-volume`, `--docker-runtime`, `--docker-internet`, and
+`--vm-*` flag spellings remain accepted. New commands should use the shorter
+names above. `--network off` explicitly disables networking for either backend;
+VM networking remains enabled by default for compatibility. VM-only settings
+such as `--gpu` and `--guest-runtime` cannot be combined with `--docker`.
+VM-specific environment defaults are ignored when selecting Docker.
+
+On Linux, `--vm` checks access to `/dev/kvm`, the KVM API, and VM creation
+before account setup. If KVM is unavailable, the error explains how to enable
+it and shows `hand --docker IMAGE --volume NAME` as the explicit alternative.
+No backend is selected automatically.
 
 The on-demand `host` pool remains libkrun-only; Docker is available through the
 single `hand` command and the `nanocodex_vm::docker` library API.

--- a/bin/nanocodex/src/nanocodex2/hand_workspace.rs
+++ b/bin/nanocodex/src/nanocodex2/hand_workspace.rs
@@ -1,0 +1,64 @@
+//! Shared Hand operations over explicitly selected execution backends.
+
+use nanocodex_tools::ToolsBuilder;
+use nanocodex_vm::{
+    VmWorkspace, VmWorkspaceError,
+    docker::{DockerWorkspace, DockerWorkspaceError},
+    tools::{VmToolSessionError, VmToolSessionHandle},
+};
+
+pub(crate) enum HandWorkspace {
+    Vm(VmWorkspace),
+    Docker(DockerWorkspace),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ShutdownError {
+    #[error(transparent)]
+    Vm(#[from] VmWorkspaceError),
+    #[error(transparent)]
+    Docker(#[from] DockerWorkspaceError),
+}
+
+impl ShutdownError {
+    pub(crate) fn is_busy(&self) -> bool {
+        matches!(
+            self,
+            Self::Vm(VmWorkspaceError::Session(
+                VmToolSessionError::ActiveCapabilities(_) | VmToolSessionError::ActiveRequests(_)
+            )) | Self::Docker(DockerWorkspaceError::Session(
+                VmToolSessionError::ActiveCapabilities(_) | VmToolSessionError::ActiveRequests(_)
+            ))
+        )
+    }
+}
+
+impl HandWorkspace {
+    pub(crate) fn control(&self) -> VmToolSessionHandle {
+        match self {
+            Self::Vm(workspace) => workspace.control(),
+            Self::Docker(workspace) => workspace.control(),
+        }
+    }
+
+    pub(crate) fn guest_workspace(&self) -> &str {
+        match self {
+            Self::Vm(workspace) => workspace.guest_workspace(),
+            Self::Docker(workspace) => workspace.guest_workspace(),
+        }
+    }
+
+    pub(crate) fn attachment_tools_builder(&self) -> ToolsBuilder {
+        match self {
+            Self::Vm(workspace) => workspace.attachment_tools_builder(),
+            Self::Docker(workspace) => workspace.attachment_tools_builder(),
+        }
+    }
+
+    pub(crate) async fn shutdown(&self) -> Result<(), ShutdownError> {
+        match self {
+            Self::Vm(workspace) => workspace.shutdown().await.map_err(Into::into),
+            Self::Docker(workspace) => workspace.shutdown().await.map_err(Into::into),
+        }
+    }
+}

--- a/bin/nanocodex/src/nanocodex2/main.rs
+++ b/bin/nanocodex/src/nanocodex2/main.rs
@@ -10,6 +10,11 @@
 mod config;
 mod control;
 mod hand_observability;
+#[cfg(any(
+    all(target_os = "linux", not(target_env = "musl")),
+    all(target_os = "macos", target_arch = "aarch64")
+))]
+mod hand_workspace;
 mod host;
 #[allow(dead_code)]
 mod installation;
@@ -87,7 +92,7 @@ enum Command {
     Account(nanocodex_cli_auth::Account),
     /// Attach this machine's workspace to an existing managed agent.
     Attach(Attach),
-    /// Register one retained libkrun VM as a compute hand for the account.
+    /// Register a retained VM or Docker workspace as a compute hand for the account.
     Hand(Hand),
     /// Connect this machine's native workspace to the account over outbound HTTPS.
     NativeHand(native_hand::NativeHand),
@@ -153,8 +158,30 @@ struct Hand {
     observability: HandObservabilityArgs,
 
     /// Writable raw ext4 image or development directory used as the retained VM root.
-    #[arg(long = "vm", visible_alias = "vm-rootfs", value_name = "ROOTFS")]
-    rootfs: PathBuf,
+    #[arg(
+        long = "vm",
+        visible_alias = "vm-rootfs",
+        value_name = "ROOTFS",
+        required_unless_present = "docker",
+        conflicts_with = "docker"
+    )]
+    rootfs: Option<PathBuf>,
+
+    /// Run a container Hand using this local image, without requiring KVM.
+    #[arg(long, value_name = "IMAGE", requires = "docker_volume", conflicts_with_all = ["rootfs", "vm_guest_runtime", "vm_firmware"])]
+    docker: Option<String>,
+
+    /// Persistent named workspace volume; also provides exclusive Hand ownership.
+    #[arg(long, value_name = "VOLUME", requires = "docker")]
+    docker_volume: Option<String>,
+
+    /// Enable ordinary Docker bridge internet access (Docker Hands default to offline).
+    #[arg(long, requires = "docker", conflicts_with = "vm_no_network")]
+    docker_internet: bool,
+
+    /// Explicit Docker OCI runtime; fails if unavailable, with no fallback.
+    #[arg(long, value_name = "RUNTIME", requires = "docker")]
+    docker_runtime: Option<String>,
 
     /// Statically linked Linux guest executable used with a raw ext4 root.
     #[arg(long, value_name = "ELF", env = "NANOCODEX_VM_GUEST_RUNTIME")]
@@ -489,11 +516,12 @@ async fn run(cli: Cli) -> Result<(), ManagedError> {
 }
 
 async fn launch_vm_hand(command: &Hand) -> Result<vm_hand::VmHand, ManagedError> {
-    let (root_kind, root_bytes) = match std::fs::metadata(&command.rootfs) {
-        Ok(metadata) if metadata.is_file() => ("file", metadata.len()),
-        Ok(metadata) if metadata.is_dir() => ("directory", 0),
-        Ok(_) => ("other", 0),
-        Err(_) => ("missing", 0),
+    let (root_kind, root_bytes) = match command.rootfs.as_ref().map(std::fs::metadata) {
+        Some(Ok(metadata)) if metadata.is_file() => ("file", metadata.len()),
+        Some(Ok(metadata)) if metadata.is_dir() => ("directory", 0),
+        Some(Ok(_)) => ("other", 0),
+        Some(Err(_)) => ("missing", 0),
+        None => ("docker", 0),
     };
     let span = tracing::info_span!(
         target: "nanocodex2",
@@ -505,7 +533,8 @@ async fn launch_vm_hand(command: &Hand) -> Result<vm_hand::VmHand, ManagedError>
         vm.memory.limit_mib = command.vm_memory_mib,
         vm.root.kind = root_kind,
         vm.root.bytes = root_bytes,
-        network.enabled = !command.vm_no_network,
+        network.enabled = if command.docker.is_some() { command.docker_internet } else { !command.vm_no_network },
+        hand.backend = if command.docker.is_some() { "docker" } else { "libkrun" },
         status = tracing::field::Empty,
         duration_ns = tracing::field::Empty,
     );
@@ -514,7 +543,7 @@ async fn launch_vm_hand(command: &Hand) -> Result<vm_hand::VmHand, ManagedError>
         tracing::info!(
             target: "nanocodex2",
             stage = "vm.launch.starting",
-            "starting VM hand"
+            "starting Hand workspace"
         );
         let result = vm_hand::VmHand::start(command).await;
         span.record(
@@ -528,7 +557,7 @@ async fn launch_vm_hand(command: &Hand) -> Result<vm_hand::VmHand, ManagedError>
                 tracing::info!(
                     target: "nanocodex2",
                     stage = "vm.launch.ready",
-                    "VM guest is ready"
+                    "Hand guest is ready"
                 );
             }
             Err(_) => {
@@ -537,7 +566,7 @@ async fn launch_vm_hand(command: &Hand) -> Result<vm_hand::VmHand, ManagedError>
                 tracing::error!(
                     target: "nanocodex2",
                     stage = "vm.launch.failed",
-                    "VM guest failed to start"
+                    "Hand guest failed to start"
                 );
             }
         }
@@ -574,14 +603,12 @@ async fn serve_vm_hand(client: &ManagedClient, command: Hand) -> Result<(), Mana
     tracing::info!(
         target: "nanocodex2",
         stage = "vm.hand.ready",
-        "VM hand is ready; press Ctrl-C to detach"
+        "Hand is ready; press Ctrl-C to detach"
     );
     let closed = attachment.clone();
     let attachment_result = tokio::select! {
-        signal = tokio::signal::ctrl_c() => {
-            signal.map_err(|error| ManagedError::Configuration(
-                format!("failed to listen for Ctrl-C: {error}")
-            ))?;
+        signal = service::shutdown_signal() => {
+            signal?;
             attachment.clone().detach().await
         }
         result = closed.closed() => result,
@@ -613,7 +640,7 @@ async fn shutdown_vm_hand(hand: vm_hand::VmHand) -> Result<(), ManagedError> {
         tracing::info!(
             target: "nanocodex2",
             stage = "vm.shutdown.starting",
-            "stopping VM guest"
+            "stopping Hand guest"
         );
         let result = hand.shutdown().await;
         span.record(
@@ -626,7 +653,7 @@ async fn shutdown_vm_hand(hand: vm_hand::VmHand) -> Result<(), ManagedError> {
             tracing::info!(
                 target: "nanocodex2",
                 stage = "vm.shutdown.completed",
-                "VM guest stopped"
+                "Hand guest stopped"
             );
         } else {
             span.record("status", "failed");
@@ -634,7 +661,7 @@ async fn shutdown_vm_hand(hand: vm_hand::VmHand) -> Result<(), ManagedError> {
             tracing::error!(
                 target: "nanocodex2",
                 stage = "vm.shutdown.failed",
-                "VM guest failed to stop cleanly"
+                "Hand guest failed to stop cleanly"
             );
         }
         result
@@ -652,10 +679,8 @@ async fn connect_vm_hand(
         .attach(target)
         .metadata(AttachmentMetadata::machine(hand.machine().clone()));
     let connected = tokio::select! {
-        signal = tokio::signal::ctrl_c() => {
-            signal.map_err(|error| ManagedError::Configuration(
-                format!("failed to listen for Ctrl-C: {error}")
-            ))?;
+        signal = service::shutdown_signal() => {
+            signal?;
             Ok(None)
         }
         connected = connector.connect() => connected

--- a/bin/nanocodex/src/nanocodex2/main.rs
+++ b/bin/nanocodex/src/nanocodex2/main.rs
@@ -152,80 +152,156 @@ struct AgentReference {
     managed_origin: Option<String>,
 }
 
-#[derive(Args)]
-struct Hand {
-    #[command(flatten)]
-    observability: HandObservabilityArgs,
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum HandNetwork {
+    Off,
+    Internet,
+}
 
-    /// Writable raw ext4 image or development directory used as the retained VM root.
+#[derive(Args)]
+#[command(
+    group(clap::ArgGroup::new("backend").required(true).args(["rootfs", "docker"])),
+    after_help = "Choose exactly one backend; startup never falls back to another backend.\n\nExamples:\n  nanocodex2 hand --docker nanocodex-hand:local --volume my-workspace\n  nanocodex2 hand --vm root.ext4 --guest-runtime /path/to/nanocodex-vm-guest\n\nUse --network internet to give a Docker Hand internet access."
+)]
+struct Hand {
+    /// VM with a persistent ext4 root (Linux KVM or Apple Silicon Hypervisor.framework).
     #[arg(
         long = "vm",
-        visible_alias = "vm-rootfs",
+        alias = "vm-rootfs",
         value_name = "ROOTFS",
-        required_unless_present = "docker",
-        conflicts_with = "docker"
+        help_heading = "Backend"
     )]
     rootfs: Option<PathBuf>,
 
-    /// Run a container Hand using this local image, without requiring KVM.
-    #[arg(long, value_name = "IMAGE", requires = "docker_volume", conflicts_with_all = ["rootfs", "vm_guest_runtime", "vm_firmware"])]
+    /// Container using an existing Linux Docker image; no KVM required.
+    #[arg(long, value_name = "IMAGE", requires = "docker_volume", conflicts_with_all = ["vm_guest_runtime", "vm_firmware", "vm_gpu"], help_heading = "Backend")]
     docker: Option<String>,
 
-    /// Persistent named workspace volume; also provides exclusive Hand ownership.
-    #[arg(long, value_name = "VOLUME", requires = "docker")]
+    /// Persistent named Docker workspace volume (required with --docker).
+    #[arg(
+        long = "volume",
+        alias = "docker-volume",
+        value_name = "VOLUME",
+        requires = "docker",
+        help_heading = "Workspace"
+    )]
     docker_volume: Option<String>,
 
-    /// Enable ordinary Docker bridge internet access (Docker Hands default to offline).
-    #[arg(long, requires = "docker", conflicts_with = "vm_no_network")]
+    /// Guest network access [default: off for Docker, internet for VM].
+    #[arg(long, value_enum, conflicts_with_all = ["docker_internet", "vm_no_network"], help_heading = "Workspace")]
+    network: Option<HandNetwork>,
+
+    #[arg(
+        long,
+        hide = true,
+        requires = "docker",
+        conflicts_with = "vm_no_network"
+    )]
     docker_internet: bool,
 
-    /// Explicit Docker OCI runtime; fails if unavailable, with no fallback.
-    #[arg(long, value_name = "RUNTIME", requires = "docker")]
-    docker_runtime: Option<String>,
-
-    /// Statically linked Linux guest executable used with a raw ext4 root.
-    #[arg(long, value_name = "ELF", env = "NANOCODEX_VM_GUEST_RUNTIME")]
-    vm_guest_runtime: Option<PathBuf>,
-
-    /// Cache for the prepared read-only guest runtime disk.
-    #[arg(long, value_name = "PATH", default_value = ".cache/vm")]
-    vm_cache: PathBuf,
-
-    /// Directory containing the platform libkrun firmware library.
-    #[arg(long, value_name = "PATH", env = "NANOCODEX_KRUNFW_DIR")]
-    vm_firmware: Option<PathBuf>,
-
-    /// Absolute working directory inside the VM.
-    #[arg(long, value_name = "PATH", default_value = "/app")]
-    vm_workspace: String,
-
-    /// Number of virtual CPUs assigned to the hand.
-    #[arg(long, value_name = "COUNT", default_value_t = 2, value_parser = clap::value_parser!(u8).range(1..))]
-    vm_cpus: u8,
-
-    /// Guest memory in mebibytes.
-    #[arg(long, value_name = "MIB", default_value_t = 1_024, value_parser = clap::value_parser!(u32).range(1..))]
-    vm_memory_mib: u32,
-
-    /// Expose shared host Vulkan through virtio-gpu Venus.
-    #[arg(long)]
-    vm_gpu: bool,
-
-    /// Shell name described to the managed brain.
-    #[arg(long, value_name = "SHELL", default_value = "sh")]
-    vm_shell: String,
-
-    /// Disable guest internet socket proxying.
-    #[arg(long)]
+    #[arg(long, hide = true, requires = "rootfs")]
     vm_no_network: bool,
 
-    /// Stable account-local machine identifier.
-    #[arg(long, default_value = "vm")]
-    machine_id: String,
+    /// Absolute workspace directory inside the Hand.
+    #[arg(
+        long = "workspace",
+        alias = "vm-workspace",
+        value_name = "PATH",
+        default_value = "/app",
+        help_heading = "Workspace"
+    )]
+    vm_workspace: String,
 
-    /// Human-readable name shown in accountInfo().machines.
-    #[arg(long, default_value = "Nanocodex VM")]
-    machine_name: String,
+    /// CPU limit.
+    #[arg(long = "cpus", alias = "vm-cpus", value_name = "COUNT", default_value_t = 2, value_parser = clap::value_parser!(u8).range(1..), help_heading = "Resources")]
+    vm_cpus: u8,
+
+    /// Memory limit in MiB.
+    #[arg(long = "memory", alias = "vm-memory-mib", value_name = "MIB", default_value_t = 1_024, value_parser = clap::value_parser!(u32).range(1..), help_heading = "Resources")]
+    vm_memory_mib: u32,
+
+    /// Share the host GPU with a VM; requires a GPU-enabled build and Vulkan renderer.
+    #[arg(
+        long = "gpu",
+        alias = "vm-gpu",
+        requires = "rootfs",
+        help_heading = "Resources"
+    )]
+    vm_gpu: bool,
+
+    /// Stable account-local identifier [default: docker or vm, matching the backend].
+    #[arg(long, help_heading = "Identity")]
+    machine_id: Option<String>,
+
+    /// Display name [default: Nanocodex Docker Hand or Nanocodex VM].
+    #[arg(long, help_heading = "Identity")]
+    machine_name: Option<String>,
+
+    /// Static Linux guest executable for an ext4 VM (or NANOCODEX_VM_GUEST_RUNTIME).
+    #[arg(
+        long = "guest-runtime",
+        alias = "vm-guest-runtime",
+        value_name = "ELF",
+        requires = "rootfs",
+        help_heading = "VM setup"
+    )]
+    vm_guest_runtime: Option<PathBuf>,
+
+    /// Installed Docker OCI runtime, e.g. runsc; fails if unavailable.
+    #[arg(
+        long = "runtime",
+        alias = "docker-runtime",
+        value_name = "RUNTIME",
+        requires = "docker",
+        help_heading = "Advanced"
+    )]
+    docker_runtime: Option<String>,
+
+    /// Prepared VM guest disk cache.
+    #[arg(
+        long = "cache",
+        alias = "vm-cache",
+        value_name = "PATH",
+        default_value = ".cache/vm",
+        requires = "rootfs",
+        help_heading = "Advanced"
+    )]
+    vm_cache: PathBuf,
+
+    /// libkrun firmware directory (or NANOCODEX_KRUNFW_DIR).
+    #[arg(
+        long = "firmware",
+        alias = "vm-firmware",
+        value_name = "PATH",
+        requires = "rootfs",
+        help_heading = "Advanced"
+    )]
+    vm_firmware: Option<PathBuf>,
+
+    /// Shell described to the managed brain.
+    #[arg(
+        long = "shell",
+        alias = "vm-shell",
+        value_name = "SHELL",
+        default_value = "sh",
+        help_heading = "Advanced"
+    )]
+    vm_shell: String,
+
+    #[command(flatten, next_help_heading = "Logging")]
+    observability: HandObservabilityArgs,
+}
+
+impl Hand {
+    fn machine_id(&self) -> &str {
+        self.machine_id
+            .as_deref()
+            .unwrap_or(if self.docker.is_some() {
+                "docker"
+            } else {
+                "vm"
+            })
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
@@ -444,6 +520,25 @@ async fn run(cli: Cli) -> Result<(), ManagedError> {
         }
         #[cfg(target_os = "linux")]
         Some(Command::HandDesktop(command)) => return screen_native::serve_desktop(command).await,
+        Some(Command::Hand(command)) => {
+            let _observability = command
+                .observability
+                .install()
+                .map_err(|error| ManagedError::Configuration(error.to_string()))?;
+            tracing::info!(target: "nanocodex2", stage = "hand.preflight",
+                machine.id = command.machine_id(),
+                hand.backend = if command.docker.is_some() { "docker" } else { "vm" },
+                vm.cpu.count = command.vm_cpus,
+                vm.memory.limit_mib = command.vm_memory_mib,
+                vm.root.kind = command.rootfs.as_ref().map_or("container", |root| if root.exists() { "existing" } else { "missing" }),
+                "checking Hand backend support");
+            if let Err(error) = vm_hand::VmHand::preflight(&command).await {
+                tracing::error!(target: "nanocodex2", stage = "hand.preflight.failed", "Hand backend preflight failed");
+                return Err(error);
+            }
+            let client = client_from_environment(None)?;
+            return serve_vm_hand(&client, command).await;
+        }
         Some(Command::Host(command)) => {
             let _observability = command
                 .observability
@@ -465,13 +560,7 @@ async fn run(cli: Cli) -> Result<(), ManagedError> {
         Some(Command::Attach(command)) => {
             attach_tui(&client, command.agent.map(|agent| agent.agent_id)).await
         }
-        Some(Command::Hand(command)) => {
-            let _observability = command
-                .observability
-                .install()
-                .map_err(|error| ManagedError::Configuration(error.to_string()))?;
-            serve_vm_hand(&client, command).await
-        }
+        Some(Command::Hand(_)) => unreachable!("handled before managed client setup"),
         Some(Command::NativeHand(command)) => native_hand::serve(&client, command).await,
         Some(Command::HandScreen(command)) => screen_native::serve(&client, command).await,
         #[cfg(target_os = "linux")]
@@ -528,12 +617,12 @@ async fn launch_vm_hand(command: &Hand) -> Result<vm_hand::VmHand, ManagedError>
         "vm.launch",
         otel.kind = "internal",
         otel.status_code = tracing::field::Empty,
-        machine.id = command.machine_id.as_str(),
+        machine.id = command.machine_id(),
         vm.cpu.count = command.vm_cpus,
         vm.memory.limit_mib = command.vm_memory_mib,
         vm.root.kind = root_kind,
         vm.root.bytes = root_bytes,
-        network.enabled = if command.docker.is_some() { command.docker_internet } else { !command.vm_no_network },
+        network.enabled = command.network.map_or(if command.docker.is_some() { command.docker_internet } else { !command.vm_no_network }, |network| network == HandNetwork::Internet),
         hand.backend = if command.docker.is_some() { "docker" } else { "libkrun" },
         status = tracing::field::Empty,
         duration_ns = tracing::field::Empty,

--- a/bin/nanocodex/src/nanocodex2/vm_hand.rs
+++ b/bin/nanocodex/src/nanocodex2/vm_hand.rs
@@ -12,13 +12,14 @@ use nanocodex_tools::{
 };
 use nanocodex_vm::{
     VmWorkspace, VmWorkspaceError,
+    docker::DockerWorkspace,
     host::{Capabilities, Gpu, KrunFeature, VmProcessConfig},
     tools::{GuestRuntimeDisk, VmCommand, VmCommandOutput, VmToolSessionError},
 };
 use tokio::time::sleep;
 
-use super::Hand;
 pub(crate) use super::vm_hand_config::VmHandConfig;
+use super::{Hand, hand_workspace::HandWorkspace};
 
 const DEFAULT_KRUNFW_DIRECTORY: &str = ".cache/libkrunfw/libkrunfw";
 const FIRMWARE_LIBRARY: &str = if cfg!(target_os = "macos") {
@@ -45,7 +46,7 @@ impl Drop for VmDesktop {
 }
 
 pub(crate) struct VmHand {
-    workspace: VmWorkspace,
+    workspace: HandWorkspace,
     tools: Tools,
     machine: AttachmentMachine,
     _root_lock: Option<File>,
@@ -60,53 +61,70 @@ impl VmHand {
     pub(crate) async fn start_config(config: &VmHandConfig) -> Result<Self, ManagedError> {
         validate_common_config(config)?;
         let machine = attachment_machine(config)?;
-        let rootfs = config.rootfs.canonicalize().map_err(|error| {
-            configuration(format!(
-                "failed to resolve VM rootfs {}: {error}",
-                config.rootfs.display()
-            ))
-        })?;
-        let ext4 = rootfs.is_file();
-        if !ext4 && !rootfs.is_dir() {
-            return Err(configuration(format!(
-                "VM rootfs is neither a raw ext4 image nor a directory: {}",
-                rootfs.display()
-            )));
-        }
-        let root_lock = ext4.then(|| lock_writable_rootfs(&rootfs)).transpose()?;
-        let executable = std::env::current_exe()
-            .map_err(|error| configuration(format!("failed to resolve VMM executable: {error}")))?;
-        let mut builder = VmWorkspace::builder(&rootfs, executable)
-            .vmm_argument("__vm-run-config")
-            .vmm_argument("--config")
-            .guest_workspace(&config.vm_workspace)
-            .shell(&config.vm_shell)
-            .cpus(config.vm_cpus)
-            .memory_mib(config.vm_memory_mib)
-            .gpu(if config.vm_gpu {
-                Gpu::Vulkan
-            } else {
-                Gpu::Disabled
-            });
-        if ext4 {
-            let runtime = prepare_guest_runtime(config)?;
-            builder = builder.guest_runtime_disk(runtime.path().to_path_buf());
-        } else if config.vm_guest_runtime.is_some() {
-            return Err(configuration(
-                "--vm-guest-runtime is only used with raw ext4 roots; directory roots must contain /usr/local/bin/nanocodex-vm-guest",
-            ));
-        }
-        if config.vm_no_network {
-            builder = builder.offline();
-        }
-        if let Some(firmware) = firmware_directory(config) {
-            builder = builder.firmware_directory(firmware);
-        }
-        let workspace = builder.launch().await.map_err(|error| {
-            configuration(format!(
-                "failed to start VM hand and reach guest readiness: {error}"
-            ))
-        })?;
+        let (workspace, root_lock) = if let Some(docker) = &config.docker {
+            let mut builder = DockerWorkspace::builder(&docker.image, &docker.volume)
+                .guest_workspace(&config.vm_workspace)
+                .shell(&config.vm_shell)
+                .cpus(config.vm_cpus)
+                .memory_mib(config.vm_memory_mib);
+            if docker.internet {
+                builder = builder.internet();
+            }
+            if let Some(runtime) = &docker.runtime {
+                builder = builder.runtime(runtime);
+            }
+            let workspace = builder
+                .launch()
+                .await
+                .map_err(|error| configuration(error.to_string()))?;
+            (HandWorkspace::Docker(workspace), None)
+        } else {
+            let rootfs = config.rootfs.canonicalize().map_err(|error| {
+                configuration(format!(
+                    "failed to resolve VM rootfs {}: {error}",
+                    config.rootfs.display()
+                ))
+            })?;
+            let ext4 = rootfs.is_file();
+            if !ext4 && !rootfs.is_dir() {
+                return Err(configuration(format!(
+                    "VM rootfs is neither a raw ext4 image nor a directory: {}",
+                    rootfs.display()
+                )));
+            }
+            let root_lock = ext4.then(|| lock_writable_rootfs(&rootfs)).transpose()?;
+            let executable = std::env::current_exe().map_err(|error| {
+                configuration(format!("failed to resolve VMM executable: {error}"))
+            })?;
+            let mut builder = VmWorkspace::builder(&rootfs, executable)
+                .vmm_argument("__vm-run-config")
+                .vmm_argument("--config")
+                .guest_workspace(&config.vm_workspace)
+                .shell(&config.vm_shell)
+                .cpus(config.vm_cpus)
+                .memory_mib(config.vm_memory_mib)
+                .gpu(if config.vm_gpu { Gpu::vulkan() } else { Gpu::Off });
+            if ext4 {
+                let runtime = prepare_guest_runtime(config)?;
+                builder = builder.guest_runtime_disk(runtime.path().to_path_buf());
+            } else if config.vm_guest_runtime.is_some() {
+                return Err(configuration(
+                    "--vm-guest-runtime is only used with raw ext4 roots; directory roots must contain /usr/local/bin/nanocodex-vm-guest",
+                ));
+            }
+            if config.vm_no_network {
+                builder = builder.offline();
+            }
+            if let Some(firmware) = firmware_directory(config) {
+                builder = builder.firmware_directory(firmware);
+            }
+            let workspace = builder.launch().await.map_err(|error| {
+                configuration(format!(
+                    "failed to start VM hand and reach guest readiness: {error}"
+                ))
+            })?;
+            (HandWorkspace::Vm(workspace), root_lock)
+        };
         let tools = match workspace.attachment_tools_builder().build() {
             Ok(tools) => tools,
             Err(error) => {
@@ -314,10 +332,9 @@ impl VmHand {
         loop {
             match self.workspace.shutdown().await {
                 Ok(()) => return Ok(()),
-                Err(VmWorkspaceError::Session(
-                    VmToolSessionError::ActiveCapabilities(_)
-                    | VmToolSessionError::ActiveRequests(_),
-                )) if started_at.elapsed() < CAPABILITY_DRAIN_TIMEOUT => {
+                Err(error)
+                    if error.is_busy() && started_at.elapsed() < CAPABILITY_DRAIN_TIMEOUT =>
+                {
                     sleep(CAPABILITY_DRAIN_INTERVAL).await;
                 }
                 Err(error) => {
@@ -347,7 +364,9 @@ fn validate_common_config(config: &VmHandConfig) -> Result<(), ManagedError> {
         )));
     }
     #[cfg(target_os = "linux")]
-    preflight_kvm_device(Path::new("/dev/kvm"))?;
+    if config.docker.is_none() {
+        preflight_kvm_device(Path::new("/dev/kvm"))?;
+    }
     Ok(())
 }
 
@@ -385,11 +404,20 @@ fn attachment_machine(config: &VmHandConfig) -> Result<AttachmentMachine, Manage
         "process".to_owned(),
         "pty".to_owned(),
         "shell".to_owned(),
-        "vm".to_owned(),
+        if config.docker.is_some() {
+            "container"
+        } else {
+            "vm"
+        }
+        .to_owned(),
         format!("cpu:{}", config.vm_cpus),
         format!("memory-mib:{}", config.vm_memory_mib),
     ];
-    if !config.vm_no_network {
+    if config
+        .docker
+        .as_ref()
+        .map_or(!config.vm_no_network, |docker| docker.internet)
+    {
         capabilities.push("network".to_owned());
     }
     capabilities.sort_unstable();
@@ -483,6 +511,48 @@ fn configuration(message: impl Into<String>) -> ManagedError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn docker_hand_skips_kvm_and_advertises_container_isolation() {
+        let config = VmHandConfig {
+            rootfs: PathBuf::new(),
+            docker: Some(super::super::vm_hand_config::DockerHandConfig {
+                image: "image".into(),
+                volume: "workspace".into(),
+                internet: false,
+                runtime: None,
+            }),
+            vm_guest_runtime: None,
+            vm_cache: PathBuf::new(),
+            vm_firmware: None,
+            vm_workspace: "/app".into(),
+            vm_cpus: 2,
+            vm_memory_mib: 1024,
+            vm_shell: "sh".into(),
+            vm_no_network: false,
+            machine_id: "docker-hand".into(),
+            machine_name: "Docker Hand".into(),
+        };
+        validate_common_config(&config).unwrap();
+        let machine = serde_json::to_value(attachment_machine(&config).unwrap()).unwrap();
+        let capabilities = machine["capabilities"].as_array().unwrap();
+        assert!(capabilities.iter().any(|value| value == "container"));
+        assert!(
+            !capabilities
+                .iter()
+                .any(|value| value == "vm" || value == "network")
+        );
+        let mut internet = config;
+        internet.docker.as_mut().unwrap().internet = true;
+        let machine = serde_json::to_value(attachment_machine(&internet).unwrap()).unwrap();
+        assert!(
+            machine["capabilities"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|value| value == "network")
+        );
+    }
 
     #[test]
     fn installed_guest_assets_resolve_firmware_without_a_working_directory() {

--- a/bin/nanocodex/src/nanocodex2/vm_hand.rs
+++ b/bin/nanocodex/src/nanocodex2/vm_hand.rs
@@ -11,7 +11,7 @@ use nanocodex_tools::{
     attachment::{AttachmentMachine, AttachmentTarget},
 };
 use nanocodex_vm::{
-    VmWorkspace, VmWorkspaceError,
+    VmWorkspace,
     docker::DockerWorkspace,
     host::{Capabilities, Gpu, KrunFeature, VmProcessConfig},
     tools::{GuestRuntimeDisk, VmCommand, VmCommandOutput, VmToolSessionError},
@@ -54,6 +54,35 @@ pub(crate) struct VmHand {
 }
 
 impl VmHand {
+    pub(crate) async fn preflight(config: &Hand) -> Result<(), ManagedError> {
+        let config = VmHandConfig::from(config);
+        validate_common_config(&config)?;
+        attachment_machine(&config)?;
+        if let Some(docker) = &config.docker {
+            let mut builder = DockerWorkspace::builder(&docker.image, &docker.volume)
+                .guest_workspace(&config.vm_workspace)
+                .cpus(config.vm_cpus)
+                .memory_mib(config.vm_memory_mib);
+            if let Some(runtime) = &docker.runtime {
+                builder = builder.runtime(runtime);
+            }
+            builder
+                .preflight()
+                .await
+                .map_err(|error| configuration(error.to_string()))?;
+        } else {
+            let root = config.rootfs.metadata().map_err(|error| configuration(format!(
+                "VM root {} is unavailable: {error}; --vm must point to an existing writable ext4 image or development root directory", config.rootfs.display()
+            )))?;
+            if root.is_file() && config.vm_guest_runtime.is_none() {
+                return Err(configuration(
+                    "an ext4 VM requires --guest-runtime ELF or NANOCODEX_VM_GUEST_RUNTIME; build the guest with `just build-vm-guest`",
+                ));
+            }
+        }
+        Ok(())
+    }
+
     pub(crate) async fn start(config: &Hand) -> Result<Self, ManagedError> {
         Self::start_config(&VmHandConfig::from(config)).await
     }
@@ -103,7 +132,11 @@ impl VmHand {
                 .shell(&config.vm_shell)
                 .cpus(config.vm_cpus)
                 .memory_mib(config.vm_memory_mib)
-                .gpu(if config.vm_gpu { Gpu::vulkan() } else { Gpu::Off });
+                .gpu(if config.vm_gpu {
+                    Gpu::Vulkan
+                } else {
+                    Gpu::Disabled
+                });
             if ext4 {
                 let runtime = prepare_guest_runtime(config)?;
                 builder = builder.guest_runtime_disk(runtime.path().to_path_buf());
@@ -128,11 +161,11 @@ impl VmHand {
         let tools = match workspace.attachment_tools_builder().build() {
             Ok(tools) => tools,
             Err(error) => {
-                let message = format!("failed to prepare VM hand tools: {error}");
+                let message = format!("failed to prepare Hand tools: {error}");
                 return match workspace.shutdown().await {
                     Ok(()) => Err(configuration(message)),
                     Err(shutdown) => Err(configuration(format!(
-                        "{message}; VM shutdown also failed: {shutdown}"
+                        "{message}; Hand shutdown also failed: {shutdown}"
                     ))),
                 };
             }
@@ -348,24 +381,35 @@ impl VmHand {
 }
 
 fn validate_common_config(config: &VmHandConfig) -> Result<(), ManagedError> {
+    if config.docker.is_some() && config.vm_gpu {
+        return Err(configuration(
+            "--gpu is supported only with --vm; Docker Hands use software rendering",
+        ));
+    }
     if config.vm_gpu
         && !Capabilities::detect()
             .map_err(|error| configuration(error.to_string()))?
             .has(KrunFeature::Gpu)
     {
         return Err(configuration(
-            "--vm-gpu requires a host built with nanocodex-vm/gpu and a Vulkan renderer",
+            "--gpu requires a host built with nanocodex-vm/gpu and a Vulkan renderer",
         ));
     }
     if !Path::new(&config.vm_workspace).is_absolute() {
         return Err(configuration(format!(
-            "--vm-workspace must be an absolute guest path, got {:?}",
+            "--workspace must be an absolute guest path, got {:?}",
             config.vm_workspace
         )));
     }
     #[cfg(target_os = "linux")]
     if config.docker.is_none() {
         preflight_kvm_device(Path::new("/dev/kvm"))?;
+        let kvm = kvm_ioctls::Kvm::new().map_err(|error| unavailable_kvm(error.to_string()))?;
+        if kvm.get_api_version() != 12 {
+            return Err(unavailable_kvm("unsupported KVM API version".into()));
+        }
+        kvm.create_vm()
+            .map_err(|error| unavailable_kvm(error.to_string()))?;
     }
     Ok(())
 }
@@ -374,15 +418,17 @@ fn validate_common_config(config: &VmHandConfig) -> Result<(), ManagedError> {
 // Hand can run ordinary processes inside a container without being able to host
 // VMs; it needs a passed-through, accessible KVM character device as well.
 #[cfg(any(target_os = "linux", test))]
+fn unavailable_kvm(detail: String) -> ManagedError {
+    configuration(format!(
+        "VM backend is unavailable: Linux VM hosting requires working KVM at /dev/kvm: {detail}. Enable hardware/nested virtualization and grant this user read/write access to /dev/kvm. Alternatively, use `hand --docker IMAGE --volume NAME` with a Linux Docker daemon. No fallback was attempted"
+    ))
+}
+
+#[cfg(any(target_os = "linux", test))]
 fn preflight_kvm_device(path: &Path) -> Result<(), ManagedError> {
     use std::os::unix::fs::FileTypeExt as _;
 
-    let unavailable = |detail: String| {
-        configuration(format!(
-            "Linux VM hosting requires a readable and writable KVM character device at {}: {detail}. Enable hardware virtualization and grant this user access to /dev/kvm; containers and nested VMs must expose /dev/kvm from a host that supports nested virtualization",
-            path.display()
-        ))
-    };
+    let unavailable = |detail: String| unavailable_kvm(format!("{}: {detail}", path.display()));
     let file = OpenOptions::new()
         .read(true)
         .write(true)
@@ -528,6 +574,7 @@ mod tests {
             vm_workspace: "/app".into(),
             vm_cpus: 2,
             vm_memory_mib: 1024,
+            vm_gpu: false,
             vm_shell: "sh".into(),
             vm_no_network: false,
             machine_id: "docker-hand".into(),

--- a/bin/nanocodex/src/nanocodex2/vm_hand_config.rs
+++ b/bin/nanocodex/src/nanocodex2/vm_hand_config.rs
@@ -2,10 +2,11 @@ use std::path::PathBuf;
 
 use super::Hand;
 
-/// Complete single-VM launch recipe shared by every platform backend.
+/// Complete single-Hand launch recipe shared by every supported backend.
 #[derive(Clone, Debug)]
 pub(crate) struct VmHandConfig {
     pub(crate) rootfs: PathBuf,
+    pub(crate) docker: Option<DockerHandConfig>,
     pub(crate) vm_guest_runtime: Option<PathBuf>,
     pub(crate) vm_cache: PathBuf,
     pub(crate) vm_firmware: Option<PathBuf>,
@@ -22,7 +23,13 @@ pub(crate) struct VmHandConfig {
 impl From<&Hand> for VmHandConfig {
     fn from(config: &Hand) -> Self {
         Self {
-            rootfs: config.rootfs.clone(),
+            rootfs: config.rootfs.clone().unwrap_or_default(),
+            docker: config.docker.as_ref().map(|image| DockerHandConfig {
+                image: image.clone(),
+                volume: config.docker_volume.clone().unwrap_or_default(),
+                internet: config.docker_internet,
+                runtime: config.docker_runtime.clone(),
+            }),
             vm_guest_runtime: config.vm_guest_runtime.clone(),
             vm_cache: config.vm_cache.clone(),
             vm_firmware: config.vm_firmware.clone(),
@@ -36,4 +43,12 @@ impl From<&Hand> for VmHandConfig {
             machine_name: config.machine_name.clone(),
         }
     }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct DockerHandConfig {
+    pub(crate) image: String,
+    pub(crate) volume: String,
+    pub(crate) internet: bool,
+    pub(crate) runtime: Option<String>,
 }

--- a/bin/nanocodex/src/nanocodex2/vm_hand_config.rs
+++ b/bin/nanocodex/src/nanocodex2/vm_hand_config.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use super::Hand;
+use super::{Hand, HandNetwork};
 
 /// Complete single-Hand launch recipe shared by every supported backend.
 #[derive(Clone, Debug)]
@@ -27,20 +27,43 @@ impl From<&Hand> for VmHandConfig {
             docker: config.docker.as_ref().map(|image| DockerHandConfig {
                 image: image.clone(),
                 volume: config.docker_volume.clone().unwrap_or_default(),
-                internet: config.docker_internet,
+                internet: config.network.map_or(config.docker_internet, |value| {
+                    value == HandNetwork::Internet
+                }),
                 runtime: config.docker_runtime.clone(),
             }),
-            vm_guest_runtime: config.vm_guest_runtime.clone(),
+            vm_guest_runtime: config.vm_guest_runtime.clone().or_else(|| {
+                config
+                    .docker
+                    .is_none()
+                    .then(|| std::env::var_os("NANOCODEX_VM_GUEST_RUNTIME").map(PathBuf::from))
+                    .flatten()
+            }),
             vm_cache: config.vm_cache.clone(),
-            vm_firmware: config.vm_firmware.clone(),
+            vm_firmware: config.vm_firmware.clone().or_else(|| {
+                config
+                    .docker
+                    .is_none()
+                    .then(|| std::env::var_os("NANOCODEX_KRUNFW_DIR").map(PathBuf::from))
+                    .flatten()
+            }),
             vm_workspace: config.vm_workspace.clone(),
             vm_cpus: config.vm_cpus,
             vm_memory_mib: config.vm_memory_mib,
             vm_gpu: config.vm_gpu,
             vm_shell: config.vm_shell.clone(),
-            vm_no_network: config.vm_no_network,
-            machine_id: config.machine_id.clone(),
-            machine_name: config.machine_name.clone(),
+            vm_no_network: config
+                .network
+                .map_or(config.vm_no_network, |value| value == HandNetwork::Off),
+            machine_id: config.machine_id().to_owned(),
+            machine_name: config.machine_name.clone().unwrap_or_else(|| {
+                if config.docker.is_some() {
+                    "Nanocodex Docker Hand"
+                } else {
+                    "Nanocodex VM"
+                }
+                .to_owned()
+            }),
         }
     }
 }
@@ -51,4 +74,88 @@ pub(crate) struct DockerHandConfig {
     pub(crate) volume: String,
     pub(crate) internet: bool,
     pub(crate) runtime: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Cli, Command};
+    use clap::Parser as _;
+
+    fn config(args: &[&str]) -> VmHandConfig {
+        let cli = Cli::try_parse_from(
+            ["nanocodex2", "hand"]
+                .into_iter()
+                .chain(args.iter().copied()),
+        )
+        .unwrap();
+        let Some(Command::Hand(hand)) = cli.command else {
+            panic!("expected Hand")
+        };
+        VmHandConfig::from(&hand)
+    }
+
+    #[test]
+    fn canonical_and_legacy_resource_flags_select_the_same_docker_config() {
+        for args in [
+            vec![
+                "--docker",
+                "image",
+                "--volume",
+                "work",
+                "--cpus",
+                "4",
+                "--memory",
+                "2048",
+                "--workspace",
+                "/workspace",
+                "--network",
+                "internet",
+                "--runtime",
+                "runsc",
+            ],
+            vec![
+                "--docker",
+                "image",
+                "--docker-volume",
+                "work",
+                "--vm-cpus",
+                "4",
+                "--vm-memory-mib",
+                "2048",
+                "--vm-workspace",
+                "/workspace",
+                "--docker-internet",
+                "--docker-runtime",
+                "runsc",
+            ],
+        ] {
+            let config = config(&args);
+            let docker = config.docker.unwrap();
+            assert_eq!(
+                (docker.image.as_str(), docker.volume.as_str()),
+                ("image", "work")
+            );
+            assert!(docker.internet);
+            assert_eq!(docker.runtime.as_deref(), Some("runsc"));
+            assert_eq!((config.vm_cpus, config.vm_memory_mib), (4, 2048));
+            assert_eq!(config.vm_workspace, "/workspace");
+            assert_eq!(config.machine_id, "docker");
+            assert!(config.vm_guest_runtime.is_none());
+        }
+    }
+
+    #[test]
+    fn network_defaults_and_vm_identity_remain_compatible() {
+        let docker = config(&["--docker", "image", "--volume", "work"]);
+        assert!(!docker.docker.unwrap().internet);
+        let vm = config(&["--vm", "root.ext4"]);
+        assert!(!vm.vm_no_network);
+        assert_eq!(vm.machine_id, "vm");
+        assert_eq!(vm.machine_name, "Nanocodex VM");
+        for flag in [vec!["--network", "off"], vec!["--vm-no-network"]] {
+            let args = [vec!["--vm", "root.ext4"], flag].concat();
+            assert!(config(&args).vm_no_network);
+        }
+    }
 }

--- a/bin/nanocodex/src/nanocodex2/vm_hand_unsupported.rs
+++ b/bin/nanocodex/src/nanocodex2/vm_hand_unsupported.rs
@@ -9,6 +9,19 @@ pub(crate) use super::vm_hand_config::VmHandConfig;
 pub(crate) struct VmHand;
 
 impl VmHand {
+    pub(crate) async fn preflight(config: &Hand) -> Result<(), ManagedError> {
+        let backend = if config.docker.is_some() {
+            "Docker"
+        } else {
+            "VM"
+        };
+        Err(ManagedError::Configuration(format!(
+            "{backend} Hands are not supported by this {}/{} build; use a glibc Linux or Apple Silicon macOS build. Linux Docker Hands require a Linux Docker daemon; Linux VM Hands additionally require KVM. No fallback was attempted",
+            std::env::consts::OS,
+            std::env::consts::ARCH
+        )))
+    }
+
     pub(crate) async fn start(_config: &Hand) -> Result<Self, ManagedError> {
         Err(unsupported())
     }

--- a/bin/nanocodex/src/nanocodex2/vm_host.rs
+++ b/bin/nanocodex/src/nanocodex2/vm_host.rs
@@ -1655,6 +1655,7 @@ mod supported {
             let locked_template_root = locked_file_path(&template_lock);
             let hand_template = vm_hand::VmHandConfig {
                 rootfs: config.vm_template.clone(),
+                docker: None,
                 vm_guest_runtime: Some(config.vm_guest_runtime.clone()),
                 vm_cache: config.vm_cache.clone(),
                 vm_firmware: config.vm_firmware.clone(),

--- a/bin/nanocodex/tests/nanocodex2_managed.rs
+++ b/bin/nanocodex/tests/nanocodex2_managed.rs
@@ -36,12 +36,16 @@ async fn hand_help_exposes_the_vm_and_machine_contract() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(
-        stdout.contains("Usage: nanocodex2 hand [OPTIONS] --vm <ROOTFS>"),
+        stdout.contains("Usage: nanocodex2 hand [OPTIONS]"),
         "{stdout}"
     );
     assert!(!stdout.contains("AGENT_ID"), "{stdout}");
     for expected in [
         "--vm <ROOTFS>",
+        "--docker <IMAGE>",
+        "--docker-volume <VOLUME>",
+        "--docker-internet",
+        "--docker-runtime <RUNTIME>",
         "--vm-guest-runtime <ELF>",
         "--vm-workspace <PATH>",
         "--vm-cpus <COUNT>",
@@ -56,6 +60,57 @@ async fn hand_help_exposes_the_vm_and_machine_contract() {
         assert!(
             stdout.contains(expected),
             "missing {expected:?} in:\n{stdout}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn hand_requires_an_explicit_backend_and_rejects_mixed_options() {
+    for args in [
+        vec!["hand"],
+        vec!["hand", "--docker", "image"],
+        vec!["hand", "--docker-volume", "work"],
+        vec![
+            "hand",
+            "--vm",
+            "root.ext4",
+            "--docker",
+            "image",
+            "--docker-volume",
+            "work",
+        ],
+        vec!["hand", "--vm", "root.ext4", "--docker-internet"],
+        vec![
+            "hand",
+            "--docker",
+            "image",
+            "--docker-volume",
+            "work",
+            "--vm-firmware",
+            "/tmp/fw",
+        ],
+        vec![
+            "hand",
+            "--docker",
+            "image",
+            "--docker-volume",
+            "work",
+            "--docker-internet",
+            "--vm-no-network",
+        ],
+    ] {
+        let output = tokio::process::Command::new(env!("CARGO_BIN_EXE_nanocodex2"))
+            .args(&args)
+            .env_remove("NANOCODEX_VM_GUEST_RUNTIME")
+            .env_remove("NANOCODEX_KRUNFW_DIR")
+            .output()
+            .await
+            .unwrap();
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "{args:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
         );
     }
 }
@@ -1752,4 +1807,222 @@ async fn headless_settings_and_cron_use_the_managed_contract() {
         json!({"cron": "0 9 * * *", "timezone": "Europe/Athens", "input": "Summarize progress", "enabled": true, "session_mode": "new"})
     );
     assert_eq!(requests[5].0, "DELETE");
+}
+
+#[cfg(any(
+    all(target_os = "linux", not(target_env = "musl")),
+    all(target_os = "macos", target_arch = "aarch64")
+))]
+mod docker_hand_live {
+    use super::*;
+    use axum::extract::ws::WebSocket;
+    use serde_json::{Value, json};
+    use tokio::sync::mpsc;
+
+    #[derive(Clone)]
+    struct Service {
+        authorization: String,
+        ready: mpsc::UnboundedSender<&'static str>,
+    }
+
+    async fn receive(socket: &mut WebSocket) -> Value {
+        loop {
+            let Some(Ok(Message::Text(text))) = socket.recv().await else {
+                panic!("Hand socket closed early")
+            };
+            let message: Value = serde_json::from_str(&text).unwrap();
+            if message["type"] != "ping" {
+                return message;
+            }
+            send(socket, json!({"type":"pong","nonce":message["nonce"]})).await;
+        }
+    }
+    async fn send(socket: &mut WebSocket, message: Value) {
+        socket
+            .send(Message::Text(message.to_string().into()))
+            .await
+            .unwrap();
+    }
+    async fn tools(
+        State(state): State<Service>,
+        headers: HeaderMap,
+        upgrade: WebSocketUpgrade,
+    ) -> Response<Body> {
+        assert_eq!(headers["authorization"], state.authorization);
+        upgrade.on_upgrade(move |mut socket| async move {
+            let catalog = receive(&mut socket).await;
+            assert_eq!(catalog["type"], "catalog");
+            let machine = &catalog["machines"][0];
+            assert_eq!(machine["id"], "docker-cli-test");
+            assert_eq!(machine["workspace"], "/app");
+            let capabilities = machine["capabilities"].as_array().unwrap();
+            assert!(capabilities.iter().any(|v| v == "container"));
+            assert!(!capabilities.iter().any(|v| v == "vm" || v == "network"));
+            send(&mut socket, json!({"type":"ready"})).await;
+            send(&mut socket, json!({
+                "type":"call", "session_id":"docker-cli-agent", "call_id":"docker-cli-command",
+                "model":"test", "name":"exec_command",
+                "input":{"cmd":"test -z \"${NC_API_KEY-}${NANOCODEX_API_KEY-}\" && test ! -e /dev/kvm && printf 'docker-cli-proof\\n' > /app/proof && cat /app/proof", "login":false},
+                "output_token_budget":1024, "output_byte_budget":131072,
+                "deadline_at":9_000_000_000_000_u64,
+            })).await;
+            let result = receive(&mut socket).await;
+            assert_eq!(result["type"], "result");
+            assert_eq!(result["outcome"]["status"], "completed");
+            assert_eq!(result["outcome"]["output"]["success"], true, "{result}");
+            assert!(result["outcome"]["output"]["output"].as_str().unwrap().contains("docker-cli-proof"), "{result}");
+            send(&mut socket, json!({"type":"ack","call_id":"docker-cli-command"})).await;
+            state.ready.send("tools").unwrap();
+            assert_eq!(receive(&mut socket).await["type"], "drain");
+            send(&mut socket, json!({"type":"draining"})).await;
+        })
+    }
+    async fn screen(
+        State(state): State<Service>,
+        headers: HeaderMap,
+        upgrade: WebSocketUpgrade,
+    ) -> Response<Body> {
+        assert_eq!(headers["authorization"], state.authorization);
+        upgrade.on_upgrade(move |mut socket| async move {
+            send(
+                &mut socket,
+                json!({"type":"ready","connection_id":"docker-screen"}),
+            )
+            .await;
+            let catalog = receive(&mut socket).await;
+            assert_eq!(catalog["type"], "catalog");
+            assert_eq!(catalog["machine_id"], "docker-cli-test");
+            send(
+                &mut socket,
+                json!({"type":"published","generation":"docker-screen-generation"}),
+            )
+            .await;
+            send(
+                &mut socket,
+                json!({"type":"viewer","viewer_id":"test-viewer","surface_id":"desktop"}),
+            )
+            .await;
+            send(
+                &mut socket,
+                json!({"type":"frame_request","viewer_id":"test-viewer"}),
+            )
+            .await;
+            let frame = receive(&mut socket).await;
+            assert_eq!(frame["type"], "frame");
+            assert!(frame["jpeg"].as_str().unwrap().starts_with("/9j/"));
+            state.ready.send("screen").unwrap();
+            while socket.recv().await.is_some() {}
+        })
+    }
+
+    struct WorkspaceVolume(String);
+    impl Drop for WorkspaceVolume {
+        fn drop(&mut self) {
+            let output = std::process::Command::new("docker")
+                .args(["ps", "-aq", "--filter", &format!("volume={}", self.0)])
+                .output()
+                .unwrap();
+            for id in String::from_utf8_lossy(&output.stdout).lines() {
+                let _ = std::process::Command::new("docker")
+                    .args(["rm", "-f", id])
+                    .output();
+            }
+            let _ = std::process::Command::new("docker")
+                .args(["volume", "rm", &self.0])
+                .output();
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires the built Docker Hand image and a Linux Docker daemon"]
+    async fn docker_hand_publishes_tools_and_screen_then_drains_on_sigterm() {
+        let image =
+            std::env::var("NANOCODEX_DOCKER_TEST_IMAGE").expect("set NANOCODEX_DOCKER_TEST_IMAGE");
+        let volume = WorkspaceVolume(format!("nanocodex-cli-test-{}", uuid::Uuid::new_v4()));
+        let key = format!("ncx_live_{}_{}", "a".repeat(12), "b".repeat(43));
+        let (ready, mut events) = mpsc::unbounded_channel();
+        let service = Service {
+            authorization: format!("Bearer {key}"),
+            ready,
+        };
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let origin = format!("http://{}", listener.local_addr().unwrap());
+        let app = Router::new()
+            .route("/v1/account/tool-host", get(tools))
+            .route("/v1/account/hands/host", get(screen))
+            .with_state(service);
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let config = tempfile::tempdir().unwrap();
+        let mut child = tokio::process::Command::new(env!("CARGO_BIN_EXE_nanocodex2"))
+            .args([
+                "hand",
+                "--docker",
+                &image,
+                "--docker-volume",
+                &volume.0,
+                "--machine-id",
+                "docker-cli-test",
+            ])
+            .env("NC_API_KEY", &key)
+            .env("NANOCODEX_MANAGED_URL", origin)
+            .env("NANOCODEX_HOME", config.path())
+            .env_remove("NANOCODEX_API_KEY")
+            .env_remove("NANOCODEX_VM_GUEST_RUNTIME")
+            .env_remove("NANOCODEX_KRUNFW_DIR")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .unwrap();
+        let ready = tokio::time::timeout(std::time::Duration::from_secs(60), async {
+            let first = events.recv().await.unwrap();
+            let second = events.recv().await.unwrap();
+            assert_ne!(first, second);
+        })
+        .await;
+        if ready.is_err() {
+            let _ = child.start_kill();
+            let output = child.wait_with_output().await.unwrap();
+            panic!(
+                "Docker Hand did not publish: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(i32::try_from(child.id().unwrap()).unwrap()),
+            nix::sys::signal::Signal::SIGTERM,
+        )
+        .unwrap();
+        let output =
+            tokio::time::timeout(std::time::Duration::from_secs(30), child.wait_with_output())
+                .await
+                .unwrap()
+                .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(!String::from_utf8_lossy(&output.stderr).contains(&key));
+        assert!(!String::from_utf8_lossy(&output.stdout).contains(&key));
+        let containers = tokio::process::Command::new("docker")
+            .args(["ps", "-aq", "--filter", &format!("volume={}", volume.0)])
+            .output()
+            .await
+            .unwrap();
+        assert!(
+            containers.stdout.is_empty(),
+            "SIGTERM left a container behind"
+        );
+        let volume_exists = tokio::process::Command::new("docker")
+            .args(["volume", "inspect", &volume.0])
+            .output()
+            .await
+            .unwrap();
+        assert!(
+            volume_exists.status.success(),
+            "SIGTERM deleted the workspace volume"
+        );
+        server.abort();
+    }
 }

--- a/bin/nanocodex/tests/nanocodex2_managed.rs
+++ b/bin/nanocodex/tests/nanocodex2_managed.rs
@@ -43,13 +43,13 @@ async fn hand_help_exposes_the_vm_and_machine_contract() {
     for expected in [
         "--vm <ROOTFS>",
         "--docker <IMAGE>",
-        "--docker-volume <VOLUME>",
-        "--docker-internet",
-        "--docker-runtime <RUNTIME>",
-        "--vm-guest-runtime <ELF>",
-        "--vm-workspace <PATH>",
-        "--vm-cpus <COUNT>",
-        "--vm-memory-mib <MIB>",
+        "--volume <VOLUME>",
+        "--network <NETWORK>",
+        "--runtime <RUNTIME>",
+        "--guest-runtime <ELF>",
+        "--workspace <PATH>",
+        "--cpus <COUNT>",
+        "--memory <MIB>",
         "--machine-id <MACHINE_ID>",
         "--machine-name <MACHINE_NAME>",
         "--log-filter <LOG_FILTER>",
@@ -69,7 +69,18 @@ async fn hand_requires_an_explicit_backend_and_rejects_mixed_options() {
     for args in [
         vec!["hand"],
         vec!["hand", "--docker", "image"],
-        vec!["hand", "--docker-volume", "work"],
+        vec!["hand", "--volume", "work"],
+        vec!["hand", "--docker", "image", "--volume", "work", "--gpu"],
+        vec![
+            "hand",
+            "--docker",
+            "image",
+            "--volume",
+            "work",
+            "--network",
+            "bogus",
+        ],
+        vec!["hand", "--vm", "root", "--runtime", "runsc"],
         vec![
             "hand",
             "--vm",
@@ -204,7 +215,7 @@ async fn hand_json_tracing_exposes_resources_without_paths_or_credentials() {
         .collect::<Vec<_>>();
     assert!(!traces.is_empty(), "{stderr}");
     let encoded = serde_json::to_string(&traces).unwrap();
-    assert!(encoded.contains("vm.launch"), "{encoded}");
+    assert!(encoded.contains("hand.preflight"), "{encoded}");
     assert!(encoded.contains("failed"), "{encoded}");
     for expected in ["trace-hand", "24", "98304", "missing"] {
         assert!(
@@ -1958,8 +1969,10 @@ mod docker_hand_live {
                 "hand",
                 "--docker",
                 &image,
-                "--docker-volume",
+                "--volume",
                 &volume.0,
+                "--network",
+                "off",
                 "--machine-id",
                 "docker-cli-test",
             ])
@@ -2024,5 +2037,64 @@ mod docker_hand_live {
             "SIGTERM deleted the workspace volume"
         );
         server.abort();
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn docker_preflight_errors_are_actionable_before_account_login() {
+    use std::os::unix::fs::PermissionsExt as _;
+    let dir = tempfile::tempdir().unwrap();
+    let docker = dir.path().join("docker");
+    for (script, extra, expected) in [
+        (None, vec![], "Install the Docker CLI"),
+        (Some("exit 1"), vec![], "start a Linux Docker daemon"),
+        (
+            Some("echo '{\"OSType\":\"windows\"}'"),
+            vec![],
+            "switch Docker to Linux containers",
+        ),
+        (
+            Some(
+                "echo '{\"OSType\":\"linux\",\"Architecture\":\"x86_64\",\"Runtimes\":{\"runc\":{}}}'",
+            ),
+            vec!["--runtime", "runsc"],
+            "not configured on this daemon",
+        ),
+        (
+            Some(
+                "if [ \"$1\" = info ]; then echo '{\"OSType\":\"linux\",\"Architecture\":\"x86_64\"}'; else exit 1; fi",
+            ),
+            vec![],
+            "pnpm build:hand-docker",
+        ),
+        (
+            Some(
+                "if [ \"$1\" = info ]; then echo '{\"OSType\":\"linux\",\"Architecture\":\"x86_64\"}'; else echo linux/arm64; fi",
+            ),
+            vec![],
+            "rebuild the image",
+        ),
+    ] {
+        if let Some(script) = script {
+            std::fs::write(&docker, format!("#!/bin/sh\n{script}\n")).unwrap();
+            std::fs::set_permissions(&docker, std::fs::Permissions::from_mode(0o700)).unwrap();
+        }
+        let output = tokio::process::Command::new(env!("CARGO_BIN_EXE_nanocodex2"))
+            .args(["hand", "--docker", "image", "--volume", "work"])
+            .args(extra)
+            .env_clear()
+            .env("PATH", dir.path())
+            .env("NANOCODEX_HOME", dir.path())
+            // VM environment defaults must not invalidate Docker selection.
+            .env("NANOCODEX_VM_GUEST_RUNTIME", "/missing/guest")
+            .env("NANOCODEX_KRUNFW_DIR", "/missing/firmware")
+            .current_dir(dir.path())
+            .output()
+            .await
+            .unwrap();
+        assert_eq!(output.status.code(), Some(1));
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains(expected), "{stderr}");
     }
 }

--- a/crates/experimental/nanocodex-vm/Cargo.toml
+++ b/crates/experimental/nanocodex-vm/Cargo.toml
@@ -113,6 +113,11 @@ name = "image_live_build"
 path = "tests/image_live_build.rs"
 required-features = ["host"]
 
+[[test]]
+name = "docker_live"
+path = "tests/docker_live.rs"
+required-features = ["host"]
+
 [lints.rust]
 unsafe_code = "deny"
 

--- a/crates/experimental/nanocodex-vm/README.md
+++ b/crates/experimental/nanocodex-vm/README.md
@@ -427,3 +427,36 @@ artifact independently from the host feature.
 
 See `docs/VM.md` in the repository for CLI operation, egress composition, and
 build commands.
+
+## Docker workspaces
+
+[`docker::DockerWorkspace`] runs the same Rust guest tool protocol through a
+Linux Docker daemon without KVM. It provides persistent named workspace
+volumes, bounded startup and shutdown, exclusive per-volume Hand ownership,
+resource limits, a read-only root, and a non-root guest. Network access is off
+by default; `.internet()` enables ordinary Docker bridge access. Containers
+share the Docker host kernel and are an explicitly selected isolation mode.
+
+```rust,no_run
+use nanocodex_vm::docker::DockerWorkspace;
+
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
+let workspace = DockerWorkspace::builder("nanocodex-hand:local", "my-hand-workspace")
+    .cpus(2)
+    .memory_mib(1024)
+    .launch().await?;
+let tools = workspace.attachment_tools_builder().build()?;
+// Attach these tools using the ordinary Hosted Tools contract.
+drop(tools);
+workspace.shutdown().await?; // The named volume survives.
+# Ok(())
+# }
+```
+
+Build the image with `pnpm build:hand-docker`. See the
+[Docker Hand operator guide](../../../bin/nanocodex/nanocodex2/README.md#docker-hand-no-kvm)
+for image requirements, desktop support, network semantics, and stale-container
+recovery. The launcher never forwards the host environment or account
+credentials into the guest and does not mount host directories or the Docker
+socket. A daemon administrator remains trusted. Broker-only networking and
+on-demand Docker pools are not part of this backend.

--- a/crates/experimental/nanocodex-vm/image/Dockerfile.hand
+++ b/crates/experimental/nanocodex-vm/image/Dockerfile.hand
@@ -1,0 +1,14 @@
+# Build with pnpm build:hand-docker. The context contains the static Linux runtime.
+FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
+RUN apk add --no-cache ca-certificates bash curl git python3 nodejs npm \
+        xvfb openbox xterm font-dejavu mesa-dri-gallium \
+    && addgroup -g 1000 nanocodex \
+    && adduser -D -u 1000 -G nanocodex nanocodex \
+    && mkdir -p /app /workspace \
+    && chown 1000:1000 /app /workspace
+COPY --chmod=0755 nanocodex-vm-guest /usr/local/bin/nanocodex-vm-guest
+ENV DISPLAY=:0
+USER 1000:1000
+WORKDIR /app
+ENTRYPOINT ["/usr/local/bin/nanocodex-vm-guest"]
+CMD ["/app"]

--- a/crates/experimental/nanocodex-vm/src/docker.rs
+++ b/crates/experimental/nanocodex-vm/src/docker.rs
@@ -1,0 +1,596 @@
+//! Docker workspaces using the same retained guest protocol as libkrun.
+//!
+//! Containers share the Docker host's kernel. This backend does not silently
+//! substitute for VM isolation and never mounts host paths or the Docker socket.
+
+use std::{
+    path::Path,
+    process::Stdio,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use nanocodex_tools::ToolsBuilder;
+use sha2::{Digest, Sha256};
+use tokio::process::Command;
+
+use crate::tools::{VmToolSession, VmToolSessionError, VmToolSessionHandle, VmTools};
+
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
+const OWNER_LABEL: &str = "org.nanocodex.hand.lease";
+
+/// Failure to configure, launch, or stop a Docker workspace.
+#[derive(Debug, thiserror::Error)]
+pub enum DockerWorkspaceError {
+    /// An option cannot be represented safely by the Docker launch contract.
+    #[error("invalid Docker workspace configuration: {0}")]
+    Configuration(String),
+    /// The Docker CLI or daemon failed.
+    #[error("Docker {operation} failed: {detail}")]
+    Docker {
+        /// Operation which failed.
+        operation: String,
+        /// Docker diagnostic or timeout.
+        detail: String,
+    },
+    /// The guest protocol failed.
+    #[error(transparent)]
+    Session(#[from] VmToolSessionError),
+}
+
+/// Builder for an unprivileged container and a persistent named workspace volume.
+///
+/// The image must contain the Linux guest runtime at
+/// `/usr/local/bin/nanocodex-vm-guest`, `/bin/sh`, and `/bin/sync`. The workspace
+/// directory in the image must be writable by UID/GID 1000. Images are pulled
+/// explicitly by the operator, outside the bounded launch path.
+///
+/// Network access is disabled by default. [`Self::internet`] explicitly permits
+/// ordinary Docker bridge networking; it is not a broker-enforced egress mode.
+#[derive(Clone, Debug)]
+pub struct DockerWorkspaceBuilder {
+    image: String,
+    volume: String,
+    workspace: String,
+    shell: String,
+    cpus: u8,
+    memory_mib: u32,
+    internet: bool,
+    runtime: Option<String>,
+}
+
+/// A retained container whose standard tools and desktop share one guest session.
+///
+/// The named workspace volume survives shutdown and container replacement.
+/// One deterministic container name acts as a daemon-side lease on the volume;
+/// concurrent launches using the same volume fail instead of sharing it.
+/// Docker administrators can still access the volume or start other containers.
+pub struct DockerWorkspace {
+    session: VmToolSession,
+    container: Arc<ContainerLease>,
+    shutdown: tokio::sync::Mutex<()>,
+    workspace: String,
+    shell: String,
+}
+
+impl DockerWorkspace {
+    /// Configures one workspace using an explicitly selected image and volume.
+    #[must_use]
+    pub fn builder(image: impl Into<String>, volume: impl Into<String>) -> DockerWorkspaceBuilder {
+        DockerWorkspaceBuilder {
+            image: image.into(),
+            volume: volume.into(),
+            workspace: "/app".into(),
+            shell: "sh".into(),
+            cpus: 2,
+            memory_mib: 1024,
+            internet: false,
+            runtime: None,
+        }
+    }
+
+    /// Absolute workspace path inside the container.
+    #[must_use]
+    pub fn guest_workspace(&self) -> &str {
+        &self.workspace
+    }
+
+    /// Clone-cheap control capability for host-owned guest services.
+    #[must_use]
+    pub fn control(&self) -> VmToolSessionHandle {
+        self.session.handle()
+    }
+
+    /// Clone-cheap standard tools backed by the retained Docker guest.
+    #[must_use]
+    pub fn tools(&self) -> VmTools {
+        self.session.tools()
+    }
+
+    /// Standard workspace tools (including patches and images) for an embedded agent.
+    /// Web search, image generation, and planning keep their normal host behavior.
+    #[must_use]
+    pub fn tools_builder(&self) -> ToolsBuilder {
+        self.configure_tools(self.tools().tools_builder())
+    }
+
+    /// Process tools for the managed Hand cwd namespace, matching VM attachments.
+    #[must_use]
+    pub fn attachment_tools_builder(&self) -> ToolsBuilder {
+        self.configure_tools(self.tools().attachment_tools_builder())
+    }
+
+    fn configure_tools(&self, builder: ToolsBuilder) -> ToolsBuilder {
+        builder
+            .working_directory(self.workspace.clone())
+            .default_shell(self.shell.clone())
+    }
+
+    /// Syncs and stops the guest, then removes its container, retaining the volume.
+    ///
+    /// # Errors
+    /// Rejects live tool/control capabilities, or reports protocol/cleanup failures.
+    pub async fn shutdown(&self) -> Result<(), DockerWorkspaceError> {
+        // A concurrent caller must not force-remove the container while another
+        // caller is still syncing the guest filesystem.
+        let _shutdown = self.shutdown.lock().await;
+        let result = self.session.shutdown().await;
+        if matches!(
+            result,
+            Err(VmToolSessionError::ActiveCapabilities(_) | VmToolSessionError::ActiveRequests(_))
+        ) {
+            return result.map_err(Into::into);
+        }
+        self.container.remove().await?;
+        result.map_err(Into::into)
+    }
+}
+
+impl DockerWorkspaceBuilder {
+    /// Sets the absolute guest directory mounted from the named volume.
+    #[must_use]
+    pub fn guest_workspace(mut self, path: impl Into<String>) -> Self {
+        self.workspace = path.into();
+        self
+    }
+    /// Sets the shell described by the standard tools.
+    #[must_use]
+    pub fn shell(mut self, shell: impl Into<String>) -> Self {
+        self.shell = shell.into();
+        self
+    }
+    /// Sets a positive CPU quota.
+    #[must_use]
+    pub const fn cpus(mut self, cpus: u8) -> Self {
+        self.cpus = cpus;
+        self
+    }
+    /// Sets a positive memory limit, with no additional swap allowance.
+    #[must_use]
+    pub const fn memory_mib(mut self, memory: u32) -> Self {
+        self.memory_mib = memory;
+        self
+    }
+    /// Enables ordinary bridge networking, without egress filtering.
+    #[must_use]
+    pub const fn internet(mut self) -> Self {
+        self.internet = true;
+        self
+    }
+    /// Selects a daemon-configured OCI runtime (for example `runsc`).
+    /// There is no fallback if the requested runtime is unavailable.
+    #[must_use]
+    pub fn runtime(mut self, runtime: impl Into<String>) -> Self {
+        self.runtime = Some(runtime.into());
+        self
+    }
+
+    fn validate(&self) -> Result<(), DockerWorkspaceError> {
+        let invalid = |message: &str| DockerWorkspaceError::Configuration(message.into());
+        if self.image.is_empty()
+            || self.image.starts_with('-')
+            || self.image.chars().any(char::is_whitespace)
+        {
+            return Err(invalid("image must be a nonempty Docker image reference"));
+        }
+        if self.volume.len() < 2
+            || !self
+                .volume
+                .bytes()
+                .next()
+                .is_some_and(|b| b.is_ascii_alphanumeric())
+            || !self
+                .volume
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b"_.-".contains(&b))
+        {
+            return Err(invalid(
+                "volume must be a named Docker volume, not a host path",
+            ));
+        }
+        // Mounts over runtime/system paths can replace the trusted entrypoint or
+        // make it impossible to provide the private temporary filesystem.
+        if !Path::new(&self.workspace).is_absolute()
+            || self.workspace == "/"
+            || self.workspace.contains("//")
+            || self.workspace.ends_with('/')
+            || self.workspace.split('/').any(|p| p == "." || p == "..")
+            || self
+                .workspace
+                .chars()
+                .any(|c| c.is_control() || c == ',' || c == '"')
+            || [
+                "/bin", "/sbin", "/usr", "/etc", "/dev", "/proc", "/sys", "/run", "/tmp",
+            ]
+            .iter()
+            .any(|p| self.workspace == *p || self.workspace.starts_with(&format!("{p}/")))
+        {
+            return Err(invalid(
+                "workspace must be an absolute data directory outside system and temporary paths",
+            ));
+        }
+        if self.cpus == 0 || self.memory_mib == 0 {
+            return Err(invalid("CPU and memory limits must be positive"));
+        }
+        if self.runtime.as_ref().is_some_and(|r| {
+            r.is_empty()
+                || r.starts_with('-')
+                || !r
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b"_.-".contains(&b))
+        }) {
+            return Err(invalid("runtime must be a Docker runtime name"));
+        }
+        Ok(())
+    }
+
+    fn create_command(&self, lease: &ContainerLease) -> Command {
+        let mut command = docker();
+        command.args([
+            "container",
+            "create",
+            "--pull=never",
+            "--interactive",
+            "--init",
+            "--log-driver=none",
+            "--no-healthcheck",
+            "--name",
+            &lease.name,
+            "--label",
+            &format!("{OWNER_LABEL}={}", lease.owner),
+            "--label",
+            "org.nanocodex.hand.backend=docker",
+            "--user",
+            "1000:1000",
+            "--cap-drop=ALL",
+            "--security-opt=no-new-privileges",
+            "--read-only",
+            "--pids-limit=512",
+            "--cpus",
+            &self.cpus.to_string(),
+            "--memory",
+            &format!("{}m", self.memory_mib),
+            "--memory-swap",
+            &format!("{}m", self.memory_mib),
+            "--network",
+            if self.internet { "bridge" } else { "none" },
+            "--tmpfs",
+            "/tmp:rw,nosuid,nodev,size=256m,mode=1777",
+            "--tmpfs",
+            "/run:rw,nosuid,nodev,size=64m,mode=1777",
+            "--mount",
+            &format!(
+                "type=volume,source={},target={}",
+                self.volume, self.workspace
+            ),
+            "--workdir",
+            &self.workspace,
+            "--env",
+            &format!("HOME={}/.home", self.workspace),
+            "--entrypoint",
+            "/bin/sh",
+        ]);
+        // Docker CLI config can automatically inject proxy URLs (including
+        // credentials). Explicit empty values suppress that host-side default.
+        for name in [
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "FTP_PROXY",
+            "ALL_PROXY",
+            "NO_PROXY",
+            "http_proxy",
+            "https_proxy",
+            "ftp_proxy",
+            "all_proxy",
+            "no_proxy",
+        ] {
+            command.args(["--env", &format!("{name}=")]);
+        }
+        if let Some(runtime) = &self.runtime {
+            command.args(["--runtime", runtime]);
+        }
+        // Positional shell arguments keep workspace paths out of shell source.
+        command.args([
+            &self.image,
+            "-ec",
+            "mkdir -p -- \"$HOME\"; exec /usr/local/bin/nanocodex-vm-guest \"$1\"",
+            "nanocodex",
+            &self.workspace,
+        ]);
+        command
+    }
+
+    /// Creates a container, attaches its stdio, and waits for typed guest readiness.
+    ///
+    /// # Errors
+    /// Fails on invalid options, unavailable Docker/image/runtime, an occupied
+    /// workspace lease, or a guest which does not become ready within 30 seconds.
+    /// The image must be for a Linux Docker daemon. No KVM device is needed.
+    pub async fn launch(self) -> Result<DockerWorkspace, DockerWorkspaceError> {
+        self.validate()?;
+        let info = run(docker().args(["info", "--format", "{{.OSType}}"]), "info").await?;
+        if info.trim() != "linux" {
+            return Err(DockerWorkspaceError::Configuration(
+                "a Linux Docker daemon is required".into(),
+            ));
+        }
+        let container = Arc::new(ContainerLease {
+            name: format!(
+                "nanocodex-hand-{}",
+                hex::encode(Sha256::digest(self.volume.as_bytes()))
+            ),
+            owner: format!(
+                "{}-{}",
+                std::process::id(),
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_nanos()
+            ),
+            removed: AtomicBool::new(false),
+        });
+        // Finish creation even if the caller cancels launch. Its lease stays
+        // alive until Docker has answered, then cleans up if nobody received it.
+        let creating = Arc::clone(&container);
+        let mut create_command = self.create_command(&container);
+        tokio::spawn(async move {
+            let result = run(
+                &mut create_command,
+                "container create (workspace may already be in use)",
+            )
+            .await;
+            if result.is_err() {
+                // A duplicate launch's label does not match the current owner.
+                let _ = creating.remove().await;
+            }
+            result
+        })
+        .await
+        .map_err(|error| DockerWorkspaceError::Docker {
+            operation: "container create".into(),
+            detail: error.to_string(),
+        })??;
+        let mut command = docker();
+        command.args([
+            "container",
+            "start",
+            "--attach",
+            "--interactive",
+            &container.name,
+        ]);
+        let session = match VmToolSession::spawn(&mut command) {
+            Ok(session) => session,
+            Err(error) => {
+                container.remove().await?;
+                return Err(error.into());
+            }
+        };
+        session.retain(Arc::clone(&container));
+        let ready = tokio::time::timeout(COMMAND_TIMEOUT, session.ready())
+            .await
+            .unwrap_or(Err(VmToolSessionError::StartupTimeout(COMMAND_TIMEOUT)));
+        if let Err(error) = ready {
+            session.terminate().await;
+            container.remove().await?;
+            return Err(error.into());
+        }
+        Ok(DockerWorkspace {
+            session,
+            container,
+            shutdown: tokio::sync::Mutex::new(()),
+            workspace: self.workspace,
+            shell: self.shell,
+        })
+    }
+}
+
+fn docker() -> Command {
+    // Docker's connection configuration stays on the host. No host environment
+    // variable is forwarded into the container unless explicitly set above.
+    let mut command = Command::new("docker");
+    command.stdin(Stdio::null()).kill_on_drop(true);
+    command
+}
+
+async fn run(command: &mut Command, operation: &str) -> Result<String, DockerWorkspaceError> {
+    let fail = |detail: String| DockerWorkspaceError::Docker {
+        operation: operation.into(),
+        detail,
+    };
+    let output = tokio::time::timeout(COMMAND_TIMEOUT, command.output())
+        .await
+        .map_err(|_| fail(format!("timed out after {COMMAND_TIMEOUT:?}")))?
+        .map_err(|error| fail(error.to_string()))?;
+    if !output.status.success() {
+        return Err(fail(
+            String::from_utf8_lossy(&output.stderr).trim().to_owned(),
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+struct ContainerLease {
+    name: String,
+    owner: String,
+    removed: AtomicBool,
+}
+
+impl ContainerLease {
+    async fn remove(&self) -> Result<(), DockerWorkspaceError> {
+        if self.removed.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        // Match both the deterministic name and this launch's unique label,
+        // then remove by immutable ID. A duplicate launch or a replacement
+        // container can never be removed by this lease. No match is idempotent.
+        let ids = run(
+            docker().args([
+                "container",
+                "ls",
+                "--all",
+                "--no-trunc",
+                "--filter",
+                &format!("name=^/{}$", self.name),
+                "--filter",
+                &format!("label={OWNER_LABEL}={}", self.owner),
+                "--format",
+                "{{.ID}}",
+            ]),
+            "container lookup",
+        )
+        .await?;
+        for id in ids.lines().filter(|id| !id.is_empty()) {
+            run(
+                docker().args(["container", "rm", "--force", "--volumes", id]),
+                "container rm",
+            )
+            .await?;
+        }
+        self.removed.store(true, Ordering::Release);
+        Ok(())
+    }
+}
+
+impl Drop for ContainerLease {
+    fn drop(&mut self) {
+        if self.removed.load(Ordering::Acquire) {
+            return;
+        }
+        let lease = Self {
+            name: self.name.clone(),
+            owner: self.owner.clone(),
+            removed: AtomicBool::new(true),
+        };
+        // A runtime may itself be shutting down. A bounded independent reaper
+        // also works when the final capability is dropped outside Tokio.
+        let _ = std::thread::Builder::new()
+            .name("docker-hand-cleanup".into())
+            .spawn(move || {
+                if let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    lease.removed.store(false, Ordering::Release);
+                    let _ = runtime.block_on(lease.remove());
+                }
+                // Failed cleanup must not recursively spawn another reaper.
+                lease.removed.store(true, Ordering::Release);
+            });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_mounts_and_resource_limits_fail_before_docker() {
+        for volume in ["/tmp/work", "../work", "x,y", "-work", "", "x"] {
+            assert!(
+                DockerWorkspace::builder("image", volume)
+                    .validate()
+                    .is_err(),
+                "{volume}"
+            );
+        }
+        for workspace in [
+            "/",
+            "relative",
+            "/app/../etc",
+            "/usr/local",
+            "/run",
+            "/app,readonly",
+            "/app\n",
+            "//usr",
+            "/app/",
+        ] {
+            assert!(
+                DockerWorkspace::builder("image", "work")
+                    .guest_workspace(workspace)
+                    .validate()
+                    .is_err(),
+                "{workspace}"
+            );
+        }
+        assert!(
+            DockerWorkspace::builder("image", "work")
+                .cpus(0)
+                .validate()
+                .is_err()
+        );
+        assert!(
+            DockerWorkspace::builder("image", "work")
+                .memory_mib(0)
+                .validate()
+                .is_err()
+        );
+        assert!(
+            DockerWorkspace::builder("image", "work")
+                .runtime("--privileged")
+                .validate()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn launch_contract_does_not_inherit_host_privileges_or_network() {
+        let lease = ContainerLease {
+            name: "hand".into(),
+            owner: "owner".into(),
+            removed: AtomicBool::new(true),
+        };
+        let command = DockerWorkspace::builder("image", "workspace").create_command(&lease);
+        let args: Vec<_> = command
+            .as_std()
+            .get_args()
+            .map(|s| s.to_str().unwrap())
+            .collect();
+        for pair in [
+            ["--user", "1000:1000"],
+            ["--network", "none"],
+            ["--mount", "type=volume,source=workspace,target=/app"],
+        ] {
+            assert!(args.windows(2).any(|a| a == pair));
+        }
+        for variable in [
+            "HTTP_PROXY=",
+            "HTTPS_PROXY=",
+            "ALL_PROXY=",
+            "http_proxy=",
+            "https_proxy=",
+            "all_proxy=",
+        ] {
+            assert!(args.windows(2).any(|pair| pair == ["--env", variable]));
+        }
+        assert!(args.contains(&"--log-driver=none"));
+        assert!(args.contains(&"--read-only"));
+        assert!(args.contains(&"--cap-drop=ALL"));
+        assert!(args.contains(&"--security-opt=no-new-privileges"));
+        assert!(!args.contains(&"--privileged"));
+        assert!(!args.contains(&"--pid=host"));
+        assert!(!args.contains(&"--rm"));
+    }
+}

--- a/crates/experimental/nanocodex-vm/src/docker.rs
+++ b/crates/experimental/nanocodex-vm/src/docker.rs
@@ -323,20 +323,52 @@ impl DockerWorkspaceBuilder {
         command
     }
 
+    /// Checks options, the Docker daemon, the selected runtime, and the local image.
+    /// Does not create containers or volumes.
+    ///
+    /// # Errors
+    /// Reports unavailable Docker, non-Linux daemons/images, missing runtimes/images,
+    /// and images built for a different daemon architecture.
+    pub async fn preflight(&self) -> Result<(), DockerWorkspaceError> {
+        self.validate()?;
+        let info = run(docker().args(["info", "--format", "{{json .}}"]), "info")
+            .await.map_err(|error| DockerWorkspaceError::Configuration(format!(
+                "Docker backend is unavailable: {error}. Install the Docker CLI and start a Linux Docker daemon; verify access with `docker info`"
+            )))?;
+        let info: serde_json::Value = serde_json::from_str(&info).map_err(|error| {
+            DockerWorkspaceError::Configuration(format!(
+                "invalid Docker daemon information: {error}"
+            ))
+        })?;
+        validate_daemon(&info, self.runtime.as_deref())?;
+        let image = run(docker().args(["image", "inspect", "--format", "{{.Os}}/{{.Architecture}}", &self.image]), "image inspect")
+            .await.map_err(|error| DockerWorkspaceError::Configuration(format!(
+                "Docker image {:?} is unavailable locally: {error}. Build the bundled image with `pnpm build:hand-docker`, or explicitly pull your Hand image before starting; startup never pulls images",
+                self.image
+            )))?;
+        let architecture = match info["Architecture"].as_str().unwrap_or_default() {
+            "x86_64" | "amd64" => "amd64",
+            "aarch64" | "arm64" => "arm64",
+            other => other,
+        };
+        if image.trim() != format!("linux/{architecture}") {
+            return Err(DockerWorkspaceError::Configuration(format!(
+                "Docker image {:?} is {}, but this daemon requires linux/{architecture}; rebuild the image for the selected Docker daemon",
+                self.image,
+                image.trim()
+            )));
+        }
+        Ok(())
+    }
+
     /// Creates a container, attaches its stdio, and waits for typed guest readiness.
     ///
     /// # Errors
     /// Fails on invalid options, unavailable Docker/image/runtime, an occupied
     /// workspace lease, or a guest which does not become ready within 30 seconds.
-    /// The image must be for a Linux Docker daemon. No KVM device is needed.
+    /// No KVM device is needed. Startup never changes the selected backend.
     pub async fn launch(self) -> Result<DockerWorkspace, DockerWorkspaceError> {
-        self.validate()?;
-        let info = run(docker().args(["info", "--format", "{{.OSType}}"]), "info").await?;
-        if info.trim() != "linux" {
-            return Err(DockerWorkspaceError::Configuration(
-                "a Linux Docker daemon is required".into(),
-            ));
-        }
+        self.preflight().await?;
         let container = Arc::new(ContainerLease {
             name: format!(
                 "nanocodex-hand-{}",
@@ -405,6 +437,27 @@ impl DockerWorkspaceBuilder {
             shell: self.shell,
         })
     }
+}
+
+fn validate_daemon(
+    info: &serde_json::Value,
+    runtime: Option<&str>,
+) -> Result<(), DockerWorkspaceError> {
+    if info["OSType"] != "linux" {
+        return Err(DockerWorkspaceError::Configuration(
+            "Docker Hands require a Linux Docker daemon; switch Docker to Linux containers or select a Linux Docker context".into()
+        ));
+    }
+    if let Some(runtime) = runtime
+        && !info["Runtimes"]
+            .as_object()
+            .is_some_and(|runtimes| runtimes.contains_key(runtime))
+    {
+        return Err(DockerWorkspaceError::Configuration(format!(
+            "Docker runtime {runtime:?} is not configured on this daemon; install/configure it or omit --runtime to use the daemon default. No fallback was attempted"
+        )));
+    }
+    Ok(())
 }
 
 fn docker() -> Command {

--- a/crates/experimental/nanocodex-vm/src/lib.rs
+++ b/crates/experimental/nanocodex-vm/src/lib.rs
@@ -113,6 +113,16 @@ pub mod tools;
 ))]
 mod workspace;
 
+/// Docker workspaces for Linux daemons without a KVM requirement.
+#[cfg(all(
+    feature = "host",
+    any(
+        all(target_os = "linux", not(target_env = "musl")),
+        all(target_os = "macos", target_arch = "aarch64")
+    )
+))]
+pub mod docker;
+
 /// Low-level host-side VM configuration and lifecycle components.
 ///
 /// Most applications should start with [`crate::VmWorkspaceBuilder`]. This

--- a/crates/experimental/nanocodex-vm/src/tools/session.rs
+++ b/crates/experimental/nanocodex-vm/src/tools/session.rs
@@ -326,6 +326,7 @@ struct VmToolSessionInner {
     child: StdMutex<Option<Child>>,
     egress: StdMutex<Option<EgressLease>>,
     process_config: StdMutex<Option<PrivateVmProcessConfig>>,
+    lifetime_guards: StdMutex<Vec<Arc<dyn std::any::Any + Send + Sync>>>,
 }
 
 #[derive(Default)]
@@ -582,6 +583,7 @@ impl VmToolSession {
                 child: StdMutex::new(Some(child)),
                 egress: StdMutex::new(None),
                 process_config: StdMutex::new(None),
+                lifetime_guards: StdMutex::new(Vec::new()),
             });
             runtime.spawn(write_requests(
                 input,
@@ -605,6 +607,11 @@ impl VmToolSession {
         });
         record_vm_result(&span, started_at, &result);
         result
+    }
+
+    /// Retains an external runtime owner until the last tool capability drops.
+    pub(crate) fn retain<T: std::any::Any + Send + Sync>(&self, guard: Arc<T>) {
+        lock_unpoisoned(&self.handle.inner.lifetime_guards).push(guard);
     }
 
     /// Returns a clone-cheap capability for this session.
@@ -800,7 +807,7 @@ impl VmToolSession {
         result
     }
 
-    async fn terminate(&self) {
+    pub(crate) async fn terminate(&self) {
         let child = begin_termination(&self.handle.inner);
         if let Some(mut child) = child {
             let _ = tokio::time::timeout(self.handle.inner.shutdown_timeout, child.wait()).await;

--- a/crates/experimental/nanocodex-vm/tests/docker_live.rs
+++ b/crates/experimental/nanocodex-vm/tests/docker_live.rs
@@ -1,0 +1,368 @@
+//! Run with NANOCODEX_DOCKER_TEST_IMAGE=nanocodex-hand:local cargo test
+//! -p nanocodex-vm --test docker_live -- --ignored --nocapture.
+#![cfg(any(
+    all(target_os = "linux", not(target_env = "musl")),
+    all(target_os = "macos", target_arch = "aarch64")
+))]
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use nanocodex_tools::{
+    ToolContext, ToolInput,
+    contract::{ToolOutputBody, ToolOutputContent},
+    runtime::ToolRuntime,
+};
+use nanocodex_vm::{
+    docker::{DockerWorkspace, DockerWorkspaceError},
+    tools::{VmCommand, VmToolSessionError},
+};
+use serde_json::{json, value::to_raw_value};
+use std::{
+    process::Stdio,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+struct Volume(String);
+impl Volume {
+    fn new() -> Self {
+        Self(format!(
+            "nanocodex-docker-test-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+    async fn containers(&self) -> String {
+        docker(&[
+            "container",
+            "ls",
+            "--all",
+            "--filter",
+            &format!("volume={}", self.0),
+            "--format",
+            "{{.ID}}",
+        ])
+        .await
+    }
+}
+impl Drop for Volume {
+    fn drop(&mut self) {
+        // Unique test-only volumes; never enumerate or prune unrelated resources.
+        let output = std::process::Command::new("docker")
+            .args([
+                "container",
+                "ls",
+                "--all",
+                "--filter",
+                &format!("volume={}", self.0),
+                "--format",
+                "{{.ID}}",
+            ])
+            .output()
+            .unwrap();
+        for id in String::from_utf8_lossy(&output.stdout).lines() {
+            let _ = std::process::Command::new("docker")
+                .args(["container", "rm", "--force", id])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status();
+        }
+        let _ = std::process::Command::new("docker")
+            .args(["volume", "rm", &self.0])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+}
+fn image() -> String {
+    std::env::var("NANOCODEX_DOCKER_TEST_IMAGE")
+        .expect("set NANOCODEX_DOCKER_TEST_IMAGE to the built Hand image")
+}
+async fn docker(args: &[&str]) -> String {
+    let output = tokio::time::timeout(
+        Duration::from_secs(30),
+        tokio::process::Command::new("docker")
+            .args(args)
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap()
+}
+async fn tool(runtime: &ToolRuntime, name: &str, input: ToolInput) -> String {
+    let output = runtime
+        .execute_tool(
+            name,
+            input,
+            ToolContext::new("test", "docker-live", "call", &[], 4000),
+        )
+        .await
+        .unwrap();
+    assert!(output.success, "{:?}", output.output);
+    match output.output {
+        ToolOutputBody::Text(text) => text,
+        other => panic!("unexpected output: {other:?}"),
+    }
+}
+fn function(value: serde_json::Value) -> ToolInput {
+    ToolInput::Function(to_raw_value(&value).unwrap())
+}
+
+#[tokio::test]
+#[ignore = "requires a Linux Docker daemon and the built Hand image; no KVM needed"]
+async fn tools_isolation_exclusive_ownership_and_persistence() {
+    let volume = Volume::new();
+    let workspace = DockerWorkspace::builder(image(), &volume.0)
+        .launch()
+        .await
+        .unwrap();
+    let control = workspace.control();
+    let output = control
+        .command(VmCommand::new("/bin/sh").arg("-ec").arg(concat!(
+            "test \"$(id -u)\" = 1000; ",
+            "test ! -e /dev/kvm; test ! -e /var/run/docker.sock; ",
+            "test -z \"${NANOCODEX_DOCKER_HOST_SENTINEL-}\"; ",
+            "grep -q 'CapEff:.*0000000000000000' /proc/self/status; ",
+            "grep -q 'NoNewPrivs:.*1' /proc/self/status; ",
+            "! touch /etc/nanocodex-test; ",
+            "test ! -e /sys/class/net/eth0; ",
+            "printf isolation-ok"
+        )))
+        .await
+        .unwrap();
+    assert_eq!(
+        output.exit_code,
+        0,
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(output.stdout, b"isolation-ok");
+    let id = volume.containers().await;
+    let inspect: serde_json::Value =
+        serde_json::from_str(&docker(&["inspect", id.trim()]).await).unwrap();
+    assert_eq!(inspect[0]["HostConfig"]["Memory"], 1024 * 1024 * 1024);
+    assert_eq!(inspect[0]["HostConfig"]["NanoCpus"], 2_000_000_000u64);
+    assert_eq!(inspect[0]["HostConfig"]["NetworkMode"], "none");
+    assert_eq!(inspect[0]["HostConfig"]["ReadonlyRootfs"], true);
+
+    let tools = workspace
+        .tools_builder()
+        .web_search(false)
+        .image_generation(false)
+        .build()
+        .unwrap();
+    let runtime = ToolRuntime::new_with_tools("/app", None, None, &tools);
+    let patched = tool(
+        &runtime,
+        "apply_patch",
+        ToolInput::Freeform(
+            "*** Begin Patch\n*** Add File: /app/persistent.txt\n+retained\n*** End Patch".into(),
+        ),
+    )
+    .await;
+    assert!(patched.contains("persistent.txt"), "{patched}");
+    let first = tool(&runtime, "exec_command", function(json!({"cmd":"read line; printf 'received:%s' \"$line\"", "tty":true,"yield_time_ms":100,"login":false}))).await;
+    let sid: u64 = first
+        .lines()
+        .find_map(|line| line.strip_prefix("Process running with session ID "))
+        .unwrap()
+        .parse()
+        .unwrap();
+    let resumed = tool(
+        &runtime,
+        "write_stdin",
+        function(json!({"session_id":sid,"chars":"hello\n","yield_time_ms":1000})),
+    )
+    .await;
+    assert!(resumed.contains("received:hello"), "{resumed}");
+
+    assert!(
+        DockerWorkspace::builder(image(), &volume.0)
+            .launch()
+            .await
+            .is_err()
+    );
+    assert_eq!(
+        control.read_file("/app/persistent.txt").await.unwrap(),
+        b"retained\n"
+    );
+    assert!(matches!(
+        workspace.shutdown().await,
+        Err(DockerWorkspaceError::Session(
+            VmToolSessionError::ActiveCapabilities(_)
+        ))
+    ));
+    drop(runtime);
+    drop(tools);
+    drop(control);
+    workspace.shutdown().await.unwrap();
+    assert!(volume.containers().await.trim().is_empty());
+    let next = DockerWorkspace::builder(image(), &volume.0)
+        .launch()
+        .await
+        .unwrap();
+    assert_eq!(
+        next.control()
+            .read_file("/app/persistent.txt")
+            .await
+            .unwrap(),
+        b"retained\n"
+    );
+    let (first, second) = tokio::join!(next.shutdown(), next.shutdown());
+    first.unwrap();
+    assert!(matches!(
+        second,
+        Err(DockerWorkspaceError::Session(VmToolSessionError::Closed))
+    ));
+}
+
+#[tokio::test]
+#[ignore = "requires a Linux Docker daemon and the built Hand image; no KVM needed"]
+async fn startup_failure_cleans_up_and_explicit_internet_works() {
+    let volume = Volume::new();
+    assert!(
+        DockerWorkspace::builder(image(), &volume.0)
+            .runtime("nanocodex-missing-runtime")
+            .launch()
+            .await
+            .is_err()
+    );
+    assert!(volume.containers().await.trim().is_empty());
+    let workspace = DockerWorkspace::builder(image(), &volume.0)
+        .internet()
+        .launch()
+        .await
+        .unwrap();
+    let output = workspace
+        .control()
+        .command(
+            VmCommand::new("/bin/sh")
+                .arg("-ec")
+                .arg("test -e /sys/class/net/eth0"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(output.exit_code, 0);
+    workspace.shutdown().await.unwrap();
+    assert!(volume.containers().await.trim().is_empty());
+}
+
+#[tokio::test]
+#[ignore = "requires a Linux Docker daemon and the built Hand image; no KVM needed"]
+async fn desktop_and_last_capability_cleanup() {
+    let volume = Volume::new();
+    let workspace = DockerWorkspace::builder(image(), &volume.0)
+        .launch()
+        .await
+        .unwrap();
+    let control = workspace.control();
+    let runner = workspace.control();
+    let task = tokio::spawn(async move {
+        runner
+            .command(
+                VmCommand::new("/usr/local/bin/nanocodex-vm-guest")
+                    .arg("--desktop")
+                    .arg("/app")
+                    .arg("/run/nanocodex-hand-desktop")
+                    .timeout(Duration::from_secs(60)),
+            )
+            .await
+    });
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while control
+        .read_file("/run/nanocodex-hand-desktop/ready")
+        .await
+        .is_err()
+    {
+        assert!(
+            !task.is_finished(),
+            "desktop exited before readiness: {:?}",
+            task.await
+        );
+        assert!(Instant::now() < deadline, "desktop readiness timed out");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    let output = control
+        .command(
+            VmCommand::new("/usr/local/bin/nanocodex-vm-guest")
+                .arg("--desktop-request")
+                .arg(r#"{"action":"observe"}"#)
+                .arg("/run/nanocodex-hand-desktop"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        output.exit_code,
+        0,
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let frame: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(frame["status"], "ok");
+    let jpeg = STANDARD.decode(frame["jpeg"].as_str().unwrap()).unwrap();
+    assert!(jpeg.starts_with(&[0xff, 0xd8, 0xff]));
+    control
+        .write_file("/app/screen.jpg", jpeg, 0o600)
+        .await
+        .unwrap();
+    {
+        let tools = workspace
+            .tools_builder()
+            .web_search(false)
+            .image_generation(false)
+            .build()
+            .unwrap();
+        let runtime = ToolRuntime::new_with_tools("/app", None, None, &tools);
+        let output = runtime
+            .execute_tool(
+                "view_image",
+                function(json!({"path":"/app/screen.jpg"})),
+                ToolContext::new("test", "docker-live", "image", &[], 4000),
+            )
+            .await
+            .unwrap();
+        assert!(output.success, "{:?}", output.output);
+        assert!(
+            matches!(output.output, ToolOutputBody::Content(items) if items.iter().any(|item| matches!(item, ToolOutputContent::InputImage { .. })))
+        );
+    }
+
+    let output = control
+        .command(
+            VmCommand::new("/usr/local/bin/nanocodex-vm-guest")
+                .arg("--desktop-request")
+                .arg(r#"{"action":"shutdown"}"#)
+                .arg("/run/nanocodex-hand-desktop"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(output.exit_code, 0);
+    assert_eq!(task.await.unwrap().unwrap().exit_code, 0);
+    drop(workspace);
+    // The final control capability still owns the running container.
+    assert_eq!(
+        control
+            .command(VmCommand::new("/bin/true"))
+            .await
+            .unwrap()
+            .exit_code,
+        0
+    );
+    drop(control);
+    let deadline = Instant::now() + Duration::from_secs(35);
+    while !volume.containers().await.trim().is_empty() {
+        assert!(
+            Instant::now() < deadline,
+            "last capability did not release the container"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "predev": "portless proxy start --port ${PORTLESS_PORT:-443}",
     "dev": "turbo run dev --filter=nanocodex-web --filter=@nanocodex/connect-playground",
     "build": "turbo run build",
+    "build:hand-docker": "bash scripts/build-hand-docker.sh",
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
     "deploy:egress": "pnpm --filter nanocodex-egress-service run deploy:broker",

--- a/scripts/build-hand-docker.sh
+++ b/scripts/build-hand-docker.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build for the selected Docker daemon, including remote Docker contexts.
+repo=$(cd "$(dirname "$0")/.." && pwd)
+cd "$repo"
+image=${1:-nanocodex-hand:local}
+platform=$(docker version --format '{{.Server.Os}}/{{.Server.Arch}}')
+case "$platform" in
+  linux/arm64) target=aarch64-unknown-linux-musl ;;
+  linux/amd64) target=x86_64-unknown-linux-musl ;;
+  *) printf 'Unsupported Docker platform: %s\n' "$platform" >&2; exit 1 ;;
+esac
+
+cargo build --locked --release -p nanocodex-vm --bin nanocodex-vm-guest \
+  --no-default-features --features guest-runtime --target "$target"
+context=$(mktemp -d)
+trap 'rm -rf "$context"' EXIT
+cp "${CARGO_TARGET_DIR:-target}/$target/release/nanocodex-vm-guest" "$context/"
+cp crates/experimental/nanocodex-vm/image/Dockerfile.hand "$context/Dockerfile"
+docker build --platform "$platform" --tag "$image" "$context"

--- a/typos.toml
+++ b/typos.toml
@@ -47,5 +47,3 @@ daa = "daa"
 # `iz` appears inside the exact retained benchmark flag
 # `flag{gc0d3_iz_ch4LLenGiNg}`.
 iz = "iz"
-# Mesa's OpenGL-over-Vulkan driver is named Zink.
-Zink = "Zink"

--- a/typos.toml
+++ b/typos.toml
@@ -47,3 +47,5 @@ daa = "daa"
 # `iz` appears inside the exact retained benchmark flag
 # `flag{gc0d3_iz_ch4LLenGiNg}`.
 iz = "iz"
+# Mesa's OpenGL-over-Vulkan driver is named Zink.
+Zink = "Zink"


### PR DESCRIPTION
Adds `nanocodex2 hand --docker IMAGE --volume NAME` so a Linux Docker daemon can run a Hand without `/dev/kvm`. It reuses the Rust guest protocol and desktop publisher, with a persistent workspace volume and explicit `container` capability. `pnpm build:hand-docker` builds the matching Linux image.

The container runs as UID 1000 with a read-only root, dropped capabilities, CPU/memory/PID limits, and private temporary filesystems. Account credentials and screen authority stay in the host. Docker proxy defaults are cleared so credential-bearing proxy URLs are not injected, and guest protocol output is not stored in Docker logs.

Workspace ownership is reserved by a deterministic container name. Duplicate launches cannot remove the current owner; shutdown removes only the owned container and retains the named volume. Tool capabilities retain the container lifetime. Ctrl-C/SIGTERM drains attached work and syncs the guest.

Network access defaults to offline. `--network internet` explicitly enables ordinary bridge networking, and `--runtime` selects an installed runtime without fallback. This does not implement broker-only egress or Sentinel. The on-demand `host` pool remains libkrun-only; gVisor compatibility is not yet validated. The operator guide documents stale-container recovery after a killed host or unavailable daemon.

Inspired by [Muse's separation of execution from credential and permission services](https://research.meta.ai/blog/security-and-safety-for-ai-agents-our-approach-with-muse).

CLI selection stays explicit: `hand --vm ROOTFS` or `hand --docker IMAGE --volume NAME`. Shared options are `--workspace`, `--cpus`, `--memory`, and `--network off|internet`; old flag spellings remain accepted. Help groups backend choice ahead of workspace/resources and advanced options. Docker/VM default machine identities are distinct.

Backend preflight runs before account setup. Linux VM startup checks device access, the KVM API, and VM creation, with an explicit Docker alternative in the error. Docker startup checks the CLI/daemon, Linux mode, local image and architecture, and requested OCI runtime. VM-only flags are rejected with Docker; VM environment defaults do not affect Docker.

Validation:
- Rebased onto `origin/master` at `84668e03`, including the shared shutdown handler and Mesa software renderer.
- Built the updated ARM64 Linux guest and Docker image locally; AMD64 image build and live Docker/CLI tests also passed in CI.
- Live Docker tests: shell/PTY resume, patches, image reads, desktop capture, offline isolation, duplicate ownership, failure cleanup, concurrent shutdown, and persistence across container replacement.
- End-to-end CLI test: authenticated tool and screen publication to a local service, credential absence in the guest, and SIGTERM cleanup preserving the volume.
- 119 VM library tests, 5 Hand unit tests, and 12 managed CLI contract tests passed.
- Focused clippy/rustdoc, workspace rustfmt, dependency policy, spelling, and package boundary checks passed locally. CI runs the Docker and CLI journeys on AMD64 Linux.
- All CI checks passed on `27092cdf`. An unchanged eval process-timeout test failed on the first run, passed six focused local runs, and passed in the full workspace retry.
- Remote Latitude validation on `paradigm` (Linux AMD64, Docker 29.1.5): built commit `27092cdf` on the server and passed all 3 live Docker tests plus the CLI tool/screen/SIGTERM test. Repeated all 4 successfully in a private user/mount namespace with `/dev/kvm` masked by `/dev/null`; the host device remained unchanged. No test containers or volumes remained.


CLI follow-up: 13 managed CLI tests, 8 Hand/config tests, all 4 live Docker/CLI tests, clippy, formatting, and dependency checks passed locally. CI also checks the actual CLI with KVM masked in a private mount namespace.
