### PR TITLE
fix(ios): route queued steering through the active-turn API

### DIFF
--- a/apple/InboxCore/Sources/InboxCore/ConversationItem.swift
+++ b/apple/InboxCore/Sources/InboxCore/ConversationItem.swift
@@ -9,7 +9,11 @@ public struct ConversationItem: Identifiable, Equatable {
     public var activity: [TranscriptRow] = []
     public var isRunning = false
 
-    public static func group(_ rows: [TranscriptRow], activeTurns: Set<String> = []) -> [ConversationItem] {
+    public static func group(_ rows: [TranscriptRow], activeTurns: [String] = []) -> [ConversationItem] {
+        // The service returns unfinished turns in admission order, including
+        // queued follow-ups. Only the head can be executing. Keeping that order
+        // also handles messages queued by another device or restored from history.
+        let executingTurn = activeTurns.first
         var result: [ConversationItem] = [], indices: [String: Int] = [:]
         var lastIsActivity: [String: Bool] = [:], fallback = "history"
         var order: [String] = [], turns: [String: [TranscriptRow]] = [:]
@@ -31,14 +35,14 @@ public struct ConversationItem: Identifiable, Equatable {
                 }
             } else {
                 result.append(.init(id: row.id, message: row))
-                if row.role == "You", activeTurns.contains(turn), indices[turn] == nil {
+                if row.role == "You", executingTurn == turn, indices[turn] == nil {
                     indices[turn] = result.count
                     result.append(.init(id: "activity-" + turn))
                 }
             }
         }
         for (turn, index) in indices {
-            result[index].isRunning = activeTurns.contains(turn) && lastIsActivity[turn] == true
+            result[index].isRunning = executingTurn == turn && lastIsActivity[turn] == true
         }
         return result.filter { $0.message != nil || !$0.activity.isEmpty || $0.isRunning }
     }

--- a/apple/InboxCore/Sources/InboxCore/ManagedClient.swift
+++ b/apple/InboxCore/Sources/InboxCore/ManagedClient.swift
@@ -493,11 +493,12 @@ public struct EventPage: Sendable {
 
 /// Capture agent and turn identity at the button press, before any await or swipe.
 public struct AgentCommand: Equatable, Sendable {
-    public enum Kind: Equatable, Sendable { case followUp, steer, stop }
+    public enum Kind: Equatable, Sendable { case followUp, steer, withdrawSteer, stop }
     public let agentID: String
     public let turnID: String
     public let input: String
     public var images: [JSON] = []
+    public var rawInput: JSON?
     public let kind: Kind
     public let requestID: String
     public init(agentID: String, turnID: String = "", input: String = "", kind: Kind, requestID: String = UUID().uuidString) {
@@ -505,13 +506,14 @@ public struct AgentCommand: Equatable, Sendable {
     }
     public func requestSpec() throws -> (path: String, body: JSON?, key: String?) {
         let path = try ManagedClient.agentPath(agentID) + "/turns"
-        let content: JSON = images.isEmpty ? .string(input) : .array(
+        let content: JSON = rawInput ?? (images.isEmpty ? .string(input) : .array(
             (input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? [] : [.object(["type": .string("text"), "text": .string(input)])]) + images
-        )
-        let body: JSON = .object(kind == .followUp ? ["id": .string(requestID), "input": content] : ["input": content])
+        ))
+        let body: JSON = .object(kind == .followUp ? ["id": .string(requestID), "input": content] : ["input": content, "message_id": .string(requestID)])
         if kind == .followUp { return (path, body, "inbox:" + requestID) }
         guard !turnID.isEmpty, turnID.range(of: #"^[A-Za-z0-9._:-]{1,128}$"#, options: .regularExpression) != nil,
               let segment = turnID.addingPercentEncoding(withAllowedCharacters: .alphanumerics) else { throw APIError.invalidResponse }
+        if kind == .withdrawSteer { return (path + "/" + segment + "/withdraw-steer", .object(["message_id": .string(requestID)]), nil) }
         return (path + "/" + segment + (kind == .steer ? "/steer" : "/cancel"), kind == .steer ? body : nil, nil)
     }
 }

--- a/apple/InboxCore/Sources/InboxCore/MessageQueuePresentation.swift
+++ b/apple/InboxCore/Sources/InboxCore/MessageQueuePresentation.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Queue admission is not execution. Keep pending input out of the conversation
+/// until it starts, and use server order even after relaunch or another device's send.
+public struct MessageQueuePresentation {
+    public let messages: [PendingMessage]
+    public let rows: [TranscriptRow]
+    public let attachmentNames: [String: [String]]
+
+    public init(agentID: String, rows: [TranscriptRow], pending: [PendingMessage], activeTurns: [String],
+                cancelledTurns: Set<String> = [], executingTurns: Set<String> = []) {
+        var byID = Dictionary(uniqueKeysWithValues: pending.filter { $0.agentID == agentID }.map { ($0.id, $0) })
+        for (id, existing) in byID where existing.remoteAdmission == true {
+            guard let row = rows.first(where: { $0.role == "You" && ($0.turnID ?? $0.id) == id }) else { continue }
+            var updated = PendingMessage(agentID: agentID, input: row.text, predecessor: existing.predecessor, id: id)
+            updated.remoteAdmission = true
+            updated.phase = existing.phase
+            updated.error = existing.error
+            updated.acceptedCursor = existing.acceptedCursor ?? row.cursor
+            byID[id] = updated
+        }
+        let executed = executingTurns.union(rows.compactMap { row in
+            ["Agent", "Thinking", "Tool"].contains(row.role) ? row.turnID : nil
+        })
+        for id in executed { byID.removeValue(forKey: id) }
+        for (index, turnID) in activeTurns.enumerated() where byID[turnID] == nil && !cancelledTurns.contains(turnID)
+            && !executed.contains(turnID) {
+            let row = rows.first(where: { $0.role == "You" && ($0.turnID ?? $0.id) == turnID })
+            var message = PendingMessage(agentID: agentID, input: row?.text ?? "Message queued on another device", predecessor: index > 0 ? activeTurns[index - 1] : "", id: turnID)
+            message.remoteAdmission = true
+            message.phase = .queued
+            message.acceptedCursor = row?.cursor
+            byID[turnID] = message
+        }
+        // A stale predecessor is not a lifecycle state. The displayed queue
+        // must advance even before an older local send receipt is reconciled.
+        let ordered = activeTurns.enumerated().compactMap { index, id -> PendingMessage? in
+            guard var message = byID.removeValue(forKey: id) else { return nil }
+            if message.phase == .queued { message.predecessor = index > 0 ? activeTurns[index - 1] : "" }
+            return message
+        }
+        messages = ordered + pending.compactMap { $0.agentID == agentID ? byID.removeValue(forKey: $0.id) : nil }
+        attachmentNames = Dictionary(uniqueKeysWithValues: messages.map { message in
+            let row = rows.first { ($0.turnID ?? $0.id) == message.id && $0.role == "You" }
+            let names = (message.attachments ?? []).map(\.name) + (row?.imageFiles ?? []).map(\.name) + (row?.videos ?? []).map(\.name)
+            var seen = Set<String>()
+            return (message.id, names.filter { seen.insert($0).inserted })
+        })
+        let queuedIDs = Set(messages.map(\.id))
+        self.rows = rows.compactMap { row in
+            let turnID = row.turnID ?? row.id
+            guard !queuedIDs.contains(turnID) else { return nil }
+            var row = row
+            if row.role == "You", cancelledTurns.contains(turnID) {
+                row.role = "Status"
+                row.text = "Cancelled request: " + row.text
+            }
+            return row
+        }
+    }
+}

--- a/apple/InboxCore/Sources/InboxCore/PendingMessage.swift
+++ b/apple/InboxCore/Sources/InboxCore/PendingMessage.swift
@@ -13,24 +13,20 @@ public struct PendingMessage: Identifiable, Codable, Equatable, Sendable {
     public var error: String?
     public var attachments: [MessageAttachment]?
     public var contextIDs: [String]?
+    /// A server-owned admission reconstructed for display/control, never resubmission.
+    public var remoteAdmission: Bool?
     public init(agentID: String, input: String, predecessor: String, id: String = UUID().uuidString, contextIDs: [String]? = nil, attachments: [MessageAttachment]? = nil) {
         self.id = id; self.agentID = agentID; self.input = input; self.predecessor = predecessor
         self.contextIDs = contextIDs; self.attachments = attachments
     }
-    /// Admission stores a message durably; it does not mean execution began.
-    /// Resolve from local delivery state and the server queue for other devices.
-    public static func deliveryLabel(turnID: String, pending: PendingMessage?, activeTurns: [String]) -> String? {
-        if let pending {
-            switch pending.phase {
-            case .submitting: return "Sending…"
-            case .queued: return "Queued · not started"
-            case .starting: return "Queued · stopping current turn…"
-            case .cancelling: return "Cancelling…"
-            case .failed: return "Delivery unconfirmed"
-            }
+    public var queueTitle: String {
+        switch phase {
+        case .submitting: return "Sending…"
+        case .queued: return predecessor.isEmpty ? (remoteAdmission == true ? "Waiting for execution update" : "Waiting to start") : "Queued · runs after current turn"
+        case .starting: return "Stopping current turn…"
+        case .cancelling: return "Cancelling…"
+        case .failed: return "Delivery unconfirmed"
         }
-        if let index = activeTurns.firstIndex(of: turnID), index > 0 { return "Queued · not started" }
-        return nil
     }
     public var submission: AgentCommand { AgentCommand(agentID: agentID, input: input, kind: .followUp, requestID: id) }
     public var interruption: AgentCommand? {

--- a/apple/InboxCore/Sources/InboxCore/PendingMessage.swift
+++ b/apple/InboxCore/Sources/InboxCore/PendingMessage.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-/// A durable follow-up is admitted once. "Steer now" resolves and captures an
-/// unfinished predecessor; it never submits the follow-up a second time.
+/// A durable follow-up is admitted once. Steering captures its active target;
+/// SteeringTransfer fences the queued source before injecting through the API.
 public struct PendingMessage: Identifiable, Codable, Equatable, Sendable {
     public enum Phase: String, Codable, Sendable { case submitting, queued, starting, cancelling, failed }
     public let id: String
@@ -31,7 +31,7 @@ public struct PendingMessage: Identifiable, Codable, Equatable, Sendable {
     public var submission: AgentCommand { AgentCommand(agentID: agentID, input: input, kind: .followUp, requestID: id) }
     public var interruption: AgentCommand? {
         guard phase == .queued, !predecessor.isEmpty, predecessor != id else { return nil }
-        return AgentCommand(agentID: agentID, turnID: predecessor, kind: .stop)
+        return AgentCommand(agentID: agentID, turnID: predecessor, input: input, kind: .steer, requestID: id)
     }
     /// The server lists unfinished turns in queue order. A predecessor captured
     /// when sending may since have completed or been cancelled on another device.
@@ -40,7 +40,7 @@ public struct PendingMessage: Identifiable, Codable, Equatable, Sendable {
         guard activeTurns.contains(id) || (!predecessor.isEmpty && activeTurns.contains(predecessor)) else { return nil }
         let preceding = activeTurns.prefix { $0 != id }
         guard let target = preceding.first, target != id else { return nil }
-        return AgentCommand(agentID: agentID, turnID: target, kind: .stop)
+        return AgentCommand(agentID: agentID, turnID: target, input: input, kind: .steer, requestID: id)
     }
     public mutating func acknowledge(_ receipt: JSON) throws {
         guard receipt["turn_id"].string == id else { throw APIError.invalidResponse }

--- a/apple/InboxCore/Sources/InboxCore/PendingMessage.swift
+++ b/apple/InboxCore/Sources/InboxCore/PendingMessage.swift
@@ -17,6 +17,21 @@ public struct PendingMessage: Identifiable, Codable, Equatable, Sendable {
         self.id = id; self.agentID = agentID; self.input = input; self.predecessor = predecessor
         self.contextIDs = contextIDs; self.attachments = attachments
     }
+    /// Admission stores a message durably; it does not mean execution began.
+    /// Resolve from local delivery state and the server queue for other devices.
+    public static func deliveryLabel(turnID: String, pending: PendingMessage?, activeTurns: [String]) -> String? {
+        if let pending {
+            switch pending.phase {
+            case .submitting: return "Sending…"
+            case .queued: return "Queued · not started"
+            case .starting: return "Queued · stopping current turn…"
+            case .cancelling: return "Cancelling…"
+            case .failed: return "Delivery unconfirmed"
+            }
+        }
+        if let index = activeTurns.firstIndex(of: turnID), index > 0 { return "Queued · not started" }
+        return nil
+    }
     public var submission: AgentCommand { AgentCommand(agentID: agentID, input: input, kind: .followUp, requestID: id) }
     public var interruption: AgentCommand? {
         guard phase == .queued, !predecessor.isEmpty, predecessor != id else { return nil }

--- a/apple/InboxCore/Sources/InboxCore/SteeringTransfer.swift
+++ b/apple/InboxCore/Sources/InboxCore/SteeringTransfer.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Moves an already-admitted follow-up into the active turn without cancelling
+/// that active turn. The source queue fence and steer admission are separate.
+public struct SteeringTransfer: Identifiable, Codable, Equatable, Sendable {
+    public enum Phase: String, Codable, Sendable {
+        case preparing, removingQueued, ready, sending, accepted, withdrawing, withdrawn, unconfirmed
+    }
+    public var id: String { sourceTurnID }
+    public let agentID: String
+    public let sourceTurnID: String
+    public let targetTurnID: String
+    public var phase: Phase = .preparing
+    public var error: String?
+    public var withdrawRequested = false
+    public var wasAccepted = false
+    public init(agentID: String, sourceTurnID: String, targetTurnID: String) {
+        self.agentID = agentID; self.sourceTurnID = sourceTurnID; self.targetTurnID = targetTurnID
+    }
+    public var sourceCancellation: AgentCommand { .init(agentID: agentID, turnID: sourceTurnID, kind: .stop) }
+    public func command(input: JSON) -> AgentCommand {
+        var command = AgentCommand(agentID: agentID, turnID: targetTurnID, kind: .steer, requestID: id)
+        command.rawInput = input
+        return command
+    }
+    public var withdrawal: AgentCommand { .init(agentID: agentID, turnID: targetTurnID, kind: .withdrawSteer, requestID: id) }
+    public func sourceIsFenced(_ receipt: JSON) -> Bool {
+        receipt["turn_id"].string == sourceTurnID && ["cancelling", "cancelled"].contains(receipt["state"].string)
+    }
+    public func isAccepted(_ receipt: JSON) -> Bool {
+        receipt["turn_id"].string == targetTurnID && receipt["state"].string == "steering"
+    }
+    public func withdrawalResult(_ receipt: JSON) -> Bool? {
+        guard receipt["turn_id"].string == targetTurnID, receipt["message_id"].string == id,
+              case .bool(let withdrawn) = receipt["withdrawn"] else { return nil }
+        return withdrawn
+    }
+    public var title: String {
+        switch phase {
+        case .preparing, .removingQueued, .ready: return "Preparing steering…"
+        case .sending: return "Sending steering…"
+        case .accepted: return "Steering sent"
+        case .withdrawing: return "Withdrawing steering…"
+        case .withdrawn: return "Steering withdrawn"
+        case .unconfirmed: return "Steering delivery unconfirmed"
+        }
+    }
+    public var canResume: Bool { [.preparing, .removingQueued, .ready, .withdrawing].contains(phase) }
+    public mutating func restore() {
+        if phase == .sending {
+            phase = .unconfirmed
+            error = "The steering response was not received. It may already be in use; it will not be sent again automatically."
+        }
+    }
+}

--- a/apple/InboxCore/Tests/InboxCoreTests/ConversationItemTests.swift
+++ b/apple/InboxCore/Tests/InboxCoreTests/ConversationItemTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import InboxCore
+
+final class ConversationItemTests: XCTestCase {
+    func testQueuedSteeringMessageDoesNotAppearToBeExecuting() {
+        var original = TranscriptRow(id: "original-message", role: "You", text: "Start work")
+        original.turnID = "original"
+        var wait = TranscriptRow(id: "wait", role: "Tool", text: "Wait", running: true)
+        wait.turnID = "original"
+        var correction = TranscriptRow(id: "correction-message", role: "You", text: "Show each desktop")
+        correction.turnID = "correction"
+        let rows = [original, wait, correction]
+
+        let queued = ConversationItem.group(rows, activeTurns: ["original", "correction"])
+        XCTAssertEqual(queued.compactMap(\.message).map(\.text), ["Start work", "Show each desktop"])
+        XCTAssertEqual(queued.filter(\.isRunning).map(\.id), ["activity-original"])
+        XCTAssertFalse(queued.contains { $0.id == "activity-correction" })
+
+        // Completion or an acknowledged steer advances the durable queue.
+        let started = ConversationItem.group(rows, activeTurns: ["correction"])
+        XCTAssertEqual(started.filter(\.isRunning).map(\.id), ["activity-correction"])
+        XCTAssertEqual(started.first { $0.id == "activity-original" }?.activity.map(\.id), ["wait"])
+        XCTAssertFalse(ConversationItem.group(rows).contains(where: \.isRunning))
+    }
+
+    func testQueueHeadOutsideHistoryDoesNotPromoteVisibleFollowUp() {
+        var correction = TranscriptRow(id: "message", role: "You", text: "Next request")
+        correction.turnID = "queued"
+        let items = ConversationItem.group([correction], activeTurns: ["outside-window", "queued"])
+        XCTAssertEqual(items.count, 1)
+        XCTAssertFalse(items.contains(where: \.isRunning))
+    }
+}

--- a/apple/InboxCore/Tests/InboxCoreTests/MessageQueuePresentationTests.swift
+++ b/apple/InboxCore/Tests/InboxCoreTests/MessageQueuePresentationTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import InboxCore
+
+final class MessageQueuePresentationTests: XCTestCase {
+    private func row(_ turn: String, role: String = "You") -> TranscriptRow {
+        var row = TranscriptRow(id: "row-" + turn, role: role, text: "Text " + turn)
+        row.turnID = turn
+        return row
+    }
+    private func message(_ id: String, phase: PendingMessage.Phase = .queued) -> PendingMessage {
+        var message = PendingMessage(agentID: "a", input: "Text " + id, predecessor: "running", id: id)
+        message.phase = phase
+        return message
+    }
+    func testAdmissionHasExactlyOneRepresentationUntilExecution() {
+        let rows = [row("running"), row("queued")]
+        let waiting = MessageQueuePresentation(agentID: "a", rows: rows, pending: [message("queued")], activeTurns: ["running", "queued"], executingTurns: ["running"])
+        XCTAssertEqual(waiting.messages.map(\.id), ["queued"])
+        XCTAssertEqual(waiting.rows.map(\.turnID), ["running"])
+        let started = MessageQueuePresentation(agentID: "a", rows: rows, pending: [], activeTurns: ["queued"], executingTurns: ["queued"])
+        XCTAssertTrue(started.messages.isEmpty)
+        XCTAssertEqual(started.rows.map(\.turnID), ["running", "queued"])
+    }
+    func testFirstSendAndEveryUnresolvedStateStayInQueue() {
+        for phase in [PendingMessage.Phase.submitting, .queued, .starting, .cancelling, .failed] {
+            var message = message("first", phase: phase)
+            message.predecessor = ""
+            let projection = MessageQueuePresentation(agentID: "a", rows: [row("first")], pending: [message], activeTurns: ["first"])
+            XCTAssertEqual(projection.messages.count, 1)
+            XCTAssertTrue(projection.rows.isEmpty)
+            XCTAssertEqual(projection.messages[0].phase, phase)
+        }
+    }
+    func testRemoteQueueUsesServerOrderBeforeLocalPending() {
+        let projection = MessageQueuePresentation(agentID: "a", rows: [row("running"), row("remote"), row("local")],
+            pending: [message("local"), message("uploading", phase: .submitting)], activeTurns: ["running", "remote", "local"], executingTurns: ["running"])
+        XCTAssertEqual(projection.messages.map(\.id), ["remote", "local", "uploading"])
+        XCTAssertEqual(projection.messages.first?.interruption(activeTurns: ["running", "remote", "local"])?.turnID, "running")
+        XCTAssertEqual(projection.rows.map(\.turnID), ["running"])
+    }
+    func testQueueReconstructedWithoutLocalStoragePreservesAttachments() throws {
+        var queued = row("remote")
+        queued.imageFiles = [try MessageAttachment(name: "Photo.png", mediaType: "image/png", byteCount: 20)]
+        let projection = MessageQueuePresentation(agentID: "a", rows: [queued], pending: [], activeTurns: ["outside-history", "remote"], executingTurns: ["outside-history"])
+        XCTAssertEqual(projection.attachmentNames["remote"], ["Photo.png"])
+        XCTAssertNil(projection.messages.first?.attachments, "Remote attachments are not locally owned files")
+        XCTAssertEqual(projection.messages.first?.remoteAdmission, true)
+        XCTAssertTrue(projection.rows.isEmpty)
+    }
+    func testExecutionWinsOverLateSubmissionReceiptAndStaleQueueSnapshot() {
+        let projection = MessageQueuePresentation(agentID: "a", rows: [row("started")], pending: [message("started", phase: .submitting)],
+            activeTurns: ["older", "started"], executingTurns: ["older", "started"])
+        XCTAssertTrue(projection.messages.isEmpty)
+        XCTAssertEqual(projection.rows.count, 1)
+    }
+    func testQueueHeadDoesNotClaimToWaitBehindStalePredecessor() {
+        let projection = MessageQueuePresentation(agentID: "a", rows: [row("next")], pending: [message("next")], activeTurns: ["next"])
+        XCTAssertEqual(projection.messages.first?.queueTitle, "Waiting to start")
+        XCTAssertNil(projection.messages.first?.interruption(activeTurns: ["next"]))
+    }
+    func testAdoptedRemoteContentRefreshesWithoutLosingControlIntent() {
+        var adopted = message("remote", phase: .cancelling)
+        adopted.remoteAdmission = true
+        adopted.acceptedCursor = Cursor(rawValue: "42")
+        adopted.error = "Stop unconfirmed"
+        var loaded = row("remote")
+        loaded.text = "Actual queued request"
+        let projection = MessageQueuePresentation(agentID: "a", rows: [loaded], pending: [adopted],
+            activeTurns: ["running", "remote"], executingTurns: ["running"])
+        XCTAssertEqual(projection.messages.first?.input, "Actual queued request")
+        XCTAssertEqual(projection.messages.first?.phase, .cancelling)
+        XCTAssertEqual(projection.messages.first?.error, "Stop unconfirmed")
+        XCTAssertEqual(projection.messages.first?.acceptedCursor, adopted.acceptedCursor)
+        XCTAssertFalse(adopted.hasFinished(activeTurns: [], stateCursor: Cursor(rawValue: "41")!))
+        XCTAssertTrue(adopted.hasFinished(activeTurns: [], stateCursor: Cursor(rawValue: "43")!))
+    }
+    func testRemoteHeadNeedsExecutionEvidenceBeforePromotion() {
+        let waiting = MessageQueuePresentation(agentID: "a", rows: [row("head")], pending: [], activeTurns: ["head"])
+        XCTAssertEqual(waiting.messages.first?.queueTitle, "Waiting for execution update")
+        XCTAssertTrue(waiting.rows.isEmpty)
+        let started = MessageQueuePresentation(agentID: "a", rows: [row("head")], pending: [], activeTurns: ["head"], executingTurns: ["head"])
+        XCTAssertTrue(started.messages.isEmpty)
+        XCTAssertEqual(started.rows.count, 1)
+    }
+    func testMissingRemotePayloadStillOwnsItsQueuePosition() {
+        let projection = MessageQueuePresentation(agentID: "a", rows: [row("local")], pending: [message("local")],
+            activeTurns: ["running", "remote", "local"], executingTurns: ["running"])
+        XCTAssertEqual(projection.messages.map(\.id), ["remote", "local"])
+        XCTAssertEqual(projection.messages.first?.remoteAdmission, true)
+    }
+    func testCancellationDoesNotProduceNormalSubmittedBubble() {
+        let projection = MessageQueuePresentation(agentID: "a", rows: [row("cancelled")], pending: [], activeTurns: [], cancelledTurns: ["cancelled"])
+        XCTAssertTrue(projection.messages.isEmpty)
+        XCTAssertEqual(projection.rows.first?.role, "Status")
+        XCTAssertEqual(projection.rows.first?.text, "Cancelled request: Text cancelled")
+    }
+    func testOtherAgentAndStaleSnapshotDoNotHideOrLoseMessages() {
+        let unresolved = message("unconfirmed", phase: .failed)
+        let projection = MessageQueuePresentation(agentID: "a", rows: [row("unconfirmed")], pending: [unresolved], activeTurns: [])
+        XCTAssertEqual(projection.messages, [unresolved])
+        XCTAssertTrue(projection.rows.isEmpty)
+        let other = MessageQueuePresentation(agentID: "b", rows: [row("unconfirmed")], pending: [unresolved], activeTurns: [])
+        XCTAssertTrue(other.messages.isEmpty)
+        XCTAssertEqual(other.rows.count, 1)
+    }
+}

--- a/apple/InboxCore/Tests/InboxCoreTests/PendingMessageTests.swift
+++ b/apple/InboxCore/Tests/InboxCoreTests/PendingMessageTests.swift
@@ -25,15 +25,15 @@ final class PendingMessageTests: XCTestCase {
         XCTAssertEqual(try restored.submission.requestSpec().body?["input"].string, original.input)
         XCTAssertEqual(restored.contextIDs, ["capture-a"])
     }
-    func testForceOnlyCancelsCapturedPredecessor() throws {
+    func testSteeringCapturesPredecessorWithoutStoppingIt() throws {
         var message = PendingMessage(agentID: "agent-a", input: "New direction", predecessor: "old", id: "queued")
         XCTAssertNil(message.interruption)
         message.phase = .queued
         let spec = try XCTUnwrap(message.interruption).requestSpec()
-        XCTAssertEqual(spec.path, "/v1/agents/agent-a/turns/old/cancel")
-        XCTAssertNil(spec.body)
+        XCTAssertEqual(spec.path, "/v1/agents/agent-a/turns/old/steer")
+        XCTAssertEqual(spec.body, .object(["input": .string("New direction"), "message_id": .string("queued")]))
         message.phase = .starting
-        XCTAssertNil(message.interruption, "Repeated force taps cannot start another cancellation")
+        XCTAssertNil(message.interruption, "Repeated taps cannot dispatch another steer")
         message.restore()
         XCTAssertNil(message.interruption, "Relaunch must not turn an in-flight control into a fresh steer")
         XCTAssertEqual(message.phase, .starting)
@@ -42,7 +42,7 @@ final class PendingMessageTests: XCTestCase {
         var selfTarget = PendingMessage(agentID: "a", input: "x", predecessor: "same", id: "same")
         selfTarget.phase = .queued; XCTAssertNil(selfTarget.interruption)
     }
-    func testSteeringUsesQueueOrderAndNeverCancelsItsOwnOrNewerTurn() throws {
+    func testSteeringUsesQueueOrderAndNeverTargetsItsOwnOrNewerTurn() throws {
         var message = PendingMessage(agentID: "a", input: "Correction", predecessor: "finished", id: "queued")
         message.phase = .queued
         XCTAssertEqual(message.interruption(activeTurns: ["current", "queued"])?.turnID, "current")

--- a/apple/InboxCore/Tests/InboxCoreTests/PendingMessageTests.swift
+++ b/apple/InboxCore/Tests/InboxCoreTests/PendingMessageTests.swift
@@ -2,6 +2,25 @@ import XCTest
 @testable import InboxCore
 
 final class PendingMessageTests: XCTestCase {
+    func testTranscriptDeliveryLabelDistinguishesAdmissionFromExecution() {
+        var pending = PendingMessage(agentID: "a", input: "Correction", predecessor: "running", id: "queued")
+        func label(_ message: PendingMessage?) -> String? {
+            PendingMessage.deliveryLabel(turnID: "queued", pending: message, activeTurns: ["running", "queued"])
+        }
+        XCTAssertEqual(label(pending), "Sending…")
+        pending.phase = .queued
+        XCTAssertEqual(label(pending), "Queued · not started")
+        pending.phase = .starting
+        XCTAssertEqual(label(pending), "Queued · stopping current turn…")
+        pending.phase = .cancelling
+        XCTAssertEqual(label(pending), "Cancelling…")
+        pending.phase = .failed
+        XCTAssertEqual(label(pending), "Delivery unconfirmed")
+        XCTAssertEqual(label(nil), "Queued · not started", "Restored and other-device queues need the same label")
+        XCTAssertNil(PendingMessage.deliveryLabel(turnID: "queued", pending: nil, activeTurns: ["queued"]))
+        XCTAssertNil(PendingMessage.deliveryLabel(turnID: "queued", pending: nil, activeTurns: []))
+    }
+
     func testAttachmentReferencesSurviveRetryWithoutEmbeddingImageBytes() throws {
         let attachment = try MessageAttachment(name: "Image.jpg", byteCount: 4096)
         let message = PendingMessage(agentID: "a", input: "Describe this", predecessor: "previous", id: "same-turn", attachments: [attachment])

--- a/apple/InboxCore/Tests/InboxCoreTests/PendingMessageTests.swift
+++ b/apple/InboxCore/Tests/InboxCoreTests/PendingMessageTests.swift
@@ -2,25 +2,6 @@ import XCTest
 @testable import InboxCore
 
 final class PendingMessageTests: XCTestCase {
-    func testTranscriptDeliveryLabelDistinguishesAdmissionFromExecution() {
-        var pending = PendingMessage(agentID: "a", input: "Correction", predecessor: "running", id: "queued")
-        func label(_ message: PendingMessage?) -> String? {
-            PendingMessage.deliveryLabel(turnID: "queued", pending: message, activeTurns: ["running", "queued"])
-        }
-        XCTAssertEqual(label(pending), "Sending…")
-        pending.phase = .queued
-        XCTAssertEqual(label(pending), "Queued · not started")
-        pending.phase = .starting
-        XCTAssertEqual(label(pending), "Queued · stopping current turn…")
-        pending.phase = .cancelling
-        XCTAssertEqual(label(pending), "Cancelling…")
-        pending.phase = .failed
-        XCTAssertEqual(label(pending), "Delivery unconfirmed")
-        XCTAssertEqual(label(nil), "Queued · not started", "Restored and other-device queues need the same label")
-        XCTAssertNil(PendingMessage.deliveryLabel(turnID: "queued", pending: nil, activeTurns: ["queued"]))
-        XCTAssertNil(PendingMessage.deliveryLabel(turnID: "queued", pending: nil, activeTurns: []))
-    }
-
     func testAttachmentReferencesSurviveRetryWithoutEmbeddingImageBytes() throws {
         let attachment = try MessageAttachment(name: "Image.jpg", byteCount: 4096)
         let message = PendingMessage(agentID: "a", input: "Describe this", predecessor: "previous", id: "same-turn", attachments: [attachment])

--- a/apple/InboxCore/Tests/InboxCoreTests/SteeringTransferTests.swift
+++ b/apple/InboxCore/Tests/InboxCoreTests/SteeringTransferTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import XCTest
+@testable import InboxCore
+
+final class SteeringTransferTests: XCTestCase {
+    private let transfer = SteeringTransfer(agentID: "agent", sourceTurnID: "queued-source", targetTurnID: "running-target")
+    private var multimodalInput: JSON {
+        .array([
+            .object(["type": .string("text"), "text": .string("  Keep this\nexactly 🐝  ")]),
+            .object(["type": .string("image"), "image_url": .string("https://example.invalid/original.png?x=1&y=2")]),
+            .object(["type": .string("text"), "text": .string("Original video reference: /brain/attachments/original-video.mp4")])
+        ])
+    }
+
+    func testSteerUsesStableSourceMessageIDAndCapturedCurrentTarget() throws {
+        let command = transfer.command(input: .string("follow up"))
+        let spec = try command.requestSpec()
+        XCTAssertEqual(command.requestID, "queued-source")
+        XCTAssertEqual(command.turnID, "running-target")
+        XCTAssertEqual(spec.path, "/v1/agents/agent/turns/running%2Dtarget/steer")
+        XCTAssertEqual(spec.body, .object(["input": .string("follow up"), "message_id": .string("queued-source")]))
+        XCTAssertNil(spec.key)
+        XCTAssertEqual(transfer.command(input: .string("follow up")), command)
+    }
+
+    func testRawMultimodalInputIsPreservedExactlyAndOverridesConvenienceFields() throws {
+        var command = AgentCommand(agentID: "agent", turnID: "running-target", input: "must not replace original", kind: .steer, requestID: "queued-source")
+        command.images = [.string("must not append")]
+        command.rawInput = multimodalInput
+        XCTAssertEqual(try command.requestSpec().body, .object([
+            "input": multimodalInput, "message_id": .string("queued-source")
+        ]))
+        XCTAssertEqual(try transfer.command(input: multimodalInput).requestSpec().body, try command.requestSpec().body)
+    }
+
+    func testCancellationFencesQueuedSourceAndWithdrawalUsesOriginalSteerIdentity() throws {
+        let cancel = try transfer.sourceCancellation.requestSpec()
+        XCTAssertEqual(transfer.sourceCancellation.turnID, "queued-source")
+        XCTAssertEqual(cancel.path, "/v1/agents/agent/turns/queued%2Dsource/cancel")
+        XCTAssertNil(cancel.body)
+        XCTAssertNil(cancel.key)
+        let withdrawal = transfer.withdrawal
+        XCTAssertEqual(withdrawal.turnID, transfer.command(input: multimodalInput).turnID)
+        XCTAssertEqual(withdrawal.requestID, "queued-source")
+        let spec = try withdrawal.requestSpec()
+        XCTAssertEqual(spec.path, "/v1/agents/agent/turns/running%2Dtarget/withdraw-steer")
+        XCTAssertEqual(spec.body, .object(["message_id": .string("queued-source")]))
+        XCTAssertNil(spec.key)
+    }
+
+    func testSendingRestoreBecomesUnconfirmedAndNeverAutomaticallyResumes() throws {
+        var value = transfer
+        value.phase = .sending
+        value = try JSONDecoder().decode(SteeringTransfer.self, from: JSONEncoder().encode(value))
+        value.restore()
+        XCTAssertEqual(value.phase, .unconfirmed)
+        XCTAssertFalse(value.canResume)
+        XCTAssertNotNil(value.error)
+        let restored = value
+        value.restore()
+        XCTAssertEqual(value, restored)
+        XCTAssertFalse(value.canResume)
+        XCTAssertEqual(value.command(input: multimodalInput).requestID, "queued-source")
+    }
+
+    func testSafePreparationAndWithdrawalPhasesResumeAfterRestore() throws {
+        for phase: SteeringTransfer.Phase in [.preparing, .removingQueued, .ready, .withdrawing] {
+            var value = transfer
+            value.phase = phase
+            value = try JSONDecoder().decode(SteeringTransfer.self, from: JSONEncoder().encode(value))
+            value.restore()
+            XCTAssertEqual(value.phase, phase)
+            XCTAssertTrue(value.canResume, "\(phase)")
+        }
+        for phase: SteeringTransfer.Phase in [.sending, .accepted, .withdrawn, .unconfirmed] {
+            var value = transfer
+            value.phase = phase
+            XCTAssertFalse(value.canResume, "\(phase)")
+        }
+    }
+
+    func testCodableRoundTripRetainsIdentityPhaseAndWithdrawalIntent() throws {
+        for phase: SteeringTransfer.Phase in [.preparing, .removingQueued, .ready, .sending, .accepted, .withdrawing, .withdrawn, .unconfirmed] {
+            var value = transfer
+            value.phase = phase
+            value.error = "Response unavailable"
+            value.withdrawRequested = true
+            value.wasAccepted = true
+            let decoded = try JSONDecoder().decode(SteeringTransfer.self, from: JSONEncoder().encode(value))
+            XCTAssertEqual(decoded, value)
+            XCTAssertEqual(decoded.id, "queued-source")
+            XCTAssertEqual(decoded.command(input: multimodalInput), value.command(input: multimodalInput))
+            XCTAssertEqual(decoded.withdrawal, value.withdrawal)
+        }
+    }
+
+    func testReceiptsCannotConfirmAnotherTurnOrInferWithdrawal() {
+        XCTAssertTrue(transfer.sourceIsFenced(.object(["turn_id": .string("queued-source"), "state": .string("cancelling")])))
+        XCTAssertFalse(transfer.sourceIsFenced(.object(["turn_id": .string("running-target"), "state": .string("cancelling")])))
+        XCTAssertFalse(transfer.sourceIsFenced(.object(["turn_id": .string("queued-source"), "state": .string("completed")])))
+        XCTAssertTrue(transfer.isAccepted(.object(["turn_id": .string("running-target"), "state": .string("steering")])))
+        XCTAssertFalse(transfer.isAccepted(.object(["turn_id": .string("queued-source"), "state": .string("steering")])))
+        XCTAssertNil(transfer.withdrawalResult(.object(["turn_id": .string("running-target"), "message_id": .string("queued-source")])))
+        XCTAssertNil(transfer.withdrawalResult(.object(["turn_id": .string("running-target"), "message_id": .string("other"), "withdrawn": .bool(true)])))
+        XCTAssertEqual(transfer.withdrawalResult(.object(["turn_id": .string("running-target"), "message_id": .string("queued-source"), "withdrawn": .bool(false)])), false)
+    }
+
+    func testHTTPCommandsSendExactBodiesAndDistinctSourceAndTargetPaths() async throws {
+        let payload = multimodalInput
+        var paths: [String] = []
+        let fixture = try HTTPFixture { request in
+            paths.append(request.path)
+            XCTAssertEqual(request.method, "POST")
+            XCTAssertEqual(request.headers["authorization"], "Bearer " + fixtureKey)
+            XCTAssertNil(request.headers["idempotency-key"])
+            switch request.path {
+            case "/v1/agents/agent/turns/queued-source/cancel":
+                XCTAssertTrue(request.body.isEmpty)
+            case "/v1/agents/agent/turns/running-target/steer":
+                XCTAssertEqual(try? JSONDecoder().decode(JSON.self, from: request.body), .object([
+                    "input": payload, "message_id": .string("queued-source")
+                ]))
+            case "/v1/agents/agent/turns/running-target/withdraw-steer":
+                XCTAssertEqual(try? JSONDecoder().decode(JSON.self, from: request.body), .object([
+                    "message_id": .string("queued-source")
+                ]))
+            default: XCTFail("Unexpected request: \(request.path)")
+            }
+            return .init(body: "{}")
+        }
+        defer { fixture.close() }
+        let client = ManagedClient(credential: try AccountCredential(origin: fixture.origin, apiKey: fixtureKey), configuration: fixture.configuration)
+        defer { client.close() }
+        _ = try await client.command(transfer.sourceCancellation)
+        _ = try await client.command(transfer.command(input: payload))
+        _ = try await client.command(transfer.withdrawal)
+        XCTAssertEqual(paths, [
+            "/v1/agents/agent/turns/queued-source/cancel",
+            "/v1/agents/agent/turns/running-target/steer",
+            "/v1/agents/agent/turns/running-target/withdraw-steer"
+        ])
+    }
+}

--- a/apple/NanocodexInbox/InboxModel.swift
+++ b/apple/NanocodexInbox/InboxModel.swift
@@ -224,9 +224,32 @@ final class InboxModel: ObservableObject {
     var attentionCount: Int { cards.filter { $0.isInInbox(seen: seenCursor($0.id), deferred: deferred[$0.id]) && $0.needsAttention(seen: seenCursor($0.id)) }.count }
     var runningCount: Int { cards.filter(\.isRunning).count }
     var controllableTurns: [String] {
-        guard let card = focused else { return [] }
-        let queued = Set(pending.filter { $0.agentID == card.id }.map(\.id))
-        return card.activeTurns.filter { !queued.contains($0) }
+        guard let head = focused?.activeTurns.first else { return [] }
+        return pending.contains { $0.agentID == focused?.id && $0.id == head } ? [] : [head]
+    }
+    func queuePresentation(agentID: String, rows: [TranscriptRow]) -> MessageQueuePresentation {
+        let history = agentID == focused?.id ? events : tabHistories[agentID]?.events ?? []
+        let cancelled = Set(history.filter { $0.type == "turn_cancelled" }.map(\.turnID))
+        let started = Set(history.filter { event in
+            event.type == "event" && ["run.started", "assistant.delta", "assistant.message", "reasoning.summary.delta", "tool.call", "tool.result"].contains(event.data["event"]["type"].string)
+        }.map(\.turnID))
+        return MessageQueuePresentation(agentID: agentID, rows: rows, pending: pending,
+            activeTurns: cards.first { $0.id == agentID }?.activeTurns ?? [],
+            cancelledTurns: cancelled,
+            executingTurns: isDemo ? Set((cards.first { $0.id == agentID }?.activeTurns ?? []).prefix(1)) : started)
+    }
+    var focusedQueue: MessageQueuePresentation {
+        queuePresentation(agentID: focused?.id ?? "", rows: rows)
+    }
+    private func retainQueuedMessage(_ id: String) {
+        guard !pending.contains(where: { $0.id == id }),
+              var message = focusedQueue.messages.first(where: { $0.id == id }) else { return }
+        // The queue snapshot proves admission even when its history row has not
+        // loaded. Retain that watermark so reconnect can settle missing events.
+        if let cursor = cards.first(where: { $0.id == message.agentID })?.stateCursor {
+            message.acceptedCursor = max(message.acceptedCursor ?? .zero, cursor)
+        }
+        pending.append(message)
     }
     var focusedTurn: String { controllableTurns.contains(selectedTurn) ? selectedTurn : controllableTurns.first ?? "" }
     var stopTarget: String { focusedTurn.isEmpty ? focusedPending.first?.id ?? "" : focusedTurn }
@@ -234,7 +257,10 @@ final class InboxModel: ObservableObject {
         cancellations.first { $0.agentID == agentID && $0.turnID == turnID }
     }
     func steeringTarget(_ message: PendingMessage) -> AgentCommand? {
-        guard focusedPending.first?.id == message.id,
+        guard focusedQueue.messages.first(where: { candidate in
+                  let stop = cancellation(agentID: candidate.agentID, turnID: candidate.id)
+                  return !(candidate.phase == .cancelling && stop?.acknowledged == true && stop?.error == nil)
+              })?.id == message.id,
               let card = cards.first(where: { $0.id == message.agentID }) else { return nil }
         let available = card.activeTurns.filter { turnID in
             !cancellations.contains { $0.agentID == card.id && $0.turnID == turnID && $0.acknowledged && $0.error == nil }
@@ -1588,7 +1614,7 @@ final class InboxModel: ObservableObject {
         }
         catch { self.error = error.localizedDescription; return false }
         let attachments = focusedAttachments
-        let predecessor = focusedPending.last?.id ?? focusedTurn
+        let predecessor = focusedQueue.messages.last?.id ?? focusedTurn
         let message = PendingMessage(agentID: card.id, input: input, predecessor: predecessor, contextIDs: captured.map(\.id), attachments: attachments.isEmpty ? nil : attachments)
         attachmentDrafts[card.id] = nil; attachmentErrors[card.id] = nil
         pending.append(message); drafts[card.id] = ""; selectedContext[card.id] = nil; excludedContext[card.id] = nil; busy.insert(card.id); notice = nil; persist()
@@ -1599,6 +1625,7 @@ final class InboxModel: ObservableObject {
     }
     func retryPending(_ id: String) {
         guard let index = pending.firstIndex(where: { $0.id == id }), pending[index].phase == .failed,
+              pending[index].remoteAdmission != true,
               !busy.contains(pending[index].agentID) else { return }
         pending[index].phase = .submitting; pending[index].error = nil
         let message = pending[index], epoch = generation
@@ -1709,6 +1736,7 @@ final class InboxModel: ObservableObject {
     }
 
     private func submit(_ message: PendingMessage, epoch: UUID) async {
+        guard message.remoteAdmission != true else { return }
         defer {
             let agentID = resolvedAgentID(message.agentID)
             if generation == epoch, !pending.contains(where: { $0.agentID == agentID && $0.id != message.id && $0.phase == .submitting }) {
@@ -1766,6 +1794,8 @@ final class InboxModel: ObservableObject {
         }
     }
     func steerNow(_ id: String) {
+        guard connected else { return }
+        retainQueuedMessage(id)
         guard let message = pending.first(where: { $0.id == id }),
               let command = steeringTarget(message),
               let index = pending.firstIndex(where: { $0.id == id }) else { return }
@@ -1774,6 +1804,8 @@ final class InboxModel: ObservableObject {
         requestCancellation(agentID: message.agentID, turnID: command.turnID)
     }
     func cancelPending(_ id: String) {
+        guard connected else { return }
+        retainQueuedMessage(id)
         guard let index = pending.firstIndex(where: { $0.id == id }) else { return }
         // Nothing can reach the service before creation resolves.
         if pendingCreations.contains(pending[index].agentID) {
@@ -1986,7 +2018,16 @@ final class InboxModel: ObservableObject {
         // Cancelling a queued item must not start its successor while an older
         // turn is still running. Rebase the successor onto that older turn.
         let wasQueued = pending.contains { $0.agentID == agentID && $0.id == turnID }
-        if wasQueued { removeCancelledPending(turnID) }
+        if wasQueued {
+            var history = demoRows[agentID] ?? DemoContent.rows(agentID)
+            for index in history.indices where history[index].role == "You" && (history[index].turnID ?? history[index].id) == turnID {
+                history[index].role = "Status"
+                history[index].text = "Cancelled request: " + history[index].text
+            }
+            demoRows[agentID] = history
+            if focused?.id == agentID { rows = history }
+            removeCancelledPending(turnID)
+        }
         if let next = pending.first(where: { $0.agentID == agentID && $0.predecessor == turnID && $0.phase != .failed && $0.phase != .submitting }) {
             pending.removeAll { $0.id == next.id }
             var history = demoRows[agentID] ?? DemoContent.rows(agentID)
@@ -1999,7 +2040,8 @@ final class InboxModel: ObservableObject {
     }
     func stop(agentID: String, turnID: String) {
         guard !turnID.isEmpty else { return }
-        if pending.contains(where: { $0.agentID == agentID && $0.id == turnID }) { cancelPending(turnID) }
+        if pending.contains(where: { $0.agentID == agentID && $0.id == turnID })
+            || (agentID == focused?.id && focusedQueue.messages.contains(where: { $0.id == turnID })) { cancelPending(turnID) }
         else { requestCancellation(agentID: agentID, turnID: turnID) }
     }
     func retry() async { if let id = focused?.id, let command = retries[id], command.kind == .followUp { await perform(command) } }

--- a/apple/NanocodexInbox/InboxModel.swift
+++ b/apple/NanocodexInbox/InboxModel.swift
@@ -85,6 +85,8 @@ final class InboxModel: ObservableObject {
     @Published var pending: [PendingMessage] = [] { didSet { scheduleAgentNotifications() } }
     @Published private(set) var cancellations: [PendingTurnCancellation] = []
     private let cancellationTasks = TurnCancellationTasks()
+    private let steeringTasks = TurnCancellationTasks()
+    @Published var steeringTransfers: [SteeringTransfer] = []
     @Published private(set) var attachmentDrafts: [String: [MessageAttachment]] = [:]
     private var attachmentURLs: [String: URL] = [:]
     private var attachmentMovieURLs: [String: URL] = [:]
@@ -233,10 +235,23 @@ final class InboxModel: ObservableObject {
         let started = Set(history.filter { event in
             event.type == "event" && ["run.started", "assistant.delta", "assistant.message", "reasoning.summary.delta", "tool.call", "tool.result"].contains(event.data["event"]["type"].string)
         }.map(\.turnID))
-        return MessageQueuePresentation(agentID: agentID, rows: rows, pending: pending,
-            activeTurns: cards.first { $0.id == agentID }?.activeTurns ?? [],
-            cancelledTurns: cancelled,
-            executingTurns: isDemo ? Set((cards.first { $0.id == agentID }?.activeTurns ?? []).prefix(1)) : started)
+        let transfers = steeringTransfers.filter { $0.agentID == agentID }
+        let transferred = Set(transfers.map(\.sourceTurnID))
+        let displayed = rows.compactMap { row -> TranscriptRow? in
+            guard let transfer = transfers.first(where: { $0.sourceTurnID == (row.turnID ?? row.id) }) else { return row }
+            guard transfer.wasAccepted || transfer.phase == .withdrawn
+                || (transfer.phase == .unconfirmed && !pending.contains(where: { $0.id == transfer.id })) else { return nil }
+            guard row.role == "You" else { return nil }
+            var row = row
+            if transfer.phase == .withdrawn { row.role = "Status"; row.text = "Steering withdrawn: " + row.text }
+            else if !transfer.wasAccepted { row.role = "Status"; row.text = "Steering delivery unconfirmed: " + row.text; row.detail = transfer.error ?? "" }
+            else { row.detail = transfer.error ?? (transfer.phase == .withdrawing ? transfer.title : "Steering sent to the active turn") }
+            return row
+        }
+        let active = (cards.first { $0.id == agentID }?.activeTurns ?? []).filter { !transferred.contains($0) }
+        return MessageQueuePresentation(agentID: agentID, rows: displayed, pending: pending,
+            activeTurns: active, cancelledTurns: cancelled.subtracting(transferred),
+            executingTurns: (isDemo ? Set(active.prefix(1)) : started).subtracting(transferred))
     }
     var focusedQueue: MessageQueuePresentation {
         queuePresentation(agentID: focused?.id ?? "", rows: rows)
@@ -654,7 +669,7 @@ final class InboxModel: ObservableObject {
         scheduledJobs = []; scheduledJobAgents = [:]; schedulesLoading = false; schedulesLoaded = false; schedulesError = nil
         for task in creationTasks.values { task.cancel() }
         creationTasks = [:]; pendingCreations = []; creationErrors = [:]; createdAgentIDs = [:]
-        cancellationTasks.cancelAll(); cancellations = []
+        cancellationTasks.cancelAll(); cancellations = []; steeringTasks.cancelAll(); steeringTransfers = []
         deviceHand?.close(); deviceHand = nil; deviceHandConnected = false
         endHandBackgroundTime()
         #if os(iOS)
@@ -706,6 +721,7 @@ final class InboxModel: ObservableObject {
         guard connected, !isDemo, isActive else { return }
         for id in pendingCreations where creationErrors[id] == nil { prepareAgent(id) }
         resumeCancellations(restart: true)
+        resumeSteering()
         updateDeviceHand()
         let previousPolling = polling
         previousPolling?.cancel()
@@ -1793,18 +1809,129 @@ final class InboxModel: ObservableObject {
             }
         }
     }
+    func steeringTransfer(_ id: String) -> SteeringTransfer? { steeringTransfers.first { $0.id == id } }
     func steerNow(_ id: String) {
         guard connected else { return }
+        if let index = steeringTransfers.firstIndex(where: { $0.id == id }) {
+            guard steeringTransfers[index].canResume else { return }
+            steeringTransfers[index].error = nil
+            persist(); startSteering(id)
+            return
+        }
         retainQueuedMessage(id)
         guard let message = pending.first(where: { $0.id == id }),
               let command = steeringTarget(message),
               let index = pending.firstIndex(where: { $0.id == id }) else { return }
         pending[index].predecessor = command.turnID
         pending[index].phase = .starting; pending[index].error = nil
-        requestCancellation(agentID: message.agentID, turnID: command.turnID)
+        steeringTransfers.append(.init(agentID: message.agentID, sourceTurnID: id, targetTurnID: command.turnID))
+        persist(); startSteering(id)
+    }
+    private func resumeSteering() {
+        for transfer in steeringTransfers where transfer.canResume && transfer.error == nil { startSteering(transfer.id) }
+    }
+    func withdrawSteering(_ id: String) {
+        guard connected, let index = steeringTransfers.firstIndex(where: { $0.id == id }), steeringTransfers[index].phase != .withdrawn else { return }
+        steeringTransfers[index].withdrawRequested = true
+        steeringTransfers[index].error = nil
+        persist(); startSteering(id)
+    }
+    private func changeSteering(_ id: String, _ update: (inout SteeringTransfer) -> Void) {
+        guard let index = steeringTransfers.firstIndex(where: { $0.id == id }) else { return }
+        update(&steeringTransfers[index]); persist()
+    }
+    private func completeSteering(_ id: String) {
+        if let message = pending.first(where: { $0.id == id }) {
+            rebaseSuccessors(of: message)
+            pending.removeAll { $0.id == id }
+            releaseAttachments(message.attachments ?? [])
+        }
+        persist()
+    }
+    private func startSteering(_ id: String) {
+        let epoch = generation
+        steeringTasks.start(id) { [self] in
+            guard let initial = steeringTransfer(id), generation == epoch else { return }
+            prepareHandForBackground()
+            do {
+                var input: JSON = .null
+                if [.preparing, .removingQueued, .ready].contains(initial.phase) {
+                    // Re-read the exact admitted payload, including remote image/video
+                    // references. A transcript excerpt is never steering input.
+                    let source: JSON
+                    if isDemo { source = .object(["turn_id": .string(id), "input": .string(pending.first { $0.id == id }?.input ?? ""), "state": .string("accepted")]) }
+                    else {
+                        guard let client else { throw APIError.invalidCredential }
+                        source = try await client.turn(agentID: initial.agentID, turnID: id)
+                    }
+                    guard generation == epoch, !Task.isCancelled else { return }
+                    guard source["turn_id"].string == id, source["input"] != .null else { throw APIError.invalidResponse }
+                    input = source["input"]
+                    if initial.phase != .ready {
+                        guard ["accepted", "cancelling", "cancelled"].contains(source["state"].string) else { throw APIError.http(409) }
+                        changeSteering(id) { $0.phase = .removingQueued }
+                        await preferences.flush()
+                        guard generation == epoch, !Task.isCancelled else { return }
+                        let receipt = try await execute(initial.sourceCancellation)
+                        guard generation == epoch, !Task.isCancelled else { return }
+                        guard initial.sourceIsFenced(receipt) else { throw APIError.invalidResponse }
+                        // This is a durable fence for the queued follow-up. Its
+                        // terminal event can wait behind the still-running target.
+                        changeSteering(id) { $0.phase = .ready }
+                        handTasks.endObservation(id: id, outcome: .paused)
+                    }
+                    if steeringTransfer(id)?.withdrawRequested == true {
+                        changeSteering(id) { $0.phase = .withdrawn }
+                        completeSteering(id); return
+                    }
+                    changeSteering(id) { $0.phase = .sending }
+                    await preferences.flush()
+                    guard generation == epoch, !Task.isCancelled else { return }
+                    let receipt = try await execute(initial.command(input: input))
+                    guard generation == epoch, !Task.isCancelled else { return }
+                    guard initial.isAccepted(receipt) else { throw APIError.invalidResponse }
+                    changeSteering(id) { $0.phase = .accepted; $0.wasAccepted = true; $0.error = nil }
+                    completeSteering(id)
+                }
+                guard let current = steeringTransfer(id), current.withdrawRequested else { return }
+                changeSteering(id) { $0.phase = .withdrawing }
+                await preferences.flush()
+                guard generation == epoch, !Task.isCancelled else { return }
+                let receipt = try await execute(current.withdrawal)
+                guard generation == epoch, !Task.isCancelled else { return }
+                guard let withdrawn = current.withdrawalResult(receipt) else { throw APIError.invalidResponse }
+                if withdrawn {
+                    changeSteering(id) { $0.phase = .withdrawn; $0.error = nil }
+                    completeSteering(id)
+                } else {
+                    changeSteering(id) {
+                        $0.phase = $0.wasAccepted ? .accepted : .unconfirmed
+                        $0.error = "Steering could not be withdrawn; it may already be in use."
+                        $0.withdrawRequested = false
+                    }
+                    // The API cannot prove delivery after an uncertain send.
+                    // Keep that fact in history rather than claiming cancellation.
+                    if !current.wasAccepted { completeSteering(id) }
+                }
+            } catch {
+                guard generation == epoch, !Task.isCancelled else { return }
+                changeSteering(id) { transfer in
+                    if transfer.phase == .sending {
+                        if let api = error as? APIError, [.http(401), .http(403), .http(404), .http(409)].contains(api) {
+                            transfer.phase = .ready
+                            transfer.error = "Steering was rejected by the target turn. The message is retained; no replacement turn was started."
+                        } else {
+                            transfer.phase = .unconfirmed
+                            transfer.error = "Steering delivery is unconfirmed. It may already be in use; it will not be sent again automatically."
+                        }
+                    } else { transfer.error = "Steering could not be confirmed. Retry keeps the same message and target." }
+                }
+            }
+        }
     }
     func cancelPending(_ id: String) {
         guard connected else { return }
+        if steeringTransfer(id) != nil { withdrawSteering(id); return }
         retainQueuedMessage(id)
         guard let index = pending.firstIndex(where: { $0.id == id }) else { return }
         // Nothing can reach the service before creation resolves.
@@ -1943,10 +2070,10 @@ final class InboxModel: ObservableObject {
             if let intent = cancellation(agentID: id, turnID: event.turnID) { finishCancellation(intent, event: event) }
         }
         for event in events where event.type == "turn_cancelled" {
-            if pending.contains(where: { $0.agentID == id && $0.id == event.turnID }) { removeCancelledPending(event.turnID) }
+            if steeringTransfer(event.turnID) == nil, pending.contains(where: { $0.agentID == id && $0.id == event.turnID }) { removeCancelledPending(event.turnID) }
         }
         let finished = pending.filter { message in
-            message.agentID == id && (message.hasStarted(in: events)
+            message.agentID == id && steeringTransfer(message.id) == nil && (message.hasStarted(in: events)
                 || state.map { message.hasFinished(activeTurns: $0.activeTurns, stateCursor: $0.stateCursor) } == true)
         }
         for message in finished {
@@ -1967,9 +2094,23 @@ final class InboxModel: ObservableObject {
             cancellations = (try? JSONDecoder().decode([PendingTurnCancellation].self, from: data)) ?? []
             for index in cancellations.indices { cancellations[index].error = nil }
         }
-        // Migrate older saved in-flight controls without losing the user's Stop.
-        for message in pending where message.phase == .starting || message.phase == .cancelling {
-            let turnID = message.phase == .cancelling ? message.id : message.predecessor
+        if let data = UserDefaults.standard.data(forKey: "inbox.steering." + scope) {
+            steeringTransfers = (try? JSONDecoder().decode([SteeringTransfer].self, from: data)) ?? []
+            for index in steeringTransfers.indices { steeringTransfers[index].restore() }
+        }
+        // A crash can occur after the steering acknowledgement is persisted but
+        // before its source leaves pending. Complete that local bookkeeping.
+        for transfer in steeringTransfers where transfer.wasAccepted || transfer.phase == .withdrawn {
+            if pending.contains(where: { $0.id == transfer.id }) { completeSteering(transfer.id) }
+        }
+        for index in pending.indices where pending[index].phase == .starting && steeringTransfer(pending[index].id) == nil {
+            pending[index].phase = .queued
+            pending[index].error = "Steering has not been sent. Tap Steer now to update the active turn."
+        }
+        // Restore explicit queued cancellation, never infer a stop of the active
+        // turn from the old cancel-and-continue presentation phase.
+        for message in pending where message.phase == .cancelling {
+            let turnID = message.id
             let intent = PendingTurnCancellation(agentID: message.agentID, turnID: turnID)
             if !turnID.isEmpty, !cancellations.contains(where: { $0.id == intent.id }) { cancellations.append(intent) }
         }
@@ -1977,12 +2118,23 @@ final class InboxModel: ObservableObject {
     private func execute(_ command: AgentCommand) async throws -> JSON {
         voice.noteTypedInput(conversationID: command.agentID)
         if isDemo {
-            let delayKey = command.kind == .stop ? "NANOCODEX_DEMO_CANCEL_DELAY_MS" : "NANOCODEX_DEMO_DELAY_MS"
+            let delayKey = command.kind == .stop ? "NANOCODEX_DEMO_CANCEL_DELAY_MS" : command.kind == .steer ? "NANOCODEX_DEMO_STEER_DELAY_MS" : "NANOCODEX_DEMO_DELAY_MS"
             let delay = Int(ProcessInfo.processInfo.environment[delayKey] ?? ProcessInfo.processInfo.environment["NANOCODEX_DEMO_DELAY_MS"] ?? "200") ?? 200
             try await Task.sleep(for: .milliseconds(delay))
-            let fault = command.kind == .stop ? "cancel" : "submit"
+            let fault = command.kind == .stop ? "cancel" : command.kind == .steer ? "steer" : "submit"
             if ProcessInfo.processInfo.environment["NANOCODEX_DEMO_FAIL_ONCE"] == fault, demoFaults.insert(fault).inserted {
                 throw APIError.http(503)
+            }
+            if command.kind == .steer {
+                guard cards.contains(where: { $0.id == command.agentID && $0.activeTurns.contains(command.turnID) }) else { throw APIError.http(409) }
+                return .object(["turn_id": .string(command.turnID), "state": .string("steering")])
+            }
+            if command.kind == .withdrawSteer {
+                return .object(["turn_id": .string(command.turnID), "message_id": .string(command.requestID), "withdrawn": .bool(ProcessInfo.processInfo.environment["NANOCODEX_DEMO_STEER_CONSUMED"] != "1")])
+            }
+            if command.kind == .stop, steeringTransfer(command.turnID) != nil,
+               let index = cards.firstIndex(where: { $0.id == command.agentID }) {
+                cards[index].activeTurns.removeAll { $0 == command.turnID }
             }
             return .object(["turn_id": .string(command.kind == .followUp ? command.requestID : command.turnID), "state": .string(command.kind == .stop ? "cancelling" : "accepted")])
         }
@@ -2169,7 +2321,7 @@ final class InboxModel: ObservableObject {
         let scope = scope, drafts = drafts, attachmentDrafts = attachmentDrafts, seen = seen
         let closedConversationIDs = closedConversationIDs
         let selectedContext = selectedContext, excludedContext = excludedContext
-        let pending = pending, cancellations = cancellations, pendingCreations = pendingCreations
+        let pending = pending, cancellations = cancellations, steeringTransfers = steeringTransfers, pendingCreations = pendingCreations
         let isDemo = isDemo, demoRows = demoRows
         let demoTurns = isDemo ? Dictionary(uniqueKeysWithValues: cards.map { ($0.id, $0.activeTurns) }) : [:]
         preferences.enqueue { defaults in
@@ -2181,6 +2333,7 @@ final class InboxModel: ObservableObject {
             defaults.set(excludedContext, forKey: "inbox.contextExclusions." + scope)
             if let data = try? JSONEncoder().encode(pending) { defaults.set(data, forKey: "inbox.pending." + scope) }
             if let data = try? JSONEncoder().encode(cancellations) { defaults.set(data, forKey: "inbox.cancellations." + scope) }
+            if let data = try? JSONEncoder().encode(steeringTransfers) { defaults.set(data, forKey: "inbox.steering." + scope) }
             defaults.set(Array(pendingCreations), forKey: "inbox.creations." + scope)
             if isDemo {
                 if let data = try? JSONEncoder().encode(demoRows) { defaults.set(data, forKey: "inbox.demoRows." + scope) }
@@ -2229,6 +2382,7 @@ final class InboxModel: ObservableObject {
         }
         for id in pendingCreations { prepareAgent(id) }
         resumeCancellations()
+        resumeSteering()
         if ProcessInfo.processInfo.arguments.contains("--demo"),
            ProcessInfo.processInfo.environment["NANOCODEX_DEMO_VOICE"] == "1", let card = focused {
             voice.transcriptFeed.begin(conversationID: card.id, durableRows: rows, after: card.latestCursor)

--- a/apple/NanocodexInbox/InboxView.swift
+++ b/apple/NanocodexInbox/InboxView.swift
@@ -1370,7 +1370,12 @@ private struct ConversationMessageView: View {
     let agentID: String
     var pending: PendingMessage? = nil
     var body: some View {
-        ConversationMessageContent(row: row, model: model, agentID: agentID, pending: pending,
+        let turnID = row.turnID ?? row.id
+        let delivery = row.role == "You" ? PendingMessage.deliveryLabel(
+            turnID: turnID,
+            pending: pending ?? model.pending.first { $0.agentID == agentID && $0.id == turnID },
+            activeTurns: model.cards.first { $0.id == agentID }?.activeTurns ?? []) : nil
+        ConversationMessageContent(row: row, model: model, agentID: agentID, pending: pending, deliveryLabel: delivery,
                                    attachmentURLs: (pending?.attachments ?? []).map { model.attachmentURL($0) },
                                    movieURLs: (pending?.attachments ?? []).map { model.attachmentMovieURL($0) }).equatable()
     }
@@ -1381,10 +1386,11 @@ private struct ConversationMessageContent: View, Equatable {
     let model: InboxModel
     let agentID: String
     let pending: PendingMessage?
+    let deliveryLabel: String?
     let attachmentURLs: [URL?]
     let movieURLs: [URL?]
     static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.row == rhs.row && lhs.agentID == rhs.agentID && lhs.pending == rhs.pending
+        lhs.row == rhs.row && lhs.agentID == rhs.agentID && lhs.pending == rhs.pending && lhs.deliveryLabel == rhs.deliveryLabel
             && lhs.attachmentURLs == rhs.attachmentURLs && lhs.movieURLs == rhs.movieURLs
             && lhs.model === rhs.model
     }
@@ -1436,13 +1442,21 @@ private struct ConversationMessageContent: View, Equatable {
                                 .frame(maxWidth: 240).frame(height: 180).accessibilityIdentifier("message-image")
                         }
                     }
-                    Text(pending.phase == .cancelling ? "Cancelling…" : "Sending…").font(.caption).foregroundStyle(Ink.muted)
+                }
+                if let deliveryLabel {
+                    Text(deliveryLabel).font(.caption.weight(.medium)).foregroundStyle(Ink.muted)
+                        .accessibilityIdentifier("message-delivery-status")
                 }
             }
             .accessibilityElement(children: .contain)
             .accessibilityLabel(row.role == "You" ? "Your message" : row.role == "Agent" ? "Assistant message" : row.role)
             .padding(row.role == "You" ? 16 : 0)
             .background(row.role == "You" ? Ink.surface : Color.clear, in: RoundedRectangle(cornerRadius: 24))
+            .overlay {
+                if deliveryLabel != nil {
+                    RoundedRectangle(cornerRadius: 24).strokeBorder(Ink.border, style: StrokeStyle(lineWidth: 1, dash: [4, 4]))
+                }
+            }
             if row.role != "You" { Spacer(minLength: 0) }
         }.frame(maxWidth: .infinity, alignment: row.role == "You" ? .trailing : .leading)
     }

--- a/apple/NanocodexInbox/InboxView.swift
+++ b/apple/NanocodexInbox/InboxView.swift
@@ -774,10 +774,10 @@ private struct AgentComposerView: View {
                         ForEach(visiblePending) { message in
                             HStack(alignment: .center, spacing: 8) {
                                 VStack(alignment: .leading, spacing: 2) {
-                                    Text(message.queueTitle)
+                                    Text(model.steeringTransfer(message.id)?.title ?? message.queueTitle)
                                         .font(.system(size: 11)).foregroundStyle(Ink.muted)
                                     Text(ContextPrompt.separate(message.input)?.request ?? message.input).font(.system(size: 14))
-                                        .fixedSize(horizontal: false, vertical: true)
+                                        .fixedSize(horizontal: false, vertical: true).textSelection(.enabled)
                                         .accessibilityIdentifier("pending-message")
                                     if let names = model.focusedQueue.attachmentNames[message.id], !names.isEmpty {
                                         Label(names.joined(separator: ", "), systemImage: "photo")
@@ -798,14 +798,17 @@ private struct AgentComposerView: View {
                                             }
                                         }
                                     }
-                                    if let error = message.error { Text(error).font(.caption2).foregroundStyle(Ink.muted) }
+                                    if let error = model.steeringTransfer(message.id)?.error ?? message.error { Text(error).font(.caption2).foregroundStyle(Ink.muted) }
                                 }.frame(maxWidth: .infinity, alignment: .leading)
                                 if message.phase == .failed, message.remoteAdmission != true {
                                     Button { model.retryPending(message.id) } label: { Text("Retry").frame(minHeight: 44) }.accessibilityIdentifier("retry-pending")
                                         .disabled(model.busy.contains(message.agentID))
+                                } else if let transfer = model.steeringTransfer(message.id), transfer.error != nil && transfer.canResume {
+                                    Button("Retry steer") { model.steerNow(message.id) }.accessibilityIdentifier("retry-steering")
+                                        .disabled(!model.connected)
                                 } else if model.steeringTarget(message) != nil {
-                                    Button { model.steerNow(message.id) } label: { Text("Interrupt & run").frame(minHeight: 44) }.accessibilityIdentifier("steer-now")
-                                        .accessibilityHint("Stops the current turn so this queued message can run next")
+                                    Button { model.steerNow(message.id) } label: { Text("Steer now").frame(minHeight: 44) }.accessibilityIdentifier("steer-now")
+                                        .accessibilityHint("Sends this message into the current turn without stopping it")
                                         .disabled(!model.connected)
                                 }
                                 Button { model.cancelPending(message.id) } label: {
@@ -1394,7 +1397,11 @@ private struct ConversationMessageView: View {
     @ObservedObject var model: InboxModel
     let agentID: String
     var body: some View {
-        ConversationMessageContent(row: row, model: model, agentID: agentID).equatable()
+        let steering = model.steeringTransfer(row.turnID ?? row.id)
+        let canWithdraw = steering.map { transfer in
+            model.cards.first(where: { $0.id == agentID })?.activeTurns.contains(transfer.targetTurnID) == true
+        } ?? false
+        ConversationMessageContent(row: row, model: model, agentID: agentID, steering: steering, canWithdraw: canWithdraw).equatable()
     }
 }
 
@@ -1402,8 +1409,10 @@ private struct ConversationMessageContent: View, Equatable {
     let row: TranscriptRow
     let model: InboxModel
     let agentID: String
+    let steering: SteeringTransfer?
+    let canWithdraw: Bool
     static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.row == rhs.row && lhs.agentID == rhs.agentID
+        lhs.row == rhs.row && lhs.agentID == rhs.agentID && lhs.steering == rhs.steering && lhs.canWithdraw == rhs.canWithdraw
             && lhs.model === rhs.model
     }
     var body: some View {
@@ -1434,6 +1443,12 @@ private struct ConversationMessageContent: View, Equatable {
                     Text(row.text).font(.system(size: row.role == "Status" ? 14 : 17))
                         .lineSpacing(5).textSelection(.enabled)
                         .foregroundStyle(row.role == "Status" ? Ink.muted : Ink.text)
+                }
+                if !row.detail.isEmpty { Text(row.detail).font(.caption).foregroundStyle(Ink.muted) }
+                if let transfer = steering, canWithdraw, (transfer.wasAccepted || transfer.phase == .unconfirmed), transfer.phase != .withdrawn {
+                    Button(transfer.phase == .withdrawing ? "Withdrawing…" : "Withdraw steering") { model.withdrawSteering(transfer.id) }
+                        .font(.caption).accessibilityIdentifier("withdraw-steering")
+                        .disabled(!model.connected || (transfer.phase == .withdrawing && transfer.error == nil))
                 }
                 if let images = row.images {
                     ForEach(Array(images.filter { $0.hasPrefix("data:image/") }.enumerated()), id: \.offset) { _, image in

--- a/apple/NanocodexInbox/InboxView.swift
+++ b/apple/NanocodexInbox/InboxView.swift
@@ -580,7 +580,8 @@ private struct ConversationOverviewCard: View {
                     .accessibilityIdentifier("overview-close:" + card.id)
                 }
             }.padding(.leading, 12)
-            ConversationMiniature(model: model, card: card, rows: model.overviewRows(for: card.id)).equatable()
+            let queue = model.queuePresentation(agentID: card.id, rows: model.overviewRows(for: card.id))
+            ConversationMiniature(model: model, card: card, rows: queue.rows, pendingCount: queue.messages.count).equatable()
                     .frame(height: 230)
                     .frame(maxWidth: .infinity)
                     .background(Ink.background)
@@ -624,10 +625,11 @@ private struct ConversationMiniature: View, Equatable {
     let model: InboxModel
     let card: AgentCard
     let rows: [TranscriptRow]
+    let pendingCount: Int
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.card.id == rhs.card.id && lhs.card.activeTurns == rhs.card.activeTurns
             && lhs.card.error == rhs.card.error && lhs.card.checked == rhs.card.checked
-            && lhs.card.turnCount == rhs.card.turnCount && lhs.rows == rhs.rows
+            && lhs.card.turnCount == rhs.card.turnCount && lhs.rows == rhs.rows && lhs.pendingCount == rhs.pendingCount
     }
     private let scale: CGFloat = 0.48
 
@@ -635,7 +637,7 @@ private struct ConversationMiniature: View, Equatable {
         GeometryReader { viewport in
             let items = Array(ConversationItem.group(rows, activeTurns: card.activeTurns).suffix(4))
             VStack(alignment: .leading, spacing: 18) {
-                if items.isEmpty {
+                if items.isEmpty && pendingCount == 0 {
                     if let error = card.error {
                         Text(error).font(.system(size: 17)).foregroundStyle(Ink.muted)
                     } else if card.checked, card.turnCount == 0, card.previewRows.isEmpty {
@@ -660,6 +662,10 @@ private struct ConversationMiniature: View, Equatable {
                             InboxGeneratedOutputView(rows: item.activity).equatable()
                         }
                     }
+                }
+                if pendingCount > 0 {
+                    Label("\(pendingCount) pending message\(pendingCount == 1 ? "" : "s")", systemImage: "clock")
+                        .font(.system(size: 14)).foregroundStyle(Ink.muted)
                 }
             }
             .padding(20)
@@ -719,6 +725,7 @@ private struct AgentComposerView: View {
     @State private var photoTarget: InboxModel.AttachmentTarget?
     @State private var fileTarget: InboxModel.AttachmentTarget?
     @State private var pickerError: String?
+    @State private var queueContentHeight: CGFloat = 64
     #if os(iOS)
     @State private var showCamera = false
     @State private var cameraTarget: InboxModel.AttachmentTarget?
@@ -726,7 +733,7 @@ private struct AgentComposerView: View {
     #endif
 
     private var visiblePending: [PendingMessage] {
-        model.focusedPending.filter { !$0.predecessor.isEmpty || $0.phase == .failed }
+        model.focusedQueue.messages
     }
     private var sendShowsStop: Bool {
         model.draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -738,8 +745,7 @@ private struct AgentComposerView: View {
     }
     private var pendingHeight: CGFloat {
         let messages = visiblePending
-        if messages.count > 1 { return messages.contains { $0.attachments?.isEmpty == false } ? 136 : 104 }
-        return messages.first?.error == nil && (messages.first?.attachments?.isEmpty ?? true) ? 48 : 82
+        return messages.count > 1 ? 240 : 180
     }
 
     var body: some View {
@@ -768,31 +774,50 @@ private struct AgentComposerView: View {
                         ForEach(visiblePending) { message in
                             HStack(alignment: .center, spacing: 8) {
                                 VStack(alignment: .leading, spacing: 2) {
-                                    Text(message.phase == .submitting ? "Sending…" : message.phase == .starting ? "Stopping current turn…" : message.phase == .cancelling ? "Cancelling…" : message.phase == .failed ? "Not confirmed" : "Queued")
+                                    Text(message.queueTitle)
                                         .font(.system(size: 11)).foregroundStyle(Ink.muted)
-                                    Text(ContextPrompt.separate(message.input)?.request ?? message.input).font(.system(size: 13)).lineLimit(1)
+                                    Text(ContextPrompt.separate(message.input)?.request ?? message.input).font(.system(size: 14))
+                                        .fixedSize(horizontal: false, vertical: true)
                                         .accessibilityIdentifier("pending-message")
-                                    if let attachments = message.attachments, !attachments.isEmpty {
-                                        Label(attachments.map(\.name).joined(separator: ", "), systemImage: "photo")
+                                    if let names = model.focusedQueue.attachmentNames[message.id], !names.isEmpty {
+                                        Label(names.joined(separator: ", "), systemImage: "photo")
                                             .font(.caption2).lineLimit(1).accessibilityIdentifier("pending-attachments")
+                                    }
+                                    if let attachments = message.attachments, !attachments.isEmpty {
+                                        ScrollView(.horizontal) {
+                                            HStack {
+                                                ForEach(attachments) { attachment in
+                                                    if attachment.isVideo {
+                                                        AttachmentMovieThumbnail(attachment: attachment, poster: model.attachmentURL(attachment), movie: model.attachmentMovieURL(attachment))
+                                                            .frame(width: 64, height: 64)
+                                                    } else if let url = model.attachmentURL(attachment) {
+                                                        AttachmentImageView(source: .file(url), contentMode: .fit)
+                                                            .frame(width: 64, height: 64).accessibilityIdentifier("message-image")
+                                                    }
+                                                }
+                                            }
+                                        }
                                     }
                                     if let error = message.error { Text(error).font(.caption2).foregroundStyle(Ink.muted) }
                                 }.frame(maxWidth: .infinity, alignment: .leading)
-                                if message.phase == .failed {
+                                if message.phase == .failed, message.remoteAdmission != true {
                                     Button { model.retryPending(message.id) } label: { Text("Retry").frame(minHeight: 44) }.accessibilityIdentifier("retry-pending")
                                         .disabled(model.busy.contains(message.agentID))
                                 } else if model.steeringTarget(message) != nil {
-                                    Button { model.steerNow(message.id) } label: { Text("Steer now").frame(minHeight: 44) }.accessibilityIdentifier("steer-now")
+                                    Button { model.steerNow(message.id) } label: { Text("Interrupt & run").frame(minHeight: 44) }.accessibilityIdentifier("steer-now")
+                                        .accessibilityHint("Stops the current turn so this queued message can run next")
+                                        .disabled(!model.connected)
                                 }
                                 Button { model.cancelPending(message.id) } label: {
                                     Image(systemName: "xmark").frame(width: 44, height: 44).contentShape(Rectangle())
                                 }.accessibilityLabel("Cancel queued message")
-                                    .disabled(model.cancellation(agentID: message.agentID, turnID: message.id).map { $0.error == nil } ?? false)
+                                    .disabled(!model.connected || (model.cancellation(agentID: message.agentID, turnID: message.id).map { $0.error == nil } ?? false))
                             }.font(.system(size: 13, weight: .medium)).buttonStyle(.plain)
-                                .padding(.leading, 16)
+                                .padding(.horizontal, 16).padding(.vertical, 8)
                         }
                     }
-                }.frame(maxHeight: pendingHeight)
+                    .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { queueContentHeight = $0 }
+                }.frame(height: min(queueContentHeight, pendingHeight))
                     .padding(.top, 4)
                     .accessibilityIdentifier("pending-messages")
                 Rectangle().fill(Ink.border).frame(height: 0.5).padding(.horizontal, 16)
@@ -1368,16 +1393,8 @@ private struct ConversationMessageView: View {
     let row: TranscriptRow
     @ObservedObject var model: InboxModel
     let agentID: String
-    var pending: PendingMessage? = nil
     var body: some View {
-        let turnID = row.turnID ?? row.id
-        let delivery = row.role == "You" ? PendingMessage.deliveryLabel(
-            turnID: turnID,
-            pending: pending ?? model.pending.first { $0.agentID == agentID && $0.id == turnID },
-            activeTurns: model.cards.first { $0.id == agentID }?.activeTurns ?? []) : nil
-        ConversationMessageContent(row: row, model: model, agentID: agentID, pending: pending, deliveryLabel: delivery,
-                                   attachmentURLs: (pending?.attachments ?? []).map { model.attachmentURL($0) },
-                                   movieURLs: (pending?.attachments ?? []).map { model.attachmentMovieURL($0) }).equatable()
+        ConversationMessageContent(row: row, model: model, agentID: agentID).equatable()
     }
 }
 
@@ -1385,13 +1402,8 @@ private struct ConversationMessageContent: View, Equatable {
     let row: TranscriptRow
     let model: InboxModel
     let agentID: String
-    let pending: PendingMessage?
-    let deliveryLabel: String?
-    let attachmentURLs: [URL?]
-    let movieURLs: [URL?]
     static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.row == rhs.row && lhs.agentID == rhs.agentID && lhs.pending == rhs.pending && lhs.deliveryLabel == rhs.deliveryLabel
-            && lhs.attachmentURLs == rhs.attachmentURLs && lhs.movieURLs == rhs.movieURLs
+        lhs.row == rhs.row && lhs.agentID == rhs.agentID
             && lhs.model === rhs.model
     }
     var body: some View {
@@ -1432,31 +1444,11 @@ private struct ConversationMessageContent: View, Equatable {
                 }
                 ForEach(row.imageFiles ?? []) { OriginalImageAttachmentView(attachment: $0, model: model, agentID: agentID) }
                 ForEach(row.videos ?? []) { VideoAttachmentView(video: $0, model: model, agentID: agentID) }
-                if let pending {
-                    ForEach(pending.attachments ?? []) { attachment in
-                        if attachment.isVideo {
-                            AttachmentMovieThumbnail(attachment: attachment, poster: model.attachmentURL(attachment), movie: model.attachmentMovieURL(attachment))
-                                .frame(width: 200, height: 130)
-                        } else if let url = model.attachmentURL(attachment) {
-                            AttachmentImageView(source: .file(url), contentMode: .fit)
-                                .frame(maxWidth: 240).frame(height: 180).accessibilityIdentifier("message-image")
-                        }
-                    }
-                }
-                if let deliveryLabel {
-                    Text(deliveryLabel).font(.caption.weight(.medium)).foregroundStyle(Ink.muted)
-                        .accessibilityIdentifier("message-delivery-status")
-                }
             }
             .accessibilityElement(children: .contain)
             .accessibilityLabel(row.role == "You" ? "Your message" : row.role == "Agent" ? "Assistant message" : row.role)
             .padding(row.role == "You" ? 16 : 0)
             .background(row.role == "You" ? Ink.surface : Color.clear, in: RoundedRectangle(cornerRadius: 24))
-            .overlay {
-                if deliveryLabel != nil {
-                    RoundedRectangle(cornerRadius: 24).strokeBorder(Ink.border, style: StrokeStyle(lineWidth: 1, dash: [4, 4]))
-                }
-            }
             if row.role != "You" { Spacer(minLength: 0) }
         }.frame(maxWidth: .infinity, alignment: row.role == "You" ? .trailing : .leading)
     }
@@ -1479,7 +1471,7 @@ private struct ConversationView: View {
     var body: some View {
         ConversationContentView(model: model,
                                 identity: identity, readingPositions: readingPositions,
-                                revision: .init(rows: model.rows, pending: model.focusedPending,
+                                revision: .init(rows: model.focusedQueue.rows, pending: model.focusedQueue.messages,
                                                 title: model.focused?.title ?? "Conversation",
                                                 activeTurns: model.focused?.activeTurns ?? [],
                                                 loading: model.threadLoading, error: model.threadError,
@@ -1520,12 +1512,6 @@ private struct ConversationContentView: View, Equatable {
     @State private var historyDirection: HistoryDirection?
     @State private var historyRequestInFlight = false
     @State private var historyRequestFirstID: String?
-    private var pendingSubmissions: [PendingMessage] {
-        model.focusedPending.filter { message in
-            message.predecessor.isEmpty && message.phase != .failed
-                && !model.rows.contains { $0.role == "You" && ($0.id == message.id || $0.turnID == message.id) }
-        }
-    }
     private func rememberHistoryPosition(in viewport: GeometryProxy) {
         model.protectHistoryRows(Set(rowFrames.filter { $0.value.maxY > 0 && $0.value.minY < viewport.size.height }.keys))
         guard let first = rowFrames.filter({ $0.value.maxY > 0 && $0.value.minY < viewport.size.height })
@@ -1587,7 +1573,7 @@ private struct ConversationContentView: View, Equatable {
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
                 LazyVStack(alignment: .leading, spacing: 18) {
-                    if model.rows.isEmpty, pendingSubmissions.isEmpty, !model.threadLoading, model.threadError == nil {
+                    if model.rows.isEmpty, model.focusedQueue.messages.isEmpty, !model.threadLoading, model.threadError == nil {
                         VStack(alignment: .leading, spacing: 8) {
                             if model.hasOlder {
                                 Text("Earlier messages").font(.title2.weight(.medium))
@@ -1600,7 +1586,7 @@ private struct ConversationContentView: View, Equatable {
                         }.padding(.top, 24).accessibilityElement(children: .contain).accessibilityIdentifier("conversation-empty")
                     }
                     if let error = model.threadError { Text(error).font(.subheadline).foregroundStyle(Ink.muted) }
-                    ForEach(ConversationItem.group(model.rows, activeTurns: model.focused?.activeTurns ?? [])) { item in
+                    ForEach(ConversationItem.group(model.focusedQueue.rows, activeTurns: model.focused?.activeTurns ?? [])) { item in
                         Group {
                         if let row = item.message {
                         ConversationMessageView(row: row, model: model, agentID: model.focused?.id ?? "")
@@ -1616,12 +1602,6 @@ private struct ConversationContentView: View, Equatable {
                             })
                             .accessibilityElement(children: .contain)
                             .accessibilityIdentifier((item.message?.role == "You" ? "message-user-" : item.message?.role == "Agent" ? "message-assistant-" : "message-") + item.id)
-                    }
-                    ForEach(pendingSubmissions) { message in
-                        ConversationMessageView(row: .init(id: message.id, role: "You", text: message.input),
-                                                model: model, agentID: message.agentID, pending: message)
-                            .accessibilityElement(children: .contain)
-                            .accessibilityIdentifier("message-user-pending-" + message.id)
                     }
                 }.scrollTargetLayout()
                     // Keep the bottom target outside the lazy rows so it has a

--- a/apple/NanocodexInbox/InboxView.swift
+++ b/apple/NanocodexInbox/InboxView.swift
@@ -633,7 +633,7 @@ private struct ConversationMiniature: View, Equatable {
 
     var body: some View {
         GeometryReader { viewport in
-            let items = Array(ConversationItem.group(rows, activeTurns: Set(card.activeTurns)).suffix(4))
+            let items = Array(ConversationItem.group(rows, activeTurns: card.activeTurns).suffix(4))
             VStack(alignment: .leading, spacing: 18) {
                 if items.isEmpty {
                     if let error = card.error {
@@ -1586,7 +1586,7 @@ private struct ConversationContentView: View, Equatable {
                         }.padding(.top, 24).accessibilityElement(children: .contain).accessibilityIdentifier("conversation-empty")
                     }
                     if let error = model.threadError { Text(error).font(.subheadline).foregroundStyle(Ink.muted) }
-                    ForEach(ConversationItem.group(model.rows, activeTurns: Set(model.focused?.activeTurns ?? []))) { item in
+                    ForEach(ConversationItem.group(model.rows, activeTurns: model.focused?.activeTurns ?? [])) { item in
                         Group {
                         if let row = item.message {
                         ConversationMessageView(row: row, model: model, agentID: model.focused?.id ?? "")

--- a/apple/NanocodexInboxUITests/InboxUITests.swift
+++ b/apple/NanocodexInboxUITests/InboxUITests.swift
@@ -1430,6 +1430,12 @@ final class InboxUITests: XCTestCase {
 
         XCTAssertTrue(app.scrollViews["conversation"].waitForExistence(timeout: 5))
         let conversation = app.scrollViews["conversation"]
+        // A queued message has one representation in the queue, not a sent bubble.
+        let queued = app.scrollViews["pending-messages"].staticTexts.matching(NSPredicate(format: "label == %@", text))
+        if queued.count == 1 {
+            XCTAssertFalse(conversation.staticTexts[text].exists)
+            return
+        }
         let message = conversation.staticTexts[text]
         if !message.isHittable { conversation.swipeUp() }
         XCTAssertTrue(message.waitForExistence(timeout: 5))
@@ -1471,6 +1477,26 @@ final class InboxUITests: XCTestCase {
         XCTAssertEqual(self.selectedConversationTab(app).label, "Build the agent inbox")
         XCTAssertFalse(app.staticTexts["Running"].exists)
         capture(app, "glass-tabs-centered-create-no-duplicate-title")
+    }
+
+    func testQueueOwnsMessageUntilExecutionStarts() {
+        let app = launch(["NANOCODEX_DEMO_PROFILE": UUID().uuidString, "NANOCODEX_DEMO_COMPLETE_AFTER_MS": "60000",
+                          "NANOCODEX_DEMO_CANCEL_DELAY_MS": "2000"])
+        selectInbox(app)
+        let text = "Show Blender on each VM desktop"
+        queue(app, text)
+        let queueView = app.scrollViews["pending-messages"]
+        XCTAssertTrue(queueView.staticTexts[text].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.scrollViews["conversation"].staticTexts[text].exists)
+        XCTAssertEqual(app.staticTexts.matching(NSPredicate(format: "label == %@", text)).count, 1)
+        XCTAssertEqual(app.buttons["steer-now"].label, "Interrupt & run")
+        capture(app, "queue-single-representation")
+        app.buttons["steer-now"].tap()
+        XCTAssertTrue(queueView.staticTexts["Stopping current turn…"].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.scrollViews["conversation"].staticTexts[text].exists)
+        gone(app.staticTexts["pending-message"])
+        thread(app, contains: text)
+        capture(app, "queue-promoted-on-execution")
     }
 
     func testTabsPreserveIndependentDraftsAndQueuedSteering() {
@@ -1535,10 +1561,10 @@ final class InboxUITests: XCTestCase {
     }
 
     func testFailedSubmissionRetainsMessageAndRetriesOnce() {
-        let app = launch(["NANOCODEX_DEMO_FAIL_ONCE": "submit"])
+        let app = launch(["NANOCODEX_DEMO_FAIL_ONCE": "submit", "NANOCODEX_DEMO_PROFILE": UUID().uuidString])
         selectInbox(app); queue(app, "Retry only once")
         XCTAssertTrue(app.buttons["retry-pending"].waitForExistence(timeout: 5))
-        selectTab(app, id: "durability", title: "Make long sessions bulletproof"); selectInbox(app)
+        selectTab(app, id: "data", title: "Tighten the fuel forecast"); selectInbox(app)
         app.buttons["retry-pending"].doubleTap()
         XCTAssertTrue(app.buttons["steer-now"].waitForExistence(timeout: 5))
         thread(app, contains: "Retry only once")
@@ -1660,7 +1686,7 @@ final class InboxUITests: XCTestCase {
         XCTAssertTrue(app.buttons["steer-now"].waitForExistence(timeout: 5))
         app.buttons["Cancel queued message"].tap(); gone(app.staticTexts["pending-message"])
         XCTAssertTrue(app.buttons["Stop turn"].exists, "Cancelling the queued message keeps its predecessor running")
-        thread(app, contains: "Survive restart")
+        XCTAssertTrue(app.staticTexts["Cancelled request: Survive restart"].waitForExistence(timeout: 5))
     }
     func testQueuedMessageStartsNaturallyWhileReadingThread() {
         let app = launch(["NANOCODEX_DEMO_COMPLETE_AFTER_MS": "2500"])

--- a/apple/NanocodexInboxUITests/InboxUITests.swift
+++ b/apple/NanocodexInboxUITests/InboxUITests.swift
@@ -1479,7 +1479,7 @@ final class InboxUITests: XCTestCase {
         capture(app, "glass-tabs-centered-create-no-duplicate-title")
     }
 
-    func testQueueOwnsMessageUntilExecutionStarts() {
+    func testQueueBecomesSteeringWithoutStoppingCurrentTurn() {
         let app = launch(["NANOCODEX_DEMO_PROFILE": UUID().uuidString, "NANOCODEX_DEMO_COMPLETE_AFTER_MS": "60000",
                           "NANOCODEX_DEMO_CANCEL_DELAY_MS": "2000"])
         selectInbox(app)
@@ -1489,16 +1489,51 @@ final class InboxUITests: XCTestCase {
         XCTAssertTrue(queueView.staticTexts[text].waitForExistence(timeout: 5))
         XCTAssertFalse(app.scrollViews["conversation"].staticTexts[text].exists)
         XCTAssertEqual(app.staticTexts.matching(NSPredicate(format: "label == %@", text)).count, 1)
-        XCTAssertEqual(app.buttons["steer-now"].label, "Interrupt & run")
+        XCTAssertEqual(app.buttons["steer-now"].label, "Steer now")
         capture(app, "queue-single-representation")
         app.buttons["steer-now"].tap()
-        XCTAssertTrue(queueView.staticTexts["Stopping current turn…"].waitForExistence(timeout: 5))
+        XCTAssertTrue(queueView.staticTexts["Preparing steering…"].waitForExistence(timeout: 5))
         XCTAssertFalse(app.scrollViews["conversation"].staticTexts[text].exists)
         gone(app.staticTexts["pending-message"])
         thread(app, contains: text)
-        capture(app, "queue-promoted-on-execution")
+        XCTAssertEqual(app.buttons["send"].label, "Stop turn")
+        XCTAssertEqual(app.buttons["browser-tab:inbox"].value as? String, "Running")
+        XCTAssertFalse(app.staticTexts["Working on: " + text].exists, "Steering must not launch another turn")
+        XCTAssertTrue(app.buttons["withdraw-steering"].exists)
+        app.terminate(); app.launch(); selectInbox(app)
+        XCTAssertFalse(app.staticTexts["pending-message"].exists)
+        thread(app, contains: text)
+        XCTAssertTrue(app.buttons["withdraw-steering"].waitForExistence(timeout: 5))
+        app.buttons["withdraw-steering"].tap()
+        XCTAssertTrue(app.staticTexts["Steering withdrawn: " + text].waitForExistence(timeout: 5))
+        XCTAssertEqual(app.buttons["send"].label, "Stop turn")
+        capture(app, "steering-api-withdrawn-current-turn-running")
     }
 
+    func testSteeringResponseLossSurvivesRelaunchWithoutResubmission() {
+        let app = launch(["NANOCODEX_DEMO_PROFILE": UUID().uuidString, "NANOCODEX_DEMO_FAIL_ONCE": "steer"])
+        selectInbox(app); queue(app, "Retain uncertain steering")
+        XCTAssertTrue(app.buttons["steer-now"].waitForExistence(timeout: 5))
+        app.buttons["steer-now"].tap()
+        XCTAssertTrue(app.staticTexts["Steering delivery unconfirmed"].waitForExistence(timeout: 8))
+        XCTAssertFalse(app.buttons["retry-steering"].exists)
+        app.terminate(); app.launch(); selectInbox(app)
+        XCTAssertTrue(app.staticTexts["Steering delivery unconfirmed"].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.buttons["steer-now"].exists)
+        app.buttons["Cancel queued message"].tap()
+        gone(app.staticTexts["pending-message"])
+        XCTAssertEqual(app.buttons["send"].label, "Stop turn")
+    }
+    func testConsumedSteeringCannotBePresentedAsWithdrawn() {
+        let app = launch(["NANOCODEX_DEMO_PROFILE": UUID().uuidString, "NANOCODEX_DEMO_STEER_CONSUMED": "1"])
+        selectInbox(app); queue(app, "Already consumed steering")
+        XCTAssertTrue(app.buttons["steer-now"].waitForExistence(timeout: 5))
+        app.buttons["steer-now"].tap(); gone(app.staticTexts["pending-message"])
+        app.buttons["withdraw-steering"].tap()
+        XCTAssertTrue(app.staticTexts["Steering could not be withdrawn; it may already be in use."].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.staticTexts["Steering withdrawn: Already consumed steering"].exists)
+        XCTAssertEqual(app.buttons["send"].label, "Stop turn")
+    }
     func testTabsPreserveIndependentDraftsAndQueuedSteering() {
         let app = launch(["NANOCODEX_DEMO_PROFILE": UUID().uuidString])
         selectTab(app, id: "durability", title: "Make long sessions bulletproof")
@@ -1624,7 +1659,7 @@ final class InboxUITests: XCTestCase {
         let cancel = app.buttons["Cancel queued message"]
         XCTAssertTrue(cancel.isEnabled, "Steering must not disable cancelling the queued message")
         cancel.tap(); gone(app.staticTexts["pending-message"], timeout: 10)
-        XCTAssertEqual(XCTWaiter.wait(for: [XCTNSPredicateExpectation(predicate: NSPredicate(format: "value == %@", "Stopped"), object: app.buttons["browser-tab:inbox"])], timeout: 10), .completed)
+        XCTAssertEqual(XCTWaiter.wait(for: [XCTNSPredicateExpectation(predicate: NSPredicate(format: "value == %@", "Running"), object: app.buttons["browser-tab:inbox"])], timeout: 10), .completed)
     }
     func testLiveCancelQueuedMessageThenSteerItsSuccessor() throws {
         guard ProcessInfo.processInfo.environment["NANOCODEX_INBOX_LIVE"] == "1" else { throw XCTSkip("Requires a signed-in physical phone.") }
@@ -1672,8 +1707,8 @@ final class InboxUITests: XCTestCase {
         selectInbox(app); queue(app, "Keep the captured target")
         XCTAssertTrue(app.buttons["steer-now"].waitForExistence(timeout: 5))
         app.buttons["steer-now"].tap()
-        XCTAssertTrue(app.staticTexts["Cancellation unconfirmed. The queued message is retained; try again."].waitForExistence(timeout: 5))
-        app.buttons["steer-now"].tap(); gone(app.staticTexts["pending-message"])
+        XCTAssertTrue(app.buttons["retry-steering"].waitForExistence(timeout: 5))
+        app.buttons["retry-steering"].tap(); gone(app.staticTexts["pending-message"])
         thread(app, contains: "Keep the captured target")
     }
     func testPendingSurvivesRelaunchAndCanBeCancelled() {
@@ -1711,7 +1746,8 @@ final class InboxUITests: XCTestCase {
         XCTAssertEqual(app.staticTexts["pending-message"].label, "Second queued message")
         app.buttons["steer-now"].tap(); gone(app.staticTexts["pending-message"])
         thread(app, contains: "Second queued message")
-        XCTAssertTrue(app.staticTexts["Working on: Second queued message"].exists)
+        XCTAssertTrue(app.staticTexts["Steering sent to the active turn"].exists)
+        XCTAssertEqual(app.buttons["send"].label, "Stop turn")
     }
     func testFinishedAgentStaysSelectedUntilAnotherTabIsTapped() {
         let app = launch(["NANOCODEX_DEMO_FINISH_IN_THREAD": "1"])

--- a/apple/README.md
+++ b/apple/README.md
@@ -142,7 +142,7 @@ Return/Tab/Esc controls below the video.
 | Scroll a conversation | Read the full history, reasoning, and expandable tool details while keeping the composer available |
 | Attachment plus → Camera / Photos & Videos / Files | Take a photo or attach photos/videos; preview or remove attachments before sending |
 | Send / ⌘Return | Submit one durable follow-up; queue behind current work and dismiss the iPhone/iPad keyboard |
-| Interrupt & run on queued message | Cancel the unfinished turn ahead of it so the follow-up can start |
+| Steer now on queued message | Inject the queued input into the active turn through the steering API |
 | Voice | Start an interactive spoken conversation with this agent; minimize the panel to keep talking |
 | Stop turn | Immediately cancel the selected turn from the send button |
 | Bottom menu → Account settings | Manage the account and device Hand |
@@ -196,9 +196,18 @@ on the service. Foregrounding reloads history and resumes. Active-turn state
 reads cannot overwrite newer streamed events. Changing accounts invalidates old
 callbacks and cancels owned requests. Follow-up retries reuse the same turn ID
 and idempotency key. The compact queued-message row sits flush above the input inside the composer surface and survives navigation and relaunch.
-“Interrupt & run” uses cancel-and-continue: it resolves the unfinished predecessor from
-the current queue, captures that exact target at the tap, and cancels it without
-resubmitting the durable follow-up. This is not in-flight runtime injection.
+“Steer now” reads the queued turn's exact admitted input, durably cancels only
+that queued follow-up, and posts its payload to the captured active turn's
+`/steer` endpoint with a stable `message_id`. The active turn keeps running;
+the runtime applies steering at its model boundary. Cancellation of the queued
+source prevents the same input from also executing as a later turn.
+`/withdraw-steer` handles withdrawal with the same identity. A false response
+means withdrawal was not confirmed, never that the active turn should be stopped.
+Steering transfer phases and accepted markers survive relaunch. An uncertain
+POST is retained as unconfirmed and is not automatically retried: identified
+steering rejects duplicate identities, and `run.steered` does not identify the
+client message. Accepted steering is shown in conversation with a steering label;
+preparation/errors remain in the queue. Terminal-target rejection retains input.
 Stop and queued-message cancellation remain available during submission and
 account refresh. Cancellation intent survives relaunch; the send button shows
 progress until the exact turn is terminal, with a retry on an unconfirmed stop.
@@ -603,7 +612,7 @@ Verified on 2026-09-06: seven native UI checks passed, including creation delaye
 
 Conversation scroll targets retain the visible message across prepended history and new output, and new conversations open at the latest messages. Returning to the foreground resumes the existing cursor and transcript rather than clearing the screen. Conversation scrolling preserves the selected agent; navigation uses the tab strip and overview.
 
-The conversation keeps the same agent composer fixed above the keyboard while you read older messages. Sending dismisses the iPhone/iPad keyboard. Pending input appears once in the queue above the composer, including first sends, attachments, and delivery errors. Admission does not create a sent bubble: execution evidence promotes the message into the conversation. The queue follows server order across devices and relaunch; messages whose content has not loaded retain a placeholder and queue position. Cancelling and retrying keep the same identity. “Interrupt & run” stops the current turn to let the next queued message run. With an empty draft and a running turn, the send button becomes Stop; adding text or an image restores Send in the same position. Drafts, queued follow-ups, steering, and stop controls belong to the selected agent. Switching tabs or opening the overview preserves that work.
+The conversation keeps the same agent composer fixed above the keyboard while you read older messages. Sending dismisses the iPhone/iPad keyboard. Pending input appears once in the queue above the composer, including first sends, attachments, and delivery errors. Follow-up admission does not create a sent bubble: execution evidence promotes it into the conversation. API-accepted steering appears with an explicit steering label. The queue follows server order across devices and relaunch; messages whose content has not loaded retain a placeholder and queue position. Cancelling and retrying keep the same identity. “Steer now” injects the input through the active turn’s steering API without stopping that turn. With an empty draft and a running turn, the send button becomes Stop; adding text or an image restores Send in the same position. Drafts, queued follow-ups, steering, and stop controls belong to the selected agent. Switching tabs or opening the overview preserves that work.
 
 Verified on 2026-09-08: focused iPhone/iPad checks cover browser tabs, searchable live previews, the All/Running filter, app-menu navigation, independent drafts, keyboard placement, point-based reading restoration, slow creation, cancellation, and retry. The signed-in iPhone 17 Pro completed a real reply, relaunched, and retained both messages through three round trips to other tabs. InboxCore passed 68 tests with three skips. The top tab strip, bottom Back/+/overview/screens/menu bar, Back draft restoration, and activity-sorted overview were checked in iPhone and iPad simulators. These tab checks do not establish voice latency or microphone performance.
 

--- a/apple/README.md
+++ b/apple/README.md
@@ -142,7 +142,7 @@ Return/Tab/Esc controls below the video.
 | Scroll a conversation | Read the full history, reasoning, and expandable tool details while keeping the composer available |
 | Attachment plus → Camera / Photos & Videos / Files | Take a photo or attach photos/videos; preview or remove attachments before sending |
 | Send / ⌘Return | Submit one durable follow-up; queue behind current work and dismiss the iPhone/iPad keyboard |
-| Steer now on queued message | Cancel the unfinished turn ahead of it so the follow-up can start |
+| Interrupt & run on queued message | Cancel the unfinished turn ahead of it so the follow-up can start |
 | Voice | Start an interactive spoken conversation with this agent; minimize the panel to keep talking |
 | Stop turn | Immediately cancel the selected turn from the send button |
 | Bottom menu → Account settings | Manage the account and device Hand |
@@ -196,15 +196,15 @@ on the service. Foregrounding reloads history and resumes. Active-turn state
 reads cannot overwrite newer streamed events. Changing accounts invalidates old
 callbacks and cancels owned requests. Follow-up retries reuse the same turn ID
 and idempotency key. The compact queued-message row sits flush above the input inside the composer surface and survives navigation and relaunch.
-“Steer now” uses cancel-and-continue: it resolves the unfinished predecessor from
+“Interrupt & run” uses cancel-and-continue: it resolves the unfinished predecessor from
 the current queue, captures that exact target at the tap, and cancels it without
 resubmitting the durable follow-up. This is not in-flight runtime injection.
 Stop and queued-message cancellation remain available during submission and
 account refresh. Cancellation intent survives relaunch; the send button shows
 progress until the exact turn is terminal, with a retry on an unconfirmed stop.
-A queued message leaves the visible queue once its cancellation is durably
-acknowledged, so its successor can be steered while terminal confirmation
-continues in the background. Its cancellation and input remain saved until then.
+A cancelling message stays in the queue until terminal confirmation. Once its
+cancellation is durably acknowledged, its successor can be interrupted for;
+the cancelled request is retained in history as a cancellation, not a sent bubble.
 A confirmed cancellation before admission fences any late submission of that ID.
 Late send acknowledgements cannot undo cancellation. Failed sends retain input
 and retry the same identity.
@@ -603,7 +603,7 @@ Verified on 2026-09-06: seven native UI checks passed, including creation delaye
 
 Conversation scroll targets retain the visible message across prepended history and new output, and new conversations open at the latest messages. Returning to the foreground resumes the existing cursor and transcript rather than clearing the screen. Conversation scrolling preserves the selected agent; navigation uses the tab strip and overview.
 
-The conversation keeps the same agent composer fixed above the keyboard while you read older messages. Sending dismisses the iPhone/iPad keyboard; ordinary submissions do not briefly insert a queue panel. Their message bubble and local attachments appear immediately with a Sending status until admission replaces them with durable history. Queued follow-ups and delivery errors retain their controls. With an empty draft and a running turn, the send button becomes Stop; adding text or an image restores Send in the same position. Drafts, queued follow-ups, steering, and stop controls belong to the selected agent. Switching tabs or opening the overview preserves that work.
+The conversation keeps the same agent composer fixed above the keyboard while you read older messages. Sending dismisses the iPhone/iPad keyboard. Pending input appears once in the queue above the composer, including first sends, attachments, and delivery errors. Admission does not create a sent bubble: execution evidence promotes the message into the conversation. The queue follows server order across devices and relaunch; messages whose content has not loaded retain a placeholder and queue position. Cancelling and retrying keep the same identity. “Interrupt & run” stops the current turn to let the next queued message run. With an empty draft and a running turn, the send button becomes Stop; adding text or an image restores Send in the same position. Drafts, queued follow-ups, steering, and stop controls belong to the selected agent. Switching tabs or opening the overview preserves that work.
 
 Verified on 2026-09-08: focused iPhone/iPad checks cover browser tabs, searchable live previews, the All/Running filter, app-menu navigation, independent drafts, keyboard placement, point-based reading restoration, slow creation, cancellation, and retry. The signed-in iPhone 17 Pro completed a real reply, relaunched, and retained both messages through three round trips to other tabs. InboxCore passed 68 tests with three skips. The top tab strip, bottom Back/+/overview/screens/menu bar, Back draft restoration, and activity-sorted overview were checked in iPhone and iPad simulators. These tab checks do not establish voice latency or microphone performance.
 


### PR DESCRIPTION
“Steer now” previously cancelled the active turn and let the queued follow-up run as a new turn. Queued input also appeared as an ordinary submitted bubble before it began executing.

Route steering through the provided API:
- Fetch the queued turn's exact admitted input, including its original multimodal payload.
- Durably fence only that queued source through `/turns/{source}/cancel`, preventing its later normal execution.
- Send the input to `/turns/{active}/steer` with `message_id` equal to the stable source identity. The existing active turn keeps running and consumes steering at its model boundary.
- Use `/withdraw-steer` with the same target and message identity. A false withdrawal response never means cancellation succeeded and never triggers a stop of the active turn.

Persist transfer phases before requests, retain accepted steering markers across relaunch, and reconcile acknowledgement-before-local-cleanup crashes. A lost steering response stays explicitly unconfirmed and is never automatically resent. Rejected target-turn requests retain the message without silently starting a replacement turn. Safe source-fencing failures can be retried. Exact receipt identities and states are validated.

Pending messages have one queue-owned representation; ordinary follow-ups enter the conversation on execution, while API-accepted steering is explicitly labelled. Cancelled/withdrawn requests remain distinct from sent bubbles. Preserve server queue order, remote message placeholders, attachment previews, and bounded scrolling above the keyboard.

Validation:
- InboxCore: 155 tests, 150 passed, 5 opt-in integration tests skipped, zero failures.
- Eight steering contract/state tests include actual ManagedClient HTTP requests against the fixture transport, exact source/target routes, full payload preservation, stable message IDs, receipt validation, withdrawal, and restore behavior.
- Five steering simulator journeys passed across focused runs: active-turn preservation plus accepted-marker relaunch/withdrawal; lost-response relaunch without resubmission; consumed-steer withdrawal refusal; cancel during preparation; retry after source-fencing failure. Shared simulator runner-kill failures were rerun successfully on an isolated simulator.
- iOS Simulator build/test passed.

API limits: `run.steered` has no client message ID, and repeated identified steering is not an idempotent receipt lookup. Do not infer acceptance from that event or blindly retry an uncertain POST. Accepted message correlation is retained locally; other devices cannot recover it solely from that event.

Not deployed. Live production verification was not run: the local managed-agent CLI reports unauthenticated. Simulator builds reuse the existing generated voice XCFramework.
