### PR TITLE
fix(vm): enable software OpenGL in desktop Hands

### DIFF
--- a/crates/experimental/nanocodex-vm/image/Dockerfile
+++ b/crates/experimental/nanocodex-vm/image/Dockerfile
@@ -1,7 +1,7 @@
 # Build context: crates/experimental/nanocodex-vm/image.
 # The Rust guest runtime supplies capture/input and starts the X11 session.
 FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
-RUN apk add --no-cache ca-certificates xvfb openbox xterm font-dejavu \
+RUN apk add --no-cache ca-certificates xvfb openbox xterm font-dejavu mesa-dri-gallium \
     && mkdir -p /app /workspace /run/nanocodex-desktop \
     && chmod 0700 /run/nanocodex-desktop
 ENV DISPLAY=:0

--- a/crates/experimental/nanocodex-vm/image/README.md
+++ b/crates/experimental/nanocodex-vm/image/README.md
@@ -1,6 +1,11 @@
 # Rust VM desktop image
 
-This Alpine 3.21 template supplies Xvfb, Openbox, xterm, and DejaVu fonts.
+This Alpine 3.21 template supplies Xvfb, Openbox, xterm, DejaVu fonts, and
+Mesa's Gallium software renderer. The renderer gives the private X11 desktop
+a modern OpenGL core profile even when the VM host does not expose a GPU
+device, so applications such as Blender can open directly in the published
+desktop. Rendering is CPU-backed unless a future VM transport exposes an
+accelerated DRM device.
 The separately built `nanocodex-vm-guest` starts the X11 session and implements
 capture and input directly through Rust `x11rb`. The image contains no Go
 `nanocodex-remote`, Waymote, grim, Go compiler, or Zig compiler. It does not
@@ -28,9 +33,10 @@ Point the host's template configuration at the new image only after a fresh
 VM validates capture and input. Existing VMs retain their private root disk;
 changing the template does not upgrade their installed packages.
 
-To add desktop infrastructure to an existing Alpine VM, run
+To add desktop and software OpenGL infrastructure to an existing Alpine VM, run
 `upgrade-alpine.sh` as root through its connected Hand. It requires 400 MiB
 free and adds only the display packages and their dependencies. It never
 replaces a disk, edits workspace files, launches a display, or restarts the
 VM. Retain existing files and let the host owner stage the matching Rust
-guest runtime and coordinate any restart after the package upgrade.
+guest runtime and restart the VM after the package upgrade so the new Xvfb
+process can load Gallium's software driver.

--- a/crates/experimental/nanocodex-vm/image/upgrade-alpine.sh
+++ b/crates/experimental/nanocodex-vm/image/upgrade-alpine.sh
@@ -8,8 +8,8 @@ df -h /
 free_kib=$(df -Pk / | awk 'NR == 2 { print $4 }')
 # Leave a conservative margin for package unpacking and retained user files.
 test "$free_kib" -ge 409600 || { echo 'Need at least 400 MiB free; no files changed' >&2; exit 1; }
-apk add --no-cache xvfb openbox xterm font-dejavu
-apk info -v | awk '/^(xvfb|openbox|xterm|font-dejavu)-[0-9]/'
+apk add --no-cache xvfb openbox xterm font-dejavu mesa-dri-gallium
+apk info -v | awk '/^(xvfb|openbox|xterm|font-dejavu|mesa-dri-gallium)-[0-9]/'
 for binary in Xvfb openbox xterm; do command -v "$binary"; done
 df -h /
-echo 'Display packages installed. VM and guest runtime have not been restarted.'
+echo 'Display and software OpenGL packages installed. Restart the VM so Xvfb loads the driver.'

--- a/crates/experimental/nanocodex-vm/src/desktop.rs
+++ b/crates/experimental/nanocodex-vm/src/desktop.rs
@@ -374,6 +374,8 @@ fn start_x(
                 "-nolisten",
                 "local",
                 "-noreset",
+                "+extension",
+                "GLX",
                 "-auth",
             ])
             .arg(runtime.path.join("Xauthority"))


### PR DESCRIPTION
## Summary
- install Mesa Gallium software rendering in the Alpine desktop image and upgrade path
- explicitly enable GLX in the guest-managed Xvfb server
- document CPU-backed OpenGL behavior and the required restart for upgraded VMs

## Validation
- `cargo test -p nanocodex-vm` (117 unit tests and 6 doctests passed)
- live Alpine aarch64 VM: `glxinfo -B` reports llvmpipe OpenGL 4.5 after installing `mesa-dri-gallium` and restarting Xvfb
- Blender 4.3 background render completed successfully; interactive startup requirement is OpenGL 4.3