### PR TITLE
feat(hand): ship development, document, science, and creative tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,18 @@ jobs:
           RUSTDOCFLAGS: -D warnings
 
   vm-guest:
-    name: static Linux guest and Docker Hand
-    runs-on: ubuntu-latest
+    name: static Linux guest and Docker Hand (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:
       contents: read
@@ -109,7 +119,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           toolchain: stable
-          targets: x86_64-unknown-linux-musl
+          targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         with:
           cache-on-failure: true
@@ -121,17 +131,25 @@ jobs:
       - name: Build the actual static guest artifact
         run: >-
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
           cargo build --locked --package nanocodex-vm
           --bin nanocodex-vm-guest --no-default-features
-          --features guest-runtime --target x86_64-unknown-linux-musl
+          --features guest-runtime --target ${{ matrix.target }}
 
       - name: Build the Docker Hand image
         run: |
           context=$(mktemp -d)
           trap 'rm -rf "$context"' EXIT
-          cp target/x86_64-unknown-linux-musl/debug/nanocodex-vm-guest "$context/"
+          cp target/${{ matrix.target }}/debug/nanocodex-vm-guest "$context/"
           cp crates/experimental/nanocodex-vm/image/Dockerfile.hand "$context/Dockerfile"
+          cp -R crates/experimental/nanocodex-vm/image/toolkit "$context/toolkit"
           docker build --tag nanocodex-hand:ci "$context"
+      - name: Exercise offline toolkit with a read-only root and unprivileged user
+        run: >-
+          docker run --rm --network none --read-only --user 1000:1000
+          --cap-drop ALL --security-opt no-new-privileges --pids-limit 512
+          --tmpfs /tmp:rw,nosuid,nodev,size=2g --env HOME=/tmp
+          --entrypoint nanocodex-check-hand-toolkit nanocodex-hand:ci
       - name: Test Docker tools, desktop, persistence, and cleanup without KVM
         run: |
           cargo test --locked -p nanocodex-vm --test docker_live -- --ignored --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
           --tmpfs /tmp:rw,nosuid,nodev,size=256m --env HOME=/workspace
           --tmpfs /workspace:rw,exec,nosuid,nodev,uid=1000,gid=1000,size=2g
           --env TMPDIR=/workspace --workdir /workspace
-          --entrypoint nanocodex-check-hand-toolkit nanocodex-hand:ci
+          --entrypoint sh nanocodex-hand:ci -lc nanocodex-check-hand-toolkit
       - name: Test Docker tools, desktop, persistence, and cleanup without KVM
         run: |
           cargo test --locked -p nanocodex-vm --test docker_live -- --ignored --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,9 @@ jobs:
         run: >-
           docker run --rm --network none --read-only --user 1000:1000
           --cap-drop ALL --security-opt no-new-privileges --pids-limit 512
-          --tmpfs /tmp:rw,nosuid,nodev,size=2g --env HOME=/tmp
+          --tmpfs /tmp:rw,nosuid,nodev,size=256m --env HOME=/workspace
+          --tmpfs /workspace:rw,exec,nosuid,nodev,uid=1000,gid=1000,size=2g
+          --env TMPDIR=/workspace --workdir /workspace
           --entrypoint nanocodex-check-hand-toolkit nanocodex-hand:ci
       - name: Test Docker tools, desktop, persistence, and cleanup without KVM
         run: |

--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -71,7 +71,8 @@ jobs:
             if git diff --quiet "$BASE_SHA" "$GITHUB_SHA" -- \
               js/managed/Dockerfile js/managed/wrangler.jsonc js/managed/.dockerignore \
               js/managed/scripts/prepare-hand-image.mjs js/managed/scripts/bundle-hand-desktop.sh \
-              hands/remote; then
+              hands/remote crates/experimental/nanocodex-vm/image/toolkit \
+              js/managed/scripts/check-dev-stack.sh; then
               rollout=none
             fi
           fi
@@ -171,7 +172,8 @@ jobs:
             if git diff --quiet "$BASE_SHA" "$GITHUB_SHA" -- \
               js/managed/Dockerfile js/managed/wrangler.jsonc js/managed/.dockerignore \
               js/managed/scripts/prepare-hand-image.mjs js/managed/scripts/bundle-hand-desktop.sh \
-              hands/remote; then
+              hands/remote crates/experimental/nanocodex-vm/image/toolkit \
+              js/managed/scripts/check-dev-stack.sh; then
               rollout=none
             fi
           fi

--- a/.github/workflows/hand-image.yml
+++ b/.github/workflows/hand-image.yml
@@ -1,6 +1,11 @@
 name: Linux Hand image
 
 on:
+  pull_request:
+    paths:
+      - 'hands/remote/image/Dockerfile'
+      - 'crates/experimental/nanocodex-vm/image/toolkit/**'
+      - '.github/workflows/hand-image.yml'
   workflow_dispatch:
     inputs:
       publish:
@@ -50,7 +55,11 @@ jobs:
             --tag "$IMAGE:$IMAGE_TAG-$ARCH" \
             --label "org.opencontainers.image.source=https://github.com/$GITHUB_REPOSITORY" \
             --label "org.opencontainers.image.revision=$GITHUB_SHA" \
-            --file hands/remote/image/Dockerfile hands/remote
+            --file hands/remote/image/Dockerfile .
+      - name: Exercise offline creative and development tools
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: docker run --rm --network none --entrypoint nanocodex-check-hand-toolkit "$IMAGE:$IMAGE_TAG-$ARCH"
       - name: Exercise the desktop and both video encoders
         env:
           ARCH: ${{ matrix.arch }}

--- a/.github/workflows/hand-image.yml
+++ b/.github/workflows/hand-image.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Exercise offline creative and development tools
         env:
           ARCH: ${{ matrix.arch }}
-        run: docker run --rm --network none --entrypoint nanocodex-check-hand-toolkit "$IMAGE:$IMAGE_TAG-$ARCH"
+        run: docker run --rm --network none --entrypoint sh "$IMAGE:$IMAGE_TAG-$ARCH" -lc nanocodex-check-hand-toolkit
       - name: Exercise the desktop and both video encoders
         env:
           ARCH: ${{ matrix.arch }}

--- a/.github/workflows/hand-toolkit.yml
+++ b/.github/workflows/hand-toolkit.yml
@@ -1,0 +1,36 @@
+name: VM toolkit images
+on:
+  pull_request:
+    paths:
+      - 'crates/experimental/nanocodex-vm/image/**'
+      - '.github/workflows/hand-toolkit.yml'
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: vm-toolkit-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  image:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            dockerfile: Dockerfile
+          - runner: ubuntu-24.04-arm
+            dockerfile: Dockerfile.gpu
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - name: Build VM toolkit
+        env:
+          DOCKERFILE: ${{ matrix.dockerfile }}
+        run: docker build -t nanocodex-vm:toolkit -f "crates/experimental/nanocodex-vm/image/$DOCKERFILE" crates/experimental/nanocodex-vm/image
+      - name: Exercise offline toolkit
+        run: docker run --rm --network none --entrypoint nanocodex-check-hand-toolkit nanocodex-vm:toolkit
+      - name: Package and validate the 16 GiB ext4 template
+        run: bash crates/experimental/nanocodex-vm/image/build-root.sh nanocodex-vm:toolkit "$RUNNER_TEMP/desktop.ext4"

--- a/.github/workflows/hand-toolkit.yml
+++ b/.github/workflows/hand-toolkit.yml
@@ -31,6 +31,6 @@ jobs:
           DOCKERFILE: ${{ matrix.dockerfile }}
         run: docker build -t nanocodex-vm:toolkit -f "crates/experimental/nanocodex-vm/image/$DOCKERFILE" crates/experimental/nanocodex-vm/image
       - name: Exercise offline toolkit
-        run: docker run --rm --network none --entrypoint nanocodex-check-hand-toolkit nanocodex-vm:toolkit
+        run: docker run --rm --network none --entrypoint env nanocodex-vm:toolkit -i PATH=/usr/local/bin:/usr/bin:/bin HOME=/root sh -lc nanocodex-check-hand-toolkit
       - name: Package and validate the 16 GiB ext4 template
         run: bash crates/experimental/nanocodex-vm/image/build-root.sh nanocodex-vm:toolkit "$RUNNER_TEMP/desktop.ext4"

--- a/.github/workflows/sandbox-image.yml
+++ b/.github/workflows/sandbox-image.yml
@@ -7,6 +7,7 @@ on:
       - 'js/managed/scripts/prepare-hand-image.mjs'
       - 'js/managed/scripts/bundle-hand-desktop.sh'
       - 'hands/remote/**'
+      - 'crates/experimental/nanocodex-vm/image/toolkit/**'
       - '.github/workflows/sandbox-image.yml'
   workflow_dispatch:
 permissions:
@@ -41,3 +42,5 @@ jobs:
           fi
       - name: Verify tools in the final image
         run: docker run --rm --network none --entrypoint sh nanocodex-sandbox:dev /usr/local/bin/nanocodex-check-dev-stack
+      - name: Verify offline document, science, and rendering workflows
+        run: docker run --rm --network none --entrypoint nanocodex-check-hand-toolkit nanocodex-sandbox:dev

--- a/.github/workflows/sandbox-image.yml
+++ b/.github/workflows/sandbox-image.yml
@@ -41,9 +41,9 @@ jobs:
             exit 1
           fi
       - name: Verify tools in the final image
-        run: docker run --rm --network none --entrypoint sh nanocodex-sandbox:dev /usr/local/bin/nanocodex-check-dev-stack
+        run: docker run --rm --network none --entrypoint sh nanocodex-sandbox:dev -lc nanocodex-check-dev-stack
       - name: Verify offline document, science, and rendering workflows
-        run: docker run --rm --network none --entrypoint nanocodex-check-hand-toolkit nanocodex-sandbox:dev
+        run: docker run --rm --network none --entrypoint sh nanocodex-sandbox:dev -lc nanocodex-check-hand-toolkit
       - name: Reserve at least 4 GB of the 16 GB disk for workspace data
         run: >-
           docker run --rm --network none --entrypoint sh nanocodex-sandbox:dev

--- a/.github/workflows/sandbox-image.yml
+++ b/.github/workflows/sandbox-image.yml
@@ -44,3 +44,7 @@ jobs:
         run: docker run --rm --network none --entrypoint sh nanocodex-sandbox:dev /usr/local/bin/nanocodex-check-dev-stack
       - name: Verify offline document, science, and rendering workflows
         run: docker run --rm --network none --entrypoint nanocodex-check-hand-toolkit nanocodex-sandbox:dev
+      - name: Reserve at least 4 GB of the 16 GB disk for workspace data
+        run: >-
+          docker run --rm --network none --entrypoint sh nanocodex-sandbox:dev
+          -c 'bytes=$(du -sx -B1 / | cut -f1); echo "Image filesystem: $bytes bytes"; test "$bytes" -lt 12000000000'

--- a/bin/nanocodex/src/hand_setup.rs
+++ b/bin/nanocodex/src/hand_setup.rs
@@ -188,7 +188,22 @@ impl Setup {
             temporary.path().join("install.py"),
             include_str!("hand_setup/install.py"),
         )?;
+        fs::create_dir(temporary.path().join("toolkit"))?;
         for (name, content) in [
+            (
+                "toolkit/install-alpine.sh",
+                include_str!(
+                    "../../../crates/experimental/nanocodex-vm/image/toolkit/install-alpine.sh"
+                ),
+            ),
+            (
+                "toolkit/python.txt",
+                include_str!("../../../crates/experimental/nanocodex-vm/image/toolkit/python.txt"),
+            ),
+            (
+                "toolkit/check.py",
+                include_str!("../../../crates/experimental/nanocodex-vm/image/toolkit/check.py"),
+            ),
             (
                 "Dockerfile",
                 include_str!("../../../crates/experimental/nanocodex-vm/image/Dockerfile"),

--- a/bin/nanocodex/src/hand_setup.rs
+++ b/bin/nanocodex/src/hand_setup.rs
@@ -197,6 +197,12 @@ impl Setup {
                 ),
             ),
             (
+                "toolkit/install-paths.sh",
+                include_str!(
+                    "../../../crates/experimental/nanocodex-vm/image/toolkit/install-paths.sh"
+                ),
+            ),
+            (
                 "toolkit/python.txt",
                 include_str!("../../../crates/experimental/nanocodex-vm/image/toolkit/python.txt"),
             ),

--- a/bin/nanocodex/src/hand_setup/install.py
+++ b/bin/nanocodex/src/hand_setup/install.py
@@ -225,7 +225,7 @@ def main(stage, config):
             if not member.isfile():
                 raise RuntimeError("Invalid firmware archive")
             atomic(ROOT / "firmware" / "libkrunfw.so.5", archive.extractfile(member).read())
-        template_key = hashlib.sha256(b"".join((stage / name).read_bytes() for name in ["Dockerfile", "Dockerfile.ext4", "populate-ext4.sh", "build-root.sh", "toolkit/install-alpine.sh", "toolkit/python.txt", "toolkit/check.py"])).hexdigest()[:16]
+        template_key = hashlib.sha256(b"".join((stage / name).read_bytes() for name in ["Dockerfile", "Dockerfile.ext4", "populate-ext4.sh", "build-root.sh", "toolkit/install-alpine.sh", "toolkit/python.txt", "toolkit/check.py", "toolkit/install-paths.sh"])).hexdigest()[:16]
         template = ROOT / "images" / f"desktop-{template_key}.ext4"
         if not template.exists():
             print("Preparing retained VM desktop template…", flush=True)

--- a/bin/nanocodex/src/hand_setup/install.py
+++ b/bin/nanocodex/src/hand_setup/install.py
@@ -225,7 +225,7 @@ def main(stage, config):
             if not member.isfile():
                 raise RuntimeError("Invalid firmware archive")
             atomic(ROOT / "firmware" / "libkrunfw.so.5", archive.extractfile(member).read())
-        template_key = hashlib.sha256(b"".join((stage / name).read_bytes() for name in ["Dockerfile", "Dockerfile.ext4", "populate-ext4.sh", "build-root.sh"])).hexdigest()[:16]
+        template_key = hashlib.sha256(b"".join((stage / name).read_bytes() for name in ["Dockerfile", "Dockerfile.ext4", "populate-ext4.sh", "build-root.sh", "toolkit/install-alpine.sh", "toolkit/python.txt", "toolkit/check.py"])).hexdigest()[:16]
         template = ROOT / "images" / f"desktop-{template_key}.ext4"
         if not template.exists():
             print("Preparing retained VM desktop template…", flush=True)

--- a/crates/experimental/nanocodex-vm/image/Dockerfile
+++ b/crates/experimental/nanocodex-vm/image/Dockerfile
@@ -4,8 +4,10 @@ RUN rustup component add clippy rustfmt && rustup target add wasm32-unknown-unkn
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 COPY --from=rust-toolchain /usr/local/rustup /opt/rustup
 COPY --from=rust-toolchain /usr/local/cargo /opt/cargo
-COPY toolkit /opt/hand-toolkit
-RUN sh /opt/hand-toolkit/install-alpine.sh \
+COPY toolkit/install-alpine.sh toolkit/python.txt /opt/hand-toolkit/
+RUN sh /opt/hand-toolkit/install-alpine.sh
+COPY toolkit/check.py toolkit/install-paths.sh /opt/hand-toolkit/
+RUN sh /opt/hand-toolkit/install-paths.sh \
     && ln -s /opt/hand-toolkit/check.py /usr/local/bin/nanocodex-check-hand-toolkit \
     && chmod 0755 /opt/hand-toolkit/check.py
 ENV RUSTUP_HOME=/opt/rustup \

--- a/crates/experimental/nanocodex-vm/image/Dockerfile
+++ b/crates/experimental/nanocodex-vm/image/Dockerfile
@@ -1,9 +1,15 @@
 # Build context: crates/experimental/nanocodex-vm/image.
-# The Rust guest runtime supplies capture/input and starts the X11 session.
-FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
-RUN apk add --no-cache ca-certificates xvfb openbox xterm font-dejavu mesa-dri-gallium \
-    && mkdir -p /app /workspace /run/nanocodex-desktop \
-    && chmod 0700 /run/nanocodex-desktop
-ENV DISPLAY=:0
+FROM rust:1.97-alpine3.24 AS rust-toolchain
+RUN rustup component add clippy rustfmt && rustup target add wasm32-unknown-unknown
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+COPY --from=rust-toolchain /usr/local/rustup /opt/rustup
+COPY --from=rust-toolchain /usr/local/cargo /opt/cargo
+COPY toolkit /opt/hand-toolkit
+RUN sh /opt/hand-toolkit/install-alpine.sh \
+    && ln -s /opt/hand-toolkit/check.py /usr/local/bin/nanocodex-check-hand-toolkit \
+    && chmod 0755 /opt/hand-toolkit/check.py
+ENV RUSTUP_HOME=/opt/rustup \
+    PATH=/opt/hand-python/bin:/opt/cargo/bin:$PATH \
+    DISPLAY=:0
 WORKDIR /app
 CMD ["/bin/sh"]

--- a/crates/experimental/nanocodex-vm/image/Dockerfile.gpu
+++ b/crates/experimental/nanocodex-vm/image/Dockerfile.gpu
@@ -59,8 +59,10 @@ RUN mkdir -p /driver/usr/share/licenses/nanocodex-gpu-gl \
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 COPY --from=rust-toolchain /usr/local/rustup /opt/rustup
 COPY --from=rust-toolchain /usr/local/cargo /opt/cargo
-COPY toolkit /opt/hand-toolkit
-RUN sh /opt/hand-toolkit/install-alpine.sh \
+COPY toolkit/install-alpine.sh toolkit/python.txt /opt/hand-toolkit/
+RUN sh /opt/hand-toolkit/install-alpine.sh
+COPY toolkit/check.py toolkit/install-paths.sh /opt/hand-toolkit/
+RUN sh /opt/hand-toolkit/install-paths.sh \
     && ln -s /opt/hand-toolkit/check.py /usr/local/bin/nanocodex-check-hand-toolkit \
     && chmod 0755 /opt/hand-toolkit/check.py
 ENV RUSTUP_HOME=/opt/rustup \

--- a/crates/experimental/nanocodex-vm/image/Dockerfile.gpu
+++ b/crates/experimental/nanocodex-vm/image/Dockerfile.gpu
@@ -1,5 +1,7 @@
 # Apple Silicon Venus driver. Build context is this image directory.
 # Keep the hardware driver separate from the portable software desktop image.
+FROM rust:1.97-alpine3.24 AS rust-toolchain
+RUN rustup component add clippy rustfmt && rustup target add wasm32-unknown-unknown
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS build
 RUN apk add --no-cache build-base meson samurai python3 py3-mako py3-yaml \
     py3-packaging py3-setuptools bison flex libdrm-dev vulkan-headers zlib-dev \
@@ -55,10 +57,16 @@ RUN mkdir -p /driver/usr/local/bin \
 RUN mkdir -p /driver/usr/share/licenses/nanocodex-gpu-gl \
     && cp docs/license.rst /driver/usr/share/licenses/nanocodex-gpu-gl/
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
-RUN apk add --no-cache ca-certificates xvfb openbox xterm font-dejavu \
-      mesa-dri-gallium mesa-vulkan-virtio vulkan-tools vulkan-loader libxxf86vm \
-    && mkdir -p /app /workspace /run/nanocodex-desktop \
-    && chmod 0700 /run/nanocodex-desktop
+COPY --from=rust-toolchain /usr/local/rustup /opt/rustup
+COPY --from=rust-toolchain /usr/local/cargo /opt/cargo
+COPY toolkit /opt/hand-toolkit
+RUN sh /opt/hand-toolkit/install-alpine.sh \
+    && ln -s /opt/hand-toolkit/check.py /usr/local/bin/nanocodex-check-hand-toolkit \
+    && chmod 0755 /opt/hand-toolkit/check.py
+ENV RUSTUP_HOME=/opt/rustup \
+    PATH=/opt/hand-python/bin:/opt/cargo/bin:$PATH \
+    DISPLAY=:0
+RUN apk add --no-cache mesa-vulkan-virtio vulkan-tools vulkan-loader libxxf86vm
 COPY --from=venus /driver/usr/ /usr/
 COPY --from=zink /driver/ /
 COPY --chmod=755 gpu/gl /usr/local/bin/nanocodex-gpu-gl

--- a/crates/experimental/nanocodex-vm/image/Dockerfile.hand
+++ b/crates/experimental/nanocodex-vm/image/Dockerfile.hand
@@ -1,13 +1,20 @@
-# Build with pnpm build:hand-docker. The context contains the static Linux runtime.
-FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
-RUN apk add --no-cache ca-certificates bash curl git python3 nodejs npm \
-        xvfb openbox xterm font-dejavu mesa-dri-gallium \
-    && addgroup -g 1000 nanocodex \
+# Build with pnpm build:hand-docker.
+FROM rust:1.97-alpine3.24 AS rust-toolchain
+RUN rustup component add clippy rustfmt && rustup target add wasm32-unknown-unknown
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+COPY --from=rust-toolchain /usr/local/rustup /opt/rustup
+COPY --from=rust-toolchain /usr/local/cargo /opt/cargo
+COPY toolkit /opt/hand-toolkit
+RUN sh /opt/hand-toolkit/install-alpine.sh \
+    && ln -s /opt/hand-toolkit/check.py /usr/local/bin/nanocodex-check-hand-toolkit \
+    && chmod 0755 /opt/hand-toolkit/check.py
+ENV RUSTUP_HOME=/opt/rustup \
+    PATH=/opt/hand-python/bin:/opt/cargo/bin:$PATH \
+    DISPLAY=:0
+RUN addgroup -g 1000 nanocodex \
     && adduser -D -u 1000 -G nanocodex nanocodex \
-    && mkdir -p /app /workspace \
     && chown 1000:1000 /app /workspace
 COPY --chmod=0755 nanocodex-vm-guest /usr/local/bin/nanocodex-vm-guest
-ENV DISPLAY=:0
 USER 1000:1000
 WORKDIR /app
 ENTRYPOINT ["/usr/local/bin/nanocodex-vm-guest"]

--- a/crates/experimental/nanocodex-vm/image/Dockerfile.hand
+++ b/crates/experimental/nanocodex-vm/image/Dockerfile.hand
@@ -4,8 +4,10 @@ RUN rustup component add clippy rustfmt && rustup target add wasm32-unknown-unkn
 FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 COPY --from=rust-toolchain /usr/local/rustup /opt/rustup
 COPY --from=rust-toolchain /usr/local/cargo /opt/cargo
-COPY toolkit /opt/hand-toolkit
-RUN sh /opt/hand-toolkit/install-alpine.sh \
+COPY toolkit/install-alpine.sh toolkit/python.txt /opt/hand-toolkit/
+RUN sh /opt/hand-toolkit/install-alpine.sh
+COPY toolkit/check.py toolkit/install-paths.sh /opt/hand-toolkit/
+RUN sh /opt/hand-toolkit/install-paths.sh \
     && ln -s /opt/hand-toolkit/check.py /usr/local/bin/nanocodex-check-hand-toolkit \
     && chmod 0755 /opt/hand-toolkit/check.py
 ENV RUSTUP_HOME=/opt/rustup \

--- a/crates/experimental/nanocodex-vm/image/README.md
+++ b/crates/experimental/nanocodex-vm/image/README.md
@@ -32,6 +32,13 @@ The default ext4 capacity is 16 GiB. Existing images and retained workspaces are
 not replaced; create a new Hand from the rebuilt template. Allow additional host
 disk space for image layers, build caches, and per-Hand writable files. For
 creative tasks, start with `--memory 4096 --cpus 2` and increase for the workload.
+Cloudflare uses `standard-3` (2 vCPU, 8 GiB RAM, 16 GB disk) because its full
+filesystem occupies about 10 GiB. CI reserves at least 4 GB for workspace data.
+This increases compute capacity and running cost compared with `standard-1`.
+See [Cloudflare instance limits](https://developers.cloudflare.com/containers/platform/limits/).
+Docker sets `TMPDIR` to the retained workspace's `.tmp` directory so compilers can
+execute temporary programs while `/tmp` remains a restricted tmpfs. Temporary
+files count against workspace storage and can be removed when their jobs finish.
 Network policy is unchanged: Docker Hands default to `--network off`.
 
 Run `nanocodex-check-hand-toolkit /workspace/toolkit-check` inside a Hand to retain

--- a/crates/experimental/nanocodex-vm/image/README.md
+++ b/crates/experimental/nanocodex-vm/image/README.md
@@ -47,6 +47,8 @@ DOCX, XLSX, PPTX, and PDF files; converts DOCX to PDF; plots data; and renders a
 short video and a Blender CPU image. With no argument it uses temporary output.
 CI also runs it as UID 1000 with a read-only root and no network or capabilities.
 Python libraries live in `/opt/hand-python`; `python3` resolves to that environment.
+Toolchain launchers in `/usr/local/bin` preserve this setup after VM boot and in
+login shells, where OCI environment variables are unavailable or reset.
 Use a project venv for additional dependencies. Toolkit installation and smoke
 inputs are bundled by SSH setup and included in the template cache identity.
 

--- a/crates/experimental/nanocodex-vm/image/README.md
+++ b/crates/experimental/nanocodex-vm/image/README.md
@@ -1,42 +1,60 @@
-# Rust VM desktop image
+# Hand toolkit images
 
-This Alpine 3.21 template supplies Xvfb, Openbox, xterm, DejaVu fonts, and
-Mesa's Gallium software renderer. The renderer gives the private X11 desktop
-a modern OpenGL core profile even when the VM host does not expose a GPU
-device, so applications such as Blender can open directly in the published
-desktop. Rendering is CPU-backed unless a future VM transport exposes an
-accelerated DRM device.
-The separately built `nanocodex-vm-guest` starts the X11 session and implements
-capture and input directly through Rust `x11rb`. The image contains no Go
-`nanocodex-remote`, Waymote, grim, Go compiler, or Zig compiler. It does not
-use the legacy desktop image in `hands/remote/image`.
+The portable VM, Docker Hand, and Apple Silicon GPU VM images include the same
+Alpine 3.24 toolkit. Cloudflare and the standalone Linux Hand use their existing
+glibc bases with equivalent development, document, science, and creative tools.
+The specialized browser image and account relay remain separate services.
 
-Build on a Docker host (Apple Silicon VMs require `linux/arm64`):
+| Work | Installed tools |
+| --- | --- |
+| Repositories | Git, Git LFS, GitHub CLI, ripgrep, fd, jq, SSH, rsync, tmux |
+| Development | Rust 1.97, rustfmt, Clippy, WASM target, Go, Node, npm, pnpm, uv, C/C++, CMake |
+| Documents | LibreOffice, Pandoc, python-docx, python-pptx, openpyxl |
+| PDF and OCR | Poppler, qpdf, Ghostscript, Tesseract English, pypdf, ReportLab |
+| Data | NumPy, SciPy, pandas, Matplotlib, SymPy, Pillow, lxml |
+| Creative | Blender, FFmpeg, ImageMagick, Inkscape, Graphviz |
+| Browser and fonts | Chromium/Chrome, DejaVu, Noto, CJK, emoji |
+
+Cloudflare also retains Swift 6.3.3 and wasm-bindgen CLI. Alpine uses musl; it does
+not include a Swift host compiler or Apple SDKs. Use a native Mac Hand for Xcode.
+The GPU image retains its patched Mesa Venus driver. Portable VM and Docker
+images support CPU rendering; installing Blender does not grant GPU access.
+
+Build a Docker Hand with `pnpm build:hand-docker`. Build a portable VM template:
 
 ```sh
-docker build --platform linux/arm64 -t nanocodex-vm-x11:alpine3.21 \
-  crates/experimental/nanocodex-vm/image
-crates/experimental/nanocodex-vm/image/build-root.sh \
-  nanocodex-vm-x11:alpine3.21 /absolute/path/desktop-x11.ext4 2048
+docker build -t nanocodex-vm:toolkit crates/experimental/nanocodex-vm/image
+bash crates/experimental/nanocodex-vm/image/build-root.sh \
+  nanocodex-vm:toolkit /absolute/path/desktop.ext4
 ```
 
-The build uses an isolated Linux filesystem packager, with no privileged
-mounts. It preserves numeric ownership, validates required and forbidden
-files, runs read-only `e2fsck`, and compares executable bytes extracted from
-the ext4 image. The immutable output has SHA-256, source image identity,
-package inventory, executable checksums, and filesystem-check sidecars.
-The base Alpine digest is pinned; APK repository updates mean rebuilds can
-have different packages and checksums. The Rust runtime remains on its
-separate runtime disk and must match the host build.
+The default ext4 capacity is 16 GiB. Existing images and retained workspaces are
+not replaced; create a new Hand from the rebuilt template. Allow additional host
+disk space for image layers, build caches, and per-Hand writable files. For
+creative tasks, start with `--memory 4096 --cpus 2` and increase for the workload.
+Network policy is unchanged: Docker Hands default to `--network off`.
 
-Point the host's template configuration at the new image only after a fresh
-VM validates capture and input. Existing VMs retain their private root disk;
-changing the template does not upgrade their installed packages.
+Run `nanocodex-check-hand-toolkit /workspace/toolkit-check` inside a Hand to retain
+its output. It runs offline and compiles C, Rust, Go, and Node programs; creates
+DOCX, XLSX, PPTX, and PDF files; converts DOCX to PDF; plots data; and renders a
+short video and a Blender CPU image. With no argument it uses temporary output.
+CI also runs it as UID 1000 with a read-only root and no network or capabilities.
+Python libraries live in `/opt/hand-python`; `python3` resolves to that environment.
+Use a project venv for additional dependencies. Toolkit installation and smoke
+inputs are bundled by SSH setup and included in the template cache identity.
 
-To add desktop and software OpenGL infrastructure to an existing Alpine VM, run
-`upgrade-alpine.sh` as root through its connected Hand. It requires 400 MiB
-free and adds only the display packages and their dependencies. It never
-replaces a disk, edits workspace files, launches a display, or restarts the
-VM. Retain existing files and let the host owner stage the matching Rust
-guest runtime and restart the VM after the package upgrade so the new Xvfb
-process can load Gallium's software driver.
+The VM's separate `nanocodex-vm-guest` runtime starts Xvfb and implements capture
+and input through Rust `x11rb`. These images do not contain the legacy Go desktop
+runtime, Waymote, or grim. Go is available as a development tool.
+
+The filesystem packager uses no privileged mounts. It preserves numeric ownership,
+checks required executables and forbidden legacy runtimes, runs read-only `e2fsck`,
+and compares executable bytes extracted from ext4. Output includes SHA-256, source
+image identity, APK inventory, executable checksums, and filesystem-check sidecars.
+The Alpine digest is pinned; repository package updates can change rebuild output.
+The guest runtime remains a separate disk and must match the host build.
+
+`upgrade-alpine.sh` remains a limited desktop/OpenGL repair for existing Alpine
+VMs. It requires 400 MiB free and installs display packages only; it does not
+install this full toolkit. It leaves workspace files intact and never restarts a
+VM. Stage the matching guest runtime and restart separately to load a new driver.

--- a/crates/experimental/nanocodex-vm/image/build-root.sh
+++ b/crates/experimental/nanocodex-vm/image/build-root.sh
@@ -22,6 +22,7 @@ trap cleanup EXIT
 packager=$(docker build --quiet --file "$script_dir/Dockerfile.ext4" "$script_dir")
 container=$(docker create "$image")
 docker export "$container" | docker run --rm --interactive --network none \
+  --env "OUTPUT_UID=$(id -u)" --env "OUTPUT_GID=$(id -g)" \
   --mount "type=bind,source=$work,target=/out" "$packager" "$size_mib"
 printf '%s\n' "$(docker image inspect --format '{{.Id}} {{.Os}}/{{.Architecture}}' "$image")" > "$work/source.txt"
 printf '%s  %s\n' "$(awk '{print $1}' "$work/desktop.sha256")" "$output" > "$work/image.sha256"

--- a/crates/experimental/nanocodex-vm/image/build-root.sh
+++ b/crates/experimental/nanocodex-vm/image/build-root.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 image=${1:?Usage: build-root.sh IMAGE OUTPUT.ext4 [SIZE_MIB]}
 output=${2:?Usage: build-root.sh IMAGE OUTPUT.ext4 [SIZE_MIB]}
-size_mib=${3:-2048}
+size_mib=${3:-16384}
 case "$size_mib" in ''|*[!0-9]*) echo 'Expected disk size in MiB' >&2; exit 2 ;; esac
 test "$size_mib" -ge 512
 # Refuse replacement of existing images and evidence, including dangling symlinks.

--- a/crates/experimental/nanocodex-vm/image/populate-ext4.sh
+++ b/crates/experimental/nanocodex-vm/image/populate-ext4.sh
@@ -30,3 +30,6 @@ for binary in /usr/bin/Xvfb /usr/bin/openbox /usr/bin/xterm; do
   rm /checked-binary
 done
 sha256sum /out/desktop.ext4 > /out/desktop.sha256
+# Docker preserves root ownership on Linux bind mounts. Publish artifacts to the
+# invoking user while retaining the original numeric ownership inside ext4.
+chown "${OUTPUT_UID:?}:${OUTPUT_GID:?}" /out/*

--- a/crates/experimental/nanocodex-vm/image/populate-ext4.sh
+++ b/crates/experimental/nanocodex-vm/image/populate-ext4.sh
@@ -7,8 +7,8 @@ tar --extract --numeric-owner --same-owner --preserve-permissions -f - -C /rootf
 for binary in usr/bin/Xvfb usr/bin/openbox usr/bin/xterm; do
   test -x "/rootfs/$binary" || { echo "Missing executable: /$binary" >&2; exit 1; }
 done
-# Reject legacy desktop runtimes and build toolchains anywhere in the template.
-find /rootfs \( -name nanocodex-remote -o -name 'waymote*' -o -name grim -o -name zig -o -name go \) -print > /out/forbidden-files.txt
+# Reject legacy desktop runtimes anywhere in the template.
+find /rootfs \( -name nanocodex-remote -o -name 'waymote*' -o -name grim \) -print > /out/forbidden-files.txt
 test ! -s /out/forbidden-files.txt || { cat /out/forbidden-files.txt >&2; exit 1; }
 test -d /rootfs/usr/share/fonts/dejavu
 rm -f /rootfs/.dockerenv /rootfs/etc/hostname /rootfs/etc/hosts /rootfs/etc/resolv.conf

--- a/crates/experimental/nanocodex-vm/image/toolkit/check.py
+++ b/crates/experimental/nanocodex-vm/image/toolkit/check.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Offline Hand workflows. Pass an output directory to retain the artifacts."""
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+def run(*args):
+    subprocess.run(args, check=True, timeout=180)
+
+
+def check(output):
+    output.mkdir(parents=True, exist_ok=True)
+    os.chdir(output)
+    # All caches stay writable with the Docker Hand's read-only root filesystem.
+    os.environ.update(MPLCONFIGDIR=str(output / "matplotlib-cache"),
+                      GOCACHE=str(output / "go-cache"),
+                      XDG_CACHE_HOME=str(output / "cache"))
+    for command in ("git", "gh", "rg", "fd", "jq", "cc", "cmake", "node", "pnpm",
+                    "uv", "go", "rustc", "cargo", "blender", "ffmpeg", "inkscape",
+                    "libreoffice", "pandoc", "pdftoppm", "qpdf", "tesseract", "dot"):
+        assert shutil.which(command), f"Missing executable: {command}"
+    assert shutil.which("chromium") or shutil.which("google-chrome"), "Missing browser"
+    import numpy as np
+    import pandas as pd
+    from scipy.linalg import solve
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from docx import Document
+    from pptx import Presentation
+    from reportlab.pdfgen import canvas
+    from pypdf import PdfReader
+    from PIL import Image
+    from openpyxl import load_workbook
+    import sympy
+
+    assert np.allclose(solve([[2, 0], [0, 4]], [4, 8]), [2, 2])
+    assert sympy.integrate(sympy.Symbol("x"), (sympy.Symbol("x"), 0, 2)) == 2
+    frame = pd.DataFrame({"x": [1, 2, 3], "y": [1, 4, 9]})
+    frame.to_excel("data.xlsx", index=False)
+    assert load_workbook("data.xlsx").active["B4"].value == 9
+    plt.plot(frame.x, frame.y)
+    plt.savefig("plot.png")
+    doc = Document()
+    doc.add_heading("Hand toolkit", 0)
+    doc.add_picture("plot.png")
+    doc.save("report.docx")
+    assert Document("report.docx").paragraphs[0].text == "Hand toolkit"
+    deck = Presentation()
+    deck.slides.add_slide(deck.slide_layouts[5]).shapes.title.text = "Hand toolkit"
+    deck.save("slides.pptx")
+    assert len(Presentation("slides.pptx").slides) == 1
+    pdf = canvas.Canvas("report.pdf")
+    pdf.drawString(72, 720, "Hand toolkit offline check")
+    pdf.save()
+    assert "Hand toolkit" in PdfReader("report.pdf").pages[0].extract_text()
+    run("pdftoppm", "-singlefile", "-scale-to", "256", "-png", "report.pdf", "pdf-page")
+    Image.open("pdf-page.png").verify()
+    run("libreoffice", "-env:UserInstallation=file://" + str(output / "office-profile"),
+        "--headless", "--convert-to", "pdf", "--outdir", "office", "report.docx")
+    assert len(PdfReader("office/report.pdf").pages) >= 1
+    Path("graph.dot").write_text("digraph { code -> artifacts }")
+    run("dot", "-Tsvg", "graph.dot", "-o", "graph.svg")
+    run("ffmpeg", "-v", "error", "-f", "lavfi", "-i", "color=c=blue:s=64x64:d=0.2",
+        "-y", "clip.mp4")
+    Path("render.py").write_text("import bpy\n"
+        "bpy.context.scene.render.engine='CYCLES'\n"
+        "bpy.context.scene.cycles.device='CPU'\n"
+        "bpy.context.scene.cycles.samples=1\n"
+        "bpy.context.scene.render.resolution_x=32\n"
+        "bpy.context.scene.render.resolution_y=32\n"
+        "bpy.context.scene.render.resolution_percentage=100\n"
+        "bpy.context.scene.render.filepath='blender.png'\n"
+        "bpy.ops.render.render(write_still=True)\n")
+    run("blender", "--background", "--factory-startup", "--threads", "1", "--python-exit-code", "1", "--python", "render.py")
+    Image.open("blender.png").verify()
+    Path("hello.c").write_text('int main(void) { return 0; }\n')
+    run("cc", "hello.c", "-o", "hello-c")
+    run("./hello-c")
+    Path("hello.rs").write_text('fn main() { println!("rust ok"); }\n')
+    run("rustc", "hello.rs", "-o", "hello-rust")
+    run("./hello-rust")
+    Path("hello.go").write_text('package main\nfunc main() {}\n')
+    run("go", "build", "-o", "hello-go", "hello.go")
+    run("./hello-go")
+    run("node", "-e", "if (2 + 2 !== 4) process.exit(1)")
+    print(f"Hand toolkit passed: documents, PDF rendering, science, video, Blender CPU, C, Rust, Go, Node. Artifacts: {output}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        check(Path(sys.argv[1]).resolve())
+    else:
+        with tempfile.TemporaryDirectory(prefix="hand-toolkit-") as temporary:
+            check(Path(temporary))

--- a/crates/experimental/nanocodex-vm/image/toolkit/check.py
+++ b/crates/experimental/nanocodex-vm/image/toolkit/check.py
@@ -65,16 +65,30 @@ def check(output):
     assert len(PdfReader("office/report.pdf").pages) >= 1
     Path("graph.dot").write_text("digraph { code -> artifacts }")
     run("dot", "-Tsvg", "graph.dot", "-o", "graph.svg")
+    run("inkscape", "graph.svg", "--export-type=png", "--export-filename=graph.png")
+    Image.open("graph.png").verify()
+    Path("notes.md").write_text("# Toolkit\nOffline document conversion.\n")
+    run("pandoc", "notes.md", "-o", "notes.docx")
+    assert Document("notes.docx").paragraphs[0].text == "Toolkit"
+    Path("page.html").write_text("<html><body><h1>Hand toolkit</h1></body></html>")
+    # The surrounding Hand supplies the process isolation; the browser cannot
+    # create its own user namespace under Docker's no-new-privileges policy.
+    browser = shutil.which("chromium") or shutil.which("google-chrome")
+    run(browser, "--headless", "--no-sandbox", "--disable-dev-shm-usage",
+        "--no-first-run", "--no-default-browser-check",
+        "--screenshot=" + str(output / "browser.png"),
+        (output / "page.html").as_uri())
+    Image.open("browser.png").verify()
     run("ffmpeg", "-v", "error", "-f", "lavfi", "-i", "color=c=blue:s=64x64:d=0.2",
         "-y", "clip.mp4")
-    Path("render.py").write_text("import bpy\n"
+    Path("render.py").write_text("import bpy, os\n"
         "bpy.context.scene.render.engine='CYCLES'\n"
         "bpy.context.scene.cycles.device='CPU'\n"
         "bpy.context.scene.cycles.samples=1\n"
         "bpy.context.scene.render.resolution_x=32\n"
         "bpy.context.scene.render.resolution_y=32\n"
         "bpy.context.scene.render.resolution_percentage=100\n"
-        "bpy.context.scene.render.filepath='blender.png'\n"
+        "bpy.context.scene.render.filepath=os.path.abspath('blender.png')\n"
         "bpy.ops.render.render(write_still=True)\n")
     run("blender", "--background", "--factory-startup", "--threads", "1", "--python-exit-code", "1", "--python", "render.py")
     Image.open("blender.png").verify()
@@ -95,5 +109,5 @@ if __name__ == "__main__":
     if len(sys.argv) > 1:
         check(Path(sys.argv[1]).resolve())
     else:
-        with tempfile.TemporaryDirectory(prefix="hand-toolkit-") as temporary:
+        with tempfile.TemporaryDirectory(prefix="hand-toolkit-", dir=Path.cwd()) as temporary:
             check(Path(temporary))

--- a/crates/experimental/nanocodex-vm/image/toolkit/check.py
+++ b/crates/experimental/nanocodex-vm/image/toolkit/check.py
@@ -85,6 +85,8 @@ def check(output):
         "bpy.context.scene.render.engine='CYCLES'\n"
         "bpy.context.scene.cycles.device='CPU'\n"
         "bpy.context.scene.cycles.samples=1\n"
+        # Debian's Blender omits OpenImageDenoise; CPU rendering still works.
+        "bpy.context.scene.cycles.use_denoising=False\n"
         "bpy.context.scene.render.resolution_x=32\n"
         "bpy.context.scene.render.resolution_y=32\n"
         "bpy.context.scene.render.resolution_percentage=100\n"

--- a/crates/experimental/nanocodex-vm/image/toolkit/check.py
+++ b/crates/experimental/nanocodex-vm/image/toolkit/check.py
@@ -16,7 +16,7 @@ def check(output):
     output.mkdir(parents=True, exist_ok=True)
     os.chdir(output)
     # All caches stay writable with the Docker Hand's read-only root filesystem.
-    os.environ.update(MPLCONFIGDIR=str(output / "matplotlib-cache"),
+    os.environ.update(PWD=str(output), MPLCONFIGDIR=str(output / "matplotlib-cache"),
                       GOCACHE=str(output / "go-cache"),
                       XDG_CACHE_HOME=str(output / "cache"))
     for command in ("git", "gh", "rg", "fd", "jq", "cc", "cmake", "node", "pnpm",
@@ -81,16 +81,16 @@ def check(output):
     Image.open("browser.png").verify()
     run("ffmpeg", "-v", "error", "-f", "lavfi", "-i", "color=c=blue:s=64x64:d=0.2",
         "-y", "clip.mp4")
-    Path("render.py").write_text("import bpy, os\n"
+    Path("render.py").write_text("import bpy\n"
         "bpy.context.scene.render.engine='CYCLES'\n"
         "bpy.context.scene.cycles.device='CPU'\n"
         "bpy.context.scene.cycles.samples=1\n"
         "bpy.context.scene.render.resolution_x=32\n"
         "bpy.context.scene.render.resolution_y=32\n"
         "bpy.context.scene.render.resolution_percentage=100\n"
-        "bpy.context.scene.render.filepath=os.path.abspath('blender.png')\n"
+        f"bpy.context.scene.render.filepath={str(output / 'blender.png')!r}\n"
         "bpy.ops.render.render(write_still=True)\n")
-    run("blender", "--background", "--factory-startup", "--threads", "1", "--python-exit-code", "1", "--python", "render.py")
+    run("blender", "--background", "--factory-startup", "--threads", "1", "--python-exit-code", "1", "--python", str(output / "render.py"))
     Image.open("blender.png").verify()
     Path("hello.c").write_text('int main(void) { return 0; }\n')
     run("cc", "hello.c", "-o", "hello-c")

--- a/crates/experimental/nanocodex-vm/image/toolkit/install-alpine.sh
+++ b/crates/experimental/nanocodex-vm/image/toolkit/install-alpine.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -eu
+apk add --no-cache \
+    bash ca-certificates curl wget git git-lfs github-cli openssh-client \
+    ripgrep fd jq yq less vim tmux tree rsync zip unzip tar xz zstd \
+    build-base clang cmake ninja pkgconf openssl-dev linux-headers \
+    go nodejs npm pnpm uv python3 python3-dev py3-pip sqlite \
+    xvfb openbox xterm mesa-dri-gallium chromium \
+    blender ffmpeg imagemagick inkscape libreoffice pandoc-cli \
+    poppler-utils qpdf ghostscript tesseract-ocr tesseract-ocr-data-eng graphviz \
+    font-dejavu font-noto font-noto-cjk font-noto-emoji \
+    py3-numpy py3-scipy py3-pandas py3-matplotlib py3-sympy py3-pillow \
+    py3-lxml py3-openpyxl py3-reportlab
+python3 -m venv --system-site-packages /opt/hand-python
+/opt/hand-python/bin/pip install --no-cache-dir -r /opt/hand-toolkit/python.txt
+mkdir -p /app /workspace /run/nanocodex-desktop
+chmod 0700 /run/nanocodex-desktop

--- a/crates/experimental/nanocodex-vm/image/toolkit/install-paths.sh
+++ b/crates/experimental/nanocodex-vm/image/toolkit/install-paths.sh
@@ -2,6 +2,11 @@
 # ext4 does not retain OCI ENV, and login shells reset PATH. Expose the optional
 # toolchains through the standard Linux executable path in both environments.
 set -eu
+mkdir -p /etc/profile.d
+cat > /etc/profile.d/nanocodex-toolkit.sh <<'PROFILE'
+export RUSTUP_HOME="${RUSTUP_HOME:-/opt/rustup}"
+export PATH="/opt/hand-python/bin:/opt/node/bin:/opt/cargo/bin:/opt/swift/usr/bin:/usr/local/go/bin:$PATH"
+PROFILE
 for directory in /opt/hand-python/bin /opt/node/bin /opt/cargo/bin /opt/swift/usr/bin /usr/local/go/bin; do
     for command in python python3 pip pip3 pytest node npm npx pnpm pnpx cargo rustc rustdoc rustup rustfmt cargo-fmt cargo-clippy clippy-driver swift swiftc swift-driver swift-frontend swift-package swift-build swift-test swift-run sourcekit-lsp go gofmt; do
         test -x "$directory/$command" || continue

--- a/crates/experimental/nanocodex-vm/image/toolkit/install-paths.sh
+++ b/crates/experimental/nanocodex-vm/image/toolkit/install-paths.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# ext4 does not retain OCI ENV, and login shells reset PATH. Expose the optional
+# toolchains through the standard Linux executable path in both environments.
+set -eu
+for directory in /opt/hand-python/bin /opt/node/bin /opt/cargo/bin /opt/swift/usr/bin /usr/local/go/bin; do
+    for command in python python3 pip pip3 pytest node npm npx pnpm pnpx cargo rustc rustdoc rustup rustfmt cargo-fmt cargo-clippy clippy-driver swift swiftc swift-driver swift-frontend swift-package swift-build swift-test swift-run sourcekit-lsp go gofmt; do
+        test -x "$directory/$command" || continue
+        # Remove a previous symlink before writing so its target is never changed.
+        rm -f "/usr/local/bin/$command"
+        {
+            printf '#!/bin/sh\n'
+            printf 'export RUSTUP_HOME="${RUSTUP_HOME:-/opt/rustup}"\n'
+            printf 'export PATH="/opt/hand-python/bin:/opt/node/bin:/opt/cargo/bin:/opt/swift/usr/bin:/usr/local/go/bin:$PATH"\n'
+            printf 'exec "%s/%s" "$@"\n' "$directory" "$command"
+        } > "/usr/local/bin/$command"
+        chmod 0755 "/usr/local/bin/$command"
+    done
+done

--- a/crates/experimental/nanocodex-vm/image/toolkit/python.txt
+++ b/crates/experimental/nanocodex-vm/image/toolkit/python.txt
@@ -1,0 +1,6 @@
+# Pure Python additions shared by Alpine and Cloudflare.
+python-docx==1.2.0
+python-pptx==1.0.2
+pypdf==6.1.1
+httpx==0.28.1
+pytest==8.4.2

--- a/crates/experimental/nanocodex-vm/src/docker.rs
+++ b/crates/experimental/nanocodex-vm/src/docker.rs
@@ -290,6 +290,8 @@ impl DockerWorkspaceBuilder {
             &self.workspace,
             "--env",
             &format!("HOME={}/.home", self.workspace),
+            "--env",
+            &format!("TMPDIR={}/.tmp", self.workspace),
             "--entrypoint",
             "/bin/sh",
         ]);
@@ -316,7 +318,7 @@ impl DockerWorkspaceBuilder {
         command.args([
             &self.image,
             "-ec",
-            "mkdir -p -- \"$HOME\"; exec /usr/local/bin/nanocodex-vm-guest \"$1\"",
+            "mkdir -p -- \"$HOME\" \"$TMPDIR\"; exec /usr/local/bin/nanocodex-vm-guest \"$1\"",
             "nanocodex",
             &self.workspace,
         ]);

--- a/crates/experimental/nanocodex-vm/tests/docker_live.rs
+++ b/crates/experimental/nanocodex-vm/tests/docker_live.rs
@@ -134,6 +134,9 @@ async fn tools_isolation_exclusive_ownership_and_persistence() {
             "grep -q 'NoNewPrivs:.*1' /proc/self/status; ",
             "! touch /etc/nanocodex-test; ",
             "test ! -e /sys/class/net/eth0; ",
+            "test \"$TMPDIR\" = /app/.tmp; ",
+            "temporary=$(mktemp); printf '#!/bin/sh\\nexit 0\\n' > \"$temporary\"; ",
+            "chmod 700 \"$temporary\"; \"$temporary\"; rm \"$temporary\"; ",
             "printf isolation-ok"
         )))
         .await

--- a/hands/remote/image/Dockerfile
+++ b/hands/remote/image/Dockerfile
@@ -49,6 +49,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && python3 -m venv --system-site-packages /opt/hand-python \
     && /opt/hand-python/bin/pip install --no-cache-dir -r /opt/hand-toolkit/python.txt \
     && ln -s /usr/bin/fdfind /usr/local/bin/fd \
+    && sh /opt/hand-toolkit/install-paths.sh \
     && chmod 0755 /opt/hand-toolkit/check.py \
     && ln -s /opt/hand-toolkit/check.py /usr/local/bin/nanocodex-check-hand-toolkit \
     && useradd --create-home --uid 1000 --shell /bin/bash desktop \

--- a/hands/remote/image/Dockerfile
+++ b/hands/remote/image/Dockerfile
@@ -1,4 +1,4 @@
-# Build from hands/remote. Both architectures use the same pinned Waymote source.
+# Build from the repository root. Both architectures use the same pinned Waymote source.
 FROM golang:1.26.5-trixie AS waymote
 ARG TARGETARCH
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git xz-utils libwayland-dev libxkbcommon-dev && rm -rf /var/lib/apt/lists/*
@@ -19,22 +19,44 @@ RUN /opt/zig/zig build -Dcpu=baseline -Doptimize=ReleaseFast
 
 FROM golang:1.26.5-trixie AS remote
 WORKDIR /src/remote
-COPY go.mod go.sum ./
+COPY hands/remote/go.mod hands/remote/go.sum ./
 RUN go mod download
-COPY *.go ./
+COPY hands/remote/*.go ./
 RUN CGO_ENABLED=0 go build -trimpath -o /out/nanocodex-remote .
 
+FROM rust:1.97-slim-trixie AS rust-toolchain
+RUN rustup component add clippy rustfmt && rustup target add wasm32-unknown-unknown
+FROM node:24.19.0-trixie-slim AS node-toolchain
+RUN npm install --global pnpm@11.25.0
 FROM debian:trixie-slim
+COPY --from=rust-toolchain /usr/local/rustup /opt/rustup
+COPY --from=rust-toolchain /usr/local/cargo /opt/cargo
+COPY --from=node-toolchain /usr/local /opt/node
+COPY --from=remote /usr/local/go /usr/local/go
+COPY --from=ghcr.io/astral-sh/uv:0.8.11 /uv /uvx /usr/local/bin/
+ENV RUSTUP_HOME=/opt/rustup PATH=/opt/hand-python/bin:/opt/node/bin:/opt/cargo/bin:/usr/local/go/bin:$PATH
+COPY crates/experimental/nanocodex-vm/image/toolkit /opt/hand-toolkit
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates labwc foot chromium ffmpeg grim libwayland-client0 libxkbcommon0 \
       dbus-x11 wlr-randr xwayland fonts-dejavu-core curl procps \
+      build-essential clang cmake ninja-build pkg-config libssl-dev git git-lfs gh \
+      ripgrep fd-find jq openssh-client rsync zip unzip xz-utils zstd tmux tree vim-tiny \
+      blender imagemagick inkscape libreoffice pandoc poppler-utils qpdf ghostscript \
+      tesseract-ocr tesseract-ocr-eng graphviz fonts-noto-core fonts-noto-cjk fonts-noto-color-emoji \
+      python3 python3-dev python3-venv python3-pip python3-numpy python3-scipy python3-pandas \
+      python3-matplotlib python3-sympy python3-pil python3-lxml python3-openpyxl python3-reportlab \
     && rm -rf /var/lib/apt/lists/* \
+    && python3 -m venv --system-site-packages /opt/hand-python \
+    && /opt/hand-python/bin/pip install --no-cache-dir -r /opt/hand-toolkit/python.txt \
+    && ln -s /usr/bin/fdfind /usr/local/bin/fd \
+    && chmod 0755 /opt/hand-toolkit/check.py \
+    && ln -s /opt/hand-toolkit/check.py /usr/local/bin/nanocodex-check-hand-toolkit \
     && useradd --create-home --uid 1000 --shell /bin/bash desktop \
     && install -d -o desktop -g desktop -m 0700 /run/nanocodex-desktop \
     && install -d -o desktop -g desktop /workspace
 COPY --from=waymote /src/waymote/zig-out/bin/waymote-streamd /usr/local/bin/waymote-streamd
 COPY --from=remote /out/nanocodex-remote /usr/local/bin/nanocodex-remote
-COPY image/labwc /etc/nanocodex-desktop
+COPY hands/remote/image/labwc /etc/nanocodex-desktop
 ENV WLR_BACKENDS=headless WLR_RENDERER=pixman WLR_HEADLESS_OUTPUTS=1 \
     XDG_RUNTIME_DIR=/run/nanocodex-desktop WAYLAND_DISPLAY=wayland-0 \
     XDG_SESSION_TYPE=wayland XDG_CURRENT_DESKTOP=labwc

--- a/hands/remote/image/README.md
+++ b/hands/remote/image/README.md
@@ -85,7 +85,7 @@ For a local native build, use the host architecture (`arm64` on Apple Silicon):
 
 ```sh
 docker buildx build --platform linux/arm64 --load \
-  --tag nanocodex-server-hand:local --file hands/remote/image/Dockerfile hands/remote
+  --tag nanocodex-server-hand:local --file hands/remote/image/Dockerfile .
 bash hands/remote/image/smoke.sh nanocodex-server-hand:local arm64
 ```
 

--- a/js/managed/Dockerfile
+++ b/js/managed/Dockerfile
@@ -132,7 +132,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         poppler-utils qpdf ghostscript tesseract-ocr tesseract-ocr-eng graphviz \
         fonts-noto-core fonts-noto-cjk fonts-noto-color-emoji \
     && rm -rf /var/lib/apt/lists/* \
-    && python3 -m venv /opt/hand-python \
+    && uv venv --python /usr/bin/python3 --seed /opt/hand-python \
     && /opt/hand-python/bin/pip install --no-cache-dir \
         numpy==2.2.6 scipy==1.15.3 pandas==2.3.3 matplotlib==3.10.6 \
         sympy==1.14.0 Pillow==11.3.0 lxml==6.0.2 openpyxl==3.1.5 reportlab==4.4.4 \

--- a/js/managed/Dockerfile
+++ b/js/managed/Dockerfile
@@ -125,6 +125,22 @@ RUN ln -s /usr/bin/fdfind /usr/local/bin/fd \
     && pnpm --version \
     && uv --version
 
+# Creative, document, OCR, and scientific tools are available without a download.
+COPY .generated/toolkit /opt/hand-toolkit
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        blender ffmpeg imagemagick inkscape libreoffice pandoc \
+        poppler-utils qpdf ghostscript tesseract-ocr tesseract-ocr-eng graphviz \
+        fonts-noto-core fonts-noto-cjk fonts-noto-color-emoji \
+    && rm -rf /var/lib/apt/lists/* \
+    && python3 -m venv /opt/hand-python \
+    && /opt/hand-python/bin/pip install --no-cache-dir \
+        numpy==2.2.6 scipy==1.15.3 pandas==2.3.3 matplotlib==3.10.6 \
+        sympy==1.14.0 Pillow==11.3.0 lxml==6.0.2 openpyxl==3.1.5 reportlab==4.4.4 \
+        -r /opt/hand-toolkit/python.txt \
+    && chmod 0755 /opt/hand-toolkit/check.py \
+    && ln -s /opt/hand-toolkit/check.py /usr/local/bin/nanocodex-check-hand-toolkit
+ENV PATH=/opt/hand-python/bin:${PATH}
+
 COPY scripts/check-dev-stack.sh /usr/local/bin/nanocodex-check-dev-stack
 RUN sh /usr/local/bin/nanocodex-check-dev-stack
 

--- a/js/managed/Dockerfile
+++ b/js/managed/Dockerfile
@@ -143,7 +143,7 @@ RUN sh /opt/hand-toolkit/install-paths.sh \
     && ln -s /opt/hand-toolkit/check.py /usr/local/bin/nanocodex-check-hand-toolkit
 ENV PATH=/opt/hand-python/bin:${PATH}
 
-COPY scripts/check-dev-stack.sh /usr/local/bin/nanocodex-check-dev-stack
+COPY --chmod=0755 scripts/check-dev-stack.sh /usr/local/bin/nanocodex-check-dev-stack
 RUN sh /usr/local/bin/nanocodex-check-dev-stack
 
 COPY --from=hand /out/nanocodex-remote /usr/local/bin/nanocodex-remote

--- a/js/managed/Dockerfile
+++ b/js/managed/Dockerfile
@@ -126,7 +126,7 @@ RUN ln -s /usr/bin/fdfind /usr/local/bin/fd \
     && uv --version
 
 # Creative, document, OCR, and scientific tools are available without a download.
-COPY .generated/toolkit /opt/hand-toolkit
+COPY .generated/toolkit/python.txt /opt/hand-toolkit/python.txt
 RUN apt-get update && apt-get install -y --no-install-recommends \
         blender ffmpeg imagemagick inkscape libreoffice pandoc \
         poppler-utils qpdf ghostscript tesseract-ocr tesseract-ocr-eng graphviz \
@@ -136,7 +136,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && /opt/hand-python/bin/pip install --no-cache-dir \
         numpy==2.2.6 scipy==1.15.3 pandas==2.3.3 matplotlib==3.10.6 \
         sympy==1.14.0 Pillow==11.3.0 lxml==6.0.2 openpyxl==3.1.5 reportlab==4.4.4 \
-        -r /opt/hand-toolkit/python.txt \
+        -r /opt/hand-toolkit/python.txt
+COPY .generated/toolkit/check.py .generated/toolkit/install-paths.sh /opt/hand-toolkit/
+RUN sh /opt/hand-toolkit/install-paths.sh \
     && chmod 0755 /opt/hand-toolkit/check.py \
     && ln -s /opt/hand-toolkit/check.py /usr/local/bin/nanocodex-check-hand-toolkit
 ENV PATH=/opt/hand-python/bin:${PATH}

--- a/js/managed/scripts/prepare-hand-image.mjs
+++ b/js/managed/scripts/prepare-hand-image.mjs
@@ -11,3 +11,8 @@ for (const name of await readdir(source)) {
   }
 }
 await cp(`${source}/image/labwc`, `${target}/labwc`, { recursive: true });
+
+const toolkit = fileURLToPath(new URL("../../../crates/experimental/nanocodex-vm/image/toolkit/", import.meta.url));
+const toolkitTarget = fileURLToPath(new URL("../.generated/toolkit/", import.meta.url));
+await rm(toolkitTarget, { recursive: true, force: true });
+await cp(toolkit, toolkitTarget, { recursive: true });

--- a/js/managed/wrangler.jsonc
+++ b/js/managed/wrangler.jsonc
@@ -244,7 +244,7 @@
         {
           "class_name": "Sandbox",
           "image": "./Dockerfile",
-          "instance_type": "standard-1"
+          "instance_type": "standard-3"
         }
       ]
     }
@@ -253,7 +253,8 @@
     {
       "class_name": "Sandbox",
       "image": "./Dockerfile",
-      "instance_type": "standard-1",
+      // The full toolkit occupies about 10 GiB; retain room for builds and artifacts.
+      "instance_type": "standard-3",
       // Preserve active containers across the current >120s build journey during rollouts.
       "rollout_active_grace_period": 300
     }

--- a/scripts/build-hand-docker.sh
+++ b/scripts/build-hand-docker.sh
@@ -18,4 +18,5 @@ context=$(mktemp -d)
 trap 'rm -rf "$context"' EXIT
 cp "${CARGO_TARGET_DIR:-target}/$target/release/nanocodex-vm-guest" "$context/"
 cp crates/experimental/nanocodex-vm/image/Dockerfile.hand "$context/Dockerfile"
+cp -R crates/experimental/nanocodex-vm/image/toolkit "$context/toolkit"
 docker build --platform "$platform" --tag "$image" "$context"


### PR DESCRIPTION
Fresh Hands now include developer, document/PDF/OCR, scientific Python, browser, and creative tools: Rust, Go, Node/pnpm, uv, Blender, FFmpeg, LibreOffice, Pandoc, Inkscape, and the corresponding Python libraries. Native VM, Docker, GPU VM, standalone Linux, and Cloudflare images share the toolkit checks. Cloudflare retains Swift; the GPU image retains the latest Venus/Zink presentation fixes.

Toolchains remain available after VM boot and in login shells. Docker uses executable workspace temporary files for compiler tests. SSH setup bundles and hashes every image input, and ext4 export returns artifacts to the invoking Linux user. VM templates default to 16 GiB. Cloudflare moves from standard-1 to standard-3 (2 vCPU, 8 GiB RAM, 16 GB disk); this increases running cost and leaves room beyond the roughly 11.5 GB image filesystem. CI enforces at least 4 GB of workspace headroom.

Validation:
- Offline compiler, document conversion, browser, video, and Blender rendering checks; unprivileged Docker with a read-only root; ext4 filesystem and ownership checks.
- Real [Docker thread](https://nanocodex.gakonst.workers.dev/agent/01a091e9-c83e-7392-bb70-b761e79803bd) on the Latitude host with KVM masked out: PASS on the final image, including post-merge restart persistence, retained compiled programs, and nonblank images.
- Real [VM thread](https://nanocodex.gakonst.workers.dev/agent/01a091e9-cb18-722e-8f59-45a92943e5b4) booted from the rebuilt image: PASS on the final image, including post-merge disk persistence, retained compiled programs, and nonblank-image checks.
- Full Cloudflare image passes offline compiler/rendering checks locally. The [fresh Cloudflare thread](https://nanocodex.gakonst.workers.dev/agent/01a0921f-b2ae-7647-9fad-f39cea9d5d00) passed the compiler suite and full toolkit after the container rollout completed. LibreOffice timed out when its profile was on R2; the unchanged toolkit passed in local `/tmp` scratch, and copied PNGs, DOCX/XLSX/PPTX, and PDFs reopened from R2. The image docs now specify local scratch for Cloudflare. Core CI, AMD64/ARM64 Docker and standalone image checks, portable/GPU VM checks, Cloudflare image and preview checks, and Native Mac checks passed. The separate iPhone UI job was still running at merge.

The [standalone image publication](https://github.com/gakonst/nanocodex/actions/runs/34641948392) passed AMD64/ARM64 toolkit, codec, and baseline CPU checks. The immutable manifest is anonymously accessible and selected in production via #313. Its exact ARM64 capture binary also starts on the local Linux VM.
