### PR TITLE
fix(hand): select the published hosted toolkit image

### DIFF
--- a/hands/remote/image/README.md
+++ b/hands/remote/image/README.md
@@ -92,3 +92,12 @@ bash hands/remote/image/smoke.sh nanocodex-server-hand:local arm64
 Use the native CI jobs for the combined release. The Cloudflare image's native
 cross-compiler is specific to its AMD64 SDK target and is not the server image
 release path.
+
+## Current toolkit release
+
+The production pin uses `ghcr.io/gakonst/nanocodex-hand@sha256:cf44994c9ca68dd69962cb52cf8e9af572550763780d57483bfcaa05e2ab337b`.
+[Publication run 34641948392](https://github.com/gakonst/nanocodex/actions/runs/34641948392)
+built master commit `b1e10a50f9f89fdae9d1ae1b1468fad4d69fd3f0`, passed the
+AMD64 and ARM64 toolkit, desktop, codec, and baseline CPU checks, and published
+the immutable two-architecture receipt. Anonymous manifest access was verified.
+Existing server Hands pick up this image when explicitly reconnected.

--- a/js/managed/wrangler.jsonc
+++ b/js/managed/wrangler.jsonc
@@ -167,7 +167,7 @@
     "AGENT_IDLE_TIMEOUT_MS": "30000",
     "MANAGED_AGENT_DIRECT_CREDENTIALS": "true",
     "NANOCODEX_SANDBOX_DESKTOPS": "true",
-    "NANOCODEX_HAND_IMAGE": "ghcr.io/gakonst/nanocodex-hand@sha256:0cdd809e526c7e88827b9f46be5a665d9e3ca94a78a66d42f2a6a7110400e3c3",
+    "NANOCODEX_HAND_IMAGE": "ghcr.io/gakonst/nanocodex-hand@sha256:cf44994c9ca68dd69962cb52cf8e9af572550763780d57483bfcaa05e2ab337b",
     "MANAGED_BROWSER_PROVIDER": "cloudflare"
   },
   "env": {


### PR DESCRIPTION
Newly connected SSH Hands still selected the older desktop image after the toolkit release. Point `NANOCODEX_HAND_IMAGE` at the published toolkit manifest, so subsequent server setup includes the development, document, science, and creative tools. Existing server Hands adopt it when explicitly reconnected.

[Publication run 34641948392](https://github.com/gakonst/nanocodex/actions/runs/34641948392) built merged master `b1e10a50`, passed native AMD64/ARM64 toolkit, desktop, codec, and baseline CPU checks, and published the immutable receipt. Anonymous manifest access verifies both architectures. The Wrangler diff changes only this image reference.

The published ARM64 capture layer was fetched directly from GHCR, SHA-256 verified, and its exact binary started successfully on the local ARM64 Linux VM using the existing desktop runtime. Full-image toolkit and codec checks passed in the publication workflow.
